### PR TITLE
Feat/34 38 source language filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.1.9
+
+### Added
+- `--language` filter for search (swift, objc) - CLI and MCP (#34)
+- `source` parameter to MCP `search_docs` tool (#38)
+
+### Changed
+- Database schema v5 - added `language` column to docs_fts and docs_metadata
+- **BREAKING**: Requires database rebuild (`rm ~/.cupertino/search.db && cupertino save`)
+
+---
+
 ## 0.1.8
 
 ### Added

--- a/Packages/Sources/CLI/Commands/SearchCommand.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand.swift
@@ -34,6 +34,12 @@ struct SearchCommand: AsyncParsableCommand {
 
     @Option(
         name: .shortAndLong,
+        help: "Filter by programming language: swift, objc"
+    )
+    var language: String?
+
+    @Option(
+        name: .shortAndLong,
         help: "Maximum number of results to return"
     )
     var limit: Int = Shared.Constants.Limit.defaultSearchLimit
@@ -73,6 +79,7 @@ struct SearchCommand: AsyncParsableCommand {
             query: query,
             source: source,
             framework: framework,
+            language: language,
             limit: limit
         )
 

--- a/Packages/Sources/SearchToolProvider/CupertinoSearchToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CupertinoSearchToolProvider.swift
@@ -71,6 +71,7 @@ public actor CupertinoSearchToolProvider: ToolProvider {
 
         let source = arguments?[Shared.Constants.MCP.schemaParamSource]?.value as? String
         let framework = arguments?[Shared.Constants.MCP.schemaParamFramework]?.value as? String
+        let language = arguments?[Shared.Constants.MCP.schemaParamLanguage]?.value as? String
         let defaultLimit = Shared.Constants.Limit.defaultSearchLimit
         let requestedLimit = (arguments?[Shared.Constants.MCP.schemaParamLimit]?.value as? Int) ?? defaultLimit
         let limit = min(requestedLimit, Shared.Constants.Limit.maxSearchLimit)
@@ -80,6 +81,7 @@ public actor CupertinoSearchToolProvider: ToolProvider {
             query: query,
             source: source,
             framework: framework,
+            language: language,
             limit: limit
         )
 
@@ -91,6 +93,9 @@ public actor CupertinoSearchToolProvider: ToolProvider {
         }
         if let framework {
             markdown += "_Filtered to framework: **\(framework)**_\n\n"
+        }
+        if let language {
+            markdown += "_Filtered to language: **\(language)**_\n\n"
         }
 
         markdown += "Found **\(results.count)** result\(results.count == 1 ? "" : "s"):\n\n"

--- a/Packages/Sources/Shared/Constants.swift
+++ b/Packages/Sources/Shared/Constants.swift
@@ -132,7 +132,7 @@ extension Shared {
             public static let userAgent = "CupertinoCrawler/1.0"
 
             /// Current version
-            public static let version = "0.1.8"
+            public static let version = "0.1.9"
         }
 
         // MARK: - Display Names
@@ -402,6 +402,9 @@ extension Shared {
 
             /// JSON Schema parameter: framework
             public static let schemaParamFramework = "framework"
+
+            /// JSON Schema parameter: language
+            public static let schemaParamLanguage = "language"
 
             /// JSON Schema parameter: limit
             public static let schemaParamLimit = "limit"

--- a/Packages/Sources/Shared/Models.swift
+++ b/Packages/Sources/Shared/Models.swift
@@ -21,6 +21,7 @@ public struct StructuredDocumentationPage: Codable, Sendable, Identifiable, Hash
     public let codeExamples: [CodeExample]
 
     // Apple-specific metadata (nil for non-Apple sources)
+    public let language: String? // Programming language (swift, objc, etc.)
     public let platforms: [String]?
     public let module: String?
     public let conformsTo: [String]? // Protocols this type conforms to
@@ -45,6 +46,7 @@ public struct StructuredDocumentationPage: Codable, Sendable, Identifiable, Hash
         overview: String? = nil,
         sections: [Section] = [],
         codeExamples: [CodeExample] = [],
+        language: String? = nil,
         platforms: [String]? = nil,
         module: String? = nil,
         conformsTo: [String]? = nil,
@@ -64,6 +66,7 @@ public struct StructuredDocumentationPage: Codable, Sendable, Identifiable, Hash
         self.overview = overview
         self.sections = sections
         self.codeExamples = codeExamples
+        self.language = language
         self.platforms = platforms
         self.module = module
         self.conformsTo = conformsTo

--- a/Packages/Tests/CLITests/CLITests.swift
+++ b/Packages/Tests/CLITests/CLITests.swift
@@ -15,13 +15,14 @@ struct CommandRegistrationTests {
     func subcommandsRegistered() {
         let config = Cupertino.configuration
 
-        #expect(config.subcommands.count == 6)
+        #expect(config.subcommands.count == 7)
         #expect(config.subcommands.contains { $0 == FetchCommand.self })
         #expect(config.subcommands.contains { $0 == SaveCommand.self })
         #expect(config.subcommands.contains { $0 == ServeCommand.self })
         #expect(config.subcommands.contains { $0 == SearchCommand.self })
         #expect(config.subcommands.contains { $0 == ReadCommand.self })
         #expect(config.subcommands.contains { $0 == DoctorCommand.self })
+        #expect(config.subcommands.contains { $0 == CleanupCommand.self })
     }
 
     @Test("Default subcommand is ServeCommand")

--- a/docs/commands/search/README.md
+++ b/docs/commands/search/README.md
@@ -55,7 +55,20 @@ cupertino search "View" --framework swiftui
 cupertino search "URL" --framework foundation
 ```
 
-### -l, --limit
+### -l, --language
+
+Filter results by programming language.
+
+**Type:** String
+**Values:** `swift`, `objc`
+
+**Example:**
+```bash
+cupertino search "URLSession" --language swift
+cupertino search "NSURLSession" --language objc
+```
+
+### --limit
 
 Maximum number of results to return.
 

--- a/docs/commands/search/option (--)/language.md
+++ b/docs/commands/search/option (--)/language.md
@@ -1,0 +1,53 @@
+# --language
+
+Filter search results by programming language.
+
+## Synopsis
+
+```bash
+cupertino search <query> --language <language>
+cupertino search <query> -l <language>
+```
+
+## Description
+
+Filters search results to show only documentation written for a specific programming language. Most Apple documentation is available in both Swift and Objective-C variants.
+
+## Values
+
+| Value | Description |
+|-------|-------------|
+| `swift` | Swift documentation |
+| `objc` | Objective-C documentation |
+
+## Examples
+
+### Swift Only
+
+```bash
+cupertino search "URLSession" --language swift
+```
+
+### Objective-C Only
+
+```bash
+cupertino search "NSURLSession" --language objc
+```
+
+### Combined with Other Filters
+
+```bash
+cupertino search "async" --language swift --framework foundation
+```
+
+## Notes
+
+- Most Swift Evolution proposals are Swift-only
+- Swift.org documentation is Swift-only
+- Apple framework documentation often has both Swift and Objective-C variants
+- If not specified, searches all languages
+
+## See Also
+
+- [--source](../source.md) - Filter by documentation source
+- [--framework](../framework.md) - Filter by framework

--- a/docs/commands/serve/README.md
+++ b/docs/commands/serve/README.md
@@ -141,6 +141,7 @@ Full-text search across all documentation.
 - `query` (required): Search keywords
 - `source` (optional): Filter by source (apple-docs, swift-book, swift-org, swift-evolution, packages)
 - `framework` (optional): Filter by framework name
+- `language` (optional): Filter by language (swift, objc)
 - `limit` (optional): Max results (default: 20, max: 100)
 
 ### list_frameworks

--- a/docs/tools/search_docs/README.md
+++ b/docs/tools/search_docs/README.md
@@ -69,6 +69,18 @@ Filter results to a specific framework (applies to `apple-docs` source).
 
 Use `list_frameworks` to see available framework names.
 
+### language (optional)
+
+Filter results by programming language.
+
+**Type:** String
+
+**Default:** None (searches all languages)
+
+**Values:**
+- `"swift"` - Swift documentation
+- `"objc"` - Objective-C documentation
+
 ### limit (optional)
 
 Maximum number of results to return.


### PR DESCRIPTION
  Title: Add language filter and source param to search

  Description:

  Adds search filters for programming language and syncs MCP tool with CLI capabilities.

  Changes

  Issue #34 - Language Filter:
  - Added --language option to CLI search (swift, objc)
  - Added language parameter to MCP search_docs tool
  - Schema v5 adds language column to docs_fts and docs_metadata
  - Parses interfaceLanguage from Apple JSON
  - Heuristic detection for Obj-C patterns when language not in metadata

  Issue #38 - MCP Source Parameter:
  - Added source parameter to MCP search_docs tool (was missing vs CLI)

  Breaking Change

  Database schema v5 requires rebuild:
  rm ~/.cupertino/search.db && cupertino save

  Documentation

  - Added docs/commands/search/option (--)/language.md
  - Updated docs/commands/search/README.md
  - Updated docs/commands/serve/README.md
  - Updated docs/tools/search_docs/README.md

  Closes #34, closes #38