### PR TITLE
fix: include resource bundle in release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           swift build -c release --arch arm64
           cp .build/release/cupertino ../cupertino-arm64
+          # Copy resource bundle (only need one, it's the same for both archs)
+          cp -R .build/arm64-apple-macosx/release/Cupertino_Resources.bundle ../
 
       - name: Build for x86_64
         working-directory: Packages
@@ -105,8 +107,8 @@ jobs:
           # Get version from tag
           VERSION=${GITHUB_REF#refs/tags/}
 
-          # Create archive
-          tar -czvf cupertino-${VERSION}-macos-universal.tar.gz cupertino
+          # Create archive with binary and resource bundle
+          tar -czvf cupertino-${VERSION}-macos-universal.tar.gz cupertino Cupertino_Resources.bundle
 
           # Calculate checksum
           shasum -a 256 cupertino-${VERSION}-macos-universal.tar.gz > cupertino-${VERSION}-macos-universal.tar.gz.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.3.4
+
+### Added
+- **One-Command Install** - Single curl command installs everything (#82)
+  - `bash <(curl -sSL .../install.sh)` - Downloads binary and databases
+  - Pre-built universal binary (arm64 + x86_64)
+  - Code signed with Developer ID Application certificate
+  - Notarized with Apple for Gatekeeper approval
+  - GitHub Actions workflow for automated releases
+- Closes #79, #82
+
+---
+
 ## 0.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ For development setup, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Project Status
 
-**Version:** 0.3.0
+**Version:** 0.3.4
 **Status:** 🚧 Active Development
 
 - ✅ All core functionality working


### PR DESCRIPTION
## Summary

- Include `Cupertino_Resources.bundle` in release archive
- Install bundle alongside binary in `/usr/local/bin/`
- Fix clone directory conflict in install script

## Fixes

Closes #84

## Test Plan

- [ ] Build release binary
- [ ] Verify bundle is included in tar.gz
- [ ] Run `cupertino save` from installed binary
