### PR TITLE
feat(cli): add setup and release commands for instant database download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 0.2.8
+
+### Added
+- **Remote Sync** - New `--remote` flag for `cupertino save` command (#52)
+  - Stream documentation directly from GitHub without local crawling
+  - Instant setup in ~30 minutes instead of 20+ hours
+  - Resumable - if interrupted, continue from where you left off
+  - No disk bloat - streams directly to SQLite
+  - Uses raw.githubusercontent.com (no API rate limits)
+- **RemoteSync Package** - New standalone Swift 6 package with strict concurrency
+  - `RemoteIndexer` actor for orchestrating remote sync
+  - `GitHubFetcher` actor for HTTP operations
+  - `RemoteIndexState` Sendable struct for state persistence
+  - `AnimatedProgress` for terminal progress display
+  - 20 unit tests covering all functionality
+
+### Documentation
+- Updated README with "Instant Setup" quick start section
+- Added `docs/commands/save/option (--)/remote.md` documentation
+- Updated `docs/commands/save/README.md` with remote mode examples
+
+### Related Issues
+- Closes #52
+
+---
+
 ## 0.2.7
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
-## 0.2.8
+## 0.3.0
 
 ### Added
+- **Setup Command** - Instant database download from GitHub Releases (#65)
+  - `cupertino setup` - Download pre-built databases in ~30 seconds
+  - Version parity - CLI version matches release tag for schema compatibility
+  - Progress bar with percentage and download size
+  - `--base-dir` option for custom location
+  - `--force` flag to re-download
+- **Release Command** - Automated database publishing for maintainers (#66)
+  - `cupertino release` - Package and upload databases to GitHub Releases
+  - Creates versioned zip with SHA256 checksum
+  - `--dry-run` for local testing
+  - Handles existing releases (deletes and recreates)
 - **Remote Sync** - New `--remote` flag for `cupertino save` command (#52)
   - Stream documentation directly from GitHub without local crawling
-  - Instant setup in ~30 minutes instead of 20+ hours
+  - Build database locally in ~45 minutes instead of 20+ hours
   - Resumable - if interrupted, continue from where you left off
   - No disk bloat - streams directly to SQLite
   - Uses raw.githubusercontent.com (no API rate limits)
@@ -12,15 +23,16 @@
   - `GitHubFetcher` actor for HTTP operations
   - `RemoteIndexState` Sendable struct for state persistence
   - `AnimatedProgress` for terminal progress display
-  - 20 unit tests covering all functionality
 
 ### Documentation
-- Updated README with "Instant Setup" quick start section
-- Added `docs/commands/save/option (--)/remote.md` documentation
-- Updated `docs/commands/save/README.md` with remote mode examples
+- Updated README with "Instant Setup" quick start using `cupertino setup`
+- Added `docs/commands/setup/README.md` documentation
+- Added `docs/commands/release/README.md` documentation
+- Added `docs/commands/save/option (--)/remote/` documentation
+- Updated `docs/commands/README.md` with new commands
 
 ### Related Issues
-- Closes #52
+- Closes #52, #65, #66
 
 ---
 

--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -26,6 +26,7 @@ let macOSOnlyProducts: [Product] = [
     .singleTargetLibrary("MCPSupport"),
     .singleTargetLibrary("SearchToolProvider"),
     .singleTargetLibrary("MCPClient"),
+    .singleTargetLibrary("RemoteSync"),
     .executable(name: "cupertino", targets: ["CLI"]),
     .executable(name: "cupertino-tui", targets: ["TUI"]),
     .executable(name: "mock-ai-agent", targets: ["MockAIAgent"]),
@@ -157,6 +158,15 @@ let targets: [Target] = {
         dependencies: ["MCPClient", "TestSupport"]
     )
 
+    let remoteSyncTarget = Target.target(
+        name: "RemoteSync",
+        dependencies: []
+    )
+    let remoteSyncTestsTarget = Target.testTarget(
+        name: "RemoteSyncTests",
+        dependencies: ["RemoteSync", "TestSupport"]
+    )
+
     let cliTarget = Target.executableTarget(
         name: "CLI",
         dependencies: [
@@ -166,6 +176,7 @@ let targets: [Target] = {
             "Search",
             "SampleIndex",
             "Logging",
+            "RemoteSync",
             // MCP dependencies (for mcp serve command)
             "MCP",
             "MCPSupport",
@@ -257,6 +268,8 @@ let targets: [Target] = {
         searchToolProviderTestsTarget,
         mcpClientTarget,
         mcpClientTestsTarget,
+        remoteSyncTarget,
+        remoteSyncTestsTarget,
         testSupportTarget,
         cliTarget,
         tuiTarget,

--- a/Packages/Sources/CLI/Commands/ReleaseCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReleaseCommand.swift
@@ -1,0 +1,366 @@
+import ArgumentParser
+import Foundation
+import Logging
+import Shared
+
+// MARK: - Release Command
+
+@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
+struct ReleaseCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "release",
+        abstract: "Package and upload databases to GitHub Releases"
+    )
+
+    @Option(name: .long, help: "Base directory containing databases")
+    var baseDir: String?
+
+    @Option(name: .long, help: "GitHub repository (owner/repo)")
+    var repo: String = "mihaelamj/cupertino-docs"
+
+    @Flag(name: .long, help: "Create release without uploading (dry run)")
+    var dryRun: Bool = false
+
+    // MARK: - Constants
+
+    private static let searchDBFilename = "search.db"
+    private static let samplesDBFilename = "samples.db"
+
+    private static var version: String {
+        Shared.Constants.App.version
+    }
+
+    private static var releaseTag: String {
+        "v\(version)"
+    }
+
+    private static var zipFilename: String {
+        "cupertino-databases-\(releaseTag).zip"
+    }
+
+    // MARK: - Run
+
+    mutating func run() async throws {
+        Logging.ConsoleLogger.info("📦 Cupertino Release \(Self.releaseTag)\n")
+
+        let baseURL = baseDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
+            ?? Shared.Constants.defaultBaseDirectory
+
+        let searchDBURL = baseURL.appendingPathComponent(Self.searchDBFilename)
+        let samplesDBURL = baseURL.appendingPathComponent(Self.samplesDBFilename)
+
+        // Verify databases exist
+        guard FileManager.default.fileExists(atPath: searchDBURL.path) else {
+            throw ReleaseError.missingDatabase(Self.searchDBFilename, baseURL.path)
+        }
+        guard FileManager.default.fileExists(atPath: samplesDBURL.path) else {
+            throw ReleaseError.missingDatabase(Self.samplesDBFilename, baseURL.path)
+        }
+
+        // Get database sizes
+        let searchSize = try fileSize(at: searchDBURL)
+        let samplesSize = try fileSize(at: samplesDBURL)
+        Logging.ConsoleLogger.info("📊 Database sizes:")
+        Logging.ConsoleLogger.info("   search.db:  \(formatBytes(searchSize))")
+        Logging.ConsoleLogger.info("   samples.db: \(formatBytes(samplesSize))")
+
+        // Create zip
+        let zipURL = baseURL.appendingPathComponent(Self.zipFilename)
+        Logging.ConsoleLogger.info("\n📁 Creating \(Self.zipFilename)...")
+
+        try createZip(
+            containing: [searchDBURL, samplesDBURL],
+            at: zipURL
+        )
+
+        let zipSize = try fileSize(at: zipURL)
+        Logging.ConsoleLogger.info("   ✓ Created (\(formatBytes(zipSize)))")
+
+        // Calculate SHA256
+        Logging.ConsoleLogger.info("\n🔐 Calculating SHA256...")
+        let sha256 = try calculateSHA256(of: zipURL)
+        Logging.ConsoleLogger.info("   \(sha256)")
+
+        if dryRun {
+            Logging.ConsoleLogger.info("\n🏃 Dry run - skipping upload")
+            Logging.ConsoleLogger.info("   Zip file: \(zipURL.path)")
+            return
+        }
+
+        // Check for GitHub token
+        guard let token = ProcessInfo.processInfo.environment["GITHUB_TOKEN"] else {
+            throw ReleaseError.missingToken
+        }
+
+        // Check if release exists
+        Logging.ConsoleLogger.info("\n🔍 Checking for existing release...")
+        let releaseExists = try await checkReleaseExists(repo: repo, tag: Self.releaseTag, token: token)
+
+        if releaseExists {
+            Logging.ConsoleLogger.info("   Release \(Self.releaseTag) exists, updating...")
+            try await deleteRelease(repo: repo, tag: Self.releaseTag, token: token)
+        }
+
+        // Create release
+        Logging.ConsoleLogger.info("\n🚀 Creating release \(Self.releaseTag)...")
+        let uploadURL = try await createRelease(
+            repo: repo,
+            tag: Self.releaseTag,
+            token: token,
+            sha256: sha256
+        )
+        Logging.ConsoleLogger.info("   ✓ Release created")
+
+        // Upload asset
+        Logging.ConsoleLogger.info("\n⬆️  Uploading \(Self.zipFilename)...")
+        try await uploadAsset(
+            uploadURL: uploadURL,
+            file: zipURL,
+            filename: Self.zipFilename,
+            token: token
+        )
+        Logging.ConsoleLogger.info("   ✓ Upload complete")
+
+        // Cleanup
+        try? FileManager.default.removeItem(at: zipURL)
+
+        Logging.ConsoleLogger.info("\n✅ Release \(Self.releaseTag) published!")
+        Logging.ConsoleLogger.info("   https://github.com/\(repo)/releases/tag/\(Self.releaseTag)")
+    }
+
+    // MARK: - Zip
+
+    private func createZip(containing files: [URL], at destination: URL) throws {
+        // Remove existing zip
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        process.currentDirectoryURL = files[0].deletingLastPathComponent()
+        process.arguments = ["-j", destination.path] + files.map(\.lastPathComponent)
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw ReleaseError.zipFailed
+        }
+    }
+
+    // MARK: - SHA256
+
+    private func calculateSHA256(of url: URL) throws -> String {
+        let process = Process()
+        let pipe = Pipe()
+
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/shasum")
+        process.arguments = ["-a", "256", url.path]
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8),
+              let hash = output.split(separator: " ").first else {
+            throw ReleaseError.sha256Failed
+        }
+
+        return String(hash)
+    }
+
+    // MARK: - GitHub API
+
+    private func checkReleaseExists(repo: String, tag: String, token: String) async throws -> Bool {
+        let url = URL(string: "https://api.github.com/repos/\(repo)/releases/tags/\(tag)")!
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return false
+        }
+        return httpResponse.statusCode == 200
+    }
+
+    private func deleteRelease(repo: String, tag: String, token: String) async throws {
+        // Get release ID
+        let getURL = URL(string: "https://api.github.com/repos/\(repo)/releases/tags/\(tag)")!
+        var getRequest = URLRequest(url: getURL)
+        getRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        getRequest.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+
+        let (data, _) = try await URLSession.shared.data(for: getRequest)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let releaseId = json["id"] as? Int else {
+            throw ReleaseError.apiError("Failed to get release ID")
+        }
+
+        // Delete release
+        let deleteURL = URL(string: "https://api.github.com/repos/\(repo)/releases/\(releaseId)")!
+        var deleteRequest = URLRequest(url: deleteURL)
+        deleteRequest.httpMethod = "DELETE"
+        deleteRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        let (_, response) = try await URLSession.shared.data(for: deleteRequest)
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 204 else {
+            throw ReleaseError.apiError("Failed to delete release")
+        }
+
+        // Delete tag
+        let tagURL = URL(string: "https://api.github.com/repos/\(repo)/git/refs/tags/\(tag)")!
+        var tagRequest = URLRequest(url: tagURL)
+        tagRequest.httpMethod = "DELETE"
+        tagRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        _ = try? await URLSession.shared.data(for: tagRequest)
+    }
+
+    private func createRelease(
+        repo: String,
+        tag: String,
+        token: String,
+        sha256: String
+    ) async throws -> String {
+        let url = URL(string: "https://api.github.com/repos/\(repo)/releases")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "tag_name": tag,
+            "name": "Pre-built Databases \(tag) (search.db and samples.db)",
+            "body": """
+            Pre-built search databases for instant Cupertino setup.
+
+            ## Quick Install
+
+            ```bash
+            cupertino setup
+            ```
+
+            ## SHA256
+
+            ```
+            \(sha256)  \(Self.zipFilename)
+            ```
+            """,
+            "prerelease": false,
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 201 else {
+            if let errorJson = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let message = errorJson["message"] as? String {
+                throw ReleaseError.apiError(message)
+            }
+            throw ReleaseError.apiError("Failed to create release")
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let uploadURL = json["upload_url"] as? String else {
+            throw ReleaseError.apiError("Missing upload_url in response")
+        }
+
+        // Remove template part from upload URL
+        return uploadURL.replacingOccurrences(of: "{?name,label}", with: "")
+    }
+
+    private func uploadAsset(
+        uploadURL: String,
+        file: URL,
+        filename: String,
+        token: String
+    ) async throws {
+        guard let url = URL(string: "\(uploadURL)?name=\(filename)") else {
+            throw ReleaseError.apiError("Invalid upload URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("application/zip", forHTTPHeaderField: "Content-Type")
+
+        let fileData = try Data(contentsOf: file)
+        request.httpBody = fileData
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 201 else {
+            if let errorJson = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let message = errorJson["message"] as? String {
+                throw ReleaseError.apiError(message)
+            }
+            throw ReleaseError.apiError("Failed to upload asset")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func fileSize(at url: URL) throws -> Int64 {
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        return attrs[.size] as? Int64 ?? 0
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        let megabytes = Double(bytes) / 1000000
+        if megabytes >= 1000 {
+            return String(format: "%.1f GB", megabytes / 1000)
+        }
+        return String(format: "%.1f MB", megabytes)
+    }
+}
+
+// MARK: - Errors
+
+enum ReleaseError: Error, CustomStringConvertible {
+    case missingDatabase(String, String)
+    case zipFailed
+    case sha256Failed
+    case missingToken
+    case apiError(String)
+
+    var description: String {
+        switch self {
+        case .missingDatabase(let filename, let dir):
+            return "Database not found: \(filename) in \(dir)"
+        case .zipFailed:
+            return "Failed to create zip file"
+        case .sha256Failed:
+            return "Failed to calculate SHA256"
+        case .missingToken:
+            return """
+            GITHUB_TOKEN environment variable not set.
+
+            Create a token at: https://github.com/settings/tokens
+            Then: export GITHUB_TOKEN=your_token
+            """
+        case .apiError(let message):
+            return "GitHub API error: \(message)"
+        }
+    }
+}
+
+// MARK: - URL Extension
+
+private extension URL {
+    var expandingTildeInPath: URL {
+        if path.hasPrefix("~") {
+            let expandedPath = NSString(string: path).expandingTildeInPath
+            return URL(fileURLWithPath: expandedPath)
+        }
+        return self
+    }
+}

--- a/Packages/Sources/CLI/Commands/SetupCommand.swift
+++ b/Packages/Sources/CLI/Commands/SetupCommand.swift
@@ -1,0 +1,278 @@
+import ArgumentParser
+import Foundation
+import Logging
+import Shared
+
+// MARK: - Setup Command
+
+@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
+struct SetupCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "setup",
+        abstract: "Download pre-built search databases from GitHub"
+    )
+
+    @Option(name: .long, help: "Base directory for databases")
+    var baseDir: String?
+
+    @Flag(name: .long, help: "Force re-download even if files exist")
+    var force: Bool = false
+
+    // MARK: - Constants
+
+    private static let releaseBaseURL = "https://github.com/mihaelamj/cupertino-docs/releases/download"
+    private static let searchDBFilename = "search.db"
+    private static let samplesDBFilename = "samples.db"
+
+    /// Release tag matches CLI version for database schema compatibility
+    private static var releaseTag: String {
+        "v\(Shared.Constants.App.version)"
+    }
+
+    private static var zipFilename: String {
+        "cupertino-databases-\(releaseTag).zip"
+    }
+
+    private static var releaseURL: String {
+        "\(releaseBaseURL)/\(releaseTag)"
+    }
+
+    // MARK: - Run
+
+    mutating func run() async throws {
+        Logging.ConsoleLogger.info("📦 Cupertino Setup\n")
+
+        let baseURL = baseDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
+            ?? Shared.Constants.defaultBaseDirectory
+
+        // Create directory if needed
+        try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+
+        let searchDBURL = baseURL.appendingPathComponent(Self.searchDBFilename)
+        let samplesDBURL = baseURL.appendingPathComponent(Self.samplesDBFilename)
+
+        // Check if both files exist
+        let searchExists = FileManager.default.fileExists(atPath: searchDBURL.path)
+        let samplesExists = FileManager.default.fileExists(atPath: samplesDBURL.path)
+
+        if !force, searchExists, samplesExists {
+            Logging.ConsoleLogger.info("✅ Databases already exist")
+            Logging.ConsoleLogger.info("   Documentation: \(searchDBURL.path)")
+            Logging.ConsoleLogger.info("   Sample code:   \(samplesDBURL.path)")
+            Logging.ConsoleLogger.info("\n💡 Use --force to overwrite with latest version")
+            Logging.ConsoleLogger.info("💡 Start the server with: cupertino serve")
+            return
+        }
+
+        // Warn about overwriting
+        if force, searchExists || samplesExists {
+            Logging.ConsoleLogger.info("⚠️  Existing databases will be overwritten\n")
+        }
+
+        // Download and extract zip
+        let zipURL = baseURL.appendingPathComponent(Self.zipFilename)
+        try await downloadFile(
+            name: "Databases",
+            from: "\(Self.releaseURL)/\(Self.zipFilename)",
+            to: zipURL
+        )
+
+        // Extract zip
+        Logging.ConsoleLogger.info("📂 Extracting databases...")
+        try await extractZip(at: zipURL, to: baseURL)
+
+        // Remove zip file
+        try? FileManager.default.removeItem(at: zipURL)
+
+        // Verify files exist
+        guard FileManager.default.fileExists(atPath: searchDBURL.path) else {
+            throw SetupError.missingFile(Self.searchDBFilename)
+        }
+        guard FileManager.default.fileExists(atPath: samplesDBURL.path) else {
+            throw SetupError.missingFile(Self.samplesDBFilename)
+        }
+
+        // Done
+        Logging.ConsoleLogger.output("")
+        Logging.ConsoleLogger.info("✅ Setup complete!")
+        Logging.ConsoleLogger.info("   Documentation: \(searchDBURL.path)")
+        Logging.ConsoleLogger.info("   Sample code:   \(samplesDBURL.path)")
+        Logging.ConsoleLogger.info("\n💡 Start the server with: cupertino serve")
+    }
+
+    // MARK: - Extract
+
+    private func extractZip(at zipURL: URL, to destination: URL) async throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = ["-o", zipURL.path, "-d", destination.path]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw SetupError.extractionFailed
+        }
+        Logging.ConsoleLogger.info("   ✓ Extracted")
+    }
+
+    // MARK: - Download
+
+    private func downloadFile(name: String, from urlString: String, to destination: URL) async throws {
+        guard let url = URL(string: urlString) else {
+            throw SetupError.invalidURL(urlString)
+        }
+
+        Logging.ConsoleLogger.info("⬇️  Downloading \(name)...")
+        printProgress("   ⠋ Starting download...\r")
+        fflush(stdout)
+
+        // Use delegate for progress tracking
+        let delegate = DownloadDelegate(name: name)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+
+        let (tempURL, response) = try await session.download(from: url)
+
+        // Move to new line after progress
+        printProgress("\n")
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw SetupError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            if httpResponse.statusCode == 404 {
+                throw SetupError.notFound(url)
+            }
+            throw SetupError.httpError(httpResponse.statusCode)
+        }
+
+        // Get file size for display
+        let fileSize = try FileManager.default.attributesOfItem(atPath: tempURL.path)[.size] as? Int64 ?? 0
+        let sizeStr = formatBytes(fileSize)
+
+        // Move to destination
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: tempURL, to: destination)
+
+        Logging.ConsoleLogger.info("   ✓ \(name) (\(sizeStr))")
+    }
+
+    private func printProgress(_ string: String) {
+        FileHandle.standardOutput.write(Data(string.utf8))
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        let megabytes = Double(bytes) / 1000000
+        if megabytes >= 1000 {
+            return String(format: "%.1f GB", megabytes / 1000)
+        }
+        return String(format: "%.1f MB", megabytes)
+    }
+}
+
+// MARK: - Errors
+
+enum SetupError: Error, CustomStringConvertible {
+    case invalidURL(String)
+    case invalidResponse
+    case notFound(URL)
+    case httpError(Int)
+    case extractionFailed
+    case missingFile(String)
+
+    var description: String {
+        switch self {
+        case .invalidURL(let url):
+            return "Invalid URL: \(url)"
+        case .invalidResponse:
+            return "Invalid response from server"
+        case .notFound(let url):
+            return """
+            File not found: \(url)
+
+            The release may not exist yet. Check: https://github.com/mihaelamj/cupertino-docs/releases
+            """
+        case .httpError(let code):
+            return "HTTP error: \(code)"
+        case .extractionFailed:
+            return "Failed to extract zip file"
+        case .missingFile(let filename):
+            return "Expected file not found after extraction: \(filename)"
+        }
+    }
+}
+
+// MARK: - Download Delegate
+
+private final class DownloadDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    let name: String
+    private let barWidth = 30
+    private let spinner = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+    private var spinnerIndex = 0
+
+    init(name: String) {
+        self.name = name
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        let currentSpinner = spinner[spinnerIndex % spinner.count]
+        spinnerIndex += 1
+
+        // If size unknown, show indeterminate progress
+        guard totalBytesExpectedToWrite > 0 else {
+            let downloaded = formatBytes(totalBytesWritten)
+            let output = "\r   \(currentSpinner) Downloading... \(downloaded)"
+            FileHandle.standardOutput.write(Data(output.utf8))
+            fflush(stdout)
+            return
+        }
+
+        let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        let filled = Int(progress * Double(barWidth))
+        let empty = barWidth - filled
+
+        let bar = String(repeating: "█", count: filled) + String(repeating: "░", count: empty)
+        let percent = String(format: "%3.0f%%", progress * 100)
+        let downloaded = formatBytes(totalBytesWritten)
+        let total = formatBytes(totalBytesExpectedToWrite)
+
+        let output = "\r   \(currentSpinner) [\(bar)] \(percent) (\(downloaded)/\(total))"
+        FileHandle.standardOutput.write(Data(output.utf8))
+        fflush(stdout)
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        // Required delegate method - actual file handling done in downloadFile
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        let megabytes = Double(bytes) / 1000000
+        if megabytes >= 1000 {
+            return String(format: "%.1f GB", megabytes / 1000)
+        }
+        return String(format: "%.1f MB", megabytes)
+    }
+}
+
+// MARK: - URL Extension
+
+private extension URL {
+    var expandingTildeInPath: URL {
+        if path.hasPrefix("~") {
+            let expandedPath = NSString(string: path).expandingTildeInPath
+            return URL(fileURLWithPath: expandedPath)
+        }
+        return self
+    }
+}

--- a/Packages/Sources/CLI/Cupertino.swift
+++ b/Packages/Sources/CLI/Cupertino.swift
@@ -11,6 +11,7 @@ struct Cupertino: AsyncParsableCommand {
         abstract: "MCP Server for Apple Documentation, Swift Evolution, and Swift Packages",
         version: Shared.Constants.App.version,
         subcommands: [
+            SetupCommand.self,
             FetchCommand.self,
             SaveCommand.self,
             IndexCommand.self,
@@ -24,6 +25,7 @@ struct Cupertino: AsyncParsableCommand {
             ReadSampleFileCommand.self,
             DoctorCommand.self,
             CleanupCommand.self,
+            ReleaseCommand.self,
         ],
         defaultSubcommand: ServeCommand.self
     )

--- a/Packages/Sources/RemoteSync/AnimatedProgress.swift
+++ b/Packages/Sources/RemoteSync/AnimatedProgress.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+// MARK: - Animated Progress Display
+
+/// Terminal progress display for remote sync operations.
+/// Shows animated progress bar with ETA and current status.
+public struct AnimatedProgress: Sendable {
+    /// Progress bar width in characters
+    public let barWidth: Int
+
+    /// Whether to use emoji in output
+    public let useEmoji: Bool
+
+    public init(barWidth: Int = 20, useEmoji: Bool = true) {
+        self.barWidth = barWidth
+        self.useEmoji = useEmoji
+    }
+
+    // MARK: - Rendering
+
+    /// Render progress to string (for terminal output)
+    public func render(_ progress: RemoteSyncProgress) -> String {
+        var lines: [String] = []
+
+        // Header
+        let header = useEmoji ? "🚀 Building database from remote..." : "Building database from remote..."
+        lines.append(header)
+        lines.append("")
+
+        // Phase and framework progress
+        let phaseIcon = useEmoji ? phaseEmoji(progress.phase) : "-"
+        let frameworkBar = renderBar(
+            current: progress.frameworkIndex,
+            total: progress.frameworksTotal
+        )
+        let phaseLabel = progress.phase.rawValue.capitalized
+        let counts = "\(progress.frameworkIndex)/\(progress.frameworksTotal)"
+        lines.append("\(phaseIcon) \(phaseLabel): \(frameworkBar) \(counts)")
+
+        // Current framework and file progress
+        if let framework = progress.framework {
+            let fileProgress = progress.filesTotal > 0
+                ? "(\(progress.fileIndex)/\(progress.filesTotal) files)"
+                : "(loading...)"
+            lines.append("   Current: \(framework) \(fileProgress)")
+        }
+
+        lines.append("")
+
+        // Time info
+        let elapsedStr = formatDuration(progress.elapsed)
+        let etaStr = progress.estimatedTimeRemaining.map { formatDuration($0) } ?? "--:--"
+        let timeIcon = useEmoji ? "⏱️ " : ""
+        lines.append("\(timeIcon)Elapsed: \(elapsedStr) | ETA: \(etaStr)")
+
+        // Overall progress percentage
+        let percentStr = String(format: "%.1f%%", progress.overallProgress * 100)
+        let progressIcon = useEmoji ? "📊" : "-"
+        lines.append("\(progressIcon) Overall: \(percentStr)")
+
+        return lines.joined(separator: "\n")
+    }
+
+    /// Render a single-line status update
+    public func renderCompact(_ progress: RemoteSyncProgress) -> String {
+        let bar = renderBar(current: progress.frameworkIndex, total: progress.frameworksTotal)
+        let framework = progress.framework ?? "..."
+        let fileInfo = progress.filesTotal > 0 ? " (\(progress.fileIndex)/\(progress.filesTotal))" : ""
+        return "\(bar) \(progress.frameworkIndex)/\(progress.frameworksTotal) \(framework)\(fileInfo)"
+    }
+
+    // MARK: - Private Helpers
+
+    private func renderBar(current: Int, total: Int) -> String {
+        guard total > 0 else { return "[\(String(repeating: "░", count: barWidth))]" }
+
+        let progress = Double(current) / Double(total)
+        let filled = Int(progress * Double(barWidth))
+        let empty = barWidth - filled
+
+        let filledStr = String(repeating: "█", count: filled)
+        let emptyStr = String(repeating: "░", count: empty)
+
+        return "[\(filledStr)\(emptyStr)]"
+    }
+
+    private func formatDuration(_ interval: TimeInterval) -> String {
+        let totalSeconds = Int(interval)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        } else {
+            return String(format: "%02d:%02d", minutes, seconds)
+        }
+    }
+
+    private func phaseEmoji(_ phase: RemoteIndexState.Phase) -> String {
+        switch phase {
+        case .docs: return "📚"
+        case .evolution: return "📋"
+        case .archive: return "📜"
+        case .swiftOrg: return "🔶"
+        case .packages: return "📦"
+        }
+    }
+}
+
+// MARK: - Terminal Output
+
+/// Protocol for terminal output (allows testing)
+public protocol TerminalOutput: Sendable {
+    func write(_ string: String)
+    func clearLine()
+    func moveCursorUp(_ lines: Int)
+}
+
+/// Standard terminal output using print
+public struct StandardTerminalOutput: TerminalOutput, Sendable {
+    public init() {}
+
+    public func write(_ string: String) {
+        print(string)
+    }
+
+    public func clearLine() {
+        print("\u{1B}[2K\u{1B}[G", terminator: "")
+    }
+
+    public func moveCursorUp(_ lines: Int) {
+        print("\u{1B}[\(lines)A", terminator: "")
+    }
+}
+
+// MARK: - Progress Reporter
+
+/// Reports progress to terminal with animated updates
+public final class ProgressReporter: @unchecked Sendable {
+    private let display: AnimatedProgress
+    private let output: TerminalOutput
+    private var lastLineCount: Int = 0
+    private let lock = NSLock()
+
+    public init(
+        display: AnimatedProgress = AnimatedProgress(),
+        output: TerminalOutput = StandardTerminalOutput()
+    ) {
+        self.display = display
+        self.output = output
+    }
+
+    /// Update progress display
+    public func update(_ progress: RemoteSyncProgress) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        // Clear previous output
+        if lastLineCount > 0 {
+            output.moveCursorUp(lastLineCount)
+            for _ in 0..<lastLineCount {
+                output.clearLine()
+                output.write("")
+            }
+            output.moveCursorUp(lastLineCount)
+        }
+
+        // Render and output new progress
+        let rendered = display.render(progress)
+        let lines = rendered.components(separatedBy: "\n")
+        lastLineCount = lines.count
+
+        for line in lines {
+            output.clearLine()
+            output.write(line)
+        }
+    }
+
+    /// Print final summary
+    public func finish(message: String) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        output.write("")
+        output.write(message)
+    }
+}

--- a/Packages/Sources/RemoteSync/GitHubFetcher.swift
+++ b/Packages/Sources/RemoteSync/GitHubFetcher.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+// MARK: - GitHub Fetcher
+
+/// Actor for fetching documentation from GitHub.
+/// Uses raw.githubusercontent.com for content (no rate limits) and GitHub API for directory listings.
+public actor GitHubFetcher {
+    /// Repository in format "owner/repo"
+    public let repository: String
+
+    /// Branch name
+    public let branch: String
+
+    /// URL session for HTTP requests
+    private let session: URLSession
+
+    // MARK: - Initialization
+
+    public init(
+        repository: String = RemoteSync.defaultRepository,
+        branch: String = RemoteSync.defaultBranch,
+        session: URLSession = .shared
+    ) {
+        self.repository = repository
+        self.branch = branch
+        self.session = session
+    }
+
+    // MARK: - Directory Listing (GitHub API)
+
+    /// Fetch list of directories in a path (e.g., frameworks in /docs)
+    public func fetchDirectoryList(path: String) async throws -> [String] {
+        let url = buildAPIURL(path: path)
+        let (data, response) = try await session.data(from: url)
+
+        try validateResponse(response, for: url)
+
+        let items = try JSONDecoder().decode([GitHubContentItem].self, from: data)
+        return items
+            .filter { $0.type == "dir" }
+            .map(\.name)
+            .sorted()
+    }
+
+    /// Fetch list of files in a directory
+    public func fetchFileList(path: String) async throws -> [GitHubFileInfo] {
+        let url = buildAPIURL(path: path)
+        let (data, response) = try await session.data(from: url)
+
+        try validateResponse(response, for: url)
+
+        let items = try JSONDecoder().decode([GitHubContentItem].self, from: data)
+        return items
+            .filter { $0.type == "file" }
+            .map { GitHubFileInfo(name: $0.name, path: $0.path, size: $0.size ?? 0) }
+            .sorted { $0.name < $1.name }
+    }
+
+    // MARK: - File Content (Raw GitHub)
+
+    /// Fetch raw file content
+    public func fetchFileContent(path: String) async throws -> Data {
+        let url = buildRawURL(path: path)
+        let (data, response) = try await session.data(from: url)
+
+        try validateResponse(response, for: url)
+
+        return data
+    }
+
+    /// Fetch and decode JSON file
+    public func fetchJSON<T: Decodable>(path: String, as type: T.Type) async throws -> T {
+        let data = try await fetchFileContent(path: path)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(type, from: data)
+    }
+
+    /// Fetch file as string
+    public func fetchString(path: String) async throws -> String {
+        let data = try await fetchFileContent(path: path)
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw GitHubFetcherError.invalidEncoding(path: path)
+        }
+        return string
+    }
+
+    // MARK: - URL Building
+
+    private func buildAPIURL(path: String) -> URL {
+        let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        let urlString = "\(RemoteSync.gitHubAPIBaseURL)/repos/\(repository)/contents/\(cleanPath)?ref=\(branch)"
+        return URL(string: urlString)!
+    }
+
+    private func buildRawURL(path: String) -> URL {
+        let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        let urlString = "\(RemoteSync.rawGitHubBaseURL)/\(repository)/\(branch)/\(cleanPath)"
+        return URL(string: urlString)!
+    }
+
+    // MARK: - Response Validation
+
+    private func validateResponse(_ response: URLResponse, for url: URL) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GitHubFetcherError.invalidResponse(url: url)
+        }
+
+        switch httpResponse.statusCode {
+        case 200...299:
+            return
+        case 403:
+            throw GitHubFetcherError.rateLimited
+        case 404:
+            throw GitHubFetcherError.notFound(url: url)
+        default:
+            throw GitHubFetcherError.httpError(statusCode: httpResponse.statusCode, url: url)
+        }
+    }
+}
+
+// MARK: - Supporting Types
+
+/// Information about a file in the repository
+public struct GitHubFileInfo: Sendable, Equatable {
+    public let name: String
+    public let path: String
+    public let size: Int
+
+    public init(name: String, path: String, size: Int) {
+        self.name = name
+        self.path = path
+        self.size = size
+    }
+}
+
+/// GitHub API content item response
+private struct GitHubContentItem: Decodable {
+    let name: String
+    let path: String
+    let type: String
+    let size: Int?
+}
+
+// MARK: - Errors
+
+/// Errors from GitHub fetcher
+public enum GitHubFetcherError: Error, Sendable, CustomStringConvertible {
+    case invalidResponse(url: URL)
+    case notFound(url: URL)
+    case rateLimited
+    case httpError(statusCode: Int, url: URL)
+    case invalidEncoding(path: String)
+
+    public var description: String {
+        switch self {
+        case let .invalidResponse(url):
+            return "Invalid response from \(url)"
+        case let .notFound(url):
+            return "Not found: \(url)"
+        case .rateLimited:
+            return "GitHub API rate limit exceeded. Try again later or use authentication."
+        case let .httpError(statusCode, url):
+            return "HTTP \(statusCode) from \(url)"
+        case let .invalidEncoding(path):
+            return "Invalid UTF-8 encoding in file: \(path)"
+        }
+    }
+}

--- a/Packages/Sources/RemoteSync/RemoteIndexState.swift
+++ b/Packages/Sources/RemoteSync/RemoteIndexState.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+// MARK: - Remote Index State
+
+/// Persistent state for resumable remote indexing.
+/// Tracks progress at file level within each framework for precise resume.
+public struct RemoteIndexState: Codable, Sendable, Equatable {
+    /// App version that created this state
+    public let version: String
+
+    /// When indexing started
+    public let started: Date
+
+    /// Current phase being indexed
+    public let phase: Phase
+
+    /// Phases that have been completed
+    public let phasesCompleted: [Phase]
+
+    /// Current framework being indexed (nil if between frameworks)
+    public let currentFramework: String?
+
+    /// Frameworks that have been fully indexed in current phase
+    public let frameworksCompleted: [String]
+
+    /// Total number of frameworks in current phase
+    public let frameworksTotal: Int
+
+    /// Current file index within the current framework
+    public let currentFileIndex: Int
+
+    /// Total files in current framework
+    public let filesTotal: Int
+
+    /// Indexing phases in order
+    public enum Phase: String, Codable, Sendable, CaseIterable {
+        case docs
+        case evolution
+        case archive
+        case swiftOrg
+        case packages
+    }
+
+    // MARK: - Initialization
+
+    public init(
+        version: String,
+        started: Date = Date(),
+        phase: Phase = .docs,
+        phasesCompleted: [Phase] = [],
+        currentFramework: String? = nil,
+        frameworksCompleted: [String] = [],
+        frameworksTotal: Int = 0,
+        currentFileIndex: Int = 0,
+        filesTotal: Int = 0
+    ) {
+        self.version = version
+        self.started = started
+        self.phase = phase
+        self.phasesCompleted = phasesCompleted
+        self.currentFramework = currentFramework
+        self.frameworksCompleted = frameworksCompleted
+        self.frameworksTotal = frameworksTotal
+        self.currentFileIndex = currentFileIndex
+        self.filesTotal = filesTotal
+    }
+
+    // MARK: - State Updates (returns new state - immutable)
+
+    /// Start a new phase
+    public func startingPhase(_ phase: Phase, frameworksTotal: Int) -> RemoteIndexState {
+        RemoteIndexState(
+            version: version,
+            started: started,
+            phase: phase,
+            phasesCompleted: phasesCompleted,
+            currentFramework: nil,
+            frameworksCompleted: [],
+            frameworksTotal: frameworksTotal,
+            currentFileIndex: 0,
+            filesTotal: 0
+        )
+    }
+
+    /// Start a new framework within current phase
+    public func startingFramework(_ name: String, filesTotal: Int) -> RemoteIndexState {
+        RemoteIndexState(
+            version: version,
+            started: started,
+            phase: phase,
+            phasesCompleted: phasesCompleted,
+            currentFramework: name,
+            frameworksCompleted: frameworksCompleted,
+            frameworksTotal: frameworksTotal,
+            currentFileIndex: 0,
+            filesTotal: filesTotal
+        )
+    }
+
+    /// Update file progress within current framework
+    public func updatingFileIndex(_ index: Int) -> RemoteIndexState {
+        RemoteIndexState(
+            version: version,
+            started: started,
+            phase: phase,
+            phasesCompleted: phasesCompleted,
+            currentFramework: currentFramework,
+            frameworksCompleted: frameworksCompleted,
+            frameworksTotal: frameworksTotal,
+            currentFileIndex: index,
+            filesTotal: filesTotal
+        )
+    }
+
+    /// Complete current framework
+    public func completingFramework() -> RemoteIndexState {
+        guard let framework = currentFramework else { return self }
+        return RemoteIndexState(
+            version: version,
+            started: started,
+            phase: phase,
+            phasesCompleted: phasesCompleted,
+            currentFramework: nil,
+            frameworksCompleted: frameworksCompleted + [framework],
+            frameworksTotal: frameworksTotal,
+            currentFileIndex: 0,
+            filesTotal: 0
+        )
+    }
+
+    /// Complete current phase
+    public func completingPhase() -> RemoteIndexState {
+        RemoteIndexState(
+            version: version,
+            started: started,
+            phase: phase,
+            phasesCompleted: phasesCompleted + [phase],
+            currentFramework: nil,
+            frameworksCompleted: [],
+            frameworksTotal: 0,
+            currentFileIndex: 0,
+            filesTotal: 0
+        )
+    }
+
+    // MARK: - Persistence
+
+    /// Save state to file
+    public func save(to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// Load state from file
+    public static func load(from url: URL) throws -> RemoteIndexState {
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(RemoteIndexState.self, from: data)
+    }
+
+    /// Check if state file exists
+    public static func exists(at url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path)
+    }
+
+    /// Delete state file
+    public static func delete(at url: URL) throws {
+        if exists(at: url) {
+            try FileManager.default.removeItem(at: url)
+        }
+    }
+
+    // MARK: - Progress Helpers
+
+    /// Overall progress percentage (0.0 to 1.0)
+    public var overallProgress: Double {
+        let completedPhases = Double(phasesCompleted.count)
+        let totalPhases = Double(Phase.allCases.count)
+
+        // Progress within current phase
+        let phaseProgress: Double
+        if frameworksTotal > 0 {
+            let completedFrameworks = Double(frameworksCompleted.count)
+            let frameworkProgress = filesTotal > 0
+                ? Double(currentFileIndex) / Double(filesTotal)
+                : 0.0
+            phaseProgress = (completedFrameworks + frameworkProgress) / Double(frameworksTotal)
+        } else {
+            phaseProgress = 0.0
+        }
+
+        return (completedPhases + phaseProgress) / totalPhases
+    }
+
+    /// Human-readable progress string
+    public var progressDescription: String {
+        if let framework = currentFramework {
+            return "\(phase.rawValue): \(framework) (\(currentFileIndex)/\(filesTotal) files)"
+        } else {
+            return "\(phase.rawValue): \(frameworksCompleted.count)/\(frameworksTotal) frameworks"
+        }
+    }
+}
+
+// MARK: - Progress Callback
+
+/// Progress information for callbacks
+public struct RemoteSyncProgress: Sendable {
+    public let phase: RemoteIndexState.Phase
+    public let framework: String?
+    public let frameworkIndex: Int
+    public let frameworksTotal: Int
+    public let fileIndex: Int
+    public let filesTotal: Int
+    public let elapsed: TimeInterval
+    public let overallProgress: Double
+
+    public init(
+        phase: RemoteIndexState.Phase,
+        framework: String?,
+        frameworkIndex: Int,
+        frameworksTotal: Int,
+        fileIndex: Int,
+        filesTotal: Int,
+        elapsed: TimeInterval,
+        overallProgress: Double
+    ) {
+        self.phase = phase
+        self.framework = framework
+        self.frameworkIndex = frameworkIndex
+        self.frameworksTotal = frameworksTotal
+        self.fileIndex = fileIndex
+        self.filesTotal = filesTotal
+        self.elapsed = elapsed
+        self.overallProgress = overallProgress
+    }
+
+    /// Estimated time remaining based on current progress
+    public var estimatedTimeRemaining: TimeInterval? {
+        guard overallProgress > 0.01 else { return nil }
+        let totalEstimated = elapsed / overallProgress
+        return totalEstimated - elapsed
+    }
+}

--- a/Packages/Sources/RemoteSync/RemoteIndexer.swift
+++ b/Packages/Sources/RemoteSync/RemoteIndexer.swift
@@ -1,0 +1,347 @@
+import Foundation
+
+// MARK: - Indexing Context
+
+/// Groups callbacks and context for indexing operations.
+/// Reduces function parameter count while maintaining type safety.
+struct IndexingContext: Sendable {
+    let indexDocument: RemoteIndexer.DocumentIndexer
+    let onProgress: @Sendable (RemoteSyncProgress) -> Void
+    let onDocument: (@Sendable (IndexResult) -> Void)?
+}
+
+// MARK: - Remote Indexer
+
+/// Main orchestrator for streaming documentation from GitHub to search index.
+/// Handles all phases: docs, evolution, archive, swiftOrg, packages.
+public actor RemoteIndexer {
+    /// GitHub fetcher for HTTP operations
+    private let fetcher: GitHubFetcher
+
+    /// State file URL for resume support
+    private let stateFileURL: URL
+
+    /// Current indexing state
+    private var state: RemoteIndexState
+
+    /// Start time for elapsed calculation
+    private let startTime: Date
+
+    /// App version for state tracking
+    private let appVersion: String
+
+    // MARK: - Initialization
+
+    public init(
+        fetcher: GitHubFetcher = GitHubFetcher(),
+        stateFileURL: URL,
+        appVersion: String
+    ) {
+        self.fetcher = fetcher
+        self.stateFileURL = stateFileURL
+        self.appVersion = appVersion
+        startTime = Date()
+        state = RemoteIndexState(version: appVersion)
+    }
+
+    // MARK: - Resume Support
+
+    /// Check if there's a resumable state
+    public func hasResumableState() -> Bool {
+        RemoteIndexState.exists(at: stateFileURL)
+    }
+
+    /// Load existing state for resume
+    public func loadState() throws {
+        state = try RemoteIndexState.load(from: stateFileURL)
+    }
+
+    /// Get current state for resume prompt
+    public func getState() -> RemoteIndexState {
+        state
+    }
+
+    /// Clear state to start fresh
+    public func clearState() throws {
+        try RemoteIndexState.delete(at: stateFileURL)
+        state = RemoteIndexState(version: appVersion)
+    }
+
+    // MARK: - Indexing
+
+    /// Index result for a single document
+    public struct IndexResult: Sendable {
+        public let uri: String
+        public let title: String
+        public let success: Bool
+        public let error: String?
+
+        public init(uri: String, title: String, success: Bool, error: String? = nil) {
+            self.uri = uri
+            self.title = title
+            self.success = success
+            self.error = error
+        }
+    }
+
+    /// Callback type for document indexing
+    public typealias DocumentIndexer = @Sendable (
+        _ uri: String,
+        _ source: String,
+        _ framework: String?,
+        _ title: String,
+        _ content: String,
+        _ jsonData: String?
+    ) async throws -> Void
+
+    /// Run the full indexing process
+    /// - Parameters:
+    ///   - indexDocument: Callback to index each document
+    ///   - onProgress: Progress callback (called frequently)
+    ///   - onDocument: Called for each document processed
+    public func run(
+        indexDocument: DocumentIndexer,
+        onProgress: @Sendable (RemoteSyncProgress) -> Void,
+        onDocument: (@Sendable (IndexResult) -> Void)? = nil
+    ) async throws {
+        // Determine which phases to run
+        let allPhases = RemoteIndexState.Phase.allCases
+        let startPhaseIndex = allPhases.firstIndex(of: state.phase) ?? 0
+
+        for phaseIndex in startPhaseIndex..<allPhases.count {
+            let phase = allPhases[phaseIndex]
+
+            // Skip completed phases
+            if state.phasesCompleted.contains(phase) {
+                continue
+            }
+
+            try await runPhase(
+                phase,
+                indexDocument: indexDocument,
+                onProgress: onProgress,
+                onDocument: onDocument
+            )
+
+            // Mark phase complete
+            state = state.completingPhase()
+            try state.save(to: stateFileURL)
+        }
+
+        // Clean up state file on successful completion
+        try RemoteIndexState.delete(at: stateFileURL)
+    }
+
+    // MARK: - Phase Execution
+
+    private func runPhase(
+        _ phase: RemoteIndexState.Phase,
+        indexDocument: DocumentIndexer,
+        onProgress: @Sendable (RemoteSyncProgress) -> Void,
+        onDocument: (@Sendable (IndexResult) -> Void)?
+    ) async throws {
+        let path = phasePath(phase)
+        let source = phaseSource(phase)
+
+        // Get list of items (frameworks or files depending on phase)
+        let items: [String]
+        switch phase {
+        case .docs:
+            items = try await fetcher.fetchDirectoryList(path: path)
+        case .evolution, .archive, .swiftOrg, .packages:
+            // These phases may have different structures
+            items = try await fetcher.fetchDirectoryList(path: path)
+        }
+
+        // Update state with phase info
+        state = state.startingPhase(phase, frameworksTotal: items.count)
+        try state.save(to: stateFileURL)
+
+        // Determine starting index (for resume)
+        let startIndex = state.frameworksCompleted.count
+
+        for itemIndex in startIndex..<items.count {
+            let item = items[itemIndex]
+
+            // Skip already completed items
+            if state.frameworksCompleted.contains(item) {
+                continue
+            }
+
+            let context = IndexingContext(
+                indexDocument: indexDocument,
+                onProgress: onProgress,
+                onDocument: onDocument
+            )
+            try await indexItem(
+                item,
+                at: "\(path)/\(item)",
+                phase: phase,
+                source: source,
+                context: context
+            )
+
+            // Mark item complete
+            state = state.completingFramework()
+            try state.save(to: stateFileURL)
+        }
+    }
+
+    private func indexItem(
+        _ item: String,
+        at path: String,
+        phase: RemoteIndexState.Phase,
+        source: String,
+        context: IndexingContext
+    ) async throws {
+        // Get file list
+        let files = try await fetcher.fetchFileList(path: path)
+        let jsonFiles = files.filter { $0.name.hasSuffix(".json") || $0.name.hasSuffix(".md") }
+
+        // Update state
+        state = state.startingFramework(item, filesTotal: jsonFiles.count)
+        try state.save(to: stateFileURL)
+
+        // Report progress
+        reportProgress(context.onProgress)
+
+        // Determine starting file index (for resume)
+        let startFileIndex = state.currentFileIndex
+
+        for fileIndex in startFileIndex..<jsonFiles.count {
+            let file = jsonFiles[fileIndex]
+
+            // Update file progress
+            state = state.updatingFileIndex(fileIndex)
+
+            // Report progress periodically
+            if fileIndex % 10 == 0 {
+                reportProgress(context.onProgress)
+            }
+
+            // Fetch and index file
+            do {
+                let content = try await fetcher.fetchString(path: file.path)
+                let title = extractTitle(from: content, filename: file.name)
+                let uri = buildURI(phase: phase, item: item, filename: file.name)
+
+                // Determine framework (nil for non-docs phases)
+                let framework: String? = phase == .docs ? item : nil
+
+                try await context.indexDocument(uri, source, framework, title, content, content)
+
+                context.onDocument?(IndexResult(uri: uri, title: title, success: true))
+            } catch {
+                let uri = buildURI(phase: phase, item: item, filename: file.name)
+                context.onDocument?(IndexResult(
+                    uri: uri,
+                    title: file.name,
+                    success: false,
+                    error: error.localizedDescription
+                ))
+            }
+        }
+
+        // Final progress for this item
+        state = state.updatingFileIndex(jsonFiles.count)
+        reportProgress(context.onProgress)
+    }
+
+    // MARK: - Helpers
+
+    private func phasePath(_ phase: RemoteIndexState.Phase) -> String {
+        switch phase {
+        case .docs: return "docs"
+        case .evolution: return "swift-evolution"
+        case .archive: return "archive"
+        case .swiftOrg: return "swift-org"
+        case .packages: return "packages"
+        }
+    }
+
+    private func phaseSource(_ phase: RemoteIndexState.Phase) -> String {
+        switch phase {
+        case .docs: return "apple-docs"
+        case .evolution: return "swift-evolution"
+        case .archive: return "apple-archive"
+        case .swiftOrg: return "swift-org"
+        case .packages: return "packages"
+        }
+    }
+
+    private func buildURI(phase: RemoteIndexState.Phase, item: String, filename: String) -> String {
+        let baseName = filename
+            .replacingOccurrences(of: ".json", with: "")
+            .replacingOccurrences(of: ".md", with: "")
+
+        switch phase {
+        case .docs:
+            return "apple-docs://\(item)/\(baseName)"
+        case .evolution:
+            return "swift-evolution://\(baseName)"
+        case .archive:
+            return "apple-archive://\(item)/\(baseName)"
+        case .swiftOrg:
+            return "swift-org://\(baseName)"
+        case .packages:
+            return "packages://\(item)/\(baseName)"
+        }
+    }
+
+    private func extractTitle(from content: String, filename: String) -> String {
+        // Try to extract title from JSON
+        if let json = try? JSONSerialization.jsonObject(with: Data(content.utf8)) as? [String: Any],
+           let title = json["title"] as? String {
+            return title
+        }
+
+        // Try markdown heading
+        let lines = content.split(separator: "\n", omittingEmptySubsequences: true)
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("# ") {
+                return String(trimmed.dropFirst(2))
+            }
+        }
+
+        // Fall back to filename
+        return filename
+            .replacingOccurrences(of: ".json", with: "")
+            .replacingOccurrences(of: ".md", with: "")
+            .replacingOccurrences(of: "-", with: " ")
+            .capitalized
+    }
+
+    private func reportProgress(_ onProgress: @Sendable (RemoteSyncProgress) -> Void) {
+        let progress = RemoteSyncProgress(
+            phase: state.phase,
+            framework: state.currentFramework,
+            frameworkIndex: state.frameworksCompleted.count + (state.currentFramework != nil ? 1 : 0),
+            frameworksTotal: state.frameworksTotal,
+            fileIndex: state.currentFileIndex,
+            filesTotal: state.filesTotal,
+            elapsed: Date().timeIntervalSince(startTime),
+            overallProgress: state.overallProgress
+        )
+        onProgress(progress)
+    }
+}
+
+// MARK: - Errors
+
+public enum RemoteIndexerError: Error, Sendable, CustomStringConvertible {
+    case stateVersionMismatch(expected: String, found: String)
+    case phaseNotFound(String)
+    case indexingFailed(uri: String, underlying: String)
+
+    public var description: String {
+        switch self {
+        case let .stateVersionMismatch(expected, found):
+            return "State version mismatch: expected \(expected), found \(found)"
+        case let .phaseNotFound(phase):
+            return "Phase not found: \(phase)"
+        case let .indexingFailed(uri, underlying):
+            return "Failed to index \(uri): \(underlying)"
+        }
+    }
+}

--- a/Packages/Sources/RemoteSync/RemoteSync.swift
+++ b/Packages/Sources/RemoteSync/RemoteSync.swift
@@ -1,0 +1,20 @@
+// MARK: - RemoteSync Package
+
+/// Remote documentation streaming from GitHub to SQLite.
+/// Provides instant setup by streaming from pre-crawled cupertino-docs repo.
+public enum RemoteSync {
+    /// Package version
+    public static let version = "1.0.0"
+
+    /// Default GitHub repository for pre-crawled documentation
+    public static let defaultRepository = "mihaelamj/cupertino-docs"
+
+    /// Default branch
+    public static let defaultBranch = "main"
+
+    /// Raw GitHub content base URL
+    public static let rawGitHubBaseURL = "https://raw.githubusercontent.com"
+
+    /// GitHub API base URL
+    public static let gitHubAPIBaseURL = "https://api.github.com"
+}

--- a/Packages/Sources/Shared/Constants.swift
+++ b/Packages/Sources/Shared/Constants.swift
@@ -138,7 +138,7 @@ extension Shared {
             public static let userAgent = "CupertinoCrawler/1.0"
 
             /// Current version
-            public static let version = "0.2.7"
+            public static let version = "0.3.0"
         }
 
         // MARK: - Display Names

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -151,7 +151,7 @@ struct MCPCommandTests {
         )
 
         let server = MCPServer(name: "test-server", version: "1.0.0")
-        let provider = CupertinoSearchToolProvider(searchIndex: searchIndex)
+        let provider = DocumentationToolProvider(searchIndex: searchIndex)
 
         await server.registerToolProvider(provider)
 
@@ -195,7 +195,7 @@ struct MCPCommandTests {
             lastCrawled: Date()
         )
 
-        let provider = CupertinoSearchToolProvider(searchIndex: searchIndex)
+        let provider = DocumentationToolProvider(searchIndex: searchIndex)
 
         // Execute search
         let arguments: [String: AnyCodable] = [
@@ -350,7 +350,7 @@ struct MCPServerIntegrationTests {
             output: Shared.OutputConfiguration()
         )
         let docsProvider = DocsResourceProvider(configuration: mcpConfig)
-        let searchProvider = CupertinoSearchToolProvider(searchIndex: searchIndex)
+        let searchProvider = DocumentationToolProvider(searchIndex: searchIndex)
 
         await server.registerResourceProvider(docsProvider)
         await server.registerToolProvider(searchProvider)

--- a/Packages/Tests/RemoteSyncTests/RemoteSyncTests.swift
+++ b/Packages/Tests/RemoteSyncTests/RemoteSyncTests.swift
@@ -1,0 +1,411 @@
+import Foundation
+import Testing
+
+@testable import RemoteSync
+
+// MARK: - RemoteIndexState Tests
+
+@Suite("RemoteIndexState Tests")
+struct RemoteIndexStateTests {
+    @Test("Initial state has correct defaults")
+    func initialState() {
+        let state = RemoteIndexState(version: "1.0.0")
+
+        #expect(state.version == "1.0.0")
+        #expect(state.phase == .docs)
+        #expect(state.phasesCompleted.isEmpty)
+        #expect(state.currentFramework == nil)
+        #expect(state.frameworksCompleted.isEmpty)
+        #expect(state.frameworksTotal == 0)
+        #expect(state.currentFileIndex == 0)
+        #expect(state.filesTotal == 0)
+    }
+
+    @Test("Starting phase updates state correctly")
+    func testStartingPhase() {
+        let state = RemoteIndexState(version: "1.0.0")
+        let newState = state.startingPhase(.docs, frameworksTotal: 248)
+
+        #expect(newState.phase == .docs)
+        #expect(newState.frameworksTotal == 248)
+        #expect(newState.frameworksCompleted.isEmpty)
+        #expect(newState.currentFramework == nil)
+    }
+
+    @Test("Starting framework updates state correctly")
+    func testStartingFramework() {
+        let state = RemoteIndexState(version: "1.0.0")
+            .startingPhase(.docs, frameworksTotal: 248)
+            .startingFramework("swiftui", filesTotal: 1000)
+
+        #expect(state.currentFramework == "swiftui")
+        #expect(state.filesTotal == 1000)
+        #expect(state.currentFileIndex == 0)
+    }
+
+    @Test("Updating file index preserves other state")
+    func testUpdatingFileIndex() {
+        let state = RemoteIndexState(version: "1.0.0")
+            .startingPhase(.docs, frameworksTotal: 248)
+            .startingFramework("swiftui", filesTotal: 1000)
+            .updatingFileIndex(456)
+
+        #expect(state.currentFileIndex == 456)
+        #expect(state.currentFramework == "swiftui")
+        #expect(state.filesTotal == 1000)
+    }
+
+    @Test("Completing framework adds to completed list")
+    func testCompletingFramework() {
+        let state = RemoteIndexState(version: "1.0.0")
+            .startingPhase(.docs, frameworksTotal: 248)
+            .startingFramework("swiftui", filesTotal: 1000)
+            .updatingFileIndex(1000)
+            .completingFramework()
+
+        #expect(state.frameworksCompleted == ["swiftui"])
+        #expect(state.currentFramework == nil)
+        #expect(state.currentFileIndex == 0)
+    }
+
+    @Test("Completing phase adds to completed list")
+    func testCompletingPhase() {
+        let state = RemoteIndexState(version: "1.0.0")
+            .startingPhase(.docs, frameworksTotal: 1)
+            .startingFramework("foundation", filesTotal: 100)
+            .completingFramework()
+            .completingPhase()
+
+        #expect(state.phasesCompleted == [.docs])
+    }
+
+    @Test("Overall progress calculation")
+    func testOverallProgress() {
+        // Empty state = 0%
+        let emptyState = RemoteIndexState(version: "1.0.0")
+        #expect(emptyState.overallProgress == 0.0)
+
+        // One phase done out of 5 = 20%
+        let onePhaseComplete = RemoteIndexState(
+            version: "1.0.0",
+            phase: .evolution,
+            phasesCompleted: [.docs]
+        )
+        #expect(onePhaseComplete.overallProgress > 0.19)
+        #expect(onePhaseComplete.overallProgress < 0.21)
+    }
+
+    @Test("State persistence round-trip")
+    func statePersistence() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let stateURL = tempDir.appendingPathComponent("test-state-\(UUID().uuidString).json")
+
+        defer {
+            try? FileManager.default.removeItem(at: stateURL)
+        }
+
+        let original = RemoteIndexState(version: "1.0.0")
+            .startingPhase(.docs, frameworksTotal: 248)
+            .startingFramework("swiftui", filesTotal: 1000)
+            .updatingFileIndex(456)
+
+        try original.save(to: stateURL)
+
+        #expect(RemoteIndexState.exists(at: stateURL))
+
+        let loaded = try RemoteIndexState.load(from: stateURL)
+
+        #expect(loaded.version == original.version)
+        #expect(loaded.phase == original.phase)
+        #expect(loaded.currentFramework == original.currentFramework)
+        #expect(loaded.currentFileIndex == original.currentFileIndex)
+        #expect(loaded.filesTotal == original.filesTotal)
+    }
+
+    @Test("State deletion")
+    func stateDeletion() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let stateURL = tempDir.appendingPathComponent("test-delete-\(UUID().uuidString).json")
+
+        let state = RemoteIndexState(version: "1.0.0")
+        try state.save(to: stateURL)
+
+        #expect(RemoteIndexState.exists(at: stateURL))
+
+        try RemoteIndexState.delete(at: stateURL)
+
+        #expect(!RemoteIndexState.exists(at: stateURL))
+    }
+}
+
+// MARK: - RemoteSyncProgress Tests
+
+@Suite("RemoteSyncProgress Tests")
+struct RemoteSyncProgressTests {
+    @Test("Progress ETA calculation")
+    func progressETA() {
+        // 50% done in 60 seconds = ~60 seconds remaining
+        let progress = RemoteSyncProgress(
+            phase: .docs,
+            framework: "swiftui",
+            frameworkIndex: 124,
+            frameworksTotal: 248,
+            fileIndex: 500,
+            filesTotal: 1000,
+            elapsed: 60.0,
+            overallProgress: 0.5
+        )
+
+        let eta = progress.estimatedTimeRemaining
+        #expect(eta != nil)
+        #expect(eta! > 55.0)
+        #expect(eta! < 65.0)
+    }
+
+    @Test("Progress ETA nil for early progress")
+    func progressETAEarly() {
+        let progress = RemoteSyncProgress(
+            phase: .docs,
+            framework: nil,
+            frameworkIndex: 0,
+            frameworksTotal: 248,
+            fileIndex: 0,
+            filesTotal: 0,
+            elapsed: 1.0,
+            overallProgress: 0.001
+        )
+
+        #expect(progress.estimatedTimeRemaining == nil)
+    }
+}
+
+// MARK: - AnimatedProgress Tests
+
+@Suite("AnimatedProgress Tests")
+struct AnimatedProgressTests {
+    @Test("Progress bar rendering")
+    func progressBarRendering() {
+        let display = AnimatedProgress(barWidth: 10, useEmoji: false)
+        let progress = RemoteSyncProgress(
+            phase: .docs,
+            framework: "swiftui",
+            frameworkIndex: 5,
+            frameworksTotal: 10,
+            fileIndex: 250,
+            filesTotal: 500,
+            elapsed: 120.0,
+            overallProgress: 0.5
+        )
+
+        let rendered = display.render(progress)
+
+        #expect(rendered.contains("Docs"))
+        #expect(rendered.contains("swiftui"))
+        #expect(rendered.contains("5/10"))
+        #expect(rendered.contains("250/500"))
+    }
+
+    @Test("Compact rendering")
+    func compactRendering() {
+        let display = AnimatedProgress(barWidth: 10, useEmoji: false)
+        let progress = RemoteSyncProgress(
+            phase: .docs,
+            framework: "foundation",
+            frameworkIndex: 3,
+            frameworksTotal: 10,
+            fileIndex: 50,
+            filesTotal: 100,
+            elapsed: 30.0,
+            overallProgress: 0.3
+        )
+
+        let compact = display.renderCompact(progress)
+
+        #expect(compact.contains("3/10"))
+        #expect(compact.contains("foundation"))
+        #expect(compact.contains("50/100"))
+    }
+}
+
+// MARK: - GitHubFetcher Tests
+
+@Suite("GitHubFetcher Tests")
+struct GitHubFetcherTests {
+    // Note: Using apple/swift-evolution as test repo (NOT cupertino-docs)
+    // This is a public repo that won't change structure unexpectedly
+
+    @Test("Fetcher initialization with custom repo")
+    func fetcherInitialization() async {
+        let fetcher = GitHubFetcher(
+            repository: "apple/swift-evolution",
+            branch: "main"
+        )
+
+        // Just verify it initializes - actual network tests below
+        let repo = await fetcher.repository
+        let branch = await fetcher.branch
+
+        #expect(repo == "apple/swift-evolution")
+        #expect(branch == "main")
+    }
+
+    @Test("GitHubFileInfo equality")
+    func gitHubFileInfoEquality() {
+        let info1 = GitHubFileInfo(name: "test.json", path: "/docs/test.json", size: 1024)
+        let info2 = GitHubFileInfo(name: "test.json", path: "/docs/test.json", size: 1024)
+        let info3 = GitHubFileInfo(name: "other.json", path: "/docs/other.json", size: 2048)
+
+        #expect(info1 == info2)
+        #expect(info1 != info3)
+    }
+
+    @Test("Error descriptions")
+    func errorDescriptions() {
+        let url = URL(string: "https://example.com/test")!
+
+        let notFound = GitHubFetcherError.notFound(url: url)
+        #expect(notFound.description.contains("Not found"))
+
+        let rateLimited = GitHubFetcherError.rateLimited
+        #expect(rateLimited.description.contains("rate limit"))
+
+        let httpError = GitHubFetcherError.httpError(statusCode: 500, url: url)
+        #expect(httpError.description.contains("500"))
+
+        let invalidEncoding = GitHubFetcherError.invalidEncoding(path: "/test.json")
+        #expect(invalidEncoding.description.contains("encoding"))
+    }
+}
+
+// MARK: - RemoteIndexer Tests
+
+@Suite("RemoteIndexer Tests")
+struct RemoteIndexerTests {
+    @Test("Indexer initialization")
+    func indexerInitialization() async {
+        let tempDir = FileManager.default.temporaryDirectory
+        let stateURL = tempDir.appendingPathComponent("test-indexer-\(UUID().uuidString).json")
+
+        let indexer = RemoteIndexer(
+            fetcher: GitHubFetcher(repository: "apple/swift-evolution"),
+            stateFileURL: stateURL,
+            appVersion: "1.0.0"
+        )
+
+        let hasResumable = await indexer.hasResumableState()
+        #expect(!hasResumable)
+
+        let state = await indexer.getState()
+        #expect(state.version == "1.0.0")
+        #expect(state.phase == .docs)
+    }
+
+    @Test("Indexer state management")
+    func indexerStateManagement() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let stateURL = tempDir.appendingPathComponent("test-state-mgmt-\(UUID().uuidString).json")
+
+        defer {
+            try? FileManager.default.removeItem(at: stateURL)
+        }
+
+        // Create and save state externally
+        let existingState = RemoteIndexState(version: "1.0.0")
+            .startingPhase(.docs, frameworksTotal: 100)
+            .startingFramework("test", filesTotal: 50)
+            .updatingFileIndex(25)
+        try existingState.save(to: stateURL)
+
+        // Create indexer and check it detects resumable state
+        let indexer = RemoteIndexer(
+            fetcher: GitHubFetcher(repository: "apple/swift-evolution"),
+            stateFileURL: stateURL,
+            appVersion: "1.0.0"
+        )
+
+        let hasResumable = await indexer.hasResumableState()
+        #expect(hasResumable)
+
+        // Load state
+        try await indexer.loadState()
+        let loaded = await indexer.getState()
+        #expect(loaded.currentFramework == "test")
+        #expect(loaded.currentFileIndex == 25)
+
+        // Clear state
+        try await indexer.clearState()
+        let cleared = await indexer.hasResumableState()
+        #expect(!cleared)
+    }
+
+    @Test("IndexResult creation")
+    func indexResult() {
+        let success = RemoteIndexer.IndexResult(
+            uri: "apple-docs://swiftui/View",
+            title: "View",
+            success: true
+        )
+        #expect(success.success)
+        #expect(success.error == nil)
+
+        let failure = RemoteIndexer.IndexResult(
+            uri: "apple-docs://swiftui/View",
+            title: "View",
+            success: false,
+            error: "Network error"
+        )
+        #expect(!failure.success)
+        #expect(failure.error == "Network error")
+    }
+}
+
+// MARK: - RemoteIndexerError Tests
+
+@Suite("RemoteIndexerError Tests")
+struct RemoteIndexerErrorTests {
+    @Test("Error descriptions")
+    func testErrorDescriptions() {
+        let versionMismatch = RemoteIndexerError.stateVersionMismatch(expected: "1.0.0", found: "0.9.0")
+        #expect(versionMismatch.description.contains("1.0.0"))
+        #expect(versionMismatch.description.contains("0.9.0"))
+
+        let phaseNotFound = RemoteIndexerError.phaseNotFound("unknown")
+        #expect(phaseNotFound.description.contains("unknown"))
+
+        let indexingFailed = RemoteIndexerError.indexingFailed(uri: "test://uri", underlying: "timeout")
+        #expect(indexingFailed.description.contains("test://uri"))
+        #expect(indexingFailed.description.contains("timeout"))
+    }
+}
+
+// MARK: - Integration Tests (require network)
+
+@Suite("Integration Tests", .disabled("Requires network access"))
+struct IntegrationTests {
+    @Test("Fetch directory listing from GitHub")
+    func fetchDirectoryListing() async throws {
+        // Using swift-evolution repo (NOT cupertino-docs)
+        let fetcher = GitHubFetcher(
+            repository: "apple/swift-evolution",
+            branch: "main"
+        )
+
+        let proposals = try await fetcher.fetchDirectoryList(path: "proposals")
+
+        // swift-evolution has hundreds of proposals
+        #expect(proposals.count > 100)
+    }
+
+    @Test("Fetch file content from GitHub")
+    func fetchFileContent() async throws {
+        let fetcher = GitHubFetcher(
+            repository: "apple/swift-evolution",
+            branch: "main"
+        )
+
+        let readme = try await fetcher.fetchString(path: "README.md")
+
+        #expect(readme.contains("Swift"))
+        #expect(readme.count > 100)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -57,9 +57,12 @@ sudo ln -sf "$(pwd)/.build/release/cupertino" /usr/local/bin/cupertino
 ### Quick Reference
 
 ```bash
-# Quick Setup (Recommended) - streams from GitHub, no crawling needed
-cupertino save --remote              # Build index from pre-crawled docs (~30 min)
+# Quick Setup (Recommended) - download pre-built databases (~30 seconds)
+cupertino setup                      # Download databases from GitHub
 cupertino serve                      # Start MCP server
+
+# Alternative: Build from GitHub (~45 minutes)
+cupertino save --remote              # Stream and build locally
 
 # Or fetch documentation yourself
 cupertino fetch --type docs          # Apple Developer Documentation
@@ -85,8 +88,18 @@ cupertino serve                      # Start MCP server (explicit)
 ### Instant Setup (Recommended)
 
 ```bash
-# Stream pre-crawled documentation from GitHub (~30 minutes)
-# No crawling required - instant access to all Apple docs
+# Download pre-built databases from GitHub (~30 seconds)
+cupertino setup
+
+# Start MCP server
+cupertino serve
+```
+
+### Alternative: Build from GitHub
+
+```bash
+# Stream and build locally (~45 minutes)
+# Use this if you want to build the database yourself
 cupertino save --remote
 
 # Start MCP server
@@ -276,6 +289,7 @@ These catalogs are indexed during `cupertino save` and enable instant search wit
 | Command | Description |
 |---------|-------------|
 | `cupertino` | Start MCP server (default) |
+| `cupertino setup` | Download pre-built databases from GitHub |
 | `cupertino serve` | Start MCP server |
 | `cupertino fetch` | Download documentation |
 | `cupertino save` | Build search index |
@@ -481,7 +495,7 @@ For development setup, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Project Status
 
-**Version:** 0.2.7
+**Version:** 0.3.0
 **Status:** 🚧 Active Development
 
 - ✅ All core functionality working

--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ sudo ln -sf "$(pwd)/.build/release/cupertino" /usr/local/bin/cupertino
 ### Quick Reference
 
 ```bash
-# Fetch documentation
+# Quick Setup (Recommended) - streams from GitHub, no crawling needed
+cupertino save --remote              # Build index from pre-crawled docs (~30 min)
+cupertino serve                      # Start MCP server
+
+# Or fetch documentation yourself
 cupertino fetch --type docs          # Apple Developer Documentation
 cupertino fetch --type swift         # Swift.org documentation
 cupertino fetch --type evolution     # Swift Evolution proposals
@@ -69,7 +73,8 @@ cupertino fetch --type archive       # Apple Archive programming guides
 cupertino fetch --type all           # All types in parallel
 
 # Build indexes
-cupertino save                       # Build documentation search index
+cupertino save                       # Build documentation search index (from local files)
+cupertino save --remote              # Build from GitHub (no local files needed)
 cupertino index                      # Index sample code for search
 
 # Start server
@@ -77,7 +82,18 @@ cupertino                            # Start MCP server (default command)
 cupertino serve                      # Start MCP server (explicit)
 ```
 
-### Download Documentation
+### Instant Setup (Recommended)
+
+```bash
+# Stream pre-crawled documentation from GitHub (~30 minutes)
+# No crawling required - instant access to all Apple docs
+cupertino save --remote
+
+# Start MCP server
+cupertino serve
+```
+
+### Manual Setup (Advanced)
 
 ```bash
 # Download Apple documentation (~20-24 hours for 13,000+ pages)

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -6,6 +6,7 @@ CLI commands for the Cupertino documentation server.
 
 | Command | Description |
 |---------|-------------|
+| [setup](setup/) | **Download pre-built databases from GitHub (fastest)** |
 | [fetch](fetch/) | Download documentation from Apple, Swift Evolution, Swift.org, and Apple Archive |
 | [save](save/) | Build FTS5 search index from downloaded documentation |
 | [index](index/) | Index sample code for full-text search |
@@ -19,12 +20,13 @@ CLI commands for the Cupertino documentation server.
 | [read-sample-file](read-sample-file/) | Read a source file from a sample project |
 | [doctor](doctor/) | Check server health and configuration |
 | [cleanup](cleanup/) | Clean up downloaded sample code archives |
+| [release](release/) | Package and upload databases to GitHub Releases (maintainer only) |
 
 ## Quick Reference
 
 ```bash
-# Quick Setup (Recommended) - no crawling needed
-cupertino save --remote
+# Quick Setup (Recommended) - instant, no crawling
+cupertino setup
 cupertino serve
 
 # Or download documentation manually
@@ -65,8 +67,8 @@ cupertino doctor
 ### Quick Setup (Recommended)
 
 ```bash
-# Stream pre-crawled docs from GitHub (~30 minutes)
-cupertino save --remote
+# Download pre-built databases (~30 seconds)
+cupertino setup
 
 # Start server
 cupertino serve

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -23,12 +23,16 @@ CLI commands for the Cupertino documentation server.
 ## Quick Reference
 
 ```bash
-# Download documentation
+# Quick Setup (Recommended) - no crawling needed
+cupertino save --remote
+cupertino serve
+
+# Or download documentation manually
 cupertino fetch --type docs
 cupertino fetch --type evolution
 cupertino fetch --type archive
 
-# Build search index
+# Build search index (from local files)
 cupertino save
 
 # Start MCP server (default command)
@@ -58,7 +62,17 @@ cupertino doctor
 
 ## Workflow
 
-### Initial Setup
+### Quick Setup (Recommended)
+
+```bash
+# Stream pre-crawled docs from GitHub (~30 minutes)
+cupertino save --remote
+
+# Start server
+cupertino serve
+```
+
+### Manual Setup (Advanced)
 
 ```bash
 # 1. Download documentation (takes time)

--- a/docs/commands/release/README.md
+++ b/docs/commands/release/README.md
@@ -1,0 +1,109 @@
+# cupertino release
+
+Package and upload databases to GitHub Releases.
+
+## Synopsis
+
+```bash
+cupertino release [--base-dir <dir>] [--repo <owner/repo>] [--dry-run]
+```
+
+## Description
+
+The `release` command packages the local search databases into a zip file and uploads them to GitHub Releases. This is used by maintainers to publish new database versions that users can download via `cupertino setup`.
+
+**Note:** This command is for maintainers only. It requires a `GITHUB_TOKEN` with write access to the release repository.
+
+## Options
+
+- `--base-dir` - Directory containing databases (default: `~/.cupertino/`)
+- `--repo` - GitHub repository for releases (default: `mihaelamj/cupertino-docs`)
+- `--dry-run` - Create zip locally without uploading
+
+## Examples
+
+### Dry Run (Test Locally)
+
+```bash
+cupertino release --dry-run
+```
+
+### Publish Release
+
+```bash
+export GITHUB_TOKEN=your_token
+cupertino release
+```
+
+### Custom Repository
+
+```bash
+cupertino release --repo myorg/my-docs
+```
+
+## Output
+
+```
+📦 Cupertino Release v0.3.0
+
+📊 Database sizes:
+   search.db:  1.2 GB
+   samples.db: 192.2 MB
+
+📁 Creating cupertino-databases-v0.3.0.zip...
+   ✓ Created (228.3 MB)
+
+🔐 Calculating SHA256...
+   17dac4b84adaa04b5f976a7d1b9126630545f0101fe84ca5423163da886386a6
+
+🚀 Creating release v0.3.0...
+   ✓ Release created
+
+⬆️  Uploading cupertino-databases-v0.3.0.zip...
+   ✓ Upload complete
+
+✅ Release v0.3.0 published!
+   https://github.com/mihaelamj/cupertino-docs/releases/tag/v0.3.0
+```
+
+## Version Parity
+
+The release tag matches the CLI version from `Constants.swift`:
+
+| CLI Version | Release Tag | Zip Filename |
+|-------------|-------------|--------------|
+| 0.3.0 | v0.3.0 | cupertino-databases-v0.3.0.zip |
+| 0.4.0 | v0.4.0 | cupertino-databases-v0.4.0.zip |
+
+This ensures database schema compatibility between CLI and databases.
+
+## Workflow
+
+1. Refresh databases locally:
+   ```bash
+   cupertino fetch --type docs
+   cupertino save
+   ```
+
+2. Bump version in `Sources/Shared/Constants.swift`
+
+3. Publish release:
+   ```bash
+   cupertino release
+   ```
+
+4. Users can now run:
+   ```bash
+   cupertino setup
+   ```
+
+## Requirements
+
+- `GITHUB_TOKEN` environment variable with `repo` scope
+- Write access to the release repository
+- Local databases in `~/.cupertino/` (or specified `--base-dir`)
+
+## See Also
+
+- [setup](../setup/) - Download pre-built databases (user command)
+- [save](../save/) - Build databases locally

--- a/docs/commands/release/option (--)/base-dir.md
+++ b/docs/commands/release/option (--)/base-dir.md
@@ -1,0 +1,27 @@
+# --base-dir
+
+Directory containing databases to package.
+
+## Synopsis
+
+```bash
+cupertino release --base-dir <path>
+```
+
+## Description
+
+Specifies where to find `search.db` and `samples.db` for packaging. If not provided, defaults to `~/.cupertino/`.
+
+## Examples
+
+```bash
+# Use custom location
+cupertino release --base-dir ~/my-docs
+
+# Use absolute path
+cupertino release --base-dir /opt/cupertino
+```
+
+## Default
+
+`~/.cupertino/`

--- a/docs/commands/release/option (--)/dry-run.md
+++ b/docs/commands/release/option (--)/dry-run.md
@@ -1,0 +1,29 @@
+# --dry-run
+
+Create zip locally without uploading.
+
+## Synopsis
+
+```bash
+cupertino release --dry-run
+```
+
+## Description
+
+Creates the zip file and calculates SHA256 checksum, but does not upload to GitHub. Useful for testing the release process or inspecting the output.
+
+The zip file will be saved to the base directory (e.g., `~/.cupertino/cupertino-databases-v0.3.0.zip`).
+
+## Examples
+
+```bash
+# Test release process
+cupertino release --dry-run
+
+# Inspect the zip file
+unzip -l ~/.cupertino/cupertino-databases-v0.3.0.zip
+```
+
+## Default
+
+`false` - Upload to GitHub

--- a/docs/commands/release/option (--)/repo.md
+++ b/docs/commands/release/option (--)/repo.md
@@ -1,0 +1,27 @@
+# --repo
+
+GitHub repository for releases.
+
+## Synopsis
+
+```bash
+cupertino release --repo <owner/repo>
+```
+
+## Description
+
+Specifies the GitHub repository where databases will be uploaded. Must have write access via `GITHUB_TOKEN`.
+
+## Examples
+
+```bash
+# Use custom repository
+cupertino release --repo myorg/my-cupertino-docs
+
+# Default repository
+cupertino release --repo mihaelamj/cupertino-docs
+```
+
+## Default
+
+`mihaelamj/cupertino-docs`

--- a/docs/commands/save/README.md
+++ b/docs/commands/save/README.md
@@ -14,16 +14,23 @@ The `save` command builds a Full-Text Search (FTS5) SQLite database from previou
 
 ## Options
 
-- [--base-dir](base-dir.md) - Base directory (auto-fills all directories from standard structure)
-- [--docs-dir](docs-dir.md) - Directory containing crawled documentation
-- [--evolution-dir](evolution-dir.md) - Directory containing Swift Evolution proposals
-- [--swift-org-dir](swift-org-dir.md) - Directory containing Swift.org documentation
-- [--packages-dir](packages-dir.md) - Directory containing package READMEs
-- [--metadata-file](metadata-file.md) - Path to metadata.json file
-- [--search-db](search-db.md) - Output path for search database
-- [--clear](clear.md) - Clear existing index before building
+- [--remote](option%20%28--%29/remote/) - **Stream from GitHub** (instant setup, no local files)
+- [--base-dir](option%20%28--%29/base-dir.md) - Base directory (auto-fills all directories from standard structure)
+- [--docs-dir](option%20%28--%29/docs-dir.md) - Directory containing crawled documentation
+- [--evolution-dir](option%20%28--%29/evolution-dir.md) - Directory containing Swift Evolution proposals
+- [--swift-org-dir](option%20%28--%29/swift-org-dir.md) - Directory containing Swift.org documentation
+- [--packages-dir](option%20%28--%29/packages-dir.md) - Directory containing package READMEs
+- [--metadata-file](option%20%28--%29/metadata-file.md) - Path to metadata.json file
+- [--search-db](option%20%28--%29/search-db.md) - Output path for search database
+- [--clear](option%20%28--%29/clear.md) - Clear existing index before building
 
 ## Examples
+
+### Quick Setup (Recommended)
+Stream documentation from GitHub - no crawling needed:
+```bash
+cupertino save --remote
+```
 
 ### Build Index from Default Locations
 ```bash
@@ -67,10 +74,11 @@ The FTS5 index supports:
 
 ## Notes
 
-- Requires crawled documentation (run `cupertino fetch` first)
+- **Remote mode** (`--remote`): No prerequisites - streams from GitHub
+- **Local mode**: Requires crawled documentation (run `cupertino fetch` first)
 - Uses SQLite FTS5 for optimal search performance
 - Index size is typically ~10-20% of total documentation size
-- Supports incremental updates (without `--clear`)
+- Remote mode is resumable if interrupted
 - Compatible with MCP server for AI integration
 
 ## Next Steps

--- a/docs/commands/save/option (--)/remote/README.md
+++ b/docs/commands/save/option (--)/remote/README.md
@@ -1,0 +1,101 @@
+# --remote
+
+Stream documentation from GitHub to build search database without local files.
+
+## Usage
+
+```bash
+cupertino save --remote
+```
+
+## Description
+
+The `--remote` flag enables **instant setup** by streaming pre-crawled documentation directly from the [cupertino-docs](https://github.com/mihaelamj/cupertino-docs) GitHub repository into the search database.
+
+### Key Features
+
+- **No disk bloat**: Streams JSON directly to SQLite without saving files locally
+- **Resumable**: If interrupted, re-run and choose to resume from where you left off
+- **No rate limits**: Uses raw.githubusercontent.com (not GitHub API)
+- **Fast setup**: Minutes instead of hours of crawling
+
+### How It Works
+
+1. Fetches framework list from GitHub API (single call)
+2. For each framework/phase:
+   - Streams files via raw GitHub URLs
+   - Parses JSON and indexes directly to search.db
+   - Saves progress state for resume capability
+3. Shows animated progress with ETA
+
+### Phases
+
+| Phase | Source | Description |
+|-------|--------|-------------|
+| docs | `docs/` | 248 Apple framework documentation folders |
+| evolution | `swift-evolution/` | Swift Evolution proposals |
+| archive | `archive/` | Legacy Apple programming guides |
+| swiftOrg | `swift-org/` | Swift.org documentation |
+| packages | `packages/` | Package READMEs |
+
+### State File
+
+Progress is saved to `~/.cupertino/remote-save-state.json` for resume support:
+
+```json
+{
+  "version": "0.2.7",
+  "started": "2025-12-04T12:00:00Z",
+  "phase": "docs",
+  "phasesCompleted": [],
+  "currentFramework": "swiftui",
+  "frameworksCompleted": ["accelerate", "accessibility"],
+  "frameworksTotal": 248,
+  "currentFileIndex": 456,
+  "filesTotal": 1000
+}
+```
+
+### Resume
+
+If interrupted and re-run:
+
+```
+Found previous session
+   Phase: docs
+   Progress: 142/248 frameworks
+   Current: swiftui (456/1000 files)
+
+Resume from swiftui? [Y/n]
+```
+
+### Progress Display
+
+```
+Building database from remote...
+
+Docs: [############........] 142/248
+   Current: SwiftUI (456/1000 files)
+
+Elapsed: 12:34 | ETA: 8:21
+Overall: 28.5%
+```
+
+## Options
+
+When using `--remote`, these options change behavior:
+
+- [--base-dir](option%20%28--%29/base-dir.md) - Base directory for state file only (not documentation)
+- [--search-db](option%20%28--%29/search-db.md) - Output path for search database
+
+## Comparison
+
+| Method | Time | Disk Space | Requirements |
+|--------|------|------------|--------------|
+| `cupertino fetch` + `save` | ~20+ hours | ~50GB docs + DB | Apple account (for samples) |
+| `cupertino save --remote` | ~30 minutes | DB only (~500MB) | Internet connection |
+
+## Related
+
+- [save command](../../README.md)
+- [cupertino-docs repo](https://github.com/mihaelamj/cupertino-docs)

--- a/docs/commands/save/option (--)/remote/option (--)/base-dir.md
+++ b/docs/commands/save/option (--)/remote/option (--)/base-dir.md
@@ -1,0 +1,54 @@
+# --base-dir (with --remote)
+
+Base directory for state file storage when using remote mode.
+
+## Usage
+
+```bash
+cupertino save --remote --base-dir ~/custom-cupertino
+```
+
+## Behavior in Remote Mode
+
+When combined with `--remote`, the `--base-dir` option controls:
+
+1. **State file location**: `{base-dir}/remote-save-state.json`
+2. **Default search database path**: `{base-dir}/search.db` (unless `--search-db` is specified)
+
+### Important Difference
+
+In **local mode** (without `--remote`), `--base-dir` determines where to look for crawled documentation files.
+
+In **remote mode**, documentation is streamed from GitHub, so `--base-dir` only affects:
+- Where the resume state file is saved
+- The default location for the search database
+
+## Examples
+
+```bash
+# Use custom base directory for state and database
+cupertino save --remote --base-dir ~/my-docs
+
+# Creates:
+#   ~/my-docs/remote-save-state.json
+#   ~/my-docs/search.db
+```
+
+```bash
+# Combine with custom search-db
+cupertino save --remote --base-dir ~/my-docs --search-db ~/databases/search.db
+
+# Creates:
+#   ~/my-docs/remote-save-state.json
+#   ~/databases/search.db
+```
+
+## Default
+
+If not specified, defaults to `~/.cupertino/`.
+
+## See Also
+
+- [--remote](../README.md) - Parent option documentation
+- [--search-db](search-db.md) - Custom database path
+- [--base-dir (local mode)](../../base-dir.md) - Behavior without --remote

--- a/docs/commands/save/option (--)/remote/option (--)/search-db.md
+++ b/docs/commands/save/option (--)/remote/option (--)/search-db.md
@@ -1,0 +1,60 @@
+# --search-db (with --remote)
+
+Output path for the search database when using remote mode.
+
+## Usage
+
+```bash
+cupertino save --remote --search-db ~/custom/search.db
+```
+
+## Behavior in Remote Mode
+
+When combined with `--remote`, the `--search-db` option specifies where to write the search database.
+
+### How It Works
+
+1. Remote indexer streams documentation from GitHub
+2. Parses JSON and extracts searchable content
+3. Writes directly to the specified SQLite database
+4. No intermediate files are created
+
+### SQLite Requirement
+
+The database path must be on a **local filesystem**. SQLite does not work reliably on network drives (NFS/SMB).
+
+## Examples
+
+```bash
+# Custom database location
+cupertino save --remote --search-db /Volumes/FastSSD/search.db
+```
+
+```bash
+# Project-specific database
+cupertino save --remote --search-db ./project-docs.db
+```
+
+```bash
+# Combined with base-dir (state file separate from database)
+cupertino save --remote --base-dir ~/.cupertino --search-db ~/databases/apple.db
+```
+
+## Default
+
+If not specified:
+- Defaults to `{base-dir}/search.db`
+- If `--base-dir` is also not specified, defaults to `~/.cupertino/search.db`
+
+## Database Size
+
+| Content | Approximate Size |
+|---------|------------------|
+| Full documentation | ~150-200 MB |
+| Minimal (evolution only) | ~5 MB |
+
+## See Also
+
+- [--remote](../README.md) - Parent option documentation
+- [--base-dir](base-dir.md) - Custom state file location
+- [--search-db (local mode)](../../search-db.md) - Behavior without --remote

--- a/docs/commands/setup/README.md
+++ b/docs/commands/setup/README.md
@@ -1,0 +1,95 @@
+# cupertino setup
+
+Download pre-built search databases from GitHub.
+
+## Synopsis
+
+```bash
+cupertino setup
+```
+
+## Description
+
+The `setup` command downloads pre-built search databases from GitHub Releases, providing instant access to Apple documentation and sample code search without crawling or indexing.
+
+This is the **fastest way to get started** with Cupertino.
+
+## What Gets Downloaded
+
+| Database | Contents | Size |
+|----------|----------|------|
+| `search.db` | 22,000+ documentation pages, 261 frameworks | ~150-200 MB |
+| `samples.db` | 606 sample projects, 18,000+ source files | ~50-100 MB |
+
+## Options
+
+- `--base-dir` - Custom directory for databases (default: `~/.cupertino/`)
+- `--force` - Re-download even if files exist
+
+## Examples
+
+### Quick Setup (Recommended)
+
+```bash
+cupertino setup
+```
+
+### Custom Location
+
+```bash
+cupertino setup --base-dir ~/my-docs
+```
+
+### Force Re-download
+
+```bash
+cupertino setup --force
+```
+
+## Output
+
+```
+📦 Cupertino Setup
+
+⬇️  Downloading Documentation database...
+   [████████████████████████████░░] 93% (186.2 MB/200.0 MB)
+   ✓ Documentation database (200.0 MB)
+
+⬇️  Downloading Sample code database...
+   [██████████████████████████████] 100% (75.0 MB/75.0 MB)
+   ✓ Sample code database (75.0 MB)
+
+✅ Setup complete!
+   Documentation: /Users/you/.cupertino/search.db
+   Sample code:   /Users/you/.cupertino/samples.db
+
+💡 Start the server with: cupertino serve
+```
+
+## Comparison
+
+| Method | Time | Disk Space |
+|--------|------|------------|
+| `cupertino setup` | ~30 seconds | ~250 MB |
+| `cupertino save --remote` | ~45 minutes | ~250 MB |
+| `cupertino fetch && save` | ~20+ hours | ~3 GB + 250 MB |
+
+## Next Steps
+
+After setup, start the MCP server:
+
+```bash
+cupertino serve
+```
+
+Or simply:
+
+```bash
+cupertino
+```
+
+## See Also
+
+- [serve](../serve/) - Start MCP server
+- [save --remote](../save/option%20%28--%29/remote/) - Stream and build locally
+- [fetch](../fetch/) - Download documentation manually

--- a/docs/commands/setup/option (--)/base-dir.md
+++ b/docs/commands/setup/option (--)/base-dir.md
@@ -1,0 +1,27 @@
+# --base-dir
+
+Custom directory for database storage.
+
+## Synopsis
+
+```bash
+cupertino setup --base-dir <path>
+```
+
+## Description
+
+Specifies where to store the downloaded databases. If not provided, defaults to `~/.cupertino/`.
+
+## Examples
+
+```bash
+# Use custom location
+cupertino setup --base-dir ~/my-docs
+
+# Use absolute path
+cupertino setup --base-dir /opt/cupertino
+```
+
+## Default
+
+`~/.cupertino/`

--- a/docs/commands/setup/option (--)/force.md
+++ b/docs/commands/setup/option (--)/force.md
@@ -1,0 +1,27 @@
+# --force
+
+Re-download databases even if they exist.
+
+## Synopsis
+
+```bash
+cupertino setup --force
+```
+
+## Description
+
+By default, `setup` skips downloading if `search.db` and `samples.db` already exist. Use `--force` to re-download and overwrite existing databases.
+
+## Examples
+
+```bash
+# Update to latest databases
+cupertino setup --force
+
+# Force download to custom location
+cupertino setup --base-dir ~/docs --force
+```
+
+## Default
+
+`false` - Skip if databases exist


### PR DESCRIPTION
  ## Summary

  Adds two new commands for instant Cupertino setup:

  - **`cupertino setup`** - Download pre-built databases from GitHub Releases (~30 seconds)
  - **`cupertino release`** - Package and upload databases to GitHub (maintainer only)

  ## Changes

  - New `SetupCommand` with progress bar, version parity, and `--force` flag
  - New `ReleaseCommand` with SHA256 checksum and `--dry-run` support
  - Version bumped to `0.3.0`
  - Updated README with new quick start workflow
  - Full documentation per AGENTS.md checklist

  ## Usage

  ```bash
  # Users
  cupertino setup
  cupertino serve

  # Maintainer
  cupertino release --dry-run
  cupertino release

  Closes

  - Closes #52
  - Closes #65
  - Closes #66