### PR TITLE
Add Apple Archive documentation crawler and search support (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 0.2.3
+
+### Added
+- **Apple Archive Documentation Crawler** - Crawl legacy Apple programming guides (Core Animation, Core Graphics, Core Text, etc.) (#41)
+- `cupertino fetch --type archive` - Fetch archived Apple programming guides
+- `--include-archive` flag for search command - Include legacy guides in results
+- `include_archive` parameter for MCP `search_docs` tool
+- Framework synonyms for better search (QuartzCore↔CoreAnimation, CoreGraphics↔Quartz2D)
+- Source-based search ranking (modern docs rank higher, archive docs have slight penalty)
+- TUI Archive view for browsing and selecting archive guides
+
+### Changed
+- Archive documentation excluded from search by default (use `--include-archive` or `--source apple-archive`)
+- Updated MCP tool description to document archive features
+
+### Related Issues
+- Closes #41
+
+---
+
 ## 0.2.2
 
 ### Added

--- a/Packages/Sources/CLI/Commands/SearchCommand.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand.swift
@@ -21,10 +21,16 @@ struct SearchCommand: AsyncParsableCommand {
     @Option(
         name: .shortAndLong,
         help: """
-        Filter by source: apple-docs, swift-evolution, swift-org, swift-book, packages, apple-sample-code
+        Filter by source: apple-docs, swift-evolution, swift-org, swift-book, packages, apple-sample-code, apple-archive
         """
     )
     var source: String?
+
+    @Flag(
+        name: .long,
+        help: "Include Apple Archive documentation in results (excluded by default)"
+    )
+    var includeArchive: Bool = false
 
     @Option(
         name: .shortAndLong,
@@ -75,12 +81,14 @@ struct SearchCommand: AsyncParsableCommand {
         }
 
         // Perform search
+        // Archive is excluded by default unless --include-archive or --source apple-archive
         let results = try await searchIndex.search(
             query: query,
             source: source,
             framework: framework,
             language: language,
-            limit: limit
+            limit: limit,
+            includeArchive: includeArchive
         )
 
         // Output results

--- a/Packages/Sources/CLI/SupportingTypes.swift
+++ b/Packages/Sources/CLI/SupportingTypes.swift
@@ -12,6 +12,7 @@ extension Cupertino {
         case packages
         case packageDocs = "package-docs"
         case code
+        case archive
         case all
 
         var displayName: String {
@@ -22,6 +23,7 @@ extension Cupertino {
             case .packages: return Shared.Constants.DisplayName.packageMetadata
             case .packageDocs: return Shared.Constants.DisplayName.swiftPackages
             case .code: return Shared.Constants.DisplayName.sampleCode
+            case .archive: return Shared.Constants.DisplayName.archive
             case .all: return Shared.Constants.DisplayName.allDocs
             }
         }
@@ -34,6 +36,7 @@ extension Cupertino {
             case .packages: return "" // API-based fetching
             case .packageDocs: return "" // GitHub raw content downloading
             case .code: return "" // Web-based download
+            case .archive: return Shared.Constants.BaseURL.appleArchive
             case .all: return "" // N/A - fetches all types sequentially
             }
         }
@@ -54,6 +57,8 @@ extension Cupertino {
                 return "\(homeDir)/\(baseDir)/\(Shared.Constants.Directory.packages)"
             case .code:
                 return "\(homeDir)/\(baseDir)/\(Shared.Constants.Directory.sampleCode)"
+            case .archive:
+                return "\(homeDir)/\(baseDir)/\(Shared.Constants.Directory.archive)"
             case .all:
                 return "\(homeDir)/\(baseDir)"
             }
@@ -64,7 +69,7 @@ extension Cupertino {
         }
 
         static var directFetchTypes: [FetchType] {
-            [.packages, .packageDocs, .code]
+            [.packages, .packageDocs, .code, .archive]
         }
 
         static var allTypes: [FetchType] {

--- a/Packages/Sources/Core/AppleArchiveCrawler.swift
+++ b/Packages/Sources/Core/AppleArchiveCrawler.swift
@@ -1,0 +1,731 @@
+import Foundation
+import Logging
+import Shared
+
+// MARK: - Apple Archive Crawler
+
+/// Crawls Apple's archived documentation (static HTML pages)
+/// These are the pre-2016 guides that are no longer updated but still valuable
+extension Core {
+    @MainActor
+    public final class AppleArchiveCrawler {
+        private let outputDirectory: URL
+        private let guides: [ArchiveGuideInfo]
+        private let forceRecrawl: Bool
+
+        public init(
+            outputDirectory: URL,
+            guides: [ArchiveGuideInfo],
+            forceRecrawl: Bool = false
+        ) {
+            self.outputDirectory = outputDirectory
+            self.guides = guides
+            self.forceRecrawl = forceRecrawl
+        }
+
+        /// Convenience initializer for backward compatibility (uses empty framework)
+        public convenience init(
+            outputDirectory: URL,
+            guideURLs: [URL],
+            forceRecrawl: Bool = false
+        ) {
+            let guides = guideURLs.map { ArchiveGuideInfo(url: $0, framework: "") }
+            self.init(outputDirectory: outputDirectory, guides: guides, forceRecrawl: forceRecrawl)
+        }
+
+        // MARK: - Public API
+
+        /// Crawl all specified archive guides
+        public func crawl(
+            onProgress: (@Sendable (ArchiveProgress) -> Void)? = nil
+        ) async throws -> ArchiveStatistics {
+            var stats = ArchiveStatistics(startTime: Date())
+
+            logInfo("Starting Apple Archive crawler")
+            logInfo("   Output: \(outputDirectory.path)")
+            logInfo("   Guides: \(guides.count)")
+
+            // Create output directory
+            try FileManager.default.createDirectory(
+                at: outputDirectory,
+                withIntermediateDirectories: true
+            )
+
+            var totalPages = 0
+            var currentGuide = 0
+
+            for guide in guides {
+                currentGuide += 1
+                logInfo("\n[\(currentGuide)/\(guides.count)] Crawling: \(guide.url.lastPathComponent)")
+
+                do {
+                    // Fetch book.json to get TOC
+                    let bookJSON = try await fetchBookJSON(for: guide.url)
+                    let pages = extractPages(from: bookJSON, baseURL: guide.url)
+
+                    logInfo("   Found \(pages.count) pages")
+
+                    // Create guide subdirectory
+                    let guideDir = outputDirectory.appendingPathComponent(bookJSON.uid)
+                    try FileManager.default.createDirectory(
+                        at: guideDir,
+                        withIntermediateDirectories: true
+                    )
+
+                    // Save book.json for reference
+                    let bookJSONPath = guideDir.appendingPathComponent("book.json")
+                    let bookData = try JSONCoding.encode(bookJSON)
+                    try bookData.write(to: bookJSONPath)
+
+                    // Crawl each page
+                    for (index, page) in pages.enumerated() {
+                        do {
+                            try await crawlPage(page, to: guideDir, framework: guide.framework, stats: &stats)
+                            totalPages += 1
+
+                            // Progress callback
+                            if let onProgress {
+                                let progress = ArchiveProgress(
+                                    currentGuide: currentGuide,
+                                    totalGuides: guides.count,
+                                    currentPage: index + 1,
+                                    totalPages: pages.count,
+                                    guideName: bookJSON.title,
+                                    pageName: page.title,
+                                    stats: stats
+                                )
+                                onProgress(progress)
+                            }
+
+                            // Rate limiting
+                            try await Task.sleep(for: Shared.Constants.Delay.archivePage)
+                        } catch {
+                            stats.errors += 1
+                            logError("Failed to crawl page \(page.title): \(error)")
+                        }
+                    }
+
+                    stats.totalGuides += 1
+                } catch {
+                    stats.errors += 1
+                    logError("Failed to crawl guide \(guide.url): \(error)")
+                }
+            }
+
+            stats.endTime = Date()
+
+            logInfo("\nCrawl completed!")
+            logStatistics(stats)
+
+            return stats
+        }
+
+        // MARK: - Private Methods
+
+        private func fetchBookJSON(for guideURL: URL) async throws -> BookJSON {
+            // book.json is at the guide root (e.g., .../ObjCRuntimeGuide/book.json)
+            let bookURL = guideURL.appendingPathComponent("book.json")
+
+            let (data, response) = try await URLSession.shared.data(from: bookURL)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200
+            else {
+                throw ArchiveCrawlerError.invalidResponse(bookURL)
+            }
+
+            return try JSONDecoder().decode(BookJSON.self, from: data)
+        }
+
+        private func extractPages(from book: BookJSON, baseURL: URL) -> [ArchivePage] {
+            var pages: [ArchivePage] = []
+            var seenHrefs: Set<String> = []
+
+            func extractFromSections(_ sections: [BookSection], parentPath: String = "") {
+                for section in sections {
+                    // Only add if it has an href (actual page)
+                    if let href = section.href {
+                        // Remove fragment identifier for file path
+                        let cleanHref = href.components(separatedBy: "#").first ?? href
+
+                        // Skip if we've already seen this file (different anchor same page)
+                        guard !seenHrefs.contains(cleanHref) else {
+                            // Recursively extract from nested sections anyway
+                            if let nestedSections = section.sections {
+                                extractFromSections(nestedSections, parentPath: section.title)
+                            }
+                            continue
+                        }
+
+                        seenHrefs.insert(cleanHref)
+                        let pageURL = baseURL.appendingPathComponent(cleanHref)
+                        let page = ArchivePage(
+                            title: section.title,
+                            href: cleanHref,
+                            url: pageURL,
+                            type: section.type ?? "section",
+                            aref: section.aref
+                        )
+                        pages.append(page)
+                    }
+
+                    // Recursively extract from nested sections
+                    if let nestedSections = section.sections {
+                        extractFromSections(nestedSections, parentPath: section.title)
+                    }
+                }
+            }
+
+            extractFromSections(book.sections)
+            return pages
+        }
+
+        private func crawlPage(
+            _ page: ArchivePage,
+            to guideDir: URL,
+            framework: String,
+            stats: inout ArchiveStatistics
+        ) async throws {
+            // Determine output path - preserve directory structure
+            let relativePath = page.href.replacingOccurrences(of: ".html", with: ".md")
+            let outputPath = guideDir.appendingPathComponent(relativePath)
+
+            // Create parent directories
+            let parentDir = outputPath.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
+
+            // Check if already crawled (unless force recrawl)
+            let isNew = !FileManager.default.fileExists(atPath: outputPath.path)
+            if !isNew, !forceRecrawl {
+                stats.skippedPages += 1
+                return
+            }
+
+            // Fetch HTML
+            let (data, response) = try await URLSession.shared.data(from: page.url)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200
+            else {
+                throw ArchiveCrawlerError.invalidResponse(page.url)
+            }
+
+            guard let html = String(data: data, encoding: .utf8) else {
+                throw ArchiveCrawlerError.invalidEncoding
+            }
+
+            // Parse HTML to extract metadata and content
+            let parsed = parseArchiveHTML(html, page: page)
+
+            // Convert to markdown
+            let markdown = convertToMarkdown(parsed, framework: framework)
+
+            // Save
+            try markdown.write(to: outputPath, atomically: true, encoding: .utf8)
+
+            if isNew {
+                stats.newPages += 1
+            } else {
+                stats.updatedPages += 1
+            }
+
+            stats.totalPages += 1
+        }
+
+        private func parseArchiveHTML(_ html: String, page: ArchivePage) -> ParsedArchivePage {
+            // Extract metadata from meta tags
+            let bookTitle = extractMetaContent(from: html, name: "book-title") ?? "Unknown"
+            let chapterId = extractMetaContent(from: html, name: "chapterId")
+            let date = extractMetaContent(from: html, name: "date")
+            let description = extractMetaContent(from: html, name: "description")
+            let identifier = extractMetaContent(from: html, name: "identifier")
+            let platforms = extractMetaContent(from: html, name: "platforms")
+
+            // Extract article content
+            let content = extractArticleContent(from: html)
+
+            return ParsedArchivePage(
+                title: page.title,
+                bookTitle: bookTitle,
+                chapterId: chapterId,
+                date: date,
+                description: description,
+                identifier: identifier,
+                platforms: platforms,
+                content: content,
+                href: page.href
+            )
+        }
+
+        private func extractMetaContent(from html: String, name: String) -> String? {
+            // Match <meta id="name" name="name" content="value">
+            // or <meta name="name" content="value">
+            let patterns = [
+                #"<meta[^>]*name=[\"']\#(name)[\"'][^>]*content=[\"']([^\"']*)[\"']"#,
+                #"<meta[^>]*content=[\"']([^\"']*)[\"'][^>]*name=[\"']\#(name)[\"']"#,
+            ]
+
+            for pattern in patterns {
+                guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+                      let match = regex.firstMatch(
+                          in: html,
+                          range: NSRange(html.startIndex..., in: html)
+                      )
+                else {
+                    continue
+                }
+
+                // Content is in group 1 or 2 depending on pattern
+                for group in 1...match.numberOfRanges - 1 {
+                    if let range = Range(match.range(at: group), in: html) {
+                        let value = String(html[range])
+                        if !value.isEmpty, value != name {
+                            return value
+                        }
+                    }
+                }
+            }
+
+            return nil
+        }
+
+        private func extractArticleContent(from html: String) -> String {
+            // Extract content from <article id="contents">...</article>
+            guard let articleStart = html.range(of: #"<article[^>]*id=[\"']contents[\"'][^>]*>"#, options: .regularExpression),
+                  let articleEnd = html.range(of: "</article>", range: articleStart.upperBound..<html.endIndex)
+            else {
+                // Fallback: try to find any article tag
+                if let fallbackStart = html.range(of: "<article", options: .caseInsensitive),
+                   let tagEnd = html.range(of: ">", range: fallbackStart.upperBound..<html.endIndex),
+                   let articleEnd = html.range(of: "</article>", range: tagEnd.upperBound..<html.endIndex) {
+                    return String(html[tagEnd.upperBound..<articleEnd.lowerBound])
+                }
+                return ""
+            }
+
+            return String(html[articleStart.upperBound..<articleEnd.lowerBound])
+        }
+
+        private func convertToMarkdown(_ parsed: ParsedArchivePage, framework: String) -> String {
+            var lines: [String] = []
+
+            // YAML front matter
+            lines.append("---")
+            lines.append("title: \"\(escapeYAML(parsed.title))\"")
+            lines.append("book: \"\(escapeYAML(parsed.bookTitle))\"")
+            if !framework.isEmpty {
+                lines.append("framework: \"\(escapeYAML(framework))\"")
+            }
+            if let chapterId = parsed.chapterId {
+                lines.append("chapterId: \"\(chapterId)\"")
+            }
+            if let date = parsed.date {
+                lines.append("date: \"\(date)\"")
+            }
+            if let description = parsed.description {
+                lines.append("description: \"\(escapeYAML(description))\"")
+            }
+            if let identifier = parsed.identifier {
+                lines.append("identifier: \"\(identifier)\"")
+            }
+            if let platforms = parsed.platforms {
+                lines.append("platforms: \"\(platforms)\"")
+            }
+            lines.append("source: apple-archive")
+            lines.append("---")
+            lines.append("")
+
+            // Title
+            lines.append("# \(parsed.title)")
+            lines.append("")
+
+            // Book info
+            lines.append("> **\(parsed.bookTitle)**")
+            if let date = parsed.date {
+                lines.append("> Last updated: \(date)")
+            }
+            lines.append("")
+
+            // Convert HTML content to markdown
+            let markdownContent = htmlToMarkdown(parsed.content)
+            lines.append(markdownContent)
+
+            return lines.joined(separator: "\n")
+        }
+
+        private func escapeYAML(_ text: String) -> String {
+            text.replacingOccurrences(of: "\"", with: "\\\"")
+                .replacingOccurrences(of: "\n", with: " ")
+        }
+
+        private func htmlToMarkdown(_ html: String) -> String {
+            var result = html
+
+            // Remove script and style tags
+            result = result.replacingOccurrences(
+                of: #"<script[^>]*>[\s\S]*?</script>"#,
+                with: "",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<style[^>]*>[\s\S]*?</style>"#,
+                with: "",
+                options: .regularExpression
+            )
+
+            // Headers
+            result = result.replacingOccurrences(
+                of: #"<h1[^>]*>(.*?)</h1>"#,
+                with: "# $1\n",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<h2[^>]*>(.*?)</h2>"#,
+                with: "## $1\n",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<h3[^>]*>(.*?)</h3>"#,
+                with: "### $1\n",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<h4[^>]*>(.*?)</h4>"#,
+                with: "#### $1\n",
+                options: .regularExpression
+            )
+
+            // Paragraphs
+            result = result.replacingOccurrences(
+                of: #"<p[^>]*>(.*?)</p>"#,
+                with: "$1\n\n",
+                options: .regularExpression
+            )
+
+            // Bold and italic
+            result = result.replacingOccurrences(
+                of: #"<strong[^>]*>(.*?)</strong>"#,
+                with: "**$1**",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<b[^>]*>(.*?)</b>"#,
+                with: "**$1**",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<em[^>]*>(.*?)</em>"#,
+                with: "*$1*",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<i[^>]*>(.*?)</i>"#,
+                with: "*$1*",
+                options: .regularExpression
+            )
+
+            // Code
+            result = result.replacingOccurrences(
+                of: #"<code[^>]*>(.*?)</code>"#,
+                with: "`$1`",
+                options: .regularExpression
+            )
+
+            // Pre/code blocks - simplified
+            result = result.replacingOccurrences(
+                of: #"<pre[^>]*><code[^>]*>([\s\S]*?)</code></pre>"#,
+                with: "\n```\n$1\n```\n",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<pre[^>]*>([\s\S]*?)</pre>"#,
+                with: "\n```\n$1\n```\n",
+                options: .regularExpression
+            )
+
+            // Links
+            result = result.replacingOccurrences(
+                of: #"<a[^>]*href=[\"']([^\"']*)[\"'][^>]*>(.*?)</a>"#,
+                with: "[$2]($1)",
+                options: .regularExpression
+            )
+
+            // Lists
+            result = result.replacingOccurrences(
+                of: #"<li[^>]*>(.*?)</li>"#,
+                with: "- $1\n",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"</?[ou]l[^>]*>"#,
+                with: "\n",
+                options: .regularExpression
+            )
+
+            // Important/Note boxes
+            result = result.replacingOccurrences(
+                of: #"<div class=[\"']importantbox[\"'][^>]*>[\s\S]*?<p><strong>Important:</strong>\s*([\s\S]*?)</p>[\s\S]*?</div>"#,
+                with: "\n> **Important:** $1\n",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<aside[^>]*>([\s\S]*?)</aside>"#,
+                with: "\n> $1\n",
+                options: .regularExpression
+            )
+
+            // Remove remaining HTML tags
+            result = result.replacingOccurrences(
+                of: #"<[^>]+>"#,
+                with: "",
+                options: .regularExpression
+            )
+
+            // Decode HTML entities
+            result = decodeHTMLEntities(result)
+
+            // Clean up whitespace
+            result = result.replacingOccurrences(
+                of: #"\n{3,}"#,
+                with: "\n\n",
+                options: .regularExpression
+            )
+            result = result.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            return result
+        }
+
+        private func decodeHTMLEntities(_ text: String) -> String {
+            var result = text
+            let entities: [(String, String)] = [
+                ("&amp;", "&"),
+                ("&lt;", "<"),
+                ("&gt;", ">"),
+                ("&quot;", "\""),
+                ("&apos;", "'"),
+                ("&#39;", "'"),
+                ("&nbsp;", " "),
+                ("&mdash;", "—"),
+                ("&ndash;", "–"),
+                ("&hellip;", "..."),
+                ("&copy;", "(c)"),
+                ("&reg;", "(R)"),
+                ("&trade;", "(TM)"),
+            ]
+
+            for (entity, replacement) in entities {
+                result = result.replacingOccurrences(of: entity, with: replacement)
+            }
+
+            // Numeric entities
+            let numericPattern = #"&#(\d+);"#
+            if let regex = try? NSRegularExpression(pattern: numericPattern) {
+                let range = NSRange(result.startIndex..., in: result)
+                result = regex.stringByReplacingMatches(
+                    in: result,
+                    range: range,
+                    withTemplate: ""
+                )
+            }
+
+            return result
+        }
+
+        // MARK: - Logging
+
+        private func logInfo(_ message: String) {
+            Log.info(message, category: .archive)
+        }
+
+        private func logError(_ message: String) {
+            Log.error("Error: \(message)", category: .archive)
+        }
+
+        private func logStatistics(_ stats: ArchiveStatistics) {
+            let messages = [
+                "Statistics:",
+                "   Total guides: \(stats.totalGuides)",
+                "   Total pages: \(stats.totalPages)",
+                "   New: \(stats.newPages)",
+                "   Updated: \(stats.updatedPages)",
+                "   Skipped: \(stats.skippedPages)",
+                "   Errors: \(stats.errors)",
+                stats.duration.map { "   Duration: \(Int($0))s" } ?? "",
+                "",
+                "Output: \(outputDirectory.path)",
+            ]
+
+            for message in messages where !message.isEmpty {
+                Log.info(message, category: .archive)
+            }
+        }
+    }
+}
+
+// MARK: - Models
+
+/// Guide info containing URL and framework name for archive crawling
+public struct ArchiveGuideInfo: Sendable {
+    public let url: URL
+    public let framework: String
+
+    public init(url: URL, framework: String) {
+        self.url = url
+        self.framework = framework
+    }
+}
+
+/// Represents the book.json structure from Apple Archive
+public struct BookJSON: Codable, Sendable {
+    public let type: String?
+    public let title: String
+    public let technology: String?
+    public let version: String?
+    public let sections: [BookSection]
+    public let uid: String
+
+    public init(
+        type: String? = nil,
+        title: String,
+        technology: String? = nil,
+        version: String? = nil,
+        sections: [BookSection],
+        uid: String
+    ) {
+        self.type = type
+        self.title = title
+        self.technology = technology
+        self.version = version
+        self.sections = sections
+        self.uid = uid
+    }
+}
+
+/// Section within book.json
+public struct BookSection: Codable, Sendable {
+    public let title: String
+    public let href: String?
+    public let aref: String?
+    public let type: String?
+    public let isPart: Bool?
+    public let sections: [BookSection]?
+
+    public init(
+        title: String,
+        href: String? = nil,
+        aref: String? = nil,
+        type: String? = nil,
+        isPart: Bool? = nil,
+        sections: [BookSection]? = nil
+    ) {
+        self.title = title
+        self.href = href
+        self.aref = aref
+        self.type = type
+        self.isPart = isPart
+        self.sections = sections
+    }
+}
+
+/// Represents a page to crawl
+struct ArchivePage {
+    let title: String
+    let href: String
+    let url: URL
+    let type: String
+    let aref: String?
+}
+
+/// Parsed content from an archive HTML page
+struct ParsedArchivePage {
+    let title: String
+    let bookTitle: String
+    let chapterId: String?
+    let date: String?
+    let description: String?
+    let identifier: String?
+    let platforms: String?
+    let content: String
+    let href: String
+}
+
+// MARK: - Statistics
+
+public struct ArchiveStatistics: Sendable {
+    public var totalGuides: Int = 0
+    public var totalPages: Int = 0
+    public var newPages: Int = 0
+    public var updatedPages: Int = 0
+    public var skippedPages: Int = 0
+    public var errors: Int = 0
+    public var startTime: Date?
+    public var endTime: Date?
+
+    public init(
+        totalGuides: Int = 0,
+        totalPages: Int = 0,
+        newPages: Int = 0,
+        updatedPages: Int = 0,
+        skippedPages: Int = 0,
+        errors: Int = 0,
+        startTime: Date? = nil,
+        endTime: Date? = nil
+    ) {
+        self.totalGuides = totalGuides
+        self.totalPages = totalPages
+        self.newPages = newPages
+        self.updatedPages = updatedPages
+        self.skippedPages = skippedPages
+        self.errors = errors
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+
+    public var duration: TimeInterval? {
+        guard let start = startTime, let end = endTime else {
+            return nil
+        }
+        return end.timeIntervalSince(start)
+    }
+}
+
+// MARK: - Progress
+
+public struct ArchiveProgress: Sendable {
+    public let currentGuide: Int
+    public let totalGuides: Int
+    public let currentPage: Int
+    public let totalPages: Int
+    public let guideName: String
+    public let pageName: String
+    public let stats: ArchiveStatistics
+
+    public var percentage: Double {
+        let guideProgress = Double(currentGuide - 1) / Double(totalGuides)
+        let pageProgress = Double(currentPage) / Double(max(totalPages, 1)) / Double(totalGuides)
+        return (guideProgress + pageProgress) * 100
+    }
+
+    public var currentItem: String {
+        "\(guideName) - \(pageName)"
+    }
+}
+
+// MARK: - Errors
+
+public enum ArchiveCrawlerError: Error, LocalizedError {
+    case invalidResponse(URL)
+    case invalidEncoding
+    case bookJSONNotFound(URL)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidResponse(let url):
+            return "Invalid response from \(url)"
+        case .invalidEncoding:
+            return "Invalid text encoding"
+        case .bookJSONNotFound(let url):
+            return "book.json not found at \(url)"
+        }
+    }
+}

--- a/Packages/Sources/Core/ArchiveGuideCatalog.swift
+++ b/Packages/Sources/Core/ArchiveGuideCatalog.swift
@@ -1,0 +1,384 @@
+import Foundation
+import Resources
+import Shared
+
+// MARK: - Archive Guide Catalog
+
+/// Curated catalog of essential Apple Archive documentation guides
+/// These are classic guides that contain foundational knowledge not available elsewhere
+public enum ArchiveGuideCatalog {
+    /// Base URL for Apple's documentation archive
+    private static let baseURL = "https://developer.apple.com/library/archive/documentation"
+
+    /// User-writable location for selected guides: ~/.cupertino/selected-archive-guides.json
+    private static var userSelectionsURL: URL {
+        Shared.Constants.defaultBaseDirectory.appendingPathComponent("selected-archive-guides.json")
+    }
+
+    /// Essential programming guides worth crawling
+    /// Always reads from user-writable location (creates from bundled if missing)
+    public static var essentialGuides: [URL] {
+        essentialGuidesWithInfo.map(\.url)
+    }
+
+    /// Essential guides with full info (URL + framework)
+    /// Always reads from user-writable location (creates from bundled if missing)
+    public static var essentialGuidesWithInfo: [ArchiveGuideInfo] {
+        // Ensure user selections file exists (creates from bundled if missing)
+        ensureUserSelectionsFileExists()
+
+        // Load from user selections file
+        if let selectedGuides = loadUserSelectedGuides(), !selectedGuides.isEmpty {
+            return selectedGuides.compactMap { guide in
+                guard let url = URL(string: "\(baseURL)/\(guide.path)") else { return nil }
+                return ArchiveGuideInfo(url: url, framework: guide.framework)
+            }
+        }
+
+        // Fall back to hardcoded list if everything else fails (no framework info)
+        return essentialGuidePaths.compactMap { path in
+            guard let url = URL(string: "\(baseURL)/\(path)") else { return nil }
+            return ArchiveGuideInfo(url: url, framework: "")
+        }
+    }
+
+    /// Load selected guides with full info from user file
+    private static func loadUserSelectedGuides() -> [SelectedGuideJSON]? {
+        let selectedURL = userSelectionsURL
+
+        guard FileManager.default.fileExists(atPath: selectedURL.path) else {
+            return nil
+        }
+
+        do {
+            let data = try Data(contentsOf: selectedURL)
+            let json = try JSONDecoder().decode(SelectedArchiveGuidesJSON.self, from: data)
+            return json.guides
+        } catch {
+            return nil
+        }
+    }
+
+    /// Ensure user selections file exists, creating from bundled catalog if missing
+    private static func ensureUserSelectionsFileExists() {
+        let selectedURL = userSelectionsURL
+
+        // If file already exists, nothing to do
+        if FileManager.default.fileExists(atPath: selectedURL.path) {
+            return
+        }
+
+        // Load bundled catalog and create user file with required guides
+        guard let bundleURL = CupertinoResources.bundle.url(
+            forResource: "archive-guides-catalog",
+            withExtension: "json"
+        ) else {
+            return
+        }
+
+        do {
+            // Ensure ~/.cupertino directory exists
+            let baseDir = Shared.Constants.defaultBaseDirectory
+            if !FileManager.default.fileExists(atPath: baseDir.path) {
+                try FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+            }
+
+            // Load bundled catalog and extract required guides
+            let data = try Data(contentsOf: bundleURL)
+            let catalog = try JSONDecoder().decode(ArchiveGuidesCatalogJSON.self, from: data)
+            let requiredGuides = catalog.guides.filter(\.required)
+
+            // Create selections JSON with required guides
+            let json = SelectedArchiveGuidesJSON(
+                version: "1.0",
+                lastUpdated: ISO8601DateFormatter().string(from: Date()),
+                description: "Selected Apple Archive guides for crawling (auto-generated with required guides)",
+                count: requiredGuides.count,
+                guides: requiredGuides.map { guide in
+                    SelectedGuideJSON(
+                        title: guide.title,
+                        framework: guide.framework,
+                        category: guide.category,
+                        path: guide.path
+                    )
+                }
+            )
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let outputData = try encoder.encode(json)
+            try outputData.write(to: selectedURL)
+        } catch {
+            // Silently fail - will fall back to hardcoded defaults
+        }
+    }
+
+    /// Load selected guides from user-writable location (~/.cupertino/selected-archive-guides.json)
+    private static func loadUserSelectedGuidePaths() -> [String]? {
+        let selectedURL = userSelectionsURL
+
+        guard FileManager.default.fileExists(atPath: selectedURL.path) else {
+            return nil
+        }
+
+        do {
+            let data = try Data(contentsOf: selectedURL)
+            let json = try JSONDecoder().decode(SelectedArchiveGuidesJSON.self, from: data)
+            return json.guides.map(\.path)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Load guides from bundled catalog JSON (used for fallback)
+    private static func loadBundledCatalogPaths() -> [String]? {
+        guard let url = CupertinoResources.bundle.url(
+            forResource: "archive-guides-catalog",
+            withExtension: "json"
+        ) else {
+            return nil
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let json = try JSONDecoder().decode(ArchiveGuidesCatalogJSON.self, from: data)
+            return json.guides.map(\.path)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Path components for essential guides (relative to base documentation URL)
+    private static let essentialGuidePaths: [String] = [
+        // MARK: - Tier 1: Core Language & Runtime (still highly relevant)
+
+        // Objective-C Runtime - essential for understanding iOS/macOS internals
+        "Cocoa/Conceptual/ObjCRuntimeGuide",
+
+        // Key-Value Observing - fundamental pattern, still used
+        "Cocoa/Conceptual/KeyValueObserving",
+
+        // Key-Value Coding - foundation for bindings and many frameworks
+        "Cocoa/Conceptual/KeyValueCoding",
+
+        // Memory Management - essential for understanding ARC behavior
+        "Cocoa/Conceptual/MemoryMgmt",
+
+        // MARK: - Tier 2: Cocoa Fundamentals (timeless concepts)
+
+        // Cocoa Fundamentals - comprehensive intro to Cocoa
+        "Cocoa/Conceptual/CocoaFundamentals",
+
+        // Coding Guidelines - Apple's official naming conventions
+        "Cocoa/Conceptual/CodingGuidelines",
+
+        // Exception Programming - Objective-C exception handling
+        "Cocoa/Conceptual/Exceptions",
+
+        // Threading Programming Guide - foundational concurrency concepts
+        "Cocoa/Conceptual/Multithreading",
+
+        // MARK: - Tier 3: Application Architecture
+
+        // App Programming Guide for iOS - architecture patterns
+        "iPhone/Conceptual/iPhoneOSProgrammingGuide",
+
+        // Mac App Programming Guide
+        "General/Conceptual/MOSXAppProgrammingGuide",
+
+        // View Controller Programming Guide for iOS
+        "iPhone/Conceptual/ViewControllerPGforiPhoneOS",
+
+        // Table View Programming Guide for iOS
+        "UserExperience/Conceptual/TableView_iPhone",
+
+        // MARK: - Tier 4: Data & Persistence
+
+        // Core Data Programming Guide
+        "Cocoa/Conceptual/CoreData",
+
+        // Property List Programming Guide
+        "Cocoa/Conceptual/PropertyLists",
+
+        // Archives and Serializations
+        "Cocoa/Conceptual/Archiving",
+
+        // MARK: - Tier 5: Graphics & Animation
+
+        // Quartz 2D Programming Guide - foundational graphics
+        "GraphicsImaging/Conceptual/drawingwithquartz2d",
+
+        // Core Animation Programming Guide
+        "Cocoa/Conceptual/CoreAnimation_guide",
+
+        // Animation Types and Timing Programming Guide
+        "Cocoa/Conceptual/Animation_Types_Timing",
+
+        // MARK: - Tier 6: Text & Strings
+
+        // String Programming Guide
+        "Cocoa/Conceptual/Strings",
+
+        // Attributed String Programming Guide
+        "Cocoa/Conceptual/AttributedStrings",
+
+        // Text System Overview
+        "Cocoa/Conceptual/TextArchitecture",
+
+        // MARK: - Tier 7: Collections & Data Structures
+
+        // Collections Programming Topics
+        "Cocoa/Conceptual/Collections",
+
+        // Number and Value Programming Topics
+        "Cocoa/Conceptual/NumbersandValues",
+
+        // Date and Time Programming Guide
+        "Cocoa/Conceptual/DatesAndTimes",
+
+        // MARK: - Tier 8: System Services
+
+        // File System Programming Guide
+        "FileManagement/Conceptual/FileSystemProgrammingGuide",
+
+        // Networking Overview
+        "NetworkingInternetWeb/Conceptual/NetworkingOverview",
+
+        // URL Session Programming Guide
+        "Cocoa/Conceptual/URLLoadingSystem",
+
+        // MARK: - Tier 9: User Interface
+
+        // Auto Layout Guide
+        "UserExperience/Conceptual/AutolayoutPG",
+
+        // Human Interface Guidelines (older but foundational)
+        "UserExperience/Conceptual/MobileHIG",
+
+        // View Programming Guide for iOS
+        "WindowsViews/Conceptual/ViewPG_iPhoneOS",
+
+        // MARK: - Tier 10: Performance & Debugging
+
+        // Instruments User Guide
+        "DeveloperTools/Conceptual/InstrumentsUserGuide",
+
+        // Performance Overview
+        "Performance/Conceptual/PerformanceOverview",
+
+        // Debugging with Xcode
+        "DeveloperTools/Conceptual/debugging_with_xcode",
+
+        // MARK: - Tier 11: Security
+
+        // Secure Coding Guide
+        "Security/Conceptual/SecureCodingGuide",
+
+        // Keychain Services Programming Guide
+        "Security/Conceptual/keychainServConcepts",
+
+        // MARK: - Tier 12: Internationalization
+
+        // Internationalization and Localization Guide
+        "MacOSX/Conceptual/BPInternational",
+
+        // MARK: - Tier 13: Bundles & Resources
+
+        // Bundle Programming Guide
+        "CoreFoundation/Conceptual/CFBundles",
+
+        // Resource Programming Guide
+        "Cocoa/Conceptual/LoadingResources",
+
+        // MARK: - Tier 14: Other Essential Topics
+
+        // Notification Programming Topics
+        "Cocoa/Conceptual/Notifications",
+
+        // Timer Programming Topics
+        "Cocoa/Conceptual/Timers",
+
+        // Error Handling Programming Guide
+        "Cocoa/Conceptual/ErrorHandlingCocoa",
+
+        // Predicate Programming Guide
+        "Cocoa/Conceptual/Predicates",
+    ]
+
+    /// Quick test guides - use for testing the crawler with minimal downloads
+    public static var testGuides: [URL] {
+        [
+            // Just the Objective-C Runtime Guide - well-structured, moderate size
+            URL(string: "\(baseURL)/Cocoa/Conceptual/ObjCRuntimeGuide")!,
+        ]
+    }
+
+    // MARK: - Testing Support
+
+    /// Check if user selections file exists
+    public static var userSelectionsFileExists: Bool {
+        FileManager.default.fileExists(atPath: userSelectionsURL.path)
+    }
+
+    /// Get the user selections file URL (for testing)
+    public static var userSelectionsFileURL: URL {
+        userSelectionsURL
+    }
+
+    /// Delete the user selections file (for testing cleanup)
+    public static func deleteUserSelectionsFile() throws {
+        if FileManager.default.fileExists(atPath: userSelectionsURL.path) {
+            try FileManager.default.removeItem(at: userSelectionsURL)
+        }
+    }
+
+    /// Load required guide paths from bundled catalog (for testing)
+    public static func getRequiredGuidePaths() -> [String] {
+        guard let url = CupertinoResources.bundle.url(
+            forResource: "archive-guides-catalog",
+            withExtension: "json"
+        ) else {
+            return []
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let json = try JSONDecoder().decode(ArchiveGuidesCatalogJSON.self, from: data)
+            return json.guides.filter(\.required).map(\.path)
+        } catch {
+            return []
+        }
+    }
+}
+
+// MARK: - JSON Codable Types
+
+private struct ArchiveGuidesCatalogJSON: Codable {
+    let count: Int
+    let guides: [ArchiveGuideJSON]
+    let baseURL: String
+}
+
+private struct ArchiveGuideJSON: Codable {
+    let title: String
+    let framework: String
+    let category: String
+    let path: String
+    let description: String
+    let required: Bool
+}
+
+private struct SelectedArchiveGuidesJSON: Codable {
+    let version: String
+    let lastUpdated: String
+    let description: String
+    let count: Int
+    let guides: [SelectedGuideJSON]
+}
+
+private struct SelectedGuideJSON: Codable {
+    let title: String
+    let framework: String
+    let category: String
+    let path: String
+}

--- a/Packages/Sources/Logging/CupertinoLogger.swift
+++ b/Packages/Sources/Logging/CupertinoLogger.swift
@@ -36,6 +36,9 @@ extension Logging {
 
         /// Logger for package documentation downloads
         public static let packageDownloader = os.Logger(subsystem: subsystem, category: "package-downloader")
+
+        /// Logger for Apple archive documentation operations
+        public static let archive = os.Logger(subsystem: subsystem, category: "archive")
     }
 }
 

--- a/Packages/Sources/Logging/UnifiedLogger.swift
+++ b/Packages/Sources/Logging/UnifiedLogger.swift
@@ -67,6 +67,7 @@ public actor UnifiedLogger {
         case evolution
         case samples
         case packages
+        case archive
 
         /// Get the os.Logger for this category
         var osLogger: os.Logger {
@@ -79,6 +80,7 @@ public actor UnifiedLogger {
             case .evolution: return Logging.Logger.evolution
             case .samples: return Logging.Logger.samples
             case .packages: return Logging.Logger.packageDownloader
+            case .archive: return Logging.Logger.archive
             }
         }
     }

--- a/Packages/Sources/Resources/Resources/archive-guides-catalog.json
+++ b/Packages/Sources/Resources/Resources/archive-guides-catalog.json
@@ -1,0 +1,374 @@
+{
+  "count": 47,
+  "guides": [
+    {
+      "title": "Quartz 2D Programming Guide",
+      "framework": "CoreGraphics",
+      "category": "Core Frameworks",
+      "path": "GraphicsImaging/Conceptual/drawingwithquartz2d",
+      "description": "Foundational 2D graphics programming with Core Graphics.",
+      "required": true
+    },
+    {
+      "title": "Core Animation Programming Guide",
+      "framework": "QuartzCore",
+      "category": "Core Frameworks",
+      "path": "Cocoa/Conceptual/CoreAnimation_guide",
+      "description": "Layer-based animation and compositing.",
+      "required": true
+    },
+    {
+      "title": "Animation Types and Timing Programming Guide",
+      "framework": "QuartzCore",
+      "category": "Core Frameworks",
+      "path": "Cocoa/Conceptual/Animation_Types_Timing",
+      "description": "Animation timing functions and types.",
+      "required": true
+    },
+    {
+      "title": "Core Image Programming Guide",
+      "framework": "CoreImage",
+      "category": "Core Frameworks",
+      "path": "GraphicsImaging/Conceptual/CoreImaging",
+      "description": "Image processing and filter operations using Core Image.",
+      "required": true
+    },
+    {
+      "title": "Core Audio Overview",
+      "framework": "CoreAudio",
+      "category": "Core Frameworks",
+      "path": "MusicAudio/Conceptual/CoreAudioOverview",
+      "description": "Low-level audio services and hardware abstraction.",
+      "required": true
+    },
+    {
+      "title": "Audio Unit Hosting Guide",
+      "framework": "CoreAudio",
+      "category": "Core Frameworks",
+      "path": "MusicAudio/Conceptual/AudioUnitHostingGuide_iOS",
+      "description": "Hosting audio units for audio processing.",
+      "required": true
+    },
+    {
+      "title": "Core Text Programming Guide",
+      "framework": "CoreText",
+      "category": "Core Frameworks",
+      "path": "StringsTextFonts/Conceptual/CoreText_Programming",
+      "description": "Advanced text layout and font handling with Core Text.",
+      "required": true
+    },
+    {
+      "title": "Objective-C Runtime Programming Guide",
+      "framework": "Objective-C",
+      "category": "Language & Runtime",
+      "path": "Cocoa/Conceptual/ObjCRuntimeGuide",
+      "description": "Essential guide for understanding iOS/macOS internals and runtime behavior.",
+      "required": false
+    },
+    {
+      "title": "Key-Value Observing Programming Guide",
+      "framework": "Foundation",
+      "category": "Language & Runtime",
+      "path": "Cocoa/Conceptual/KeyValueObserving",
+      "description": "Fundamental observer pattern still used throughout Apple frameworks.",
+      "required": false
+    },
+    {
+      "title": "Key-Value Coding Programming Guide",
+      "framework": "Foundation",
+      "category": "Language & Runtime",
+      "path": "Cocoa/Conceptual/KeyValueCoding",
+      "description": "Foundation for bindings, predicates, and many framework features.",
+      "required": false
+    },
+    {
+      "title": "Memory Management Programming Guide",
+      "framework": "Objective-C",
+      "category": "Language & Runtime",
+      "path": "Cocoa/Conceptual/MemoryMgmt",
+      "description": "Essential for understanding ARC behavior and memory patterns.",
+      "required": false
+    },
+    {
+      "title": "Cocoa Fundamentals Guide",
+      "framework": "Cocoa",
+      "category": "Cocoa Fundamentals",
+      "path": "Cocoa/Conceptual/CocoaFundamentals",
+      "description": "Comprehensive introduction to Cocoa architecture and patterns.",
+      "required": false
+    },
+    {
+      "title": "Coding Guidelines for Cocoa",
+      "framework": "Cocoa",
+      "category": "Cocoa Fundamentals",
+      "path": "Cocoa/Conceptual/CodingGuidelines",
+      "description": "Apple's official naming conventions and coding style guidelines.",
+      "required": false
+    },
+    {
+      "title": "Exception Programming Topics",
+      "framework": "Objective-C",
+      "category": "Cocoa Fundamentals",
+      "path": "Cocoa/Conceptual/Exceptions",
+      "description": "Objective-C exception handling and error recovery.",
+      "required": false
+    },
+    {
+      "title": "Threading Programming Guide",
+      "framework": "Foundation",
+      "category": "Cocoa Fundamentals",
+      "path": "Cocoa/Conceptual/Multithreading",
+      "description": "Foundational concurrency concepts and thread management.",
+      "required": false
+    },
+    {
+      "title": "App Programming Guide for iOS",
+      "framework": "UIKit",
+      "category": "Application Architecture",
+      "path": "iPhone/Conceptual/iPhoneOSProgrammingGuide",
+      "description": "iOS application architecture patterns and lifecycle.",
+      "required": false
+    },
+    {
+      "title": "Mac App Programming Guide",
+      "framework": "AppKit",
+      "category": "Application Architecture",
+      "path": "General/Conceptual/MOSXAppProgrammingGuide",
+      "description": "macOS application architecture and design patterns.",
+      "required": false
+    },
+    {
+      "title": "View Controller Programming Guide for iOS",
+      "framework": "UIKit",
+      "category": "Application Architecture",
+      "path": "iPhone/Conceptual/ViewControllerPGforiPhoneOS",
+      "description": "View controller design patterns and navigation.",
+      "required": false
+    },
+    {
+      "title": "Table View Programming Guide for iOS",
+      "framework": "UIKit",
+      "category": "Application Architecture",
+      "path": "UserExperience/Conceptual/TableView_iPhone",
+      "description": "UITableView usage patterns and customization.",
+      "required": false
+    },
+    {
+      "title": "Core Data Programming Guide",
+      "framework": "CoreData",
+      "category": "Data & Persistence",
+      "path": "Cocoa/Conceptual/CoreData",
+      "description": "Core Data object graph management and persistence.",
+      "required": false
+    },
+    {
+      "title": "Property List Programming Guide",
+      "framework": "Foundation",
+      "category": "Data & Persistence",
+      "path": "Cocoa/Conceptual/PropertyLists",
+      "description": "Property list formats, reading, and writing.",
+      "required": false
+    },
+    {
+      "title": "Archives and Serializations Programming Guide",
+      "framework": "Foundation",
+      "category": "Data & Persistence",
+      "path": "Cocoa/Conceptual/Archiving",
+      "description": "Object archiving and serialization techniques.",
+      "required": false
+    },
+    {
+      "title": "String Programming Guide",
+      "framework": "Foundation",
+      "category": "Text & Strings",
+      "path": "Cocoa/Conceptual/Strings",
+      "description": "NSString and string manipulation techniques.",
+      "required": false
+    },
+    {
+      "title": "Attributed String Programming Guide",
+      "framework": "Foundation",
+      "category": "Text & Strings",
+      "path": "Cocoa/Conceptual/AttributedStrings",
+      "description": "Rich text formatting with attributed strings.",
+      "required": false
+    },
+    {
+      "title": "Text System Overview",
+      "framework": "UIKit",
+      "category": "Text & Strings",
+      "path": "Cocoa/Conceptual/TextArchitecture",
+      "description": "Cocoa text system architecture and components.",
+      "required": false
+    },
+    {
+      "title": "Collections Programming Topics",
+      "framework": "Foundation",
+      "category": "Collections & Data Structures",
+      "path": "Cocoa/Conceptual/Collections",
+      "description": "NSArray, NSDictionary, NSSet, and collection patterns.",
+      "required": false
+    },
+    {
+      "title": "Number and Value Programming Topics",
+      "framework": "Foundation",
+      "category": "Collections & Data Structures",
+      "path": "Cocoa/Conceptual/NumbersandValues",
+      "description": "NSNumber, NSValue, and numeric types.",
+      "required": false
+    },
+    {
+      "title": "Date and Time Programming Guide",
+      "framework": "Foundation",
+      "category": "Collections & Data Structures",
+      "path": "Cocoa/Conceptual/DatesAndTimes",
+      "description": "NSDate, calendars, and time zone handling.",
+      "required": false
+    },
+    {
+      "title": "File System Programming Guide",
+      "framework": "Foundation",
+      "category": "System Services",
+      "path": "FileManagement/Conceptual/FileSystemProgrammingGuide",
+      "description": "File system access and management.",
+      "required": false
+    },
+    {
+      "title": "Networking Overview",
+      "framework": "Foundation",
+      "category": "System Services",
+      "path": "NetworkingInternetWeb/Conceptual/NetworkingOverview",
+      "description": "High-level networking concepts and APIs.",
+      "required": false
+    },
+    {
+      "title": "URL Loading System Programming Guide",
+      "framework": "Foundation",
+      "category": "System Services",
+      "path": "Cocoa/Conceptual/URLLoadingSystem",
+      "description": "NSURLSession and URL loading infrastructure.",
+      "required": false
+    },
+    {
+      "title": "Auto Layout Guide",
+      "framework": "UIKit",
+      "category": "User Interface",
+      "path": "UserExperience/Conceptual/AutolayoutPG",
+      "description": "Constraint-based layout system concepts.",
+      "required": false
+    },
+    {
+      "title": "iOS Human Interface Guidelines",
+      "framework": "UIKit",
+      "category": "User Interface",
+      "path": "UserExperience/Conceptual/MobileHIG",
+      "description": "Classic iOS design principles and guidelines.",
+      "required": false
+    },
+    {
+      "title": "View Programming Guide for iOS",
+      "framework": "UIKit",
+      "category": "User Interface",
+      "path": "WindowsViews/Conceptual/ViewPG_iPhoneOS",
+      "description": "UIView hierarchy, drawing, and compositing.",
+      "required": false
+    },
+    {
+      "title": "Instruments User Guide",
+      "framework": "DeveloperTools",
+      "category": "Performance & Debugging",
+      "path": "DeveloperTools/Conceptual/InstrumentsUserGuide",
+      "description": "Performance profiling and analysis with Instruments.",
+      "required": false
+    },
+    {
+      "title": "Performance Overview",
+      "framework": "Performance",
+      "category": "Performance & Debugging",
+      "path": "Performance/Conceptual/PerformanceOverview",
+      "description": "Performance optimization strategies and best practices.",
+      "required": false
+    },
+    {
+      "title": "Debugging with Xcode",
+      "framework": "DeveloperTools",
+      "category": "Performance & Debugging",
+      "path": "DeveloperTools/Conceptual/debugging_with_xcode",
+      "description": "Xcode debugger usage and techniques.",
+      "required": false
+    },
+    {
+      "title": "Secure Coding Guide",
+      "framework": "Security",
+      "category": "Security",
+      "path": "Security/Conceptual/SecureCodingGuide",
+      "description": "Security best practices and secure coding techniques.",
+      "required": false
+    },
+    {
+      "title": "Keychain Services Programming Guide",
+      "framework": "Security",
+      "category": "Security",
+      "path": "Security/Conceptual/keychainServConcepts",
+      "description": "Secure credential storage with Keychain.",
+      "required": false
+    },
+    {
+      "title": "Internationalization and Localization Guide",
+      "framework": "Foundation",
+      "category": "Internationalization",
+      "path": "MacOSX/Conceptual/BPInternational",
+      "description": "App internationalization and localization techniques.",
+      "required": false
+    },
+    {
+      "title": "Bundle Programming Guide",
+      "framework": "CoreFoundation",
+      "category": "Bundles & Resources",
+      "path": "CoreFoundation/Conceptual/CFBundles",
+      "description": "Bundle structure and resource management.",
+      "required": false
+    },
+    {
+      "title": "Resource Programming Guide",
+      "framework": "Foundation",
+      "category": "Bundles & Resources",
+      "path": "Cocoa/Conceptual/LoadingResources",
+      "description": "Loading and managing application resources.",
+      "required": false
+    },
+    {
+      "title": "Notification Programming Topics",
+      "framework": "Foundation",
+      "category": "Other Essential Topics",
+      "path": "Cocoa/Conceptual/Notifications",
+      "description": "NotificationCenter patterns and usage.",
+      "required": false
+    },
+    {
+      "title": "Timer Programming Topics",
+      "framework": "Foundation",
+      "category": "Other Essential Topics",
+      "path": "Cocoa/Conceptual/Timers",
+      "description": "NSTimer scheduling and run loop integration.",
+      "required": false
+    },
+    {
+      "title": "Error Handling Programming Guide",
+      "framework": "Foundation",
+      "category": "Other Essential Topics",
+      "path": "Cocoa/Conceptual/ErrorHandlingCocoa",
+      "description": "NSError patterns and error recovery.",
+      "required": false
+    },
+    {
+      "title": "Predicate Programming Guide",
+      "framework": "Foundation",
+      "category": "Other Essential Topics",
+      "path": "Cocoa/Conceptual/Predicates",
+      "description": "NSPredicate query language and filtering.",
+      "required": false
+    }
+  ],
+  "baseURL": "https://developer.apple.com/library/archive/documentation"
+}

--- a/Packages/Sources/SearchToolProvider/CupertinoSearchToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CupertinoSearchToolProvider.swift
@@ -76,13 +76,18 @@ public actor CupertinoSearchToolProvider: ToolProvider {
         let requestedLimit = (arguments?[Shared.Constants.MCP.schemaParamLimit]?.value as? Int) ?? defaultLimit
         let limit = min(requestedLimit, Shared.Constants.Limit.maxSearchLimit)
 
+        // Include archive only if explicitly requested via parameter or source=apple-archive
+        let includeArchive = (arguments?[Shared.Constants.MCP.schemaParamIncludeArchive]?.value as? Bool) ?? false
+
         // Perform search
+        // Archive documentation is excluded by default unless include_archive=true or source=apple-archive
         let results = try await searchIndex.search(
             query: query,
             source: source,
             framework: framework,
             language: language,
-            limit: limit
+            limit: limit,
+            includeArchive: includeArchive
         )
 
         // Format results as markdown

--- a/Packages/Sources/Shared/Constants.swift
+++ b/Packages/Sources/Shared/Constants.swift
@@ -24,6 +24,7 @@ extension Shared {
             public static let swiftBook = "swift-book"
             public static let packages = "packages"
             public static let sampleCode = "sample-code"
+            public static let archive = "archive"
         }
 
         // MARK: - File Names
@@ -101,6 +102,11 @@ extension Shared {
             defaultBaseDirectory.appendingPathComponent(Directory.sampleCode)
         }
 
+        /// Default archive directory: ~/.cupertino/archive
+        public static var defaultArchiveDirectory: URL {
+            defaultBaseDirectory.appendingPathComponent(Directory.archive)
+        }
+
         /// Default metadata file: ~/.cupertino/metadata.json
         public static var defaultMetadataFile: URL {
             defaultBaseDirectory.appendingPathComponent(FileName.metadata)
@@ -168,6 +174,9 @@ extension Shared {
 
             /// Apple Sample Code display name
             public static let sampleCode = "Apple Sample Code"
+
+            /// Apple Archive Documentation display name
+            public static let archive = "Apple Archive Documentation"
         }
 
         // MARK: - GitHub Organizations
@@ -212,6 +221,9 @@ extension Shared {
 
             /// Apple Developer Documentation
             public static let appleDeveloperDocs = "https://developer.apple.com/documentation/"
+
+            /// Apple Archive Documentation
+            public static let appleArchive = "https://developer.apple.com/library/archive/"
 
             /// Apple Sample Code List
             public static let appleSampleCode = "https://developer.apple.com/documentation/samplecode/"
@@ -319,6 +331,9 @@ extension Shared {
             /// Apple documentation resource URI scheme
             public static let appleDocsScheme = "apple-docs://"
 
+            /// Apple archive documentation resource URI scheme
+            public static let appleArchiveScheme = "apple-archive://"
+
             /// Swift Evolution proposal resource URI scheme
             public static let swiftEvolutionScheme = "swift-evolution://"
 
@@ -374,7 +389,10 @@ extension Shared {
             /// Search docs tool description
             public static let toolSearchDocsDescription = """
             Search Apple documentation and Swift Evolution proposals by keywords. \
-            Returns a ranked list of relevant documents with URIs that can be read using resources/read.
+            Returns a ranked list of relevant documents with URIs that can be read using resources/read. \
+            Optional parameters: source (apple-docs, swift-evolution, swift-org, swift-book, apple-archive), \
+            framework (e.g. swiftui, foundation), include_archive (bool, includes legacy Apple Archive guides \
+            like Core Animation Programming Guide - useful for foundational concepts not in modern docs).
             """
 
             /// List frameworks tool description
@@ -405,6 +423,9 @@ extension Shared {
 
             /// JSON Schema parameter: language
             public static let schemaParamLanguage = "language"
+
+            /// JSON Schema parameter: include_archive
+            public static let schemaParamIncludeArchive = "include_archive"
 
             /// JSON Schema parameter: limit
             public static let schemaParamLimit = "limit"
@@ -519,6 +540,10 @@ extension Shared {
             /// Rate limit delay for package star count (normal)
             /// Rationale: Minimize total fetch time
             public static let packageStarsNormal: Duration = .seconds(0.5)
+
+            /// Delay between archive page fetches
+            /// Rationale: Respectful crawling of Apple's archive servers
+            public static let archivePage: Duration = .milliseconds(500)
         }
 
         /// Timeout values for operations

--- a/Packages/Sources/TUI/Models/ArchiveEntry.swift
+++ b/Packages/Sources/TUI/Models/ArchiveEntry.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Resources
+import Shared
+
+/// Entry representing an archive guide in the TUI
+struct ArchiveEntry {
+    let title: String
+    let framework: String
+    let category: String
+    let path: String
+    let description: String
+    var isSelected: Bool
+    var isDownloaded: Bool
+    var isRequired: Bool // Cannot be deselected if true
+
+    /// Full URL to the archive guide
+    var url: URL? {
+        URL(string: "https://developer.apple.com/library/archive/documentation/\(path)")
+    }
+}
+
+/// Catalog of archive guides loaded from bundled JSON resource
+enum ArchiveGuidesCatalog {
+    /// User-writable location for selected guides: ~/.cupertino/selected-archive-guides.json
+    private static var userSelectionsURL: URL {
+        Shared.Constants.defaultBaseDirectory.appendingPathComponent("selected-archive-guides.json")
+    }
+
+    /// All archive guides from the bundled catalog
+    static var allGuides: [ArchiveEntry] {
+        guard let url = CupertinoResources.bundle.url(
+            forResource: "archive-guides-catalog",
+            withExtension: "json"
+        ) else {
+            return []
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let catalog = try JSONDecoder().decode(ArchiveGuidesCatalogJSON.self, from: data)
+            return catalog.guides.map { guide in
+                ArchiveEntry(
+                    title: guide.title,
+                    framework: guide.framework,
+                    category: guide.category,
+                    path: guide.path,
+                    description: guide.description,
+                    isSelected: guide.required, // Required entries start selected
+                    isDownloaded: false,
+                    isRequired: guide.required
+                )
+            }
+        } catch {
+            return []
+        }
+    }
+
+    /// Load selected guides from user-writable location (~/.cupertino/selected-archive-guides.json)
+    /// If file doesn't exist, creates it from bundled catalog with required guides selected
+    static func loadSelectedGuidePaths() -> Set<String> {
+        let selectedURL = userSelectionsURL
+
+        // If user file doesn't exist, create it from bundled catalog
+        if !FileManager.default.fileExists(atPath: selectedURL.path) {
+            createDefaultSelectionsFile()
+        }
+
+        guard FileManager.default.fileExists(atPath: selectedURL.path) else {
+            return []
+        }
+
+        do {
+            let data = try Data(contentsOf: selectedURL)
+            let selected = try JSONDecoder().decode(SelectedArchiveGuidesJSON.self, from: data)
+            return Set(selected.guides.map(\.path))
+        } catch {
+            return []
+        }
+    }
+
+    /// Create default selections file from bundled catalog (required guides only)
+    private static func createDefaultSelectionsFile() {
+        guard let bundleURL = CupertinoResources.bundle.url(
+            forResource: "archive-guides-catalog",
+            withExtension: "json"
+        ) else {
+            return
+        }
+
+        do {
+            // Ensure ~/.cupertino directory exists
+            let baseDir = Shared.Constants.defaultBaseDirectory
+            if !FileManager.default.fileExists(atPath: baseDir.path) {
+                try FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+            }
+
+            // Load bundled catalog and extract required guides
+            let data = try Data(contentsOf: bundleURL)
+            let catalog = try JSONDecoder().decode(ArchiveGuidesCatalogJSON.self, from: data)
+            let requiredGuides = catalog.guides.filter(\.required)
+
+            // Create selections JSON with required guides
+            let json = SelectedArchiveGuidesJSON(
+                version: "1.0",
+                lastUpdated: ISO8601DateFormatter().string(from: Date()),
+                description: "Selected Apple Archive guides for crawling (auto-generated with required guides)",
+                count: requiredGuides.count,
+                guides: requiredGuides.map { guide in
+                    SelectedGuideJSON(
+                        title: guide.title,
+                        framework: guide.framework,
+                        category: guide.category,
+                        path: guide.path
+                    )
+                }
+            )
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let outputData = try encoder.encode(json)
+            try outputData.write(to: userSelectionsURL)
+        } catch {
+            // Silently fail - will fall back to bundled defaults
+        }
+    }
+
+    /// Save selected guides to user-writable location
+    static func saveSelectedGuides(_ guides: [ArchiveEntry]) throws {
+        // Ensure ~/.cupertino directory exists
+        let baseDir = Shared.Constants.defaultBaseDirectory
+        if !FileManager.default.fileExists(atPath: baseDir.path) {
+            try FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+        }
+
+        let selected = guides.filter(\.isSelected)
+        let json = SelectedArchiveGuidesJSON(
+            version: "1.0",
+            lastUpdated: ISO8601DateFormatter().string(from: Date()),
+            description: "Selected Apple Archive guides for crawling (TUI generated)",
+            count: selected.count,
+            guides: selected.map { guide in
+                SelectedGuideJSON(
+                    title: guide.title,
+                    framework: guide.framework,
+                    category: guide.category,
+                    path: guide.path
+                )
+            }
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(json)
+        try data.write(to: userSelectionsURL)
+    }
+}
+
+// MARK: - JSON Codable Types
+
+private struct ArchiveGuidesCatalogJSON: Codable {
+    let count: Int
+    let guides: [ArchiveGuideJSON]
+    let baseURL: String
+}
+
+private struct ArchiveGuideJSON: Codable {
+    let title: String
+    let framework: String
+    let category: String
+    let path: String
+    let description: String
+    let required: Bool
+}
+
+private struct SelectedArchiveGuidesJSON: Codable {
+    let version: String
+    let lastUpdated: String
+    let description: String
+    let count: Int
+    let guides: [SelectedGuideJSON]
+}
+
+private struct SelectedGuideJSON: Codable {
+    let title: String
+    let framework: String
+    let category: String
+    let path: String
+}

--- a/Packages/Sources/TUI/Routing/ViewRouter.swift
+++ b/Packages/Sources/TUI/Routing/ViewRouter.swift
@@ -19,6 +19,8 @@ enum ViewRouter {
             return handleHomeTransition(key: key, homeCursor: homeCursor)
         case .library:
             return handleLibraryTransition(key: key)
+        case .archive:
+            return handleArchiveTransition(key: key, state: state)
         case .settings:
             return handleSettingsTransition(key: key, state: state)
         case .packages:
@@ -35,15 +37,29 @@ enum ViewRouter {
         case .char("2"):
             return .library
         case .char("3"):
+            return .archive
+        case .char("4"):
             return .settings
         case .enter:
-            return [ViewMode.packages, .library, .settings][homeCursor]
+            return [ViewMode.packages, .library, .archive, .settings][homeCursor]
         default:
             return nil
         }
     }
 
     private static func handleLibraryTransition(key: Key) -> ViewMode? {
+        switch key {
+        case .char("h"), .escape:
+            return .home
+        default:
+            return nil
+        }
+    }
+
+    private static func handleArchiveTransition(key: Key, state: AppState) -> ViewMode? {
+        // Don't allow navigation when searching
+        guard !state.isArchiveSearching else { return nil }
+
         switch key {
         case .char("h"), .escape:
             return .home

--- a/Packages/Sources/TUI/Views/ArchiveView.swift
+++ b/Packages/Sources/TUI/Views/ArchiveView.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+@MainActor
+struct ArchiveView {
+    func render(
+        entries: [ArchiveEntry],
+        cursor: Int,
+        scrollOffset: Int,
+        width: Int,
+        height: Int,
+        filterCategory: String?,
+        searchQuery: String,
+        isSearching: Bool,
+        statusMessage: String = ""
+    ) -> String {
+        var result = Colors.reset
+
+        // Enforce minimum terminal size
+        let minWidth = 80
+        let minHeight = 24
+
+        if width < minWidth || height < minHeight {
+            result += Colors.reset
+            result += "\r\n\r\n"
+            result += "  Terminal too small!\r\n"
+            result += "  Minimum size: \(minWidth)x\(minHeight)\r\n"
+            result += "  Current size: \(width)x\(height)\r\n"
+            result += "\r\n"
+            result += "  Please resize your terminal window.\r\n"
+            return result
+        }
+
+        // Header: 4 lines, Footer: 6 lines (status + help + bottom)
+        let pageSize = height - 10
+        let page = Array(entries.dropFirst(scrollOffset).prefix(pageSize))
+
+        // Title bar
+        let selectedCount = entries.filter(\.isSelected).count
+        let downloadedCount = entries.filter(\.isDownloaded).count
+        let totalCount = entries.count
+        let title = "Apple Archive Documentation Guides"
+
+        // Calculate page numbers
+        let currentPage = entries.isEmpty ? 0 : (cursor / pageSize) + 1
+        let totalPages = entries.isEmpty ? 0 : (totalCount + pageSize - 1) / pageSize
+
+        // Stats line
+        let stats: String
+        if isSearching || !searchQuery.isEmpty {
+            let searchPrompt = isSearching ? "Search: \(searchQuery)_" : "Search: \(searchQuery)"
+            let counts = "Results: \(totalCount)"
+            let selection = "Selected: \(selectedCount)"
+            stats = String("\(searchPrompt)  \(counts)  \(selection)".prefix(width - 4))
+        } else if let category = filterCategory {
+            let filterInfo = "Category: \(category)"
+            let pageInfo = "Page: \(currentPage)/\(totalPages)  Selected: \(selectedCount)  Downloaded: \(downloadedCount)"
+            stats = String("\(filterInfo)  \(pageInfo)".prefix(width - 4))
+        } else {
+            let pageInfo = "Page: \(currentPage)/\(totalPages)  Total: \(totalCount)  Selected: \(selectedCount)  Downloaded: \(downloadedCount)"
+            stats = String(pageInfo.prefix(width - 4))
+        }
+
+        result += Box.topLeft + String(repeating: Box.horizontal, count: width - 2) + Box.topRight + "\r\n"
+        result += renderPaddedLine(title, width: width)
+        result += renderPaddedLine(stats, width: width)
+        result += Box.teeRight + String(repeating: Box.horizontal, count: width - 2) + Box.teeLeft + "\r\n"
+
+        // Archive list
+        for (index, entry) in page.enumerated() {
+            let absoluteIndex = scrollOffset + index
+            let isCurrentLine = absoluteIndex == cursor
+
+            let line = renderArchiveLine(
+                entry: entry, width: width, highlight: isCurrentLine, searchQuery: searchQuery
+            )
+            result += line + "\r\n"
+        }
+
+        // Fill remaining space
+        let remaining = pageSize - page.count
+        for _ in 0..<remaining {
+            result += Box.vertical + String(repeating: " ", count: width - 2) + Box.vertical + "\r\n"
+        }
+
+        // Footer
+        result += Box.teeRight + String(repeating: Box.horizontal, count: width - 2) + Box.teeLeft + "\r\n"
+
+        // Status message line (if any)
+        if !statusMessage.isEmpty {
+            result += renderPaddedLine(Colors.brightGreen + statusMessage + Colors.reset, width: width)
+        } else {
+            result += renderPaddedLine("", width: width)
+        }
+
+        // Help text
+        let help: String
+        if isSearching {
+            help = "Type to search  Backspace:Delete  Enter/Esc:Exit search  Ctrl+O:Open"
+        } else {
+            help = "jk/Arrows:Move  Space:Select  w:Save  o:Open  f:Filter  /:Search  h/Esc:Home  q:Quit"
+        }
+        result += renderPaddedLine(help, width: width)
+        result += Box.bottomLeft + String(repeating: Box.horizontal, count: width - 2)
+        result += Box.bottomRight + Colors.reset + "\r\n"
+
+        return result
+    }
+
+    private func renderPaddedLine(_ text: String, width: Int) -> String {
+        let contentWidth = max(10, width - 4)
+        let plainText = stripAnsiCodes(text)
+        let sanitized = TextSanitizer.removeEmojis(from: plainText)
+        let visibleLength = sanitized.count
+
+        let displayText: String
+        if visibleLength > contentWidth {
+            let truncated = String(sanitized.prefix(contentWidth - 3))
+            displayText = truncated + "..."
+        } else {
+            displayText = plainText == sanitized ? text : sanitized
+        }
+
+        let finalPlainText = stripAnsiCodes(displayText)
+        let finalSanitized = TextSanitizer.removeEmojis(from: finalPlainText)
+        let padding = max(0, contentWidth - finalSanitized.count)
+        return Box.vertical + " " + displayText + String(repeating: " ", count: padding) + " " + Box.vertical + "\r\n"
+    }
+
+    private func stripAnsiCodes(_ text: String) -> String {
+        text.replacingOccurrences(of: "\u{001B}\\[[0-9;]*m", with: "", options: .regularExpression)
+    }
+
+    private func renderArchiveLine(entry: ArchiveEntry, width: Int, highlight: Bool, searchQuery: String) -> String {
+        // Selection indicator: [R] for required+selected, [*] for selected, [ ] for unselected
+        let checkbox: String
+        if entry.isRequired {
+            checkbox = "[R]" // Required - cannot be deselected
+        } else if entry.isSelected {
+            checkbox = "[*]"
+        } else {
+            checkbox = "[ ]"
+        }
+        // Download indicator: [D] for downloaded
+        let downloadIndicator = entry.isDownloaded ? "[D]" : "   "
+
+        // Calculate available width for title
+        // Format: "│ [R] [D] Title                    │"
+        // width - 4 = content width (for "│ " and " │")
+        // checkbox(3) + space(1) + download(3) + space(1) = 8 chars for indicators
+        let contentWidth = width - 4
+        let indicatorWidth = 8 // "[R] " + "[D] "
+        let titleMaxWidth = contentWidth - indicatorWidth
+
+        // Sanitize and truncate title if too long
+        let sanitizedTitle = TextSanitizer.removeEmojis(from: entry.title)
+        let plainTitle: String
+        if sanitizedTitle.count > titleMaxWidth {
+            plainTitle = String(sanitizedTitle.prefix(titleMaxWidth - 3)) + "..."
+        } else {
+            plainTitle = sanitizedTitle
+        }
+
+        // Highlight search matches
+        let displayTitle: String
+        if !searchQuery.isEmpty {
+            displayTitle = highlightMatches(in: plainTitle, query: searchQuery, isLineHighlighted: highlight)
+        } else {
+            displayTitle = plainTitle
+        }
+
+        // Calculate padding to fill to end of line
+        let plainDisplayTitle = stripAnsiCodes(displayTitle)
+        let displayTitleWidth = plainDisplayTitle.count
+        let padding = max(0, titleMaxWidth - displayTitleWidth)
+
+        if highlight {
+            var line = Colors.bgAppleBlue + Colors.black + Colors.bold
+            line += Box.vertical + " " + checkbox + " " + downloadIndicator + " "
+            line += displayTitle + Colors.bgAppleBlue + Colors.black + Colors.bold
+            line += String(repeating: " ", count: padding) + " "
+            line += Colors.reset + Box.vertical
+            return line
+        } else {
+            var line = Box.vertical + " " + checkbox + " " + downloadIndicator + " " + displayTitle
+            line += String(repeating: " ", count: padding) + " " + Box.vertical
+            return line
+        }
+    }
+
+    private func highlightMatches(in text: String, query: String, isLineHighlighted: Bool) -> String {
+        guard !query.isEmpty else { return text }
+
+        let lowercasedText = text.lowercased()
+        let lowercasedQuery = query.lowercased()
+        var result = ""
+        var currentIndex = text.startIndex
+
+        while currentIndex < text.endIndex {
+            let remainingLowercased = String(lowercasedText[currentIndex...])
+
+            if let matchRange = remainingLowercased.range(of: lowercasedQuery) {
+                let matchOffset = remainingLowercased.distance(
+                    from: remainingLowercased.startIndex, to: matchRange.lowerBound
+                )
+
+                let matchStart = text.index(currentIndex, offsetBy: matchOffset)
+                let matchEnd = text.index(matchStart, offsetBy: query.count)
+
+                if currentIndex < matchStart {
+                    result += String(text[currentIndex..<matchStart])
+                }
+
+                if isLineHighlighted {
+                    let matchText = String(text[matchStart..<matchEnd])
+                    result += Colors.yellow + matchText + Colors.bgAppleBlue + Colors.black + Colors.bold
+                } else {
+                    let matchText = String(text[matchStart..<matchEnd])
+                    result += Colors.bgYellow + Colors.black + matchText + Colors.reset
+                }
+
+                currentIndex = matchEnd
+            } else {
+                result += String(text[currentIndex...])
+                break
+            }
+        }
+
+        return result
+    }
+}

--- a/Packages/Sources/TUI/Views/HomeView.swift
+++ b/Packages/Sources/TUI/Views/HomeView.swift
@@ -18,7 +18,8 @@ struct HomeView {
         let menuItems = [
             MenuItem(key: "1", icon: "*", title: "Packages", subtitle: "Browse \(stats.totalPackages) Swift packages"),
             MenuItem(key: "2", icon: "*", title: "Library", subtitle: "\(stats.artifactCount) artifact collections"),
-            MenuItem(key: "3", icon: "*", title: "Settings", subtitle: "Configure Cupertino"),
+            MenuItem(key: "3", icon: "*", title: "Archive", subtitle: "\(stats.archiveGuideCount) classic Apple guides"),
+            MenuItem(key: "4", icon: "*", title: "Settings", subtitle: "Configure Cupertino"),
         ]
 
         result += Box.topLeft + String(repeating: Box.horizontal, count: width - 2) + Box.topRight + "\r\n"
@@ -28,11 +29,17 @@ struct HomeView {
 
         // Stats section - compact
         result += renderPaddedLine("Quick Stats", width: width)
-        let selected = "  • \(stats.selectedPackages) selected"
-        let downloaded = "  • \(stats.downloadedPackages) downloaded"
-        let totalSize = "  • \(formatBytes(stats.totalSize))"
-        let statsLine = "\(selected)\(downloaded)\(totalSize)"
+        let selected = " \(stats.selectedPackages) pkgs"
+        let downloaded = " \(stats.downloadedPackages) dl"
+        let totalSize = " \(formatBytes(stats.totalSize))"
+        let statsLine = "•\(selected) •\(downloaded) •\(totalSize)"
         result += renderPaddedLine(statsLine, width: width)
+        result += Box.teeRight + String(repeating: Box.horizontal, count: width - 2) + Box.teeLeft + "\r\n"
+
+        // Quick Commands section
+        result += renderPaddedLine("Quick Commands:", width: width)
+        result += renderPaddedLine("  cupertino fetch --type package-docs", width: width)
+        result += renderPaddedLine("  cupertino fetch --type archive", width: width)
         result += Box.teeRight + String(repeating: Box.horizontal, count: width - 2) + Box.teeLeft + "\r\n"
 
         // Menu - compact
@@ -51,13 +58,15 @@ struct HomeView {
         // 1: separator
         // 2: stats (header + compact line)
         // 1: separator
+        // 3: quick commands (header + 2 commands)
+        // 1: separator
         // 1: "Select a view"
-        // 3: menu items
+        // 4: menu items (packages, library, archive, settings)
         // 1: separator (below)
         // 1: help
         // 1: bottom border
-        // Total: 14 lines
-        let usedLines = 14
+        // Total: 19 lines
+        let usedLines = 19
         let remaining = max(0, height - usedLines)
         for _ in 0..<remaining {
             result += Box.vertical + String(repeating: " ", count: width - 2) + Box.vertical + "\r\n"
@@ -126,5 +135,6 @@ struct HomeStats {
     let selectedPackages: Int
     let downloadedPackages: Int
     let artifactCount: Int
+    let archiveGuideCount: Int
     let totalSize: Int64
 }

--- a/Packages/Tests/CoreTests/ArchiveGuideCatalogTests.swift
+++ b/Packages/Tests/CoreTests/ArchiveGuideCatalogTests.swift
@@ -1,0 +1,228 @@
+@testable import Core
+import Foundation
+@testable import Shared
+import Testing
+
+// MARK: - ArchiveGuideCatalog Tests
+
+@Test("ArchiveGuideCatalog loads bundled catalog")
+func archiveGuideCatalogLoadsBundledCatalog() throws {
+    let requiredPaths = ArchiveGuideCatalog.getRequiredGuidePaths()
+    #expect(!requiredPaths.isEmpty, "Should have required guide paths from bundled catalog")
+    print("   ✅ Found \(requiredPaths.count) required guides in bundled catalog")
+}
+
+@Test("ArchiveGuideCatalog required guides include Core frameworks")
+func archiveGuideCatalogRequiredGuidesIncludeCoreFrameworks() throws {
+    let requiredPaths = ArchiveGuideCatalog.getRequiredGuidePaths()
+
+    // Check for expected Core framework guides
+    let hasQuartz2D = requiredPaths.contains { $0.contains("drawingwithquartz2d") }
+    let hasCoreAnimation = requiredPaths.contains { $0.contains("CoreAnimation") }
+
+    #expect(hasQuartz2D, "Required guides should include Quartz 2D (CoreGraphics)")
+    #expect(hasCoreAnimation, "Required guides should include Core Animation (QuartzCore)")
+    print("   ✅ Required guides include Core framework documentation")
+}
+
+@Test("ArchiveGuideCatalog creates user file if missing")
+func archiveGuideCatalogCreatesUserFileIfMissing() throws {
+    let fileURL = ArchiveGuideCatalog.userSelectionsFileURL
+
+    // Backup existing file if present
+    let backupURL = fileURL.deletingLastPathComponent().appendingPathComponent("selected-archive-guides.backup.json")
+    var hadExistingFile = false
+    if FileManager.default.fileExists(atPath: fileURL.path) {
+        hadExistingFile = true
+        try FileManager.default.moveItem(at: fileURL, to: backupURL)
+    }
+
+    defer {
+        // Restore backup if we had one
+        if hadExistingFile {
+            try? FileManager.default.removeItem(at: fileURL)
+            try? FileManager.default.moveItem(at: backupURL, to: fileURL)
+        }
+    }
+
+    // Ensure file doesn't exist
+    #expect(!ArchiveGuideCatalog.userSelectionsFileExists, "File should not exist before test")
+
+    // Access essentialGuides - this should create the file
+    let guides = ArchiveGuideCatalog.essentialGuides
+    #expect(!guides.isEmpty, "Should return guides")
+
+    // File should now exist
+    #expect(ArchiveGuideCatalog.userSelectionsFileExists, "File should be created after accessing essentialGuides")
+    print("   ✅ User selections file created automatically")
+}
+
+@Test("ArchiveGuideCatalog does not overwrite existing user file")
+func archiveGuideCatalogDoesNotOverwriteExistingFile() throws {
+    let fileURL = ArchiveGuideCatalog.userSelectionsFileURL
+
+    // Backup existing file if present
+    let backupURL = fileURL.deletingLastPathComponent().appendingPathComponent("selected-archive-guides.backup.json")
+    var hadExistingFile = false
+    if FileManager.default.fileExists(atPath: fileURL.path) {
+        hadExistingFile = true
+        try FileManager.default.moveItem(at: fileURL, to: backupURL)
+    }
+
+    defer {
+        // Restore backup if we had one
+        try? FileManager.default.removeItem(at: fileURL)
+        if hadExistingFile {
+            try? FileManager.default.moveItem(at: backupURL, to: fileURL)
+        }
+    }
+
+    // Create a custom user file with specific content
+    let customContent = """
+    {
+      "count": 1,
+      "description": "Test file - should not be overwritten",
+      "guides": [
+        {
+          "category": "Test",
+          "framework": "TestFramework",
+          "path": "Test/Custom/Path",
+          "title": "Custom Test Guide"
+        }
+      ],
+      "lastUpdated": "2024-01-01T00:00:00Z",
+      "version": "1.0"
+    }
+    """
+
+    // Ensure directory exists
+    try FileManager.default.createDirectory(
+        at: fileURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try customContent.write(to: fileURL, atomically: true, encoding: .utf8)
+
+    // Get modification date
+    let attrs1 = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+    let modDate1 = attrs1[.modificationDate] as? Date
+
+    // Access essentialGuides - should NOT overwrite
+    let guides = ArchiveGuideCatalog.essentialGuides
+    #expect(!guides.isEmpty, "Should return guides")
+
+    // Check file wasn't modified
+    let attrs2 = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+    let modDate2 = attrs2[.modificationDate] as? Date
+
+    #expect(modDate1 == modDate2, "File should not be modified if it already exists")
+
+    // Verify custom content is still there
+    let content = try String(contentsOf: fileURL, encoding: .utf8)
+    #expect(content.contains("Custom Test Guide"), "Custom content should be preserved")
+    print("   ✅ Existing user file not overwritten")
+}
+
+@Test("ArchiveGuideCatalog essentialGuides returns valid URLs")
+func archiveGuideCatalogEssentialGuidesReturnsValidURLs() throws {
+    let guides = ArchiveGuideCatalog.essentialGuides
+    #expect(!guides.isEmpty, "Should have essential guides")
+
+    // All URLs should be valid Apple archive URLs
+    for guide in guides {
+        #expect(
+            guide.absoluteString.hasPrefix("https://developer.apple.com/library/archive/documentation/"),
+            "Guide URL should be Apple archive URL: \(guide)"
+        )
+    }
+
+    print("   ✅ All \(guides.count) guide URLs are valid")
+}
+
+@Test("ArchiveGuideCatalog testGuides returns minimal set")
+func archiveGuideCatalogTestGuidesReturnsMinimalSet() throws {
+    let testGuides = ArchiveGuideCatalog.testGuides
+    #expect(!testGuides.isEmpty, "Should have at least one test guide")
+    #expect(testGuides.count <= 3, "Test guides should be a minimal set for testing")
+
+    // Should contain ObjC Runtime Guide
+    let hasObjCRuntime = testGuides.contains { $0.absoluteString.contains("ObjCRuntimeGuide") }
+    #expect(hasObjCRuntime, "Test guides should include ObjC Runtime Guide")
+    print("   ✅ Test guides: \(testGuides.count) guide(s)")
+}
+
+@Test("ArchiveGuideCatalog userSelectionsFileURL points to correct location")
+func archiveGuideCatalogUserSelectionsFileURLCorrect() throws {
+    let fileURL = ArchiveGuideCatalog.userSelectionsFileURL
+    let expectedPath = Shared.Constants.defaultBaseDirectory.appendingPathComponent("selected-archive-guides.json")
+
+    #expect(fileURL == expectedPath, "User selections file should be in ~/.cupertino/")
+    #expect(fileURL.lastPathComponent == "selected-archive-guides.json", "File should be named selected-archive-guides.json")
+    print("   ✅ User selections file URL: \(fileURL.path)")
+}
+
+@Test("ArchiveGuideCatalog created file contains only required guides")
+func archiveGuideCatalogCreatedFileContainsOnlyRequiredGuides() throws {
+    let fileURL = ArchiveGuideCatalog.userSelectionsFileURL
+
+    // Backup existing file if present
+    let backupURL = fileURL.deletingLastPathComponent().appendingPathComponent("selected-archive-guides.backup.json")
+    var hadExistingFile = false
+    if FileManager.default.fileExists(atPath: fileURL.path) {
+        hadExistingFile = true
+        try FileManager.default.moveItem(at: fileURL, to: backupURL)
+    }
+
+    defer {
+        // Restore backup if we had one
+        try? FileManager.default.removeItem(at: fileURL)
+        if hadExistingFile {
+            try? FileManager.default.moveItem(at: backupURL, to: fileURL)
+        }
+    }
+
+    // Ensure file doesn't exist
+    if FileManager.default.fileExists(atPath: fileURL.path) {
+        try FileManager.default.removeItem(at: fileURL)
+    }
+
+    // Trigger file creation
+    _ = ArchiveGuideCatalog.essentialGuides
+
+    // Read created file
+    let data = try Data(contentsOf: fileURL)
+    let json = try JSONDecoder().decode(TestSelectedGuidesJSON.self, from: data)
+
+    // Get required guides from bundled catalog
+    let requiredPaths = Set(ArchiveGuideCatalog.getRequiredGuidePaths())
+
+    // All guides in created file should be required
+    for guide in json.guides {
+        #expect(
+            requiredPaths.contains(guide.path),
+            "Created file should only contain required guides, but found: \(guide.path)"
+        )
+    }
+
+    #expect(
+        json.guides.count == requiredPaths.count,
+        "Created file should have same count as required guides"
+    )
+    print("   ✅ Created file contains exactly \(json.guides.count) required guides")
+}
+
+// MARK: - Test Support Types
+
+private struct TestSelectedGuidesJSON: Codable {
+    let version: String
+    let lastUpdated: String
+    let description: String
+    let count: Int
+    let guides: [TestGuideJSON]
+}
+
+private struct TestGuideJSON: Codable {
+    let title: String
+    let framework: String
+    let category: String
+    let path: String
+}

--- a/Packages/Tests/TUITests/ViewTests.swift
+++ b/Packages/Tests/TUITests/ViewTests.swift
@@ -14,6 +14,7 @@ func homeViewBasicRender() {
         selectedPackages: 10,
         downloadedPackages: 5,
         artifactCount: 3,
+        archiveGuideCount: 47,
         totalSize: 1024 * 1024 * 100 // 100 MB
     )
 
@@ -28,7 +29,7 @@ func homeViewBasicRender() {
 @Test("HomeView renders menu items")
 func homeViewMenuItems() {
     let view = HomeView()
-    let stats = HomeStats(totalPackages: 0, selectedPackages: 0, downloadedPackages: 0, artifactCount: 0, totalSize: 0)
+    let stats = HomeStats(totalPackages: 0, selectedPackages: 0, downloadedPackages: 0, artifactCount: 0, archiveGuideCount: 0, totalSize: 0)
 
     let output = view.render(cursor: 0, width: 80, height: 24, stats: stats)
 
@@ -41,7 +42,7 @@ func homeViewMenuItems() {
 @Test("HomeView handles different cursor positions")
 func homeViewCursorPositions() {
     let view = HomeView()
-    let stats = HomeStats(totalPackages: 0, selectedPackages: 0, downloadedPackages: 0, artifactCount: 0, totalSize: 0)
+    let stats = HomeStats(totalPackages: 0, selectedPackages: 0, downloadedPackages: 0, artifactCount: 0, archiveGuideCount: 0, totalSize: 0)
 
     let output0 = view.render(cursor: 0, width: 80, height: 24, stats: stats)
     let output1 = view.render(cursor: 1, width: 80, height: 24, stats: stats)
@@ -276,7 +277,7 @@ func viewsUseBoxDrawing() {
         cursor: 0,
         width: 80,
         height: 24,
-        stats: HomeStats(totalPackages: 0, selectedPackages: 0, downloadedPackages: 0, artifactCount: 0, totalSize: 0)
+        stats: HomeStats(totalPackages: 0, selectedPackages: 0, downloadedPackages: 0, artifactCount: 0, archiveGuideCount: 0, totalSize: 0)
     )
     let settingsOutput = settingsView.render(cursor: 0, width: 80, height: 24, baseDirectory: "/test", isEditing: false, editBuffer: "", statusMessage: "")
     let libraryOutput = libraryView.render(artifacts: [], cursor: 0, width: 80, height: 24)
@@ -422,7 +423,7 @@ func allViewsMatchWidth() {
         cursor: 0,
         width: width,
         height: height,
-        stats: HomeStats(totalPackages: 10, selectedPackages: 5, downloadedPackages: 3, artifactCount: 2, totalSize: 1024)
+        stats: HomeStats(totalPackages: 10, selectedPackages: 5, downloadedPackages: 3, artifactCount: 2, archiveGuideCount: 47, totalSize: 1024)
     )
     let homeLines = homeOutput.split(separator: "\r\n", omittingEmptySubsequences: false).map(String.init).filter { !$0.isEmpty }
     for (index, line) in homeLines.enumerated() {
@@ -933,7 +934,7 @@ func packageViewCombinedStates() {
 func homeViewCursorStates() {
     let homeView = HomeView()
     let width = 100
-    let stats = HomeStats(totalPackages: 10, selectedPackages: 5, downloadedPackages: 3, artifactCount: 2, totalSize: 1024)
+    let stats = HomeStats(totalPackages: 10, selectedPackages: 5, downloadedPackages: 3, artifactCount: 2, archiveGuideCount: 47, totalSize: 1024)
 
     for cursor in 0...2 {
         let output = homeView.render(cursor: cursor, width: width, height: 24, stats: stats)
@@ -956,6 +957,7 @@ func homeViewLargeNumbers() {
         selectedPackages: 888888,
         downloadedPackages: 777777,
         artifactCount: 666,
+        archiveGuideCount: 999,
         totalSize: 999999999999 // ~1TB
     )
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Swift-based tool to crawl, index, and serve Apple's developer documentation to
 
 Cupertino is a local, structured, AI-ready documentation system for Apple platforms. It:
 
-- **Crawls** Apple Developer documentation, Swift.org, Swift Evolution proposals, and Swift package metadata
+- **Crawls** Apple Developer documentation, Swift.org, Swift Evolution proposals, Apple Archive legacy guides, and Swift package metadata
 - **Indexes** everything into a fast, searchable SQLite FTS5 database with BM25 ranking
 - **Serves** documentation to AI agents like Claude via the Model Context Protocol
 - **Provides** offline access to 22,000+ documentation pages across 261 frameworks
@@ -161,6 +161,11 @@ A UIKit view controller that manages a SwiftUI view hierarchy.
   - Priority package catalogs
   - README files
   - Sample code
+
+- **Apple Archive Legacy Guides** (~75 pages)
+  - Pre-2016 programming guides (Core Animation, Quartz 2D, Core Text, etc.)
+  - Deep conceptual knowledge not in modern docs
+  - Excluded from search by default (use `--include-archive`)
 
 ### 2. Bundled Resources
 
@@ -423,7 +428,7 @@ For development setup, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Project Status
 
-**Version:** 0.2.2
+**Version:** 0.2.3
 **Status:** ✅ Production Ready
 
 - ✅ All core functionality working

--- a/docs/artifacts/README.md
+++ b/docs/artifacts/README.md
@@ -20,6 +20,7 @@ All Cupertino artifacts are stored under:
 | [docs/](folders/docs/) | Crawled Apple documentation | [README](folders/docs/) + [metadata.json](folders/docs/metadata.json.md) |
 | [swift-org/](folders/swift-org/) | Crawled Swift.org documentation | [README](folders/swift-org/) + [metadata.json](folders/docs/metadata.json.md) |
 | [swift-evolution/](folders/swift-evolution/) | Swift Evolution proposals | [README](folders/swift-evolution/) + [metadata.json](folders/docs/metadata.json.md) |
+| [archive/](folders/archive/) | Apple Archive programming guides | [README](folders/archive/) |
 | [sample-code/](folders/sample-code/) | Apple sample code ZIP files | [README](folders/sample-code/) + [.auth-cookies.json](folders/sample-code/.auth-cookies.json.md) |
 | [packages/](folders/packages/) | Swift package metadata | [README](folders/packages/) + [swift-packages-with-stars.json](folders/packages/swift-packages-with-stars.json.md) + [checkpoint.json](folders/packages/checkpoint.json.md) |
 | [search.db](folders/search.db.md) | FTS5 search index database | File documentation |
@@ -36,9 +37,11 @@ All Cupertino artifacts are stored under:
 ├── swift-org/              # Swift.org Documentation
 │   ├── metadata.json
 │   └── [content folders]/
-└── swift-evolution/        # Swift Evolution Proposals
-    ├── metadata.json
-    └── proposals/
+├── swift-evolution/        # Swift Evolution Proposals
+│   ├── metadata.json
+│   └── proposals/
+└── archive/                # Apple Archive Guides (legacy)
+    └── [guide folders]/    # TP30001066/, TP40004514/, etc.
 ```
 
 ### Fetch Artifacts
@@ -67,6 +70,7 @@ All Cupertino artifacts are stored under:
 | `cupertino fetch --type docs` | Markdown files + metadata | `~/.cupertino/docs/` |
 | `cupertino fetch --type swift` | Markdown files + metadata | `~/.cupertino/swift-org/` |
 | `cupertino fetch --type evolution` | Proposal files + metadata | `~/.cupertino/swift-evolution/` |
+| `cupertino fetch --type archive` | Markdown files | `~/.cupertino/archive/` |
 | `cupertino fetch --type code` | ZIP files + checkpoint | `~/.cupertino/sample-code/` |
 | `cupertino fetch --type packages` | Package data + checkpoint | `~/.cupertino/packages/` |
 | `cupertino save` | Search database | `~/.cupertino/search.db` |

--- a/docs/artifacts/folders/archive/README.md
+++ b/docs/artifacts/folders/archive/README.md
@@ -1,0 +1,126 @@
+# archive/ - Apple Archive Programming Guides
+
+Legacy Apple programming guides from the developer.apple.com/library/archive.
+
+## Location
+
+**Default**: `~/.cupertino/archive/`
+
+## Created By
+
+```bash
+cupertino fetch --type archive
+```
+
+## Structure
+
+```
+~/.cupertino/archive/
+├── TP30001066/                     # Quartz 2D Programming Guide
+│   ├── dq_overview.md
+│   ├── dq_context.md
+│   ├── dq_paths.md
+│   └── ...
+├── TP40004514/                     # Core Animation Programming Guide
+│   ├── CoreAnimationBasics.md
+│   ├── SettingUpLayerObjects.md
+│   └── ...
+├── TP40003577/                     # Core Text Programming Guide
+│   └── ...
+└── ...                             # ~8 guide folders
+```
+
+## Contents
+
+### Guide Folders
+Each folder is named by Apple's technical publication ID (TP######).
+
+### Markdown Files
+- Converted from Apple's HTML documentation
+- YAML front matter with metadata
+- Full content preserved
+
+### YAML Front Matter Example
+```yaml
+---
+title: "Core Animation Basics"
+book: "Core Animation Programming Guide"
+framework: "QuartzCore"
+chapterId: "TP40004514-CH1"
+date: "2015-03-09"
+source: apple-archive
+---
+```
+
+## Available Guides
+
+| TP ID | Guide Name | Framework |
+|-------|-----------|-----------|
+| TP30001066 | Quartz 2D Programming Guide | CoreGraphics |
+| TP40004514 | Core Animation Programming Guide | QuartzCore |
+| TP40003577 | Core Text Programming Guide | CoreText |
+| TP40002974 | Core Image Programming Guide | CoreImage |
+| TP40005533 | Core Audio Overview | CoreAudio |
+| TP40006166 | Animation Types and Timing | QuartzCore |
+| TP40009492 | Audio Unit Hosting Guide | CoreAudio |
+| TP40001185 | Cocoa Fundamentals Guide | Cocoa |
+
+## Size
+
+- **~75 markdown files**
+- **~5-10 MB total**
+
+## Search Behavior
+
+Archive documentation is **excluded from search by default** to prioritize modern documentation.
+
+### Include in Search Results
+```bash
+cupertino search "Core Animation" --include-archive
+```
+
+### Search Archive Only
+```bash
+cupertino search "CALayer" --source apple-archive
+```
+
+### MCP Tool Usage
+```json
+{
+  "query": "Core Animation",
+  "include_archive": true
+}
+```
+
+## Framework Synonyms
+
+Archive docs are indexed with framework synonyms for better discoverability:
+- `QuartzCore` also indexed as `CoreAnimation`
+- `CoreGraphics` also indexed as `Quartz2D`
+
+## Why Archive?
+
+These guides contain foundational knowledge not available in modern documentation:
+- Deep conceptual explanations
+- Historical context
+- Implementation details
+- Patterns still relevant today
+
+## Customizing Selection
+
+Use the TUI to select which guides to crawl:
+```bash
+cupertino-tui
+# Navigate to Archive view (4)
+# Select/deselect guides with Space
+# Save with 'w'
+```
+
+Selection is stored in `~/.cupertino/selected-archive-guides.json`.
+
+## Notes
+
+- Guides are from Apple's pre-2016 documentation archive
+- Content may reference older APIs but concepts remain valid
+- Great for understanding the "why" behind Apple frameworks
+- Modern docs often lack this level of conceptual depth

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -6,7 +6,7 @@ CLI commands for the Cupertino documentation server.
 
 | Command | Description |
 |---------|-------------|
-| [fetch](fetch/) | Download documentation from Apple, Swift Evolution, and Swift.org |
+| [fetch](fetch/) | Download documentation from Apple, Swift Evolution, Swift.org, and Apple Archive |
 | [save](save/) | Build FTS5 search index from downloaded documentation |
 | [serve](serve/) | Start MCP server for AI agent access |
 | [search](search/) | Search documentation from the command line |
@@ -20,6 +20,7 @@ CLI commands for the Cupertino documentation server.
 # Download documentation
 cupertino fetch --type docs
 cupertino fetch --type evolution
+cupertino fetch --type archive
 
 # Build search index
 cupertino save
@@ -31,6 +32,7 @@ cupertino serve
 # Search documentation
 cupertino search "SwiftUI View" --limit 10
 cupertino search "async" --source swift-evolution
+cupertino search "Core Animation" --include-archive
 
 # Read full document
 cupertino read "apple-docs://swiftui/documentation_swiftui_view" --format markdown
@@ -47,6 +49,7 @@ cupertino doctor
 # 1. Download documentation (takes time)
 cupertino fetch --type docs --max-pages 15000
 cupertino fetch --type evolution
+cupertino fetch --type archive  # Legacy programming guides
 
 # 2. Build search index
 cupertino save

--- a/docs/commands/fetch/README.md
+++ b/docs/commands/fetch/README.md
@@ -25,7 +25,9 @@ The `fetch` command is the unified fetching command that handles both web crawli
   - `swift` - Swift.org Documentation (web crawl)
   - `evolution` - Swift Evolution Proposals (web crawl)
   - `packages` - Swift Package Index metadata (direct download)
+  - `package-docs` - Swift Package READMEs (direct download)
   - `code` - Apple Sample Code (direct download)
+  - `archive` - Apple Archive guides (legacy programming guides)
   - `all` - All types in parallel
 
 ### Web Crawl Options
@@ -73,6 +75,12 @@ cupertino fetch --type packages --limit 100
 cupertino fetch --type code --authenticate
 ```
 
+### Fetch Apple Archive Guides (Legacy Documentation)
+```bash
+cupertino fetch --type archive
+# Fetches: Core Animation, Core Graphics, Core Text, etc.
+```
+
 ### Custom Web Crawl
 ```bash
 cupertino fetch --start-url https://developer.apple.com/documentation/swiftui \
@@ -96,8 +104,9 @@ cupertino fetch --type docs --force
 
 Default locations:
 - **docs**: `~/.cupertino/docs/`
-- **swift**: `~/.cupertino/swift-docs/`
+- **swift**: `~/.cupertino/swift-org/`
 - **evolution**: `~/.cupertino/swift-evolution/`
+- **archive**: `~/.cupertino/archive/`
 
 Output files:
 - **Markdown files** - Converted documentation pages

--- a/docs/commands/fetch/option (--)/type (=value)/archive.md
+++ b/docs/commands/fetch/option (--)/type (=value)/archive.md
@@ -1,0 +1,157 @@
+# --type archive
+
+Fetch Apple Archive Legacy Programming Guides
+
+## Synopsis
+
+```bash
+cupertino fetch --type archive
+```
+
+## Description
+
+Downloads legacy Apple programming guides from developer.apple.com/library/archive. These are pre-2016 guides that contain foundational knowledge and deep conceptual explanations not available in modern documentation.
+
+## Data Source
+
+**Apple Developer Archive** - https://developer.apple.com/library/archive/
+
+## Output
+
+Creates Markdown files with YAML front matter:
+- Organized by guide ID (TP######)
+- Chapter/section structure preserved
+- Framework metadata included
+
+## Default Settings
+
+| Setting | Value |
+|---------|-------|
+| Output Directory | `~/.cupertino/archive` |
+| Source | Apple Developer Archive |
+| Fetch Method | Web crawling with WKWebView |
+| Authentication | Not required |
+| Estimated Size | ~75 pages, 5-10 MB |
+
+## Examples
+
+### Fetch All Essential Guides
+```bash
+cupertino fetch --type archive
+```
+
+### Resume Interrupted Download
+```bash
+cupertino fetch --type archive --resume
+```
+
+### Force Re-download
+```bash
+cupertino fetch --type archive --force
+```
+
+### Custom Output Directory
+```bash
+cupertino fetch --type archive --output-dir ./archive
+```
+
+## Output Structure
+
+```
+~/.cupertino/archive/
+├── TP40004514/                    # Core Animation Programming Guide
+│   ├── CoreAnimationBasics.md
+│   ├── SettingUpLayerObjects.md
+│   └── ...
+├── TP30001066/                    # Quartz 2D Programming Guide
+│   ├── dq_overview.md
+│   ├── dq_context.md
+│   └── ...
+├── TP40003577/                    # Core Text Programming Guide
+│   └── ...
+└── ...                            # ~8 guide folders
+```
+
+## Available Guides
+
+| TP ID | Guide Name | Framework |
+|-------|------------|-----------|
+| TP40004514 | Core Animation Programming Guide | QuartzCore |
+| TP30001066 | Quartz 2D Programming Guide | CoreGraphics |
+| TP40003577 | Core Text Programming Guide | CoreText |
+| TP40002974 | Core Image Programming Guide | CoreImage |
+| TP40005533 | Core Audio Overview | CoreAudio |
+| TP40006166 | Animation Types and Timing | QuartzCore |
+| TP40009492 | Audio Unit Hosting Guide | CoreAudio |
+| TP40001185 | Cocoa Fundamentals Guide | Cocoa |
+
+## YAML Front Matter
+
+Each file includes metadata:
+
+```yaml
+---
+title: "Core Animation Basics"
+book: "Core Animation Programming Guide"
+framework: "QuartzCore"
+chapterId: "TP40004514-CH1"
+date: "2015-03-09"
+source: apple-archive
+---
+```
+
+## Framework Synonyms
+
+Archive docs are indexed with synonyms for better search:
+- `QuartzCore` also indexed as `CoreAnimation`
+- `CoreGraphics` also indexed as `Quartz2D`
+
+## Search Integration
+
+Archive documentation is excluded from search by default:
+
+### Include in Mixed Results
+```bash
+cupertino search "Core Animation" --include-archive
+```
+
+### Search Archive Only
+```bash
+cupertino search "CALayer" --source apple-archive
+```
+
+## Performance
+
+| Metric | Value |
+|--------|-------|
+| Download time | 5-10 minutes |
+| Incremental update | Minutes (only changed) |
+| Total storage | ~5-10 MB |
+| Pages | ~75 markdown files |
+
+## Use Cases
+
+- Deep dive into framework fundamentals
+- Understanding low-level graphics APIs
+- Learning Core Animation layer concepts
+- Core Graphics/Quartz 2D programming
+- Core Text layout and rendering
+- Audio programming fundamentals
+
+## Why Archive Documentation?
+
+Modern Apple documentation focuses on API reference but often lacks:
+- **Conceptual explanations** - The "why" behind design decisions
+- **System architecture** - How components interact
+- **Implementation patterns** - Best practices and common approaches
+- **Historical context** - Understanding API evolution
+
+Archive guides fill these gaps with comprehensive programming guides.
+
+## Notes
+
+- Content from pre-2016 Apple documentation
+- Some APIs may be deprecated but concepts remain valid
+- Excluded from default search to prioritize modern docs
+- Use `--include-archive` or `--source apple-archive` for search
+- Great complement to modern API documentation

--- a/docs/commands/search/README.md
+++ b/docs/commands/search/README.md
@@ -34,12 +34,28 @@ cupertino search "Observable macro"
 Filter results by documentation source.
 
 **Type:** String
-**Values:** `apple-docs`, `swift-evolution`, `swift-org`, `swift-book`, `packages`, `apple-sample-code`
+**Values:** `apple-docs`, `swift-evolution`, `swift-org`, `swift-book`, `packages`, `apple-sample-code`, `apple-archive`
 
 **Example:**
 ```bash
 cupertino search "concurrency" --source swift-evolution
 cupertino search "View" --source apple-docs
+cupertino search "CALayer" --source apple-archive
+```
+
+### --include-archive
+
+Include Apple Archive legacy programming guides in search results.
+
+**Type:** Flag (boolean)
+**Default:** false (archive excluded by default)
+
+Archive documentation is excluded from search by default to prioritize modern documentation. Use this flag to include legacy guides like Core Animation Programming Guide, Quartz 2D Programming Guide, etc.
+
+**Example:**
+```bash
+cupertino search "Core Animation" --include-archive
+cupertino search "CALayer" --include-archive --framework quartzcore
 ```
 
 ### -f, --framework

--- a/docs/commands/search/option (--)/include-archive.md
+++ b/docs/commands/search/option (--)/include-archive.md
@@ -1,0 +1,86 @@
+# --include-archive
+
+Include Apple Archive legacy programming guides in search results
+
+## Synopsis
+
+```bash
+cupertino search <query> --include-archive
+```
+
+## Description
+
+By default, Apple Archive legacy programming guides are excluded from search results to prioritize modern documentation. Use this flag to include them in mixed results alongside other documentation sources.
+
+## Default
+
+`false` (archive excluded)
+
+## Examples
+
+### Include Archive in Search
+```bash
+cupertino search "Core Animation" --include-archive
+```
+
+### Search All Sources Including Archive
+```bash
+cupertino search "layer" --include-archive --limit 20
+```
+
+### Framework-Specific with Archive
+```bash
+cupertino search "CALayer" --include-archive --framework quartzcore
+```
+
+## Combining with Other Options
+
+### With Framework Filter
+```bash
+cupertino search "bezier" --include-archive --framework coregraphics
+```
+
+### With JSON Output
+```bash
+cupertino search "animation timing" --include-archive --format json
+```
+
+### With Limit
+```bash
+cupertino search "graphics context" --include-archive --limit 10
+```
+
+## Comparison
+
+| Approach | Behavior |
+|----------|----------|
+| No flag | Archive excluded, modern docs only |
+| `--include-archive` | Archive included in mixed results |
+| `--source apple-archive` | Archive only, no other sources |
+
+## Use Cases
+
+- **Foundational concepts**: Archive guides explain "why" not just "what"
+- **Legacy API research**: Understanding older APIs still in use
+- **Deep dives**: When modern docs lack conceptual depth
+- **Historical context**: Understanding API evolution
+
+## Archive Content
+
+Includes these programming guides:
+- Core Animation Programming Guide
+- Quartz 2D Programming Guide
+- Core Text Programming Guide
+- Core Image Programming Guide
+- Core Audio Overview
+- Cocoa Fundamentals Guide
+
+## Search Ranking
+
+When included, archive results have a slight ranking penalty to ensure modern documentation appears first. Use `--source apple-archive` if you specifically want archive results prioritized.
+
+## Notes
+
+- Archive docs are crawled separately via `cupertino fetch --type archive`
+- Framework synonyms help discover archive content (QuartzCore = CoreAnimation)
+- Great for understanding foundational concepts not covered in modern docs

--- a/docs/commands/search/option (--)/source (=value)/apple-archive.md
+++ b/docs/commands/search/option (--)/source (=value)/apple-archive.md
@@ -1,0 +1,84 @@
+# apple-archive
+
+Apple Archive legacy programming guides source
+
+## Synopsis
+
+```bash
+cupertino search <query> --source apple-archive
+```
+
+## Description
+
+Filters search results to only include Apple Archive legacy programming guides. These are pre-2016 guides from developer.apple.com/library/archive that contain foundational knowledge not available in modern documentation.
+
+## Content
+
+- **Core Animation Programming Guide** (QuartzCore framework)
+- **Quartz 2D Programming Guide** (CoreGraphics framework)
+- **Core Text Programming Guide** (CoreText framework)
+- **Core Image Programming Guide** (CoreImage framework)
+- **Core Audio Overview** (CoreAudio framework)
+- **Cocoa Fundamentals Guide** (Cocoa framework)
+
+## Typical Size
+
+- **~75 pages** across 8 guides
+- **~5-10 MB** on disk
+
+## Examples
+
+### Search Archive Only
+```bash
+cupertino search "CALayer" --source apple-archive
+```
+
+### Search Core Animation Concepts
+```bash
+cupertino search "layer tree" --source apple-archive
+```
+
+### JSON Output
+```bash
+cupertino search "bezier path" --source apple-archive --format json
+```
+
+## URI Format
+
+Results use the `apple-archive://` URI scheme:
+
+```
+apple-archive://{guide_id}/{chapter}
+```
+
+Examples:
+- `apple-archive://TP40004514/CoreAnimationBasics`
+- `apple-archive://TP30001066/dq_context`
+
+## Framework Synonyms
+
+Archive docs are indexed with framework synonyms for better discoverability:
+- `QuartzCore` also matches `CoreAnimation`
+- `CoreGraphics` also matches `Quartz2D`
+
+## How to Populate
+
+```bash
+# Fetch archive guides (~5-10 minutes)
+cupertino fetch --type archive
+
+# Build index
+cupertino save
+```
+
+## Search Ranking
+
+Archive documentation has a slight ranking penalty compared to modern documentation. This ensures modern APIs appear first, while archive content remains discoverable for foundational concepts.
+
+## Notes
+
+- Excluded from default search results
+- Use `--source apple-archive` to search archive only
+- Use `--include-archive` to include in mixed results
+- Contains deep conceptual knowledge often missing from modern docs
+- Great for understanding the "why" behind Apple frameworks

--- a/docs/tools/search_docs/README.md
+++ b/docs/tools/search_docs/README.md
@@ -53,6 +53,7 @@ Filter results to a specific documentation source.
 - `"swift-org"` - Swift.org documentation
 - `"swift-evolution"` - Swift Evolution proposals
 - `"packages"` - Swift Package documentation
+- `"apple-archive"` - Apple Archive legacy programming guides
 
 ### framework (optional)
 
@@ -90,6 +91,18 @@ Maximum number of results to return.
 **Default:** 20
 
 **Maximum:** 100
+
+### include_archive (optional)
+
+Include Apple Archive legacy programming guides in search results.
+
+**Type:** Boolean
+
+**Default:** `false` (archive excluded by default)
+
+Archive documentation is excluded by default to prioritize modern documentation. Set to `true` to include legacy guides like Core Animation Programming Guide, Quartz 2D Programming Guide, etc. These contain foundational knowledge not available in modern docs.
+
+**Note:** You can also search archive exclusively using `source: "apple-archive"`.
 
 ## Response
 
@@ -169,6 +182,24 @@ A type whose mutable state is protected from concurrent access...
   "query": "Actors Swift concurrency isolation",
   "framework": "swift",
   "limit": 10
+}
+```
+
+### Include Archive Guides
+
+```json
+{
+  "query": "Core Animation layers",
+  "include_archive": true
+}
+```
+
+### Search Archive Only
+
+```json
+{
+  "query": "CALayer",
+  "source": "apple-archive"
 }
 ```
 


### PR DESCRIPTION
## Summary

  - Add Apple Archive documentation crawler for legacy programming guides (Core Animation, Quartz 2D, Core Text, etc.)
  - Add `cupertino fetch --type archive` command to download archived guides
  - Add `--include-archive` flag and `--source apple-archive` filter for search
  - Add `include_archive` parameter to MCP `search_docs` tool
  - Add framework synonyms for better discoverability (QuartzCore↔CoreAnimation, CoreGraphics↔Quartz2D)
  - Add source-based search ranking (modern docs prioritized over archive)
  - Archive excluded from search by default to prioritize modern documentation

