### PR TITLE
HIG support, framework aliases, Swift.org indexer fixes (v4.0.0)

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -160,7 +160,7 @@ let targets: [Target] = {
 
     let remoteSyncTarget = Target.target(
         name: "RemoteSync",
-        dependencies: []
+        dependencies: ["Shared"]
     )
     let remoteSyncTestsTarget = Target.testTarget(
         name: "RemoteSyncTests",

--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -22,6 +22,7 @@ let macOSOnlyProducts: [Product] = [
     .singleTargetLibrary("Cleanup"),
     .singleTargetLibrary("Search"),
     .singleTargetLibrary("SampleIndex"),
+    .singleTargetLibrary("Services"),
     .singleTargetLibrary("Resources"),
     .singleTargetLibrary("MCPSupport"),
     .singleTargetLibrary("SearchToolProvider"),
@@ -131,6 +132,15 @@ let targets: [Target] = {
         dependencies: ["SampleIndex", "TestSupport"]
     )
 
+    let servicesTarget = Target.target(
+        name: "Services",
+        dependencies: ["Shared", "Search", "SampleIndex"]
+    )
+    let servicesTestsTarget = Target.testTarget(
+        name: "ServicesTests",
+        dependencies: ["Services", "TestSupport"]
+    )
+
     let mcpSupportTarget = Target.target(
         name: "MCPSupport",
         dependencies: ["MCP", "Shared", "Logging", "Search"]
@@ -175,6 +185,7 @@ let targets: [Target] = {
             "Cleanup",
             "Search",
             "SampleIndex",
+            "Services",
             "Logging",
             "RemoteSync",
             // MCP dependencies (for mcp serve command)
@@ -262,6 +273,8 @@ let targets: [Target] = {
         searchTestsTarget,
         sampleIndexTarget,
         sampleIndexTestsTarget,
+        servicesTarget,
+        servicesTestsTarget,
         mcpSupportTarget,
         mcpSupportTestsTarget,
         searchToolProviderTarget,

--- a/Packages/Sources/CLI/Commands/DoctorCommand.swift
+++ b/Packages/Sources/CLI/Commands/DoctorCommand.swift
@@ -76,6 +76,7 @@ struct DoctorCommand: AsyncParsableCommand {
     private func checkDocumentationDirectories() -> Bool {
         let docsURL = URL(fileURLWithPath: docsDir).expandingTildeInPath
         let evolutionURL = URL(fileURLWithPath: evolutionDir).expandingTildeInPath
+        let higURL = Shared.Constants.defaultHIGDirectory
 
         var hasIssues = false
 
@@ -98,7 +99,15 @@ struct DoctorCommand: AsyncParsableCommand {
         } else {
             Log.output("   ⚠  Swift Evolution: \(evolutionURL.path) (not found)")
             Log.output("     → Run: cupertino fetch --type evolution")
-            hasIssues = true
+        }
+
+        // Check HIG directory
+        if FileManager.default.fileExists(atPath: higURL.path) {
+            let count = countMarkdownFiles(in: higURL)
+            Log.output("   ✓ HIG: \(higURL.path) (\(count) pages)")
+        } else {
+            Log.output("   ⚠  HIG: \(higURL.path) (not found)")
+            Log.output("     → Run: cupertino fetch --type hig")
         }
 
         Log.output("")

--- a/Packages/Sources/CLI/Commands/FetchCommand.swift
+++ b/Packages/Sources/CLI/Commands/FetchCommand.swift
@@ -55,8 +55,8 @@ struct FetchCommand: AsyncParsableCommand {
     @Flag(name: .long, help: "Resume from saved session (auto-detects and continues)")
     var resume: Bool = false
 
-    @Flag(name: .long, help: "Only download accepted/implemented proposals (evolution type only)")
-    var onlyAccepted: Bool = false
+    @Flag(name: .long, inversion: .prefixedNo, help: "Only download accepted/implemented proposals (evolution type only)")
+    var onlyAccepted: Bool = true
 
     @Option(name: .long, help: "Maximum number of items to fetch (packages/code types only)")
     var limit: Int?
@@ -272,9 +272,11 @@ struct FetchCommand: AsyncParsableCommand {
         url: URL,
         outputDirectory: URL
     ) -> Shared.Configuration {
+        // Use user-provided prefixes, or fall back to type defaults
         let prefixes: [String]? = allowedPrefixes?
             .split(separator: ",")
             .map { String($0.trimmingCharacters(in: .whitespaces)) }
+            ?? type.defaultAllowedPrefixes
 
         return Shared.Configuration(
             crawler: Shared.CrawlerConfiguration(

--- a/Packages/Sources/CLI/Commands/ListSamplesCommand.swift
+++ b/Packages/Sources/CLI/Commands/ListSamplesCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import Logging
 import SampleIndex
+import Services
 import Shared
 
 // MARK: - List Samples Command
@@ -42,24 +43,13 @@ struct ListSamplesCommand: AsyncParsableCommand {
         // Resolve database path
         let dbPath = resolveSampleDbPath()
 
-        guard FileManager.default.fileExists(atPath: dbPath.path) else {
-            Log.error("Sample index not found at \(dbPath.path)")
-            Log.output("Run 'cupertino index' to build the sample index first.")
-            throw ExitCode.failure
+        // Use ServiceContainer for managed lifecycle
+        let (projects, totalProjects, totalFiles) = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
+            let projects = try await service.listProjects(framework: framework, limit: limit)
+            let totalProjects = try await service.projectCount()
+            let totalFiles = try await service.fileCount()
+            return (projects, totalProjects, totalFiles)
         }
-
-        // Initialize database
-        let database = try await SampleIndex.Database(dbPath: dbPath)
-        defer {
-            Task {
-                await database.disconnect()
-            }
-        }
-
-        // List projects
-        let projects = try await database.listProjects(framework: framework, limit: limit)
-        let totalProjects = try await database.projectCount()
-        let totalFiles = try await database.fileCount()
 
         // Output results
         switch format {
@@ -181,17 +171,5 @@ extension ListSamplesCommand {
         case text
         case json
         case markdown
-    }
-}
-
-// MARK: - URL Extension
-
-private extension URL {
-    var expandingTildeInPath: URL {
-        if path.hasPrefix("~") {
-            let expandedPath = NSString(string: path).expandingTildeInPath
-            return URL(fileURLWithPath: expandedPath)
-        }
-        return self
     }
 }

--- a/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import Logging
 import SampleIndex
+import Services
 import Shared
 
 // MARK: - Read Sample File Command
@@ -36,35 +37,26 @@ struct ReadSampleFileCommand: AsyncParsableCommand {
         // Resolve database path
         let dbPath = resolveSampleDbPath()
 
-        guard FileManager.default.fileExists(atPath: dbPath.path) else {
-            Log.error("Sample index not found at \(dbPath.path)")
-            Log.output("Run 'cupertino index' to build the sample index first.")
-            throw ExitCode.failure
-        }
-
-        // Initialize database
-        let database = try await SampleIndex.Database(dbPath: dbPath)
-        defer {
-            Task {
-                await database.disconnect()
+        // Use ServiceContainer for managed lifecycle
+        let file = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
+            guard let file = try await service.getFile(projectId: projectId, path: filePath) else {
+                Log.error("File not found: \(filePath) in project \(projectId)")
+                Log.output("Use 'cupertino read-sample \(projectId)' to list available files.")
+                throw ExitCode.failure
             }
+            return file
         }
 
-        // Get file
-        guard let file = try await database.getFile(projectId: projectId, path: filePath) else {
-            Log.error("File not found: \(filePath) in project \(projectId)")
-            Log.output("Use 'cupertino read-sample \(projectId)' to list available files.")
-            throw ExitCode.failure
-        }
-
-        // Output results
+        // Output results using formatters
         switch format {
         case .text:
             outputText(file)
         case .json:
-            outputJSON(file)
+            let formatter = SampleFileJSONFormatter()
+            Log.output(formatter.format(file))
         case .markdown:
-            outputMarkdown(file)
+            let formatter = SampleFileMarkdownFormatter()
+            Log.output(formatter.format(file))
         }
     }
 
@@ -87,72 +79,12 @@ struct ReadSampleFileCommand: AsyncParsableCommand {
         Log.output(file.content)
     }
 
-    private func outputJSON(_ file: SampleIndex.File) {
-        struct Output: Encodable {
-            let projectId: String
-            let path: String
-            let filename: String
-            let size: Int
-            let content: String
-        }
-
-        let output = Output(
-            projectId: file.projectId,
-            path: file.path,
-            filename: file.filename,
-            size: file.size,
-            content: file.content
-        )
-
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-
-        do {
-            let data = try encoder.encode(output)
-            if let jsonString = String(data: data, encoding: .utf8) {
-                Log.output(jsonString)
-            }
-        } catch {
-            Log.error("Error encoding JSON: \(error)")
-        }
-    }
-
-    private func outputMarkdown(_ file: SampleIndex.File) {
-        Log.output("# \(file.filename)\n")
-        Log.output("**Project:** `\(file.projectId)`")
-        Log.output("**Path:** `\(file.path)`")
-        Log.output("**Size:** \(formatBytes(file.size))\n")
-
-        let language = languageForExtension(file.fileExtension)
-        Log.output("```\(language)")
-        Log.output(file.content)
-        if !file.content.hasSuffix("\n") {
-            Log.output("")
-        }
-        Log.output("```")
-    }
-
     // MARK: - Helpers
 
     private func formatBytes(_ bytes: Int) -> String {
         let formatter = ByteCountFormatter()
         formatter.countStyle = .file
         return formatter.string(fromByteCount: Int64(bytes))
-    }
-
-    private func languageForExtension(_ ext: String) -> String {
-        switch ext.lowercased() {
-        case "swift": return "swift"
-        case "h", "m", "mm": return "objc"
-        case "c": return "c"
-        case "cpp", "hpp": return "cpp"
-        case "metal": return "metal"
-        case "json": return "json"
-        case "plist": return "xml"
-        case "md": return "markdown"
-        case "strings": return "properties"
-        default: return ext
-        }
     }
 }
 
@@ -163,17 +95,5 @@ extension ReadSampleFileCommand {
         case text
         case json
         case markdown
-    }
-}
-
-// MARK: - URL Extension
-
-private extension URL {
-    var expandingTildeInPath: URL {
-        if path.hasPrefix("~") {
-            let expandedPath = NSString(string: path).expandingTildeInPath
-            return URL(fileURLWithPath: expandedPath)
-        }
-        return self
     }
 }

--- a/Packages/Sources/CLI/Commands/ReleaseCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReleaseCommand.swift
@@ -352,15 +352,3 @@ enum ReleaseError: Error, CustomStringConvertible {
         }
     }
 }
-
-// MARK: - URL Extension
-
-private extension URL {
-    var expandingTildeInPath: URL {
-        if path.hasPrefix("~") {
-            let expandedPath = NSString(string: path).expandingTildeInPath
-            return URL(fileURLWithPath: expandedPath)
-        }
-        return self
-    }
-}

--- a/Packages/Sources/CLI/Commands/SaveCommand.swift
+++ b/Packages/Sources/CLI/Commands/SaveCommand.swift
@@ -58,9 +58,6 @@ struct SaveCommand: AsyncParsableCommand {
             ?? Shared.Constants.defaultBaseDirectory
 
         // Individual options override the base-derived paths
-        let metadataURL = metadataFile.map { URL(fileURLWithPath: $0).expandingTildeInPath }
-            ?? effectiveBase.appendingPathComponent(Shared.Constants.FileName.metadata)
-
         let docsURL = docsDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
             ?? effectiveBase.appendingPathComponent(Shared.Constants.Directory.docs)
 
@@ -70,23 +67,8 @@ struct SaveCommand: AsyncParsableCommand {
         let swiftOrgURL = swiftOrgDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
             ?? effectiveBase.appendingPathComponent(Shared.Constants.Directory.swiftOrg)
 
-        let packagesURL = packagesDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
-            ?? effectiveBase.appendingPathComponent(Shared.Constants.Directory.packages)
-
         let searchDBURL = searchDB.map { URL(fileURLWithPath: $0).expandingTildeInPath }
             ?? effectiveBase.appendingPathComponent(Shared.Constants.FileName.searchDatabase)
-
-        // Load metadata if it exists (optional)
-        let metadata: CrawlMetadata?
-        if FileManager.default.fileExists(atPath: metadataURL.path) {
-            Logging.ConsoleLogger.info("📖 Loading metadata...")
-            metadata = try CrawlMetadata.load(from: metadataURL)
-            Logging.ConsoleLogger.info("   Found \(metadata!.pages.count) pages in metadata")
-        } else {
-            Logging.ConsoleLogger.info("ℹ️  No metadata.json found - will scan directory structure")
-            Logging.ConsoleLogger.info("   Note: Resume functionality requires metadata.json")
-            metadata = nil
-        }
 
         // Delete existing database to avoid FTS5 duplicate rows
         // (FTS5 doesn't support INSERT OR REPLACE properly)
@@ -138,10 +120,10 @@ struct SaveCommand: AsyncParsableCommand {
             Logging.ConsoleLogger.info("   Run 'cupertino fetch --type hig' to download HIG documentation")
         }
 
-        // Build index
+        // Build index (no metadata needed - just scans directories)
         let builder = Search.IndexBuilder(
             searchIndex: searchIndex,
-            metadata: metadata,
+            metadata: nil,
             docsDirectory: docsURL,
             evolutionDirectory: evolutionDirToUse,
             swiftOrgDirectory: swiftOrgDirToUse,

--- a/Packages/Sources/CLI/Commands/SaveCommand.swift
+++ b/Packages/Sources/CLI/Commands/SaveCommand.swift
@@ -128,6 +128,16 @@ struct SaveCommand: AsyncParsableCommand {
             Logging.ConsoleLogger.info("   Run 'cupertino fetch --type archive' to download Apple Archive documentation")
         }
 
+        // Check if HIG directory exists
+        let higURL = effectiveBase.appendingPathComponent(Shared.Constants.Directory.hig)
+        let hasHIG = FileManager.default.fileExists(atPath: higURL.path)
+        let higDirToUse = hasHIG ? higURL : nil
+
+        if !hasHIG {
+            Logging.ConsoleLogger.info("ℹ️  HIG directory not found, skipping Human Interface Guidelines")
+            Logging.ConsoleLogger.info("   Run 'cupertino fetch --type hig' to download HIG documentation")
+        }
+
         // Build index
         let builder = Search.IndexBuilder(
             searchIndex: searchIndex,
@@ -135,7 +145,8 @@ struct SaveCommand: AsyncParsableCommand {
             docsDirectory: docsURL,
             evolutionDirectory: evolutionDirToUse,
             swiftOrgDirectory: swiftOrgDirToUse,
-            archiveDirectory: archiveDirToUse
+            archiveDirectory: archiveDirToUse,
+            higDirectory: higDirToUse
         )
 
         // Note: Using a class to hold mutable state since @Sendable closures can't capture mutable vars

--- a/Packages/Sources/CLI/Commands/SearchCommand.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand.swift
@@ -21,7 +21,7 @@ struct SearchCommand: AsyncParsableCommand {
     @Option(
         name: .shortAndLong,
         help: """
-        Filter by source: apple-docs, swift-evolution, swift-org, swift-book, packages, apple-sample-code, apple-archive
+        Filter by source: apple-docs, swift-evolution, swift-org, swift-book, packages, apple-sample-code, apple-archive, hig
         """
     )
     var source: String?

--- a/Packages/Sources/CLI/Commands/SearchCommand.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 import Logging
-import Search
+import Services
 import Shared
 
 // MARK: - Search Command
@@ -63,117 +63,33 @@ struct SearchCommand: AsyncParsableCommand {
     var format: OutputFormat = .text
 
     mutating func run() async throws {
-        // Resolve database path
-        let dbPath = resolveSearchDbPath()
-
-        guard FileManager.default.fileExists(atPath: dbPath.path) else {
-            Log.error("Search database not found at \(dbPath.path)")
-            Log.output("Run 'cupertino save' to build the search index first.")
-            throw ExitCode.failure
+        // Use ServiceContainer for managed lifecycle
+        let results = try await ServiceContainer.withDocsService(dbPath: searchDb) { service in
+            try await service.search(SearchQuery(
+                text: query,
+                source: source,
+                framework: framework,
+                language: language,
+                limit: limit,
+                includeArchive: includeArchive
+            ))
         }
 
-        // Initialize search index
-        let searchIndex = try await Search.Index(dbPath: dbPath)
-        defer {
-            Task {
-                await searchIndex.disconnect()
-            }
-        }
-
-        // Perform search
-        // Archive is excluded by default unless --include-archive or --source apple-archive
-        let results = try await searchIndex.search(
-            query: query,
-            source: source,
-            framework: framework,
-            language: language,
-            limit: limit,
-            includeArchive: includeArchive
-        )
-
-        // Output results
+        // Output results using formatters
         switch format {
         case .text:
-            outputText(results)
+            let formatter = TextSearchResultFormatter(query: query)
+            Log.output(formatter.format(results))
         case .json:
-            outputJSON(results)
+            let formatter = JSONSearchResultFormatter()
+            Log.output(formatter.format(results))
         case .markdown:
-            outputMarkdown(results)
-        }
-    }
-
-    // MARK: - Path Resolution
-
-    private func resolveSearchDbPath() -> URL {
-        if let searchDb {
-            return URL(fileURLWithPath: searchDb).expandingTildeInPath
-        }
-        return Shared.Constants.defaultSearchDatabase
-    }
-
-    // MARK: - Output Formatting
-
-    private func outputText(_ results: [Search.Result]) {
-        if results.isEmpty {
-            Log.output("No results found for '\(query)'")
-            return
-        }
-
-        Log.output("Found \(results.count) result(s) for '\(query)':\n")
-
-        for (index, result) in results.enumerated() {
-            Log.output("[\(index + 1)] \(result.title)")
-            Log.output("    Source: \(result.source) | Framework: \(result.framework)")
-            Log.output("    URI: \(result.uri)")
-
-            // Show summary
-            if !result.summary.isEmpty {
-                Log.output("    \(result.summary)")
-                if result.summaryTruncated {
-                    Log.output("    ...")
-                    let wordCount = result.summary.split(separator: " ").count
-                    Log.output("    [truncated at ~\(wordCount) words] Full document: \(result.uri)")
-                }
-            }
-
-            Log.output("")
-        }
-    }
-
-    private func outputJSON(_ results: [Search.Result]) {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-
-        do {
-            let data = try encoder.encode(results)
-            if let jsonString = String(data: data, encoding: .utf8) {
-                Log.output(jsonString)
-            }
-        } catch {
-            Log.error("Error encoding JSON: \(error)")
-        }
-    }
-
-    private func outputMarkdown(_ results: [Search.Result]) {
-        if results.isEmpty {
-            Log.output("# Search Results\n\nNo results found for '\(query)'")
-            return
-        }
-
-        Log.output("# Search Results for '\(query)'\n")
-        Log.output("Found \(results.count) result(s).\n")
-
-        for (index, result) in results.enumerated() {
-            Log.output("## \(index + 1). \(result.title)\n")
-            Log.output("- **Source:** \(result.source)")
-            Log.output("- **Framework:** \(result.framework)")
-            Log.output("- **URI:** `\(result.uri)`")
-
-            if !result.summary.isEmpty {
-                Log.output("\n> \(result.summary)")
-            }
-
-            Log.output("")
+            let formatter = MarkdownSearchResultFormatter(
+                query: query,
+                filters: SearchFilters(source: source, framework: framework, language: language),
+                config: .cliDefault
+            )
+            Log.output(formatter.format(results))
         }
     }
 }
@@ -185,17 +101,5 @@ extension SearchCommand {
         case text
         case json
         case markdown
-    }
-}
-
-// MARK: - URL Extension
-
-private extension URL {
-    var expandingTildeInPath: URL {
-        if path.hasPrefix("~") {
-            let expandedPath = NSString(string: path).expandingTildeInPath
-            return URL(fileURLWithPath: expandedPath)
-        }
-        return self
     }
 }

--- a/Packages/Sources/CLI/Commands/SearchSamplesCommand.swift
+++ b/Packages/Sources/CLI/Commands/SearchSamplesCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import Logging
 import SampleIndex
+import Services
 import Shared
 
 // MARK: - Search Samples Command
@@ -51,37 +52,27 @@ struct SearchSamplesCommand: AsyncParsableCommand {
         // Resolve database path
         let dbPath = resolveSampleDbPath()
 
-        guard FileManager.default.fileExists(atPath: dbPath.path) else {
-            Log.error("Sample index not found at \(dbPath.path)")
-            Log.output("Run 'cupertino index' to build the sample index first.")
-            throw ExitCode.failure
+        // Use ServiceContainer for managed lifecycle
+        let result = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
+            try await service.search(SampleQuery(
+                text: query,
+                framework: framework,
+                searchFiles: searchFiles,
+                limit: limit
+            ))
         }
 
-        // Initialize database
-        let database = try await SampleIndex.Database(dbPath: dbPath)
-        defer {
-            Task {
-                await database.disconnect()
-            }
-        }
-
-        // Search projects
-        let projects = try await database.searchProjects(query: query, framework: framework, limit: limit)
-
-        // Optionally search files
-        var files: [SampleIndex.Database.FileSearchResult] = []
-        if searchFiles {
-            files = try await database.searchFiles(query: query, projectId: nil, limit: limit)
-        }
-
-        // Output results
+        // Output results using formatters
         switch format {
         case .text:
-            outputText(projects, files: files)
+            let formatter = SampleSearchTextFormatter(query: query, framework: framework)
+            Log.output(formatter.format(result))
         case .json:
-            outputJSON(projects, files: files)
+            let formatter = SampleSearchJSONFormatter(query: query, framework: framework)
+            Log.output(formatter.format(result))
         case .markdown:
-            outputMarkdown(projects, files: files)
+            let formatter = SampleSearchMarkdownFormatter(query: query, framework: framework)
+            Log.output(formatter.format(result))
         }
     }
 
@@ -93,156 +84,6 @@ struct SearchSamplesCommand: AsyncParsableCommand {
         }
         return SampleIndex.defaultDatabasePath
     }
-
-    // MARK: - Output Formatting
-
-    private func outputText(_ projects: [SampleIndex.Project], files: [SampleIndex.Database.FileSearchResult]) {
-        if projects.isEmpty, files.isEmpty {
-            Log.output("No results found for '\(query)'")
-            return
-        }
-
-        Log.output("Search Results for '\(query)'")
-
-        if let framework {
-            Log.output("Filtered by: \(framework)")
-        }
-
-        Log.output("")
-
-        // Projects
-        if !projects.isEmpty {
-            Log.output("Projects (\(projects.count) found):")
-            Log.output("")
-
-            for (index, project) in projects.enumerated() {
-                Log.output("[\(index + 1)] \(project.title)")
-                Log.output("    ID: \(project.id)")
-                Log.output("    Frameworks: \(project.frameworks.joined(separator: ", "))")
-                Log.output("    Files: \(project.fileCount)")
-
-                if !project.description.isEmpty {
-                    Log.output("    \(project.description.prefix(200))...")
-                }
-
-                Log.output("")
-            }
-        }
-
-        // Files
-        if !files.isEmpty {
-            Log.output("Matching Files (\(files.count) found):")
-            Log.output("")
-
-            for (index, file) in files.prefix(10).enumerated() {
-                Log.output("[\(index + 1)] \(file.filename)")
-                Log.output("    Project: \(file.projectId)")
-                Log.output("    Path: \(file.path)")
-                Log.output("    > \(file.snippet)")
-                Log.output("")
-            }
-        }
-
-        Log.output("Tip: Use 'cupertino read-sample <project_id>' to view project details")
-    }
-
-    private func outputJSON(_ projects: [SampleIndex.Project], files: [SampleIndex.Database.FileSearchResult]) {
-        struct Output: Encodable {
-            let query: String
-            let framework: String?
-            let projects: [ProjectOutput]
-            let files: [FileOutput]
-        }
-
-        struct ProjectOutput: Encodable {
-            let id: String
-            let title: String
-            let description: String
-            let frameworks: [String]
-            let fileCount: Int
-        }
-
-        struct FileOutput: Encodable {
-            let projectId: String
-            let path: String
-            let filename: String
-            let snippet: String
-            let rank: Double
-        }
-
-        let output = Output(
-            query: query,
-            framework: framework,
-            projects: projects.map {
-                ProjectOutput(
-                    id: $0.id,
-                    title: $0.title,
-                    description: $0.description,
-                    frameworks: $0.frameworks,
-                    fileCount: $0.fileCount
-                )
-            },
-            files: files.map {
-                FileOutput(
-                    projectId: $0.projectId,
-                    path: $0.path,
-                    filename: $0.filename,
-                    snippet: $0.snippet,
-                    rank: $0.rank
-                )
-            }
-        )
-
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-
-        do {
-            let data = try encoder.encode(output)
-            if let jsonString = String(data: data, encoding: .utf8) {
-                Log.output(jsonString)
-            }
-        } catch {
-            Log.error("Error encoding JSON: \(error)")
-        }
-    }
-
-    private func outputMarkdown(_ projects: [SampleIndex.Project], files: [SampleIndex.Database.FileSearchResult]) {
-        Log.output("# Sample Code Search: \"\(query)\"\n")
-
-        if let framework {
-            Log.output("_Filtered to framework: **\(framework)**_\n")
-        }
-
-        // Projects
-        Log.output("## Projects (\(projects.count) found)\n")
-
-        if projects.isEmpty {
-            Log.output("_No matching projects found._\n")
-        } else {
-            for (index, project) in projects.enumerated() {
-                Log.output("### \(index + 1). \(project.title)\n")
-                Log.output("- **ID:** `\(project.id)`")
-                Log.output("- **Frameworks:** \(project.frameworks.joined(separator: ", "))")
-                Log.output("- **Files:** \(project.fileCount)\n")
-
-                if !project.description.isEmpty {
-                    Log.output("\(project.description)\n")
-                }
-            }
-        }
-
-        // Files
-        if !files.isEmpty {
-            Log.output("\n## Matching Files (\(files.count) found)\n")
-
-            for (index, file) in files.prefix(10).enumerated() {
-                Log.output("### \(index + 1). \(file.filename)\n")
-                Log.output("- **Project:** `\(file.projectId)`")
-                Log.output("- **Path:** `\(file.path)`\n")
-                Log.output("> \(file.snippet)\n")
-            }
-        }
-    }
 }
 
 // MARK: - Output Format
@@ -252,17 +93,5 @@ extension SearchSamplesCommand {
         case text
         case json
         case markdown
-    }
-}
-
-// MARK: - URL Extension
-
-private extension URL {
-    var expandingTildeInPath: URL {
-        if path.hasPrefix("~") {
-            let expandedPath = NSString(string: path).expandingTildeInPath
-            return URL(fileURLWithPath: expandedPath)
-        }
-        return self
     }
 }

--- a/Packages/Sources/CLI/Commands/SetupCommand.swift
+++ b/Packages/Sources/CLI/Commands/SetupCommand.swift
@@ -264,15 +264,3 @@ private final class DownloadDelegate: NSObject, URLSessionDownloadDelegate, @unc
         return String(format: "%.1f MB", megabytes)
     }
 }
-
-// MARK: - URL Extension
-
-private extension URL {
-    var expandingTildeInPath: URL {
-        if path.hasPrefix("~") {
-            let expandedPath = NSString(string: path).expandingTildeInPath
-            return URL(fileURLWithPath: expandedPath)
-        }
-        return self
-    }
-}

--- a/Packages/Sources/CLI/SupportingTypes.swift
+++ b/Packages/Sources/CLI/SupportingTypes.swift
@@ -14,6 +14,7 @@ extension Cupertino {
         case code
         case samples
         case archive
+        case hig
         case all
 
         var displayName: String {
@@ -26,6 +27,7 @@ extension Cupertino {
             case .code: return Shared.Constants.DisplayName.sampleCode
             case .samples: return "Sample Code (GitHub)"
             case .archive: return Shared.Constants.DisplayName.archive
+            case .hig: return Shared.Constants.DisplayName.humanInterfaceGuidelines
             case .all: return Shared.Constants.DisplayName.allDocs
             }
         }
@@ -40,6 +42,7 @@ extension Cupertino {
             case .code: return "" // Web-based download from Apple
             case .samples: return "" // Git clone from GitHub
             case .archive: return Shared.Constants.BaseURL.appleArchive
+            case .hig: return Shared.Constants.BaseURL.appleHIG
             case .all: return "" // N/A - fetches all types sequentially
             }
         }
@@ -64,6 +67,8 @@ extension Cupertino {
                 return "\(homeDir)/\(baseDir)/\(Shared.Constants.Directory.sampleCode)"
             case .archive:
                 return "\(homeDir)/\(baseDir)/\(Shared.Constants.Directory.archive)"
+            case .hig:
+                return "\(homeDir)/\(baseDir)/\(Shared.Constants.Directory.hig)"
             case .all:
                 return "\(homeDir)/\(baseDir)"
             }
@@ -74,7 +79,7 @@ extension Cupertino {
         }
 
         static var directFetchTypes: [FetchType] {
-            [.packages, .packageDocs, .code, .samples, .archive]
+            [.packages, .packageDocs, .code, .samples, .archive, .hig]
         }
 
         static var allTypes: [FetchType] {

--- a/Packages/Sources/CLI/SupportingTypes.swift
+++ b/Packages/Sources/CLI/SupportingTypes.swift
@@ -35,7 +35,7 @@ extension Cupertino {
         var defaultURL: String {
             switch self {
             case .docs: return Shared.Constants.BaseURL.appleDeveloperDocs
-            case .swift: return Shared.Constants.BaseURL.swiftBook
+            case .swift: return Shared.Constants.BaseURL.swiftOrg
             case .evolution: return "" // N/A - uses different fetcher
             case .packages: return "" // API-based fetching
             case .packageDocs: return "" // GitHub raw content downloading
@@ -44,6 +44,19 @@ extension Cupertino {
             case .archive: return Shared.Constants.BaseURL.appleArchive
             case .hig: return Shared.Constants.BaseURL.appleHIG
             case .all: return "" // N/A - fetches all types sequentially
+            }
+        }
+
+        var defaultAllowedPrefixes: [String]? {
+            switch self {
+            case .swift:
+                // Swift docs span both www.swift.org and docs.swift.org (swift-book)
+                return [
+                    Shared.Constants.BaseURL.swiftOrg,
+                    Shared.Constants.BaseURL.swiftBook,
+                ]
+            default:
+                return nil // Auto-detect from start URL
             }
         }
 

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -399,7 +399,7 @@ extension Core {
         // MARK: - Logging
 
         private func logInfo(_ message: String) {
-            let memoryMsg = "🧠 \(String(format: "%.1f", getMemoryUsageMB()))MB | \(message)"
+            let memoryMsg = "\(String(format: "%.1f", getMemoryUsageMB()))MB | \(message)"
             Log.info(memoryMsg, category: .crawler)
             logToFile(memoryMsg)
         }

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -197,7 +197,7 @@ extension Core {
             let fwPageCount = fwStats?.pageCount ?? 0
 
             let urlString = url.absoluteString
-            let progress = "[\(visited.count)/\(configuration.maxPages)] [\(framework):\(fwPageCount + 1)]"
+            let progress = "[\(visited.count)] [\(framework):\(fwPageCount + 1)]"
             logInfo("📄 \(progress) depth=\(depth) \(urlString)")
 
             // Try JSON API first (better data quality), fall back to HTML if unavailable
@@ -418,7 +418,7 @@ extension Core {
 
             let messages = [
                 "",
-                "📊 Progress Update [\(visited.count)/\(configuration.maxPages)]:",
+                "📊 Progress Update [\(visited.count)]:",
                 "   Visited: \(visited.count) pages",
                 "   Queue: \(queue.count) pending URLs",
                 "   New: \(stats.newPages) | Updated: \(stats.updatedPages) | Skipped: \(stats.skippedPages)",

--- a/Packages/Sources/Core/HIGCrawler.swift
+++ b/Packages/Sources/Core/HIGCrawler.swift
@@ -1,0 +1,680 @@
+import Foundation
+import Logging
+import Shared
+
+#if canImport(WebKit)
+import WebKit
+#endif
+
+// MARK: - HIG Crawler
+
+// swiftlint:disable type_body_length
+// Justification: HIGCrawler is a self-contained crawler module.
+// Contains page discovery, HTML parsing, markdown conversion, and file saving.
+// Splitting would scatter related functionality and reduce cohesion.
+
+/// Crawls Apple's Human Interface Guidelines
+/// The HIG website is a JavaScript SPA, requiring WKWebView-based crawling
+extension Core {
+    @MainActor
+    public final class HIGCrawler {
+        private let outputDirectory: URL
+        private let forceRecrawl: Bool
+        private let maxPages: Int
+
+        #if canImport(WebKit)
+        private var fetcher: WKWebCrawler.WKWebContentFetcher?
+        #endif
+
+        public init(
+            outputDirectory: URL,
+            forceRecrawl: Bool = false,
+            maxPages: Int = 500
+        ) {
+            self.outputDirectory = outputDirectory
+            self.forceRecrawl = forceRecrawl
+            self.maxPages = maxPages
+        }
+
+        // MARK: - Public API
+
+        /// Crawl Human Interface Guidelines
+        public func crawl(
+            onProgress: (@Sendable (HIGProgress) -> Void)? = nil
+        ) async throws -> HIGStatistics {
+            var stats = HIGStatistics(startTime: Date())
+
+            logInfo("Starting Human Interface Guidelines crawler")
+            logInfo("   Output: \(outputDirectory.path)")
+            logInfo("   Max pages: \(maxPages)")
+
+            // Create output directory
+            try FileManager.default.createDirectory(
+                at: outputDirectory,
+                withIntermediateDirectories: true
+            )
+
+            #if canImport(WebKit)
+            // Initialize content fetcher with longer wait time for HIG SPA
+            fetcher = WKWebCrawler.WKWebContentFetcher(
+                pageLoadTimeout: .seconds(30),
+                javascriptWaitTime: .seconds(3)
+            )
+
+            // Start from HIG root
+            let rootURL = URL(string: Shared.Constants.BaseURL.appleHIG)!
+
+            // Discover all HIG pages
+            logInfo("Discovering HIG pages...")
+            let pages = try await discoverPages(from: rootURL, stats: &stats)
+            logInfo("Found \(pages.count) pages to crawl")
+
+            // Crawl each page
+            for (index, page) in pages.prefix(maxPages).enumerated() {
+                do {
+                    try await crawlPage(page, stats: &stats)
+
+                    // Progress callback
+                    if let onProgress {
+                        let progress = HIGProgress(
+                            currentPage: index + 1,
+                            totalPages: min(pages.count, maxPages),
+                            currentItem: page.title,
+                            stats: stats
+                        )
+                        onProgress(progress)
+                    }
+
+                    // Rate limiting
+                    try await Task.sleep(for: .milliseconds(500))
+
+                    // Recycle WKWebView every 50 pages to prevent memory buildup
+                    if (index + 1) % 50 == 0 {
+                        fetcher?.recycle()
+                        logInfo("♻️ Recycled WKWebView at page \(index + 1)")
+                    }
+                } catch {
+                    stats.errors += 1
+                    logError("Failed to crawl page \(page.title): \(error)")
+
+                    // Recycle on error to recover from potential WebView issues
+                    fetcher?.recycle()
+                }
+            }
+
+            // Cleanup
+            fetcher = nil
+            #else
+            logError("WebKit not available - HIG crawler requires macOS")
+            throw HIGCrawlerError.webKitNotAvailable
+            #endif
+
+            stats.endTime = Date()
+
+            logInfo("\nCrawl completed!")
+            logStatistics(stats)
+
+            return stats
+        }
+
+        // MARK: - Private Methods
+
+        #if canImport(WebKit)
+        private func discoverPages(
+            from rootURL: URL,
+            stats: inout HIGStatistics
+        ) async throws -> [HIGPage] {
+            var pages: [HIGPage] = []
+            var visited: Set<String> = []
+            var queue: [URL] = [rootURL]
+
+            // BFS to discover HIG pages
+            while !queue.isEmpty, pages.count < maxPages {
+                let url = queue.removeFirst()
+                let urlString = url.absoluteString
+
+                guard !visited.contains(urlString) else { continue }
+                visited.insert(urlString)
+
+                // Only process HIG URLs
+                guard urlString.contains("/design/human-interface-guidelines") else { continue }
+
+                // Load page and extract links
+                logInfo("Loading: \(url.lastPathComponent.isEmpty ? "root" : url.lastPathComponent)")
+                let html: String
+                do {
+                    html = try await loadPage(url: url)
+                } catch {
+                    logError("Failed to load \(url): \(error)")
+                    continue
+                }
+
+                // Extract title from page
+                let title = extractTitle(from: html) ?? url.lastPathComponent
+
+                // Determine category from URL path
+                let category = extractCategory(from: url)
+
+                // Determine platforms from content
+                let platforms = extractPlatforms(from: html)
+
+                let page = HIGPage(
+                    url: url,
+                    title: title,
+                    category: category,
+                    platforms: platforms
+                )
+                pages.append(page)
+
+                // Extract links to other HIG pages
+                let links = extractHIGLinks(from: html, baseURL: url)
+                for link in links where !visited.contains(link.absoluteString) {
+                    queue.append(link)
+                }
+            }
+
+            return pages
+        }
+
+        private func loadPage(url: URL) async throws -> String {
+            guard let fetcher else {
+                throw HIGCrawlerError.webViewNotInitialized
+            }
+
+            return try await fetcher.fetch(url: url)
+        }
+
+        private func crawlPage(_ page: HIGPage, stats: inout HIGStatistics) async throws {
+            // Determine output path
+            let filename = sanitizeFilename(page.title) + ".md"
+            let categoryDir = outputDirectory.appendingPathComponent(page.category.rawValue)
+
+            do {
+                try FileManager.default.createDirectory(at: categoryDir, withIntermediateDirectories: true)
+            } catch {
+                logError("Failed to create directory \(categoryDir.path): \(error)")
+                throw error
+            }
+
+            let outputPath = categoryDir.appendingPathComponent(filename)
+
+            // Check if already crawled
+            let isNew = !FileManager.default.fileExists(atPath: outputPath.path)
+            if !isNew, !forceRecrawl {
+                stats.skippedPages += 1
+                logInfo("⏭️ Skipped (exists): \(filename)")
+                return
+            }
+
+            // Load page content
+            logInfo("📥 Loading: \(page.title)")
+            let html = try await loadPage(url: page.url)
+
+            // Convert to markdown
+            let markdown = convertToMarkdown(html, page: page)
+
+            // Save
+            do {
+                try markdown.write(to: outputPath, atomically: true, encoding: .utf8)
+                logInfo("💾 Saved: \(outputPath.path)")
+            } catch {
+                logError("Failed to save \(outputPath.path): \(error)")
+                throw error
+            }
+
+            if isNew {
+                stats.newPages += 1
+            } else {
+                stats.updatedPages += 1
+            }
+
+            stats.totalPages += 1
+        }
+        #endif
+
+        private func extractTitle(from html: String) -> String? {
+            // Try to extract from <title> tag
+            let titlePattern = #"<title[^>]*>([^<]+)</title>"#
+            guard let regex = try? NSRegularExpression(pattern: titlePattern, options: .caseInsensitive),
+                  let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+                  let range = Range(match.range(at: 1), in: html)
+            else {
+                return nil
+            }
+
+            var title = String(html[range])
+            // Clean up title
+            title = title.replacingOccurrences(of: " - Human Interface Guidelines", with: "")
+            title = title.replacingOccurrences(of: " | Apple Developer Documentation", with: "")
+            return title.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        private func extractCategory(from url: URL) -> HIGCategory {
+            let path = url.path.lowercased()
+
+            if path.contains("/foundations") {
+                return .foundations
+            } else if path.contains("/patterns") {
+                return .patterns
+            } else if path.contains("/components") {
+                return .components
+            } else if path.contains("/technologies") {
+                return .technologies
+            } else if path.contains("/inputs") {
+                return .inputs
+            } else {
+                return .general
+            }
+        }
+
+        private func extractPlatforms(from html: String) -> [HIGPlatform] {
+            var platforms: [HIGPlatform] = []
+            let content = html.lowercased()
+
+            if content.contains("ios") || content.contains("iphone") || content.contains("ipad") {
+                platforms.append(.iOS)
+            }
+            if content.contains("macos") || content.contains("mac ") {
+                platforms.append(.macOS)
+            }
+            if content.contains("watchos") || content.contains("apple watch") {
+                platforms.append(.watchOS)
+            }
+            if content.contains("visionos") || content.contains("apple vision") {
+                platforms.append(.visionOS)
+            }
+            if content.contains("tvos") || content.contains("apple tv") {
+                platforms.append(.tvOS)
+            }
+
+            return platforms.isEmpty ? [.all] : platforms
+        }
+
+        private func extractHIGLinks(from html: String, baseURL: URL) -> [URL] {
+            var links: [URL] = []
+
+            // Extract href values
+            let hrefPattern = #"href=[\"']([^\"']*human-interface-guidelines[^\"']*)[\"']"#
+            guard let regex = try? NSRegularExpression(pattern: hrefPattern, options: .caseInsensitive) else {
+                return links
+            }
+
+            let matches = regex.matches(in: html, range: NSRange(html.startIndex..., in: html))
+
+            for match in matches {
+                guard let range = Range(match.range(at: 1), in: html) else { continue }
+                let href = String(html[range])
+
+                // Resolve relative URLs
+                if let url = URL(string: href, relativeTo: baseURL)?.absoluteURL {
+                    // Only include HIG URLs
+                    if url.host == "developer.apple.com",
+                       url.path.contains("/design/human-interface-guidelines") {
+                        // Remove fragment
+                        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+                        components?.fragment = nil
+                        if let cleanURL = components?.url {
+                            links.append(cleanURL)
+                        }
+                    }
+                }
+            }
+
+            return Array(Set(links))
+        }
+
+        private func convertToMarkdown(_ html: String, page: HIGPage) -> String {
+            var lines: [String] = []
+
+            // YAML front matter
+            lines.append("---")
+            lines.append("title: \"\(escapeYAML(page.title))\"")
+            lines.append("category: \"\(page.category.rawValue)\"")
+            lines.append("platforms: [\(page.platforms.map { "\"\($0.rawValue)\"" }.joined(separator: ", "))]")
+            lines.append("url: \"\(page.url.absoluteString)\"")
+            lines.append("source: hig")
+            lines.append("---")
+            lines.append("")
+
+            // Title
+            lines.append("# \(page.title)")
+            lines.append("")
+
+            // Category badge
+            lines.append("> **Category:** \(page.category.displayName)")
+            lines.append("> **Platforms:** \(page.platforms.map(\.displayName).joined(separator: ", "))")
+            lines.append("")
+
+            // Convert HTML content to markdown
+            let content = extractMainContent(from: html)
+            let markdownContent = htmlToMarkdown(content)
+            lines.append(markdownContent)
+
+            return lines.joined(separator: "\n")
+        }
+
+        private func extractMainContent(from html: String) -> String {
+            // Try to extract main content area
+            let patterns = [
+                #"<main[^>]*>([\s\S]*?)</main>"#,
+                #"<article[^>]*>([\s\S]*?)</article>"#,
+                #"<div[^>]*class=[\"'][^\"']*content[^\"']*[\"'][^>]*>([\s\S]*?)</div>"#,
+            ]
+
+            for pattern in patterns {
+                guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+                      let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+                      let range = Range(match.range(at: 1), in: html)
+                else {
+                    continue
+                }
+                return String(html[range])
+            }
+
+            return html
+        }
+
+        // swiftlint:disable:next function_body_length
+        // Justification: HTML to Markdown conversion requires many regex replacements.
+        // Splitting would obscure the sequential transformation pipeline.
+        private func htmlToMarkdown(_ html: String) -> String {
+            var result = html
+
+            // Remove script and style tags
+            result = result.replacingOccurrences(
+                of: #"<script[^>]*>[\s\S]*?</script>"#,
+                with: "",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<style[^>]*>[\s\S]*?</style>"#,
+                with: "",
+                options: .regularExpression
+            )
+
+            // Headers
+            for level in 1...6 {
+                let hashes = String(repeating: "#", count: level)
+                result = result.replacingOccurrences(
+                    of: #"<h\#(level)[^>]*>(.*?)</h\#(level)>"#,
+                    with: "\(hashes) $1\n",
+                    options: .regularExpression
+                )
+            }
+
+            // Paragraphs
+            result = result.replacingOccurrences(
+                of: #"<p[^>]*>(.*?)</p>"#,
+                with: "$1\n\n",
+                options: .regularExpression
+            )
+
+            // Bold and italic
+            result = result.replacingOccurrences(
+                of: #"<strong[^>]*>(.*?)</strong>"#,
+                with: "**$1**",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<b[^>]*>(.*?)</b>"#,
+                with: "**$1**",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<em[^>]*>(.*?)</em>"#,
+                with: "*$1*",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<i[^>]*>(.*?)</i>"#,
+                with: "*$1*",
+                options: .regularExpression
+            )
+
+            // Code
+            result = result.replacingOccurrences(
+                of: #"<code[^>]*>(.*?)</code>"#,
+                with: "`$1`",
+                options: .regularExpression
+            )
+
+            // Links
+            result = result.replacingOccurrences(
+                of: #"<a[^>]*href=[\"']([^\"']*)[\"'][^>]*>(.*?)</a>"#,
+                with: "[$2]($1)",
+                options: .regularExpression
+            )
+
+            // Lists
+            result = result.replacingOccurrences(
+                of: #"<li[^>]*>(.*?)</li>"#,
+                with: "- $1\n",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"</?[ou]l[^>]*>"#,
+                with: "\n",
+                options: .regularExpression
+            )
+
+            // Remove remaining HTML tags
+            result = result.replacingOccurrences(
+                of: #"<[^>]+>"#,
+                with: "",
+                options: .regularExpression
+            )
+
+            // Decode HTML entities
+            result = decodeHTMLEntities(result)
+
+            // Clean up whitespace
+            result = result.replacingOccurrences(
+                of: #"\n{3,}"#,
+                with: "\n\n",
+                options: .regularExpression
+            )
+            result = result.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            return result
+        }
+
+        private func decodeHTMLEntities(_ text: String) -> String {
+            var result = text
+            let entities: [(String, String)] = [
+                ("&amp;", "&"),
+                ("&lt;", "<"),
+                ("&gt;", ">"),
+                ("&quot;", "\""),
+                ("&apos;", "'"),
+                ("&#39;", "'"),
+                ("&nbsp;", " "),
+                ("&mdash;", "—"),
+                ("&ndash;", "–"),
+                ("&hellip;", "..."),
+            ]
+
+            for (entity, replacement) in entities {
+                result = result.replacingOccurrences(of: entity, with: replacement)
+            }
+
+            return result
+        }
+
+        private func escapeYAML(_ text: String) -> String {
+            text.replacingOccurrences(of: "\"", with: "\\\"")
+                .replacingOccurrences(of: "\n", with: " ")
+        }
+
+        private func sanitizeFilename(_ name: String) -> String {
+            let invalidChars = CharacterSet(charactersIn: "/\\:*?\"<>|")
+            return name.components(separatedBy: invalidChars).joined(separator: "-")
+                .lowercased()
+                .replacingOccurrences(of: " ", with: "-")
+        }
+
+        // MARK: - Logging
+
+        private func logInfo(_ message: String) {
+            #if canImport(WebKit)
+            let memoryMB = fetcher?.getMemoryUsageMB() ?? 0
+            let memoryMsg = "\(String(format: "%.1f", memoryMB))MB | \(message)"
+            Log.info(memoryMsg, category: .hig)
+            #else
+            Log.info(message, category: .hig)
+            #endif
+        }
+
+        private func logError(_ message: String) {
+            Log.error("Error: \(message)", category: .hig)
+        }
+
+        private func logStatistics(_ stats: HIGStatistics) {
+            let messages = [
+                "Statistics:",
+                "   Total pages: \(stats.totalPages)",
+                "   New: \(stats.newPages)",
+                "   Updated: \(stats.updatedPages)",
+                "   Skipped: \(stats.skippedPages)",
+                "   Errors: \(stats.errors)",
+                stats.duration.map { "   Duration: \(Int($0))s" } ?? "",
+                "",
+                "Output: \(outputDirectory.path)",
+            ]
+
+            for message in messages where !message.isEmpty {
+                Log.info(message, category: .hig)
+            }
+        }
+    }
+}
+
+// swiftlint:enable type_body_length
+
+// MARK: - Models
+
+/// Represents an HIG page to crawl
+public struct HIGPage: Sendable {
+    public let url: URL
+    public let title: String
+    public let category: HIGCategory
+    public let platforms: [HIGPlatform]
+
+    public init(url: URL, title: String, category: HIGCategory, platforms: [HIGPlatform]) {
+        self.url = url
+        self.title = title
+        self.category = category
+        self.platforms = platforms
+    }
+}
+
+/// HIG content categories
+public enum HIGCategory: String, Sendable, CaseIterable {
+    case foundations
+    case patterns
+    case components
+    case technologies
+    case inputs
+    case general
+
+    public var displayName: String {
+        switch self {
+        case .foundations: return "Foundations"
+        case .patterns: return "Patterns"
+        case .components: return "Components"
+        case .technologies: return "Technologies"
+        case .inputs: return "Inputs"
+        case .general: return "General"
+        }
+    }
+}
+
+/// HIG platforms
+public enum HIGPlatform: String, Sendable, CaseIterable {
+    case iOS
+    case macOS
+    case watchOS
+    case visionOS
+    case tvOS
+    case all
+
+    public var displayName: String {
+        switch self {
+        case .iOS: return "iOS"
+        case .macOS: return "macOS"
+        case .watchOS: return "watchOS"
+        case .visionOS: return "visionOS"
+        case .tvOS: return "tvOS"
+        case .all: return "All Platforms"
+        }
+    }
+}
+
+// MARK: - Statistics
+
+public struct HIGStatistics: Sendable {
+    public var totalPages: Int = 0
+    public var newPages: Int = 0
+    public var updatedPages: Int = 0
+    public var skippedPages: Int = 0
+    public var errors: Int = 0
+    public var startTime: Date?
+    public var endTime: Date?
+
+    public init(
+        totalPages: Int = 0,
+        newPages: Int = 0,
+        updatedPages: Int = 0,
+        skippedPages: Int = 0,
+        errors: Int = 0,
+        startTime: Date? = nil,
+        endTime: Date? = nil
+    ) {
+        self.totalPages = totalPages
+        self.newPages = newPages
+        self.updatedPages = updatedPages
+        self.skippedPages = skippedPages
+        self.errors = errors
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+
+    public var duration: TimeInterval? {
+        guard let start = startTime, let end = endTime else {
+            return nil
+        }
+        return end.timeIntervalSince(start)
+    }
+}
+
+// MARK: - Progress
+
+public struct HIGProgress: Sendable {
+    public let currentPage: Int
+    public let totalPages: Int
+    public let currentItem: String
+    public let stats: HIGStatistics
+
+    public var percentage: Double {
+        guard totalPages > 0 else { return 0 }
+        return Double(currentPage) / Double(totalPages) * 100
+    }
+}
+
+// MARK: - Errors
+
+public enum HIGCrawlerError: Error, LocalizedError {
+    case invalidResponse(URL)
+    case webKitNotAvailable
+    case webViewNotInitialized
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidResponse(let url):
+            return "Invalid response from \(url)"
+        case .webKitNotAvailable:
+            return "WebKit not available - HIG crawler requires macOS"
+        case .webViewNotInitialized:
+            return "WebView not initialized"
+        }
+    }
+}

--- a/Packages/Sources/Logging/CupertinoLogger.swift
+++ b/Packages/Sources/Logging/CupertinoLogger.swift
@@ -39,6 +39,9 @@ extension Logging {
 
         /// Logger for Apple archive documentation operations
         public static let archive = os.Logger(subsystem: subsystem, category: "archive")
+
+        /// Logger for Human Interface Guidelines operations
+        public static let hig = os.Logger(subsystem: subsystem, category: "hig")
     }
 }
 

--- a/Packages/Sources/Logging/UnifiedLogger.swift
+++ b/Packages/Sources/Logging/UnifiedLogger.swift
@@ -68,6 +68,7 @@ public actor UnifiedLogger {
         case samples
         case packages
         case archive
+        case hig
 
         /// Get the os.Logger for this category
         var osLogger: os.Logger {
@@ -81,6 +82,7 @@ public actor UnifiedLogger {
             case .samples: return Logging.Logger.samples
             case .packages: return Logging.Logger.packageDownloader
             case .archive: return Logging.Logger.archive
+            case .hig: return Logging.Logger.hig
             }
         }
     }

--- a/Packages/Sources/RemoteSync/RemoteIndexer.swift
+++ b/Packages/Sources/RemoteSync/RemoteIndexer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Shared
 
 // MARK: - Indexing Context
 
@@ -248,22 +249,24 @@ public actor RemoteIndexer {
     // MARK: - Helpers
 
     private func phasePath(_ phase: RemoteIndexState.Phase) -> String {
+        typealias Dir = Shared.Constants.Directory
         switch phase {
-        case .docs: return "docs"
-        case .evolution: return "swift-evolution"
-        case .archive: return "archive"
-        case .swiftOrg: return "swift-org"
-        case .packages: return "packages"
+        case .docs: return Dir.docs
+        case .evolution: return Dir.swiftEvolution
+        case .archive: return Dir.archive
+        case .swiftOrg: return Dir.swiftOrg
+        case .packages: return Dir.packages
         }
     }
 
     private func phaseSource(_ phase: RemoteIndexState.Phase) -> String {
+        typealias SP = Shared.Constants.SourcePrefix
         switch phase {
-        case .docs: return "apple-docs"
-        case .evolution: return "swift-evolution"
-        case .archive: return "apple-archive"
-        case .swiftOrg: return "swift-org"
-        case .packages: return "packages"
+        case .docs: return SP.appleDocs
+        case .evolution: return SP.swiftEvolution
+        case .archive: return SP.appleArchive
+        case .swiftOrg: return SP.swiftOrg
+        case .packages: return SP.packages
         }
     }
 

--- a/Packages/Sources/Search/SearchIndex.swift
+++ b/Packages/Sources/Search/SearchIndex.swift
@@ -244,6 +244,19 @@ extension Search {
             CREATE INDEX IF NOT EXISTS idx_docs_kind ON docs_structured(kind);
             CREATE INDEX IF NOT EXISTS idx_docs_module ON docs_structured(module);
 
+            -- Framework aliases: maps identifier, import name, and display name
+            -- identifier: appintents (lowercase, URL path, folder name)
+            -- import_name: AppIntents (CamelCase, Swift import statement)
+            -- display_name: App Intents (human-readable, from JSON module field)
+            CREATE TABLE IF NOT EXISTS framework_aliases (
+                identifier TEXT PRIMARY KEY,
+                import_name TEXT NOT NULL,
+                display_name TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_alias_import ON framework_aliases(import_name);
+            CREATE INDEX IF NOT EXISTS idx_alias_display ON framework_aliases(display_name);
+
             CREATE TABLE IF NOT EXISTS packages (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 name TEXT NOT NULL,
@@ -855,6 +868,11 @@ extension Search {
             page: StructuredDocumentationPage,
             jsonData: String
         ) async throws {
+            // Register framework alias if module is available
+            if let module = page.module, !module.isEmpty {
+                try await registerFrameworkAlias(identifier: framework, displayName: module)
+            }
+
             // First, index the basic document (FTS + metadata with json_data)
             // Extract optimized content based on document kind to improve BM25 ranking
             let content = extractOptimizedContent(from: page)
@@ -1508,6 +1526,7 @@ extension Search {
         ///   - framework: Optional framework filter (swiftui, foundation, etc. - only for apple-docs)
         ///   - language: Optional language filter (swift, objc)
         ///   - limit: Maximum number of results
+        // swiftlint:disable:next cyclomatic_complexity
         public func search(
             query: String,
             source: String? = nil,
@@ -1531,6 +1550,14 @@ extension Search {
 
             // Use explicit source or detected source
             let effectiveSource = source ?? detectedSource
+
+            // Resolve framework input to identifier (supports "appintents", "AppIntents", "App Intents")
+            let effectiveFramework: String?
+            if let framework {
+                effectiveFramework = try await resolveFrameworkIdentifier(framework)
+            } else {
+                effectiveFramework = nil
+            }
 
             // Check if user explicitly requested archive
             let archiveRequested = effectiveSource == "apple-archive"
@@ -1562,7 +1589,7 @@ extension Search {
                 // Exclude apple-archive by default unless explicitly requested or includeArchive is true
                 sql += " AND f.source != 'apple-archive'"
             }
-            if framework != nil {
+            if effectiveFramework != nil {
                 sql += " AND f.framework = ?"
             }
             if language != nil {
@@ -1591,8 +1618,8 @@ extension Search {
                 sqlite3_bind_text(statement, paramIndex, (effectiveSource as NSString).utf8String, -1, nil)
                 paramIndex += 1
             }
-            if let framework {
-                sqlite3_bind_text(statement, paramIndex, (framework as NSString).utf8String, -1, nil)
+            if let effectiveFramework {
+                sqlite3_bind_text(statement, paramIndex, (effectiveFramework as NSString).utf8String, -1, nil)
                 paramIndex += 1
             }
             if let language {
@@ -1872,6 +1899,149 @@ extension Search {
                 let framework = String(cString: frameworkPtr)
                 let count = Int(sqlite3_column_int(statement, 1))
                 frameworks[framework] = count
+            }
+
+            return frameworks
+        }
+
+        // MARK: - Framework Aliases
+
+        /// Framework info with all three name forms
+        public struct FrameworkInfo: Sendable {
+            public let identifier: String // appintents
+            public let importName: String // AppIntents
+            public let displayName: String // App Intents
+            public let docCount: Int
+        }
+
+        /// Register a framework alias (called during indexing when module is available)
+        /// - Parameters:
+        ///   - identifier: lowercase identifier from folder/URL (e.g., "appintents")
+        ///   - displayName: display name from JSON module field (e.g., "App Intents")
+        public func registerFrameworkAlias(identifier: String, displayName: String) async throws {
+            guard let database else {
+                throw SearchError.databaseNotInitialized
+            }
+
+            // Derive import name by removing spaces from display name
+            let importName = displayName.replacingOccurrences(of: " ", with: "")
+
+            let sql = """
+            INSERT INTO framework_aliases (identifier, import_name, display_name)
+            VALUES (?, ?, ?)
+            ON CONFLICT(identifier) DO UPDATE SET
+                import_name = excluded.import_name,
+                display_name = excluded.display_name;
+            """
+
+            var statement: OpaquePointer?
+            defer { sqlite3_finalize(statement) }
+
+            guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+                return // Silently fail - alias registration is not critical
+            }
+
+            sqlite3_bind_text(statement, 1, (identifier as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(statement, 2, (importName as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(statement, 3, (displayName as NSString).utf8String, -1, nil)
+
+            _ = sqlite3_step(statement)
+        }
+
+        /// Resolve any framework input (identifier, import name, or display name) to identifier
+        /// - Parameter input: Any of the three forms (e.g., "appintents", "AppIntents", "App Intents")
+        /// - Returns: The identifier form (e.g., "appintents"), or nil if not found
+        public func resolveFrameworkIdentifier(_ input: String) async throws -> String? {
+            guard let database else {
+                throw SearchError.databaseNotInitialized
+            }
+
+            // First try: exact match on identifier (most common case)
+            let normalizedInput = input.lowercased().replacingOccurrences(of: " ", with: "")
+
+            // Check if identifier exists directly
+            let checkSql = "SELECT identifier FROM framework_aliases WHERE identifier = ? LIMIT 1;"
+            var checkStmt: OpaquePointer?
+            defer { sqlite3_finalize(checkStmt) }
+
+            if sqlite3_prepare_v2(database, checkSql, -1, &checkStmt, nil) == SQLITE_OK {
+                sqlite3_bind_text(checkStmt, 1, (normalizedInput as NSString).utf8String, -1, nil)
+                if sqlite3_step(checkStmt) == SQLITE_ROW,
+                   let ptr = sqlite3_column_text(checkStmt, 0) {
+                    return String(cString: ptr)
+                }
+            }
+
+            // Second try: match on import_name or display_name
+            let sql = """
+            SELECT identifier FROM framework_aliases
+            WHERE import_name = ? OR display_name = ? OR LOWER(display_name) = ?
+            LIMIT 1;
+            """
+
+            var statement: OpaquePointer?
+            defer { sqlite3_finalize(statement) }
+
+            guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+                return nil
+            }
+
+            sqlite3_bind_text(statement, 1, (input as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(statement, 2, (input as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(statement, 3, (input.lowercased() as NSString).utf8String, -1, nil)
+
+            if sqlite3_step(statement) == SQLITE_ROW,
+               let ptr = sqlite3_column_text(statement, 0) {
+                return String(cString: ptr)
+            }
+
+            // Fallback: return normalized input (might be a valid framework not in alias table yet)
+            return normalizedInput
+        }
+
+        /// List all frameworks with full alias info and document counts
+        public func listFrameworksWithAliases() async throws -> [FrameworkInfo] {
+            guard let database else {
+                throw SearchError.databaseNotInitialized
+            }
+
+            let sql = """
+            SELECT
+                m.framework,
+                COALESCE(a.import_name, m.framework) as import_name,
+                COALESCE(a.display_name, m.framework) as display_name,
+                COUNT(*) as count
+            FROM docs_metadata m
+            LEFT JOIN framework_aliases a ON m.framework = a.identifier
+            GROUP BY m.framework
+            ORDER BY m.framework;
+            """
+
+            var statement: OpaquePointer?
+            defer { sqlite3_finalize(statement) }
+
+            guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+                let errorMessage = String(cString: sqlite3_errmsg(database))
+                throw SearchError.searchFailed("List frameworks with aliases failed: \(errorMessage)")
+            }
+
+            var frameworks: [FrameworkInfo] = []
+
+            while sqlite3_step(statement) == SQLITE_ROW {
+                guard let identifierPtr = sqlite3_column_text(statement, 0),
+                      let importNamePtr = sqlite3_column_text(statement, 1),
+                      let displayNamePtr = sqlite3_column_text(statement, 2)
+                else {
+                    continue
+                }
+
+                let info = FrameworkInfo(
+                    identifier: String(cString: identifierPtr),
+                    importName: String(cString: importNamePtr),
+                    displayName: String(cString: displayNamePtr),
+                    docCount: Int(sqlite3_column_int(statement, 3))
+                )
+                frameworks.append(info)
             }
 
             return frameworks

--- a/Packages/Sources/Search/SearchIndexBuilder.swift
+++ b/Packages/Sources/Search/SearchIndexBuilder.swift
@@ -90,12 +90,8 @@ extension Search {
         // MARK: - Private Methods
 
         private func indexAppleDocs(onProgress: (@Sendable (Int, Int) -> Void)?) async throws {
-            // Use metadata if available, otherwise scan directory
-            if let metadata {
-                try await indexAppleDocsFromMetadata(metadata: metadata, onProgress: onProgress)
-            } else {
-                try await indexAppleDocsFromDirectory(onProgress: onProgress)
-            }
+            // Always scan directory - metadata is for fetching, not indexing
+            try await indexAppleDocsFromDirectory(onProgress: onProgress)
         }
 
         private func indexAppleDocsFromMetadata(
@@ -395,6 +391,13 @@ extension Search {
                     continue
                 }
 
+                // Only index accepted/implemented proposals
+                let status = extractProposalStatus(from: content)
+                guard isAcceptedProposal(status) else {
+                    skipped += 1
+                    continue
+                }
+
                 do {
                     try await indexProposal(file: file, content: content)
                     indexed += 1
@@ -447,6 +450,47 @@ extension Search {
             )
         }
 
+        /// Extract status from Swift Evolution proposal markdown
+        private func extractProposalStatus(from markdown: String) -> String? {
+            // Format: "* Status: **Implemented (Swift 2.2)**" or "* Status: **Accepted**"
+            guard let regex = try? NSRegularExpression(pattern: Shared.Constants.Pattern.seStatus),
+                  let match = regex.firstMatch(
+                      in: markdown,
+                      range: NSRange(markdown.startIndex..., in: markdown)
+                  ),
+                  match.numberOfRanges > 1,
+                  let statusRange = Range(match.range(at: 1), in: markdown)
+            else {
+                return nil
+            }
+            return String(markdown[statusRange])
+        }
+
+        /// Check if proposal status indicates it was accepted/implemented
+        private func isAcceptedProposal(_ status: String?) -> Bool {
+            guard let status = status?.lowercased() else {
+                return false
+            }
+            // Accept proposals that are "Implemented", "Accepted", or "Accepted with revisions"
+            return status.contains("implemented") || status.contains("accepted")
+        }
+
+        /// Check if a page is a 404 error page
+        private func is404Page(title: String, content: String) -> Bool {
+            // Check title
+            if title.lowercased() == "not found" {
+                return true
+            }
+            // Check content for common 404 indicators
+            let lowerContent = content.lowercased()
+            if lowerContent.contains("the requested url was not found") ||
+                lowerContent.contains("404 not found") ||
+                lowerContent.contains("page not found") {
+                return true
+            }
+            return false
+        }
+
         // MARK: - Swift.org Documentation
 
         private func indexSwiftOrgDocs(onProgress: (@Sendable (Int, Int) -> Void)?) async throws {
@@ -459,54 +503,100 @@ extension Search {
                 return
             }
 
-            let markdownFiles = try findMarkdownFiles(in: swiftOrgDirectory)
+            // Use findDocFiles to handle both .json and .md files (same as Apple docs)
+            let docFiles = try findDocFiles(in: swiftOrgDirectory)
 
-            guard !markdownFiles.isEmpty else {
+            guard !docFiles.isEmpty else {
                 logInfo("⚠️  No Swift.org documentation found")
                 return
             }
 
-            logInfo("🔶 Indexing \(markdownFiles.count) Swift.org documentation pages...")
+            logInfo("🔶 Indexing \(docFiles.count) Swift.org documentation pages...")
 
             var indexed = 0
             var skipped = 0
 
-            for (index, file) in markdownFiles.enumerated() {
-                guard let content = try? String(contentsOf: file, encoding: .utf8) else {
-                    skipped += 1
-                    continue
-                }
-
+            for (index, file) in docFiles.enumerated() {
                 // Extract source from path: swift-org/{source}/... (swift-book or swift-org)
                 let source = extractFrameworkFromPath(file, relativeTo: swiftOrgDirectory)
                     ?? Shared.Constants.SourcePrefix.swiftOrg
 
-                // Extract title from markdown
-                let title = extractTitle(from: content) ?? file.deletingPathExtension().lastPathComponent
+                // Handle JSON and MD files (same pattern as Apple docs)
+                let structuredPage: StructuredDocumentationPage
+                let jsonString: String
+
+                if file.pathExtension == "json" {
+                    // JSON format: decode directly
+                    do {
+                        let jsonData = try Data(contentsOf: file)
+                        jsonString = String(data: jsonData, encoding: .utf8) ?? "{}"
+                        let decoder = JSONDecoder()
+                        decoder.dateDecodingStrategy = .iso8601
+                        structuredPage = try decoder.decode(StructuredDocumentationPage.self, from: jsonData)
+                    } catch {
+                        logError("Failed to decode \(file.lastPathComponent): \(error)")
+                        skipped += 1
+                        continue
+                    }
+                } else {
+                    // Markdown format: convert to StructuredDocumentationPage
+                    guard let mdContent = try? String(contentsOf: file, encoding: .utf8) else {
+                        skipped += 1
+                        continue
+                    }
+
+                    let pageURL = URL(string: "https://www.swift.org/documentation/\(file.deletingPathExtension().lastPathComponent)")
+                    guard let converted = MarkdownToStructuredPage.convert(mdContent, url: pageURL) else {
+                        logError("Failed to convert \(file.lastPathComponent) to structured page")
+                        skipped += 1
+                        continue
+                    }
+                    structuredPage = converted
+
+                    let encoder = JSONEncoder()
+                    encoder.dateEncodingStrategy = .iso8601
+                    guard let jsonData = try? encoder.encode(structuredPage),
+                          let json = String(data: jsonData, encoding: .utf8) else {
+                        logError("Failed to encode \(file.lastPathComponent) to JSON")
+                        skipped += 1
+                        continue
+                    }
+                    jsonString = json
+                }
+
+                // Skip 404/error pages
+                let title = structuredPage.title
+                let content = structuredPage.rawMarkdown ?? structuredPage.overview ?? ""
+                if is404Page(title: title, content: content) {
+                    skipped += 1
+                    continue
+                }
 
                 // Generate URI: {source}://{filename}
                 let filename = file.deletingPathExtension().lastPathComponent
                 let uri = "\(source)://\(filename)"
 
-                // Calculate content hash
-                let contentHash = HashUtilities.sha256(of: content)
-
-                // Use file modification date
-                let attributes = try? FileManager.default.attributesOfItem(atPath: file.path)
-                let modDate = attributes?[.modificationDate] as? Date ?? Date()
-
                 do {
-                    // Use extracted source (e.g., swift-book or swift-org prefix), no framework
-                    try await searchIndex.indexDocument(
+                    // Use source as framework for swift-org (swift-book or swift-org)
+                    try await searchIndex.indexStructuredDocument(
                         uri: uri,
                         source: source,
-                        framework: nil,
-                        title: title,
-                        content: content,
-                        filePath: file.path,
-                        contentHash: contentHash,
-                        lastCrawled: modDate
+                        framework: source,
+                        page: structuredPage,
+                        jsonData: jsonString
                     )
+
+                    // Index code examples if present
+                    if !structuredPage.codeExamples.isEmpty {
+                        let examples = structuredPage.codeExamples.map {
+                            (code: $0.code, language: $0.language ?? "swift")
+                        }
+                        try await searchIndex.indexCodeExamples(
+                            docUri: uri,
+                            codeExamples: examples
+                        )
+                    }
+
                     indexed += 1
                 } catch {
                     logError("Failed to index \(uri): \(error)")
@@ -514,7 +604,7 @@ extension Search {
                 }
 
                 if (index + 1) % Shared.Constants.Interval.progressLogEvery == 0 {
-                    logInfo("   Progress: \(index + 1)/\(markdownFiles.count)")
+                    logInfo("   Progress: \(index + 1)/\(docFiles.count)")
                 }
             }
 

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -12,8 +12,8 @@ public actor CompositeToolProvider: ToolProvider {
     private let sampleCodeTools: SampleCodeToolProvider?
 
     public init(searchIndex: Search.Index?, sampleDatabase: SampleIndex.Database?) {
-        self.documentationTools = searchIndex.map { DocumentationToolProvider(searchIndex: $0) }
-        self.sampleCodeTools = sampleDatabase.map { SampleCodeToolProvider(database: $0) }
+        documentationTools = searchIndex.map { DocumentationToolProvider(searchIndex: $0) }
+        sampleCodeTools = sampleDatabase.map { SampleCodeToolProvider(database: $0) }
     }
 
     // MARK: - ToolProvider
@@ -54,25 +54,6 @@ public actor CompositeToolProvider: ToolProvider {
         }
 
         // Tool not found in any provider
-        throw UnifiedToolError.unknownTool(name)
-    }
-}
-
-// MARK: - Tool Errors
-
-enum UnifiedToolError: Error, LocalizedError {
-    case unknownTool(String)
-    case missingArgument(String)
-    case invalidArgument(String, String)
-
-    var errorDescription: String? {
-        switch self {
-        case .unknownTool(let name):
-            return "Unknown tool: \(name)"
-        case .missingArgument(let arg):
-            return "Missing required argument: \(arg)"
-        case .invalidArgument(let arg, let reason):
-            return "Invalid argument '\(arg)': \(reason)"
-        }
+        throw ToolError.unknownTool(name)
     }
 }

--- a/Packages/Sources/Services/DocsSearchService.swift
+++ b/Packages/Sources/Services/DocsSearchService.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Search
+import Shared
+
+// MARK: - Documentation Search Service
+
+/// Service for searching Apple documentation, Swift Evolution, and other indexed sources.
+/// Wraps Search.Index with a clean interface for both CLI and MCP consumers.
+public actor DocsSearchService: SearchService {
+    private let index: Search.Index
+
+    /// Initialize with an existing search index
+    public init(index: Search.Index) {
+        self.index = index
+    }
+
+    /// Initialize with a database path, creating a new index connection
+    public init(dbPath: URL) async throws {
+        index = try await Search.Index(dbPath: dbPath)
+    }
+
+    // MARK: - SearchService Protocol
+
+    public func search(_ query: SearchQuery) async throws -> [Search.Result] {
+        try await index.search(
+            query: query.text,
+            source: query.source,
+            framework: query.framework,
+            language: query.language,
+            limit: query.limit,
+            includeArchive: query.includeArchive
+        )
+    }
+
+    public func read(uri: String, format: Search.Index.DocumentFormat) async throws -> String? {
+        try await index.getDocumentContent(uri: uri, format: format)
+    }
+
+    public func listFrameworks() async throws -> [String: Int] {
+        try await index.listFrameworks()
+    }
+
+    public func documentCount() async throws -> Int {
+        try await index.documentCount()
+    }
+
+    public func disconnect() async {
+        await index.disconnect()
+    }
+
+    // MARK: - Convenience Methods
+
+    /// Search with a simple text query using defaults
+    public func search(text: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> [Search.Result] {
+        try await search(SearchQuery(text: text, limit: limit))
+    }
+
+    /// Search within a specific framework
+    public func search(text: String, framework: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> [Search.Result] {
+        try await search(SearchQuery(text: text, framework: framework, limit: limit))
+    }
+
+    /// Search within a specific source (apple-docs, swift-evolution, etc.)
+    public func search(text: String, source: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> [Search.Result] {
+        try await search(SearchQuery(text: text, source: source, limit: limit))
+    }
+}

--- a/Packages/Sources/Services/Formatters/JSONFormatter.swift
+++ b/Packages/Sources/Services/Formatters/JSONFormatter.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Search
+import Shared
+
+// MARK: - JSON Search Result Formatter
+
+/// Formats search results as JSON for CLI --format json
+public struct JSONSearchResultFormatter: ResultFormatter {
+    public init() {}
+
+    public func format(_ results: [Search.Result]) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        guard let data = try? encoder.encode(results),
+              let json = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return json
+    }
+}
+
+// MARK: - Frameworks JSON Formatter
+
+/// Formats framework list as JSON
+public struct FrameworksJSONFormatter: ResultFormatter {
+    public init() {}
+
+    public func format(_ frameworks: [String: Int]) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        // Convert to array of objects for better readability
+        let frameworkList = frameworks.map { FrameworkEntry(name: $0.key, documentCount: $0.value) }
+            .sorted { $0.documentCount > $1.documentCount }
+
+        guard let data = try? encoder.encode(frameworkList),
+              let json = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return json
+    }
+
+    private struct FrameworkEntry: Encodable {
+        let name: String
+        let documentCount: Int
+    }
+}

--- a/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Search
+import Shared
+
+// MARK: - Markdown Search Result Formatter
+
+/// Formats search results as markdown for MCP tools and CLI --format markdown
+public struct MarkdownSearchResultFormatter: ResultFormatter {
+    private let query: String
+    private let filters: SearchFilters?
+    private let config: SearchResultFormatConfig
+
+    public init(
+        query: String,
+        filters: SearchFilters? = nil,
+        config: SearchResultFormatConfig = .mcpDefault
+    ) {
+        self.query = query
+        self.filters = filters
+        self.config = config
+    }
+
+    public func format(_ results: [Search.Result]) -> String {
+        var md = "# Search Results for \"\(query)\"\n\n"
+
+        // Show active filters
+        if let filters, filters.hasActiveFilters {
+            if let source = filters.source {
+                md += "_Filtered to source: **\(source)**_\n\n"
+            }
+            if let framework = filters.framework {
+                md += "_Filtered to framework: **\(framework)**_\n\n"
+            }
+            if let language = filters.language {
+                md += "_Filtered to language: **\(language)**_\n\n"
+            }
+        }
+
+        md += "Found **\(results.count)** result\(results.count == 1 ? "" : "s"):\n\n"
+
+        if results.isEmpty {
+            md += config.emptyMessage
+            return md
+        }
+
+        for (index, result) in results.enumerated() {
+            md += "## \(index + 1). \(result.title)\n\n"
+            md += "- **Framework:** `\(result.framework)`\n"
+            md += "- **URI:** `\(result.uri)`\n"
+
+            if config.showScore {
+                md += "- **Score:** \(String(format: "%.2f", result.score))\n"
+            }
+            if config.showWordCount {
+                md += "- **Words:** \(result.wordCount)\n"
+            }
+            if config.showSource {
+                md += "- **Source:** \(result.source)\n"
+            }
+
+            md += "\n\(result.summary)\n\n"
+
+            if config.showSeparators, index < results.count - 1 {
+                md += "---\n\n"
+            }
+        }
+
+        md += "\n\n"
+        md += Shared.Constants.MCP.tipUseResourcesRead
+        md += "\n"
+
+        return md
+    }
+}
+
+// MARK: - HIG Markdown Formatter
+
+/// Formats HIG search results as markdown
+public struct HIGMarkdownFormatter: ResultFormatter {
+    private let query: HIGQuery
+    private let config: SearchResultFormatConfig
+
+    public init(query: HIGQuery, config: SearchResultFormatConfig = .mcpDefault) {
+        self.query = query
+        self.config = config
+    }
+
+    public func format(_ results: [Search.Result]) -> String {
+        var md = "# HIG Search Results for \"\(query.text)\"\n\n"
+
+        if let platform = query.platform {
+            md += "_Platform: **\(platform)**_\n\n"
+        }
+        if let category = query.category {
+            md += "_Category: **\(category)**_\n\n"
+        }
+
+        md += "Found **\(results.count)** guideline\(results.count == 1 ? "" : "s"):\n\n"
+
+        if results.isEmpty {
+            md += "_No Human Interface Guidelines found matching your query._\n\n"
+            md += "**Tips:**\n"
+            md += "- Try broader design terms (e.g., 'buttons', 'typography', 'navigation')\n"
+            md += "- Specify a platform: iOS, macOS, watchOS, visionOS, tvOS\n"
+            md += "- Specify a category: foundations, patterns, components, technologies, inputs\n"
+            return md
+        }
+
+        for (index, result) in results.enumerated() {
+            md += "## \(index + 1). \(result.title)\n\n"
+            md += "- **URI:** `\(result.uri)`\n"
+
+            if config.showScore {
+                md += "- **Score:** \(String(format: "%.2f", result.score))\n"
+            }
+
+            md += "\n\(result.summary)\n\n"
+
+            if config.showSeparators, index < results.count - 1 {
+                md += "---\n\n"
+            }
+        }
+
+        md += "\n\n"
+        md += Shared.Constants.MCP.tipUseResourcesRead
+        md += "\n"
+
+        return md
+    }
+}
+
+// MARK: - Frameworks Markdown Formatter
+
+/// Formats framework list as markdown
+public struct FrameworksMarkdownFormatter: ResultFormatter {
+    private let totalDocs: Int
+
+    public init(totalDocs: Int) {
+        self.totalDocs = totalDocs
+    }
+
+    public func format(_ frameworks: [String: Int]) -> String {
+        var md = "# Available Frameworks\n\n"
+        md += "Total documents: **\(totalDocs)**\n\n"
+
+        if frameworks.isEmpty {
+            let cmd = "\(Shared.Constants.App.commandName) \(Shared.Constants.Command.buildIndex)"
+            md += Shared.Constants.MCP.messageNoFrameworks(buildIndexCommand: cmd)
+            return md
+        }
+
+        md += "| Framework | Documents |\n"
+        md += "|-----------|----------:|\n"
+
+        // Sort by document count (descending)
+        for (framework, count) in frameworks.sorted(by: { $0.value > $1.value }) {
+            md += "| `\(framework)` | \(count) |\n"
+        }
+
+        md += "\n"
+        md += Shared.Constants.MCP.tipFilterByFramework
+        md += "\n"
+
+        return md
+    }
+}

--- a/Packages/Sources/Services/Formatters/ResultFormatter.swift
+++ b/Packages/Sources/Services/Formatters/ResultFormatter.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Search
+import Shared
+
+// MARK: - Result Formatter Protocol
+
+/// Protocol for formatting search results to different output formats
+public protocol ResultFormatter {
+    associatedtype Input
+    func format(_ input: Input) -> String
+}
+
+// MARK: - Search Result Format Configuration
+
+/// Configuration for search result formatting
+public struct SearchResultFormatConfig: Sendable {
+    public let showScore: Bool
+    public let showWordCount: Bool
+    public let showSource: Bool
+    public let showSeparators: Bool
+    public let emptyMessage: String
+
+    public init(
+        showScore: Bool = false,
+        showWordCount: Bool = false,
+        showSource: Bool = true,
+        showSeparators: Bool = false,
+        emptyMessage: String = "No results found"
+    ) {
+        self.showScore = showScore
+        self.showWordCount = showWordCount
+        self.showSource = showSource
+        self.showSeparators = showSeparators
+        self.emptyMessage = emptyMessage
+    }
+
+    /// Default configuration for CLI output
+    public static let cliDefault = SearchResultFormatConfig(
+        showScore: false,
+        showWordCount: false,
+        showSource: true,
+        showSeparators: false,
+        emptyMessage: "No results found"
+    )
+
+    /// Default configuration for MCP tool output
+    public static let mcpDefault = SearchResultFormatConfig(
+        showScore: true,
+        showWordCount: true,
+        showSource: false,
+        showSeparators: true,
+        emptyMessage: "_No results found. Try broader search terms._"
+    )
+}

--- a/Packages/Sources/Services/Formatters/SampleJSONFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleJSONFormatter.swift
@@ -1,0 +1,179 @@
+import Foundation
+import SampleIndex
+import Shared
+
+// MARK: - Sample Search JSON Formatter
+
+/// Formats sample search results as JSON
+public struct SampleSearchJSONFormatter: ResultFormatter {
+    private let query: String
+    private let framework: String?
+
+    public init(query: String, framework: String? = nil) {
+        self.query = query
+        self.framework = framework
+    }
+
+    public func format(_ result: SampleSearchResult) -> String {
+        struct Output: Encodable {
+            let query: String
+            let framework: String?
+            let projects: [ProjectOutput]
+            let files: [FileOutput]
+        }
+
+        struct ProjectOutput: Encodable {
+            let id: String
+            let title: String
+            let description: String
+            let frameworks: [String]
+            let fileCount: Int
+        }
+
+        struct FileOutput: Encodable {
+            let projectId: String
+            let path: String
+            let filename: String
+            let snippet: String
+            let rank: Double
+        }
+
+        let output = Output(
+            query: query,
+            framework: framework,
+            projects: result.projects.map {
+                ProjectOutput(
+                    id: $0.id,
+                    title: $0.title,
+                    description: $0.description,
+                    frameworks: $0.frameworks,
+                    fileCount: $0.fileCount
+                )
+            },
+            files: result.files.map {
+                FileOutput(
+                    projectId: $0.projectId,
+                    path: $0.path,
+                    filename: $0.filename,
+                    snippet: $0.snippet,
+                    rank: $0.rank
+                )
+            }
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        do {
+            let data = try encoder.encode(output)
+            return String(data: data, encoding: .utf8) ?? "{}"
+        } catch {
+            return "{ \"error\": \"Failed to encode JSON: \(error.localizedDescription)\" }"
+        }
+    }
+}
+
+// MARK: - Sample List JSON Formatter
+
+/// Formats sample project list as JSON
+public struct SampleListJSONFormatter: ResultFormatter {
+    public init() {}
+
+    public func format(_ projects: [SampleIndex.Project]) -> String {
+        struct ProjectOutput: Encodable {
+            let id: String
+            let title: String
+            let description: String
+            let frameworks: [String]
+            let fileCount: Int
+        }
+
+        let output = projects.map {
+            ProjectOutput(
+                id: $0.id,
+                title: $0.title,
+                description: $0.description,
+                frameworks: $0.frameworks,
+                fileCount: $0.fileCount
+            )
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        do {
+            let data = try encoder.encode(output)
+            return String(data: data, encoding: .utf8) ?? "[]"
+        } catch {
+            return "{ \"error\": \"Failed to encode JSON: \(error.localizedDescription)\" }"
+        }
+    }
+}
+
+// MARK: - Sample Project JSON Formatter
+
+/// Formats a single sample project as JSON
+public struct SampleProjectJSONFormatter: ResultFormatter {
+    public init() {}
+
+    public func format(_ project: SampleIndex.Project) -> String {
+        struct ProjectOutput: Encodable {
+            let id: String
+            let title: String
+            let description: String
+            let frameworks: [String]
+            let fileCount: Int
+        }
+
+        let output = ProjectOutput(
+            id: project.id,
+            title: project.title,
+            description: project.description,
+            frameworks: project.frameworks,
+            fileCount: project.fileCount
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        do {
+            let data = try encoder.encode(output)
+            return String(data: data, encoding: .utf8) ?? "{}"
+        } catch {
+            return "{ \"error\": \"Failed to encode JSON: \(error.localizedDescription)\" }"
+        }
+    }
+}
+
+// MARK: - Sample File JSON Formatter
+
+/// Formats a sample file as JSON
+public struct SampleFileJSONFormatter: ResultFormatter {
+    public init() {}
+
+    public func format(_ file: SampleIndex.File) -> String {
+        struct FileOutput: Encodable {
+            let projectId: String
+            let path: String
+            let filename: String
+            let content: String
+        }
+
+        let output = FileOutput(
+            projectId: file.projectId,
+            path: file.path,
+            filename: file.filename,
+            content: file.content
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        do {
+            let data = try encoder.encode(output)
+            return String(data: data, encoding: .utf8) ?? "{}"
+        } catch {
+            return "{ \"error\": \"Failed to encode JSON: \(error.localizedDescription)\" }"
+        }
+    }
+}

--- a/Packages/Sources/Services/Formatters/SampleMarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleMarkdownFormatter.swift
@@ -1,0 +1,140 @@
+import Foundation
+import SampleIndex
+import Shared
+
+// MARK: - Sample Search Markdown Formatter
+
+/// Formats sample search results as markdown
+public struct SampleSearchMarkdownFormatter: ResultFormatter {
+    private let query: String
+    private let framework: String?
+
+    public init(query: String, framework: String? = nil) {
+        self.query = query
+        self.framework = framework
+    }
+
+    public func format(_ result: SampleSearchResult) -> String {
+        var output = "# Sample Code Search: \"\(query)\"\n\n"
+
+        if let framework {
+            output += "_Filtered to framework: **\(framework)**_\n\n"
+        }
+
+        // Projects
+        output += "## Projects (\(result.projects.count) found)\n\n"
+
+        if result.projects.isEmpty {
+            output += "_No matching projects found._\n\n"
+        } else {
+            for (index, project) in result.projects.enumerated() {
+                output += "### \(index + 1). \(project.title)\n\n"
+                output += "- **ID:** `\(project.id)`\n"
+                output += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
+                output += "- **Files:** \(project.fileCount)\n\n"
+
+                if !project.description.isEmpty {
+                    output += "\(project.description)\n\n"
+                }
+            }
+        }
+
+        // Files
+        if !result.files.isEmpty {
+            output += "\n## Matching Files (\(result.files.count) found)\n\n"
+
+            for (index, file) in result.files.prefix(10).enumerated() {
+                output += "### \(index + 1). \(file.filename)\n\n"
+                output += "- **Project:** `\(file.projectId)`\n"
+                output += "- **Path:** `\(file.path)`\n\n"
+                output += "> \(file.snippet)\n\n"
+            }
+        }
+
+        return output
+    }
+}
+
+// MARK: - Sample List Markdown Formatter
+
+/// Formats sample project list as markdown
+public struct SampleListMarkdownFormatter: ResultFormatter {
+    private let totalCount: Int
+    private let framework: String?
+
+    public init(totalCount: Int, framework: String? = nil) {
+        self.totalCount = totalCount
+        self.framework = framework
+    }
+
+    public func format(_ projects: [SampleIndex.Project]) -> String {
+        var output = "# Sample Projects\n\n"
+
+        if let framework {
+            output += "_Filtered to framework: **\(framework)**_\n\n"
+        }
+
+        output += "Showing \(projects.count) of \(totalCount) total projects.\n\n"
+
+        if projects.isEmpty {
+            output += "_No sample projects found._\n"
+        } else {
+            for (index, project) in projects.enumerated() {
+                output += "## \(index + 1). \(project.title)\n\n"
+                output += "- **ID:** `\(project.id)`\n"
+                output += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
+                output += "- **Files:** \(project.fileCount)\n\n"
+
+                if !project.description.isEmpty {
+                    let shortDesc = String(project.description.prefix(200))
+                    output += "\(shortDesc)...\n\n"
+                }
+            }
+        }
+
+        return output
+    }
+}
+
+// MARK: - Sample Project Markdown Formatter
+
+/// Formats a single sample project as markdown
+public struct SampleProjectMarkdownFormatter: ResultFormatter {
+    public init() {}
+
+    public func format(_ project: SampleIndex.Project) -> String {
+        var output = "# \(project.title)\n\n"
+        output += "- **ID:** `\(project.id)`\n"
+        output += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
+        output += "- **Files:** \(project.fileCount)\n\n"
+
+        if !project.description.isEmpty {
+            output += "## Description\n\n\(project.description)\n"
+        }
+
+        return output
+    }
+}
+
+// MARK: - Sample File Markdown Formatter
+
+/// Formats a sample file as markdown
+public struct SampleFileMarkdownFormatter: ResultFormatter {
+    public init() {}
+
+    public func format(_ file: SampleIndex.File) -> String {
+        // Determine language for syntax highlighting
+        let language = file.filename.hasSuffix(".swift") ? "swift" :
+            file.filename.hasSuffix(".m") ? "objc" :
+            file.filename.hasSuffix(".h") ? "objc" :
+            file.filename.hasSuffix(".json") ? "json" :
+            file.filename.hasSuffix(".plist") ? "xml" : ""
+
+        var output = "# \(file.filename)\n\n"
+        output += "- **Project:** `\(file.projectId)`\n"
+        output += "- **Path:** `\(file.path)`\n\n"
+        output += "```\(language)\n\(file.content)\n```\n"
+
+        return output
+    }
+}

--- a/Packages/Sources/Services/Formatters/SampleTextFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleTextFormatter.swift
@@ -1,0 +1,113 @@
+import Foundation
+import SampleIndex
+import Shared
+
+// MARK: - Sample Search Text Formatter
+
+/// Formats sample search results as plain text for CLI output
+public struct SampleSearchTextFormatter: ResultFormatter {
+    private let query: String
+    private let framework: String?
+
+    public init(query: String, framework: String? = nil) {
+        self.query = query
+        self.framework = framework
+    }
+
+    public func format(_ result: SampleSearchResult) -> String {
+        if result.isEmpty {
+            return "No results found for '\(query)'"
+        }
+
+        var output = "Search Results for '\(query)'\n"
+
+        if let framework {
+            output += "Filtered by: \(framework)\n"
+        }
+
+        output += "\n"
+
+        // Projects
+        if !result.projects.isEmpty {
+            output += "Projects (\(result.projects.count) found):\n\n"
+
+            for (index, project) in result.projects.enumerated() {
+                output += "[\(index + 1)] \(project.title)\n"
+                output += "    ID: \(project.id)\n"
+                output += "    Frameworks: \(project.frameworks.joined(separator: ", "))\n"
+                output += "    Files: \(project.fileCount)\n"
+
+                if !project.description.isEmpty {
+                    output += "    \(project.description.prefix(200))...\n"
+                }
+
+                output += "\n"
+            }
+        }
+
+        // Files
+        if !result.files.isEmpty {
+            output += "Matching Files (\(result.files.count) found):\n\n"
+
+            for (index, file) in result.files.prefix(10).enumerated() {
+                output += "[\(index + 1)] \(file.filename)\n"
+                output += "    Project: \(file.projectId)\n"
+                output += "    Path: \(file.path)\n"
+                output += "    > \(file.snippet)\n"
+                output += "\n"
+            }
+        }
+
+        output += "Tip: Use 'cupertino read-sample <project_id>' to view project details"
+
+        return output
+    }
+}
+
+// MARK: - Sample List Text Formatter
+
+/// Formats sample project list as plain text for CLI output
+public struct SampleListTextFormatter: ResultFormatter {
+    private let totalCount: Int
+
+    public init(totalCount: Int) {
+        self.totalCount = totalCount
+    }
+
+    public func format(_ projects: [SampleIndex.Project]) -> String {
+        if projects.isEmpty {
+            return "No sample projects found. Run 'cupertino index' to build the sample index."
+        }
+
+        var output = "Sample Projects (\(projects.count) of \(totalCount) total):\n\n"
+
+        for (index, project) in projects.enumerated() {
+            output += "[\(index + 1)] \(project.title)\n"
+            output += "    ID: \(project.id)\n"
+            output += "    Frameworks: \(project.frameworks.joined(separator: ", "))\n"
+            output += "    Files: \(project.fileCount)\n\n"
+        }
+
+        return output
+    }
+}
+
+// MARK: - Sample Project Text Formatter
+
+/// Formats a single sample project as plain text
+public struct SampleProjectTextFormatter: ResultFormatter {
+    public init() {}
+
+    public func format(_ project: SampleIndex.Project) -> String {
+        var output = "Project: \(project.title)\n"
+        output += "ID: \(project.id)\n"
+        output += "Frameworks: \(project.frameworks.joined(separator: ", "))\n"
+        output += "Files: \(project.fileCount)\n\n"
+
+        if !project.description.isEmpty {
+            output += "Description:\n\(project.description)\n"
+        }
+
+        return output
+    }
+}

--- a/Packages/Sources/Services/Formatters/TextFormatter.swift
+++ b/Packages/Sources/Services/Formatters/TextFormatter.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Search
+import Shared
+
+// MARK: - Text Search Result Formatter
+
+/// Formats search results as plain text for CLI output
+public struct TextSearchResultFormatter: ResultFormatter {
+    private let query: String
+    private let config: SearchResultFormatConfig
+
+    public init(query: String, config: SearchResultFormatConfig = .cliDefault) {
+        self.query = query
+        self.config = config
+    }
+
+    public func format(_ results: [Search.Result]) -> String {
+        if results.isEmpty {
+            return "No results found for '\(query)'"
+        }
+
+        var output = "Found \(results.count) result(s) for '\(query)':\n\n"
+
+        for (index, result) in results.enumerated() {
+            output += "[\(index + 1)] \(result.title)\n"
+            output += "    Source: \(result.source) | Framework: \(result.framework)\n"
+            output += "    URI: \(result.uri)\n"
+
+            if !result.summary.isEmpty {
+                output += "    \(result.summary)\n"
+                if result.summaryTruncated {
+                    output += "    ...\n"
+                    let wordCount = result.summary.split(separator: " ").count
+                    output += "    [truncated at ~\(wordCount) words] Full document: \(result.uri)\n"
+                }
+            }
+
+            output += "\n"
+        }
+
+        return output
+    }
+}
+
+// MARK: - Frameworks Text Formatter
+
+/// Formats framework list as plain text for CLI output
+public struct FrameworksTextFormatter: ResultFormatter {
+    private let totalDocs: Int
+
+    public init(totalDocs: Int) {
+        self.totalDocs = totalDocs
+    }
+
+    public func format(_ frameworks: [String: Int]) -> String {
+        if frameworks.isEmpty {
+            return "No frameworks found. Run 'cupertino save' to build the index."
+        }
+
+        var output = "Available Frameworks (\(frameworks.count) total, \(totalDocs) documents):\n\n"
+
+        // Sort by document count (descending)
+        for (framework, count) in frameworks.sorted(by: { $0.value > $1.value }) {
+            output += "  \(framework): \(count) documents\n"
+        }
+
+        return output
+    }
+}

--- a/Packages/Sources/Services/HIGSearchService.swift
+++ b/Packages/Sources/Services/HIGSearchService.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Search
+import Shared
+
+// MARK: - HIG Search Query
+
+/// Specialized query for Human Interface Guidelines searches
+public struct HIGQuery: Sendable {
+    public let text: String
+    public let platform: String? // iOS, macOS, watchOS, visionOS, tvOS
+    public let category: String? // foundations, patterns, components, technologies, inputs
+    public let limit: Int
+
+    public init(
+        text: String,
+        platform: String? = nil,
+        category: String? = nil,
+        limit: Int = Shared.Constants.Limit.defaultSearchLimit
+    ) {
+        self.text = text
+        self.platform = platform
+        self.category = category
+        self.limit = min(limit, Shared.Constants.Limit.maxSearchLimit)
+    }
+}
+
+// MARK: - HIG Search Service
+
+/// Service for searching Human Interface Guidelines.
+/// Delegates to DocsSearchService with HIG-specific source filtering.
+public actor HIGSearchService {
+    private let docsService: DocsSearchService
+
+    /// Initialize with an existing docs service
+    public init(docsService: DocsSearchService) {
+        self.docsService = docsService
+    }
+
+    /// Initialize with a search index
+    public init(index: Search.Index) {
+        docsService = DocsSearchService(index: index)
+    }
+
+    /// Initialize with a database path
+    public init(dbPath: URL) async throws {
+        let index = try await Search.Index(dbPath: dbPath)
+        docsService = DocsSearchService(index: index)
+    }
+
+    // MARK: - Search Methods
+
+    /// Search HIG with specialized query
+    public func search(_ query: HIGQuery) async throws -> [Search.Result] {
+        // Build effective query with platform/category filters
+        var effectiveText = query.text
+        if let platform = query.platform {
+            effectiveText += " \(platform)"
+        }
+        if let category = query.category {
+            effectiveText += " \(category)"
+        }
+
+        let searchQuery = SearchQuery(
+            text: effectiveText,
+            source: Shared.Constants.SourcePrefix.hig,
+            limit: query.limit,
+            includeArchive: false
+        )
+
+        return try await docsService.search(searchQuery)
+    }
+
+    /// Simple text search in HIG
+    public func search(text: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> [Search.Result] {
+        try await search(HIGQuery(text: text, limit: limit))
+    }
+
+    /// Search HIG for a specific platform
+    public func search(text: String, platform: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> [Search.Result] {
+        try await search(HIGQuery(text: text, platform: platform, limit: limit))
+    }
+
+    /// Search HIG for a specific category
+    public func search(text: String, category: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> [Search.Result] {
+        try await search(HIGQuery(text: text, category: category, limit: limit))
+    }
+
+    // MARK: - Document Access
+
+    /// Read a HIG document by URI
+    public func read(uri: String, format: Search.Index.DocumentFormat = .json) async throws -> String? {
+        try await docsService.read(uri: uri, format: format)
+    }
+
+    /// Disconnect from the underlying database
+    public func disconnect() async {
+        await docsService.disconnect()
+    }
+}

--- a/Packages/Sources/Services/README.md
+++ b/Packages/Sources/Services/README.md
@@ -1,0 +1,237 @@
+# Services Module
+
+The Services module provides a unified service layer for search operations across documentation sources. It abstracts database access and result formatting, allowing both CLI commands and MCP tool providers to share the same business logic.
+
+## Architecture
+
+```
+                     ┌─────────────────────┐
+                     │  ServiceContainer   │
+                     │  (Lifecycle Mgmt)   │
+                     └─────────┬───────────┘
+                               │
+       ┌───────────────────────┼───────────────────────┐
+       │                       │                       │
+       ▼                       ▼                       ▼
+┌──────────────┐      ┌──────────────┐      ┌──────────────┐
+│DocsSearchSvc │      │ HIGSearchSvc │      │SampleSearchSvc│
+│ (Search.Index)│      │  (delegates) │      │ (SampleIndex) │
+└──────────────┘      └──────────────┘      └──────────────┘
+       │                       │                       │
+       └───────────────────────┼───────────────────────┘
+                               │
+                               ▼
+                     ┌─────────────────────┐
+                     │     Formatters      │
+                     │ (Text/JSON/Markdown)│
+                     └─────────────────────┘
+```
+
+## Services
+
+### DocsSearchService
+
+Wraps `Search.Index` for searching Apple documentation, Swift Evolution proposals, Swift.org docs, and more.
+
+```swift
+let service = try await DocsSearchService(dbPath: dbPath)
+
+// Simple search
+let results = try await service.search(text: "View")
+
+// Search with filters
+let results = try await service.search(SearchQuery(
+    text: "Button",
+    source: "apple-docs",
+    framework: "swiftui",
+    limit: 25
+))
+
+// Read document content
+let content = try await service.read(uri: "apple-docs://swiftui/view", format: .json)
+
+// List frameworks
+let frameworks = try await service.listFrameworks()
+
+await service.disconnect()
+```
+
+### HIGSearchService
+
+Specialized service for Human Interface Guidelines with platform and category filtering.
+
+```swift
+let service = HIGSearchService(docsService: docsService)
+
+// Simple HIG search
+let results = try await service.search(text: "buttons")
+
+// Search with platform filter
+let results = try await service.search(HIGQuery(
+    text: "navigation",
+    platform: "iOS",
+    category: "patterns",
+    limit: 20
+))
+
+await service.disconnect()
+```
+
+### SampleSearchService
+
+Wraps `SampleIndex.Database` for searching Apple sample code projects and files.
+
+```swift
+let service = try await SampleSearchService(dbPath: dbPath)
+
+// Search projects and files
+let result = try await service.search(SampleQuery(
+    text: "SwiftUI",
+    framework: "swiftui",
+    searchFiles: true,
+    limit: 20
+))
+
+// Access results
+for project in result.projects {
+    print(project.title)
+}
+
+// Get project details
+let project = try await service.getProject(id: "NavigatingHierarchicalData")
+
+// Get file content
+let file = try await service.getFile(projectId: projectId, path: "ContentView.swift")
+
+await service.disconnect()
+```
+
+## ServiceContainer
+
+Manages service lifecycle with convenient factory methods.
+
+```swift
+// Managed lifecycle - service automatically disconnected
+try await ServiceContainer.withDocsService { service in
+    let results = try await service.search(text: "Actor")
+    return results
+}
+
+// HIG service with managed lifecycle
+try await ServiceContainer.withHIGService { service in
+    let results = try await service.search(text: "buttons")
+    return results
+}
+
+// Sample service with managed lifecycle
+try await ServiceContainer.withSampleService(dbPath: sampleDbPath) { service in
+    let results = try await service.search(text: "SwiftUI")
+    return results
+}
+```
+
+## Query Types
+
+### SearchQuery
+
+General-purpose query for documentation searches.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `text` | `String` | required | Search text |
+| `source` | `String?` | `nil` | Filter by source (apple-docs, swift-evolution, etc.) |
+| `framework` | `String?` | `nil` | Filter by framework |
+| `language` | `String?` | `nil` | Filter by language (swift, objc) |
+| `limit` | `Int` | 20 | Max results (clamped to 100) |
+| `includeArchive` | `Bool` | `false` | Include Apple Archive docs |
+
+### HIGQuery
+
+Specialized query for Human Interface Guidelines.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `text` | `String` | required | Search text |
+| `platform` | `String?` | `nil` | iOS, macOS, watchOS, visionOS, tvOS |
+| `category` | `String?` | `nil` | foundations, patterns, components, etc. |
+| `limit` | `Int` | 20 | Max results |
+
+### SampleQuery
+
+Query for sample code searches.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `text` | `String` | required | Search text |
+| `framework` | `String?` | `nil` | Filter by framework |
+| `searchFiles` | `Bool` | `true` | Also search file contents |
+| `limit` | `Int` | 20 | Max results |
+
+## Formatters
+
+### MarkdownSearchResultFormatter
+
+Formats search results as markdown for MCP tools.
+
+```swift
+let formatter = MarkdownSearchResultFormatter(
+    query: "View",
+    filters: SearchFilters(framework: "swiftui"),
+    config: .mcpDefault
+)
+let markdown = formatter.format(results)
+```
+
+### TextSearchResultFormatter
+
+Formats search results as plain text for CLI output.
+
+```swift
+let formatter = TextSearchResultFormatter(query: "View")
+let text = formatter.format(results)
+```
+
+### JSONSearchResultFormatter
+
+Formats search results as JSON.
+
+```swift
+let formatter = JSONSearchResultFormatter()
+let json = formatter.format(results)
+```
+
+### Format Configuration
+
+```swift
+// CLI defaults: no score/word count, show source, no separators
+let cliConfig = SearchResultFormatConfig.cliDefault
+
+// MCP defaults: show score/word count, separators between results
+let mcpConfig = SearchResultFormatConfig.mcpDefault
+
+// Custom configuration
+let config = SearchResultFormatConfig(
+    showScore: true,
+    showWordCount: false,
+    showSource: true,
+    showSeparators: true,
+    emptyMessage: "No results found"
+)
+```
+
+## Dependencies
+
+```
+Services
+├── Shared (ToolError, PathResolver, Constants)
+├── Search (Search.Index, Search.Result)
+└── SampleIndex (Database, Project, File)
+```
+
+## Design Principles
+
+1. **Single Responsibility**: Each service wraps one database type
+2. **Composition**: HIGSearchService delegates to DocsSearchService
+3. **Lifecycle Management**: ServiceContainer handles connections
+4. **Type Safety**: Specialized query types for each search domain
+5. **Flexibility**: Formatters separate output from business logic

--- a/Packages/Sources/Services/SampleSearchService.swift
+++ b/Packages/Sources/Services/SampleSearchService.swift
@@ -1,0 +1,139 @@
+import Foundation
+import SampleIndex
+import Shared
+
+// MARK: - Sample Search Query
+
+/// Query parameters for sample code searches
+public struct SampleQuery: Sendable {
+    public let text: String
+    public let framework: String?
+    public let searchFiles: Bool
+    public let limit: Int
+
+    public init(
+        text: String,
+        framework: String? = nil,
+        searchFiles: Bool = true,
+        limit: Int = Shared.Constants.Limit.defaultSearchLimit
+    ) {
+        self.text = text
+        self.framework = framework
+        self.searchFiles = searchFiles
+        self.limit = min(limit, Shared.Constants.Limit.maxSearchLimit)
+    }
+}
+
+// MARK: - Sample Search Result
+
+/// Combined result from project and file searches
+public struct SampleSearchResult: Sendable {
+    public let projects: [SampleIndex.Project]
+    public let files: [SampleIndex.Database.FileSearchResult]
+
+    public init(projects: [SampleIndex.Project], files: [SampleIndex.Database.FileSearchResult]) {
+        self.projects = projects
+        self.files = files
+    }
+
+    /// Check if the result is empty
+    public var isEmpty: Bool {
+        projects.isEmpty && files.isEmpty
+    }
+
+    /// Total count of results
+    public var totalCount: Int {
+        projects.count + files.count
+    }
+}
+
+// MARK: - Sample Search Service
+
+/// Service for searching Apple sample code projects and files.
+/// Wraps SampleIndex.Database with a clean interface.
+public actor SampleSearchService {
+    private let database: SampleIndex.Database
+
+    /// Initialize with an existing database
+    public init(database: SampleIndex.Database) {
+        self.database = database
+    }
+
+    /// Initialize with a database path
+    public init(dbPath: URL) async throws {
+        database = try await SampleIndex.Database(dbPath: dbPath)
+    }
+
+    // MARK: - Search Methods
+
+    /// Search with a specialized query
+    public func search(_ query: SampleQuery) async throws -> SampleSearchResult {
+        let projects = try await database.searchProjects(
+            query: query.text,
+            framework: query.framework,
+            limit: query.limit
+        )
+
+        var files: [SampleIndex.Database.FileSearchResult] = []
+        if query.searchFiles {
+            files = try await database.searchFiles(
+                query: query.text,
+                projectId: nil,
+                limit: query.limit
+            )
+        }
+
+        return SampleSearchResult(projects: projects, files: files)
+    }
+
+    /// Simple text search
+    public func search(text: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> SampleSearchResult {
+        try await search(SampleQuery(text: text, limit: limit))
+    }
+
+    /// Search within a specific framework
+    public func search(text: String, framework: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> SampleSearchResult {
+        try await search(SampleQuery(text: text, framework: framework, limit: limit))
+    }
+
+    // MARK: - Project Access
+
+    /// Get a project by ID
+    public func getProject(id: String) async throws -> SampleIndex.Project? {
+        try await database.getProject(id: id)
+    }
+
+    /// List all projects
+    public func listProjects(framework: String? = nil, limit: Int = 50) async throws -> [SampleIndex.Project] {
+        try await database.listProjects(framework: framework, limit: limit)
+    }
+
+    /// Get total project count
+    public func projectCount() async throws -> Int {
+        try await database.projectCount()
+    }
+
+    // MARK: - File Access
+
+    /// Get a file by project ID and path
+    public func getFile(projectId: String, path: String) async throws -> SampleIndex.File? {
+        try await database.getFile(projectId: projectId, path: path)
+    }
+
+    /// List files in a project
+    public func listFiles(projectId: String, folder: String? = nil) async throws -> [SampleIndex.File] {
+        try await database.listFiles(projectId: projectId, folder: folder)
+    }
+
+    /// Get total file count
+    public func fileCount() async throws -> Int {
+        try await database.fileCount()
+    }
+
+    // MARK: - Lifecycle
+
+    /// Disconnect from the database
+    public func disconnect() async {
+        await database.disconnect()
+    }
+}

--- a/Packages/Sources/Services/SearchService.swift
+++ b/Packages/Sources/Services/SearchService.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Search
+import Shared
+
+// MARK: - Search Service Protocol
+
+/// Protocol for search operations across different documentation sources.
+/// Provides a unified interface for CLI commands and MCP tool providers.
+public protocol SearchService: Actor {
+    /// Search for documents matching the query
+    func search(_ query: SearchQuery) async throws -> [Search.Result]
+
+    /// Get document content by URI
+    func read(uri: String, format: Search.Index.DocumentFormat) async throws -> String?
+
+    /// List all available frameworks with document counts
+    func listFrameworks() async throws -> [String: Int]
+
+    /// Get total document count
+    func documentCount() async throws -> Int
+
+    /// Disconnect from the underlying database
+    func disconnect() async
+}
+
+// MARK: - Search Query
+
+/// Common search query parameters for all search operations
+public struct SearchQuery: Sendable {
+    public let text: String
+    public let source: String?
+    public let framework: String?
+    public let language: String?
+    public let limit: Int
+    public let includeArchive: Bool
+
+    public init(
+        text: String,
+        source: String? = nil,
+        framework: String? = nil,
+        language: String? = nil,
+        limit: Int = Shared.Constants.Limit.defaultSearchLimit,
+        includeArchive: Bool = false
+    ) {
+        self.text = text
+        self.source = source
+        self.framework = framework
+        self.language = language
+        self.limit = min(limit, Shared.Constants.Limit.maxSearchLimit)
+        self.includeArchive = includeArchive
+    }
+}
+
+// MARK: - Search Filters
+
+/// Active filters for formatting search results
+public struct SearchFilters: Sendable {
+    public let source: String?
+    public let framework: String?
+    public let language: String?
+
+    public init(source: String? = nil, framework: String? = nil, language: String? = nil) {
+        self.source = source
+        self.framework = framework
+        self.language = language
+    }
+
+    /// Check if any filters are active
+    public var hasActiveFilters: Bool {
+        source != nil || framework != nil || language != nil
+    }
+}

--- a/Packages/Sources/Services/ServiceContainer.swift
+++ b/Packages/Sources/Services/ServiceContainer.swift
@@ -1,0 +1,146 @@
+import Foundation
+import SampleIndex
+import Search
+import Shared
+
+// MARK: - Service Container
+
+/// Container for managing service lifecycle and providing access to search services.
+/// Handles database connections and cleanup.
+public actor ServiceContainer {
+    private var docsService: DocsSearchService?
+    private var higService: HIGSearchService?
+    private var sampleService: SampleSearchService?
+
+    private let searchDbPath: URL
+    private let sampleDbPath: URL?
+
+    /// Initialize with database paths
+    public init(
+        searchDbPath: URL = Shared.Constants.defaultSearchDatabase,
+        sampleDbPath: URL? = nil
+    ) {
+        self.searchDbPath = searchDbPath
+        self.sampleDbPath = sampleDbPath
+    }
+
+    // MARK: - Service Access
+
+    /// Get or create the documentation search service
+    public func getDocsService() async throws -> DocsSearchService {
+        if let service = docsService {
+            return service
+        }
+
+        let service = try await DocsSearchService(dbPath: searchDbPath)
+        docsService = service
+        return service
+    }
+
+    /// Get or create the HIG search service
+    public func getHIGService() async throws -> HIGSearchService {
+        if let service = higService {
+            return service
+        }
+
+        let docsService = try await getDocsService()
+        let service = HIGSearchService(docsService: docsService)
+        higService = service
+        return service
+    }
+
+    /// Get or create the sample search service
+    public func getSampleService() async throws -> SampleSearchService {
+        if let service = sampleService {
+            return service
+        }
+
+        guard let dbPath = sampleDbPath else {
+            throw ToolError.noData("Sample database path not configured")
+        }
+
+        let service = try await SampleSearchService(dbPath: dbPath)
+        sampleService = service
+        return service
+    }
+
+    // MARK: - Lifecycle
+
+    /// Disconnect all services
+    public func disconnectAll() async {
+        if let docs = docsService {
+            await docs.disconnect()
+            docsService = nil
+        }
+
+        if let hig = higService {
+            await hig.disconnect()
+            higService = nil
+        }
+
+        if let sample = sampleService {
+            await sample.disconnect()
+            sampleService = nil
+        }
+    }
+
+    // MARK: - Convenience Factory Methods
+
+    /// Execute an operation with a docs service, handling lifecycle
+    public static func withDocsService<T>(
+        dbPath: String? = nil,
+        operation: (DocsSearchService) async throws -> T
+    ) async throws -> T {
+        let resolvedPath = PathResolver.searchDatabase(dbPath)
+
+        guard PathResolver.exists(resolvedPath) else {
+            throw ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
+        }
+
+        let service = try await DocsSearchService(dbPath: resolvedPath)
+        defer {
+            Task {
+                await service.disconnect()
+            }
+        }
+
+        return try await operation(service)
+    }
+
+    /// Execute an operation with a HIG service, handling lifecycle
+    public static func withHIGService<T>(
+        dbPath: String? = nil,
+        operation: (HIGSearchService) async throws -> T
+    ) async throws -> T {
+        let resolvedPath = PathResolver.searchDatabase(dbPath)
+
+        guard PathResolver.exists(resolvedPath) else {
+            throw ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
+        }
+
+        let index = try await Search.Index(dbPath: resolvedPath)
+        let service = HIGSearchService(index: index)
+        defer {
+            Task {
+                await service.disconnect()
+            }
+        }
+
+        return try await operation(service)
+    }
+
+    /// Execute an operation with a sample service, handling lifecycle
+    public static func withSampleService<T: Sendable>(
+        dbPath: URL,
+        operation: (SampleSearchService) async throws -> T
+    ) async throws -> T {
+        guard PathResolver.exists(dbPath) else {
+            throw ToolError.noData("Sample database not found at \(dbPath.path). Run 'cupertino index' to build the index.")
+        }
+
+        let service = try await SampleSearchService(dbPath: dbPath)
+        let result = try await operation(service)
+        await service.disconnect()
+        return result
+    }
+}

--- a/Packages/Sources/Services/Services.swift
+++ b/Packages/Sources/Services/Services.swift
@@ -1,0 +1,25 @@
+// MARK: - Services Module
+
+//
+// The Services module provides a unified service layer for search operations.
+// It abstracts database access and result formatting, allowing both CLI commands
+// and MCP tool providers to share the same business logic.
+//
+// Usage:
+//
+// ```swift
+// // Using ServiceContainer for managed lifecycle
+// try await ServiceContainer.withDocsService { service in
+//     let results = try await service.search(text: "View")
+//     let formatter = MarkdownSearchResultFormatter(query: "View")
+//     print(formatter.format(results))
+// }
+//
+// // Or create services directly
+// let service = try await DocsSearchService(dbPath: dbPath)
+// defer { Task { await service.disconnect() } }
+//
+// let results = try await service.search(SearchQuery(text: "SwiftUI"))
+// ```
+
+@_exported import Foundation

--- a/Packages/Sources/Shared/ArgumentExtractor.swift
+++ b/Packages/Sources/Shared/ArgumentExtractor.swift
@@ -1,0 +1,101 @@
+import Foundation
+import MCP
+
+// MARK: - Argument Extractor
+
+/// Helper for extracting and validating MCP tool arguments.
+/// Reduces boilerplate in tool providers by providing type-safe access to arguments.
+public struct ArgumentExtractor: Sendable {
+    private let arguments: [String: AnyCodable]?
+
+    /// Initialize with MCP tool arguments
+    public init(_ arguments: [String: AnyCodable]?) {
+        self.arguments = arguments
+    }
+
+    // MARK: - Required Arguments
+
+    /// Extract a required string argument, throwing if missing
+    public func require(_ key: String) throws -> String {
+        guard let value = arguments?[key]?.value as? String else {
+            throw ToolError.missingArgument(key)
+        }
+        return value
+    }
+
+    /// Extract a required integer argument, throwing if missing
+    public func requireInt(_ key: String) throws -> Int {
+        guard let value = arguments?[key]?.value as? Int else {
+            throw ToolError.missingArgument(key)
+        }
+        return value
+    }
+
+    /// Extract a required boolean argument, throwing if missing
+    public func requireBool(_ key: String) throws -> Bool {
+        guard let value = arguments?[key]?.value as? Bool else {
+            throw ToolError.missingArgument(key)
+        }
+        return value
+    }
+
+    // MARK: - Optional Arguments
+
+    /// Extract an optional string argument
+    public func optional(_ key: String) -> String? {
+        arguments?[key]?.value as? String
+    }
+
+    /// Extract an optional integer argument
+    public func optionalInt(_ key: String) -> Int? {
+        arguments?[key]?.value as? Int
+    }
+
+    /// Extract an optional boolean argument
+    public func optionalBool(_ key: String) -> Bool? {
+        arguments?[key]?.value as? Bool
+    }
+
+    // MARK: - Arguments with Defaults
+
+    /// Extract a string argument with a default value
+    public func optional(_ key: String, default defaultValue: String) -> String {
+        (arguments?[key]?.value as? String) ?? defaultValue
+    }
+
+    /// Extract an integer argument with a default value
+    public func optional(_ key: String, default defaultValue: Int) -> Int {
+        (arguments?[key]?.value as? Int) ?? defaultValue
+    }
+
+    /// Extract a boolean argument with a default value
+    public func optional(_ key: String, default defaultValue: Bool) -> Bool {
+        (arguments?[key]?.value as? Bool) ?? defaultValue
+    }
+
+    // MARK: - Specialized Extractors
+
+    /// Extract a limit argument, clamped to the max search limit
+    public func limit(
+        key: String = Shared.Constants.MCP.schemaParamLimit,
+        default defaultLimit: Int = Shared.Constants.Limit.defaultSearchLimit
+    ) -> Int {
+        let requested = optional(key, default: defaultLimit)
+        return min(requested, Shared.Constants.Limit.maxSearchLimit)
+    }
+
+    /// Extract a format argument for document output
+    public func format(
+        key: String = Shared.Constants.MCP.schemaParamFormat,
+        default defaultFormat: String = Shared.Constants.MCP.formatValueJSON
+    ) -> String {
+        optional(key, default: defaultFormat)
+    }
+
+    /// Check if include_archive flag is set
+    public func includeArchive(
+        key: String = Shared.Constants.MCP.schemaParamIncludeArchive
+    ) -> Bool {
+        optional(key, default: false)
+    }
+}

--- a/Packages/Sources/Shared/Constants.swift
+++ b/Packages/Sources/Shared/Constants.swift
@@ -287,10 +287,10 @@ extension Shared {
 
             // MARK: Swift.org
 
-            /// Swift.org Documentation Base
-            public static let swiftOrg = "https://docs.swift.org/"
+            /// Swift.org Documentation Base (www.swift.org for general docs)
+            public static let swiftOrg = "https://www.swift.org/documentation/"
 
-            /// Swift Book Documentation
+            /// Swift Book Documentation (hosted at docs.swift.org)
             public static let swiftBook = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/"
 
             // MARK: GitHub

--- a/Packages/Sources/Shared/Constants.swift
+++ b/Packages/Sources/Shared/Constants.swift
@@ -25,6 +25,7 @@ extension Shared {
             public static let packages = "packages"
             public static let sampleCode = "sample-code"
             public static let archive = "archive"
+            public static let hig = "hig"
         }
 
         // MARK: - File Names
@@ -107,6 +108,11 @@ extension Shared {
             defaultBaseDirectory.appendingPathComponent(Directory.archive)
         }
 
+        /// Default HIG directory: ~/.cupertino/hig
+        public static var defaultHIGDirectory: URL {
+            defaultBaseDirectory.appendingPathComponent(Directory.hig)
+        }
+
         /// Default metadata file: ~/.cupertino/metadata.json
         public static var defaultMetadataFile: URL {
             defaultBaseDirectory.appendingPathComponent(FileName.metadata)
@@ -138,7 +144,7 @@ extension Shared {
             public static let userAgent = "CupertinoCrawler/1.0"
 
             /// Current version
-            public static let version = "0.3.4"
+            public static let version = "0.3.5"
         }
 
         // MARK: - Display Names
@@ -177,6 +183,9 @@ extension Shared {
 
             /// Apple Archive Documentation display name
             public static let archive = "Apple Archive Documentation"
+
+            /// Human Interface Guidelines display name
+            public static let humanInterfaceGuidelines = "Human Interface Guidelines"
         }
 
         // MARK: - GitHub Organizations
@@ -211,6 +220,48 @@ extension Shared {
             public static let subsystem = "com.cupertino.cli"
         }
 
+        // MARK: - Source Prefixes
+
+        /// Source prefixes used for filtering search queries.
+        /// Users can prefix their search with these to filter by source type.
+        /// Example: "swift-evolution actors" searches only Swift Evolution for "actors"
+        public enum SourcePrefix {
+            /// Apple Developer Documentation source prefix
+            public static let appleDocs = "apple-docs"
+
+            /// Swift Book (The Swift Programming Language) source prefix
+            public static let swiftBook = "swift-book"
+
+            /// Swift.org documentation source prefix
+            public static let swiftOrg = "swift-org"
+
+            /// Swift Evolution proposals source prefix
+            public static let swiftEvolution = "swift-evolution"
+
+            /// Swift package documentation source prefix
+            public static let packages = "packages"
+
+            /// Apple sample code source prefix
+            public static let appleSampleCode = "apple-sample-code"
+
+            /// Apple archive documentation source prefix
+            public static let appleArchive = "apple-archive"
+
+            /// Human Interface Guidelines source prefix
+            public static let hig = "hig"
+
+            /// All known source prefixes for query detection
+            public static let allPrefixes: [String] = [
+                appleDocs,
+                swiftBook,
+                swiftOrg,
+                swiftEvolution,
+                packages,
+                appleSampleCode,
+                hig,
+            ]
+        }
+
         // MARK: - URLs
 
         public enum BaseURL {
@@ -224,6 +275,9 @@ extension Shared {
 
             /// Apple Archive Documentation
             public static let appleArchive = "https://developer.apple.com/library/archive/"
+
+            /// Apple Human Interface Guidelines
+            public static let appleHIG = "https://developer.apple.com/design/human-interface-guidelines/"
 
             /// Apple Sample Code List
             public static let appleSampleCode = "https://developer.apple.com/documentation/samplecode/"
@@ -337,6 +391,9 @@ extension Shared {
             /// Swift Evolution proposal resource URI scheme
             public static let swiftEvolutionScheme = "swift-evolution://"
 
+            /// Human Interface Guidelines resource URI scheme
+            public static let higScheme = "hig://"
+
             // MARK: Tool Names
 
             /// Search documentation tool name
@@ -347,6 +404,9 @@ extension Shared {
 
             /// Read document tool name
             public static let toolReadDocument = "read_document"
+
+            /// Search HIG tool name
+            public static let toolSearchHIG = "search_hig"
 
             // MARK: Sample Code Tool Names
 
@@ -404,7 +464,7 @@ extension Shared {
             public static let toolSearchDocsDescription = """
             Search Apple documentation and Swift Evolution proposals by keywords. \
             Returns a ranked list of relevant documents with URIs that can be read using resources/read. \
-            Optional parameters: source (apple-docs, swift-evolution, swift-org, swift-book, apple-archive), \
+            Optional parameters: source (apple-docs, swift-evolution, swift-org, swift-book, apple-archive, hig), \
             framework (e.g. swiftui, foundation), include_archive (bool, includes legacy Apple Archive guides \
             like Core Animation Programming Guide - useful for foundational concepts not in modern docs).
             """
@@ -419,6 +479,14 @@ extension Shared {
             public static let toolReadDocumentDescription = """
             Read a document by URI. Returns the full document content in the requested format. \
             Use URIs from search_docs results. Format parameter: 'json' (default, structured) or 'markdown' (rendered).
+            """
+
+            /// Search HIG tool description
+            public static let toolSearchHIGDescription = """
+            Search Apple Human Interface Guidelines by keywords. \
+            Returns a ranked list of design guidelines with URIs that can be read using resources/read. \
+            Optional parameters: platform (iOS, macOS, watchOS, visionOS, tvOS), \
+            category (foundations, patterns, components, technologies, inputs), limit.
             """
 
             // MARK: Sample Code Tool Descriptions
@@ -467,6 +535,12 @@ extension Shared {
 
             /// JSON Schema parameter: include_archive
             public static let schemaParamIncludeArchive = "include_archive"
+
+            /// JSON Schema parameter: platform (for HIG)
+            public static let schemaParamPlatform = "platform"
+
+            /// JSON Schema parameter: category (for HIG)
+            public static let schemaParamCategory = "category"
 
             /// JSON Schema parameter: limit
             public static let schemaParamLimit = "limit"

--- a/Packages/Sources/Shared/PathResolver.swift
+++ b/Packages/Sources/Shared/PathResolver.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+// MARK: - Path Resolver
+
+/// Centralized path resolution for database files and directories.
+/// Consolidates path resolution logic used across CLI commands and tool providers.
+public enum PathResolver {
+    // MARK: - Search Database
+
+    /// Resolve the search database path.
+    /// - Parameter customPath: Optional custom path (supports ~ expansion)
+    /// - Returns: Resolved URL to the search database
+    public static func searchDatabase(_ customPath: String? = nil) -> URL {
+        if let customPath {
+            return URL(fileURLWithPath: customPath).expandingTildeInPath
+        }
+        return Shared.Constants.defaultSearchDatabase
+    }
+
+    // MARK: - Directory Resolution
+
+    /// Resolve a documentation directory path.
+    /// - Parameter customPath: Optional custom path (supports ~ expansion)
+    /// - Parameter defaultPath: Default path if custom is not provided
+    /// - Returns: Resolved URL to the directory
+    public static func directory(_ customPath: String? = nil, default defaultPath: URL) -> URL {
+        if let customPath {
+            return URL(fileURLWithPath: customPath).expandingTildeInPath
+        }
+        return defaultPath
+    }
+
+    /// Resolve the docs directory.
+    public static func docsDirectory(_ customPath: String? = nil) -> URL {
+        directory(customPath, default: Shared.Constants.defaultDocsDirectory)
+    }
+
+    /// Resolve the Swift Evolution directory.
+    public static func evolutionDirectory(_ customPath: String? = nil) -> URL {
+        directory(customPath, default: Shared.Constants.defaultSwiftEvolutionDirectory)
+    }
+
+    /// Resolve the HIG directory.
+    public static func higDirectory(_ customPath: String? = nil) -> URL {
+        directory(customPath, default: Shared.Constants.defaultHIGDirectory)
+    }
+
+    /// Resolve the sample code directory.
+    public static func sampleCodeDirectory(_ customPath: String? = nil) -> URL {
+        directory(customPath, default: Shared.Constants.defaultSampleCodeDirectory)
+    }
+
+    // MARK: - Path Expansion
+
+    /// Expand a path string with tilde support.
+    /// - Parameter path: Path string (may include ~)
+    /// - Returns: Expanded URL
+    public static func expand(_ path: String) -> URL {
+        URL(fileURLWithPath: path).expandingTildeInPath
+    }
+
+    // MARK: - Validation
+
+    /// Check if a path exists.
+    /// - Parameter url: URL to check
+    /// - Returns: true if the path exists
+    public static func exists(_ url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path)
+    }
+
+    /// Check if a path exists and is a directory.
+    /// - Parameter url: URL to check
+    /// - Returns: true if the path exists and is a directory
+    public static func isDirectory(_ url: URL) -> Bool {
+        var isDir: ObjCBool = false
+        return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
+    }
+}

--- a/Packages/Sources/Shared/ToolError.swift
+++ b/Packages/Sources/Shared/ToolError.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+// MARK: - Unified Tool Error
+
+/// Unified error type for MCP tool and resource providers.
+/// Consolidates error handling across DocumentationToolProvider, SampleCodeToolProvider,
+/// CompositeToolProvider, and DocsResourceProvider.
+public enum ToolError: Error, LocalizedError, Sendable {
+    /// Unknown tool name requested
+    case unknownTool(String)
+
+    /// Required argument is missing
+    case missingArgument(String)
+
+    /// Invalid argument value with reason
+    case invalidArgument(String, String)
+
+    /// Resource not found at URI
+    case notFound(String)
+
+    /// Invalid URI format
+    case invalidURI(String)
+
+    /// No data available (e.g., no documentation crawled)
+    case noData(String)
+
+    // MARK: - LocalizedError
+
+    public var errorDescription: String? {
+        switch self {
+        case .unknownTool(let name):
+            return "Unknown tool: \(name)"
+        case .missingArgument(let arg):
+            return "Missing required argument: \(arg)"
+        case .invalidArgument(let arg, let reason):
+            return "Invalid argument '\(arg)': \(reason)"
+        case .notFound(let resource):
+            return "Not found: \(resource)"
+        case .invalidURI(let uri):
+            return "Invalid resource URI: \(uri)"
+        case .noData(let message):
+            return message
+        }
+    }
+}

--- a/Packages/Sources/TUI/Views/SettingsView.swift
+++ b/Packages/Sources/TUI/Views/SettingsView.swift
@@ -17,14 +17,15 @@ struct SettingsView {
 
         let title = "Settings"
 
+        typealias Dir = Shared.Constants.Directory
         let settings = [
             SettingItem(label: "Base Directory", value: baseDirectory, editable: true),
-            SettingItem(label: "Docs Directory", value: "docs", editable: false),
-            SettingItem(label: "Swift Evolution", value: "swift-evolution", editable: false),
-            SettingItem(label: "Swift.org", value: "swift-org", editable: false),
-            SettingItem(label: "Swift Book", value: "swift-book", editable: false),
-            SettingItem(label: "Packages", value: "packages", editable: false),
-            SettingItem(label: "Sample Code", value: "sample-code", editable: false),
+            SettingItem(label: "Docs Directory", value: Dir.docs, editable: false),
+            SettingItem(label: "Swift Evolution", value: Dir.swiftEvolution, editable: false),
+            SettingItem(label: "Swift.org", value: Dir.swiftOrg, editable: false),
+            SettingItem(label: "Swift Book", value: Dir.swiftBook, editable: false),
+            SettingItem(label: "Packages", value: Dir.packages, editable: false),
+            SettingItem(label: "Sample Code", value: Dir.sampleCode, editable: false),
         ]
 
         result += Box.topLeft + String(repeating: Box.horizontal, count: width - 2) + Box.topRight + "\r\n"

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -74,9 +74,11 @@ struct MCPCommandTests {
 
         #expect(!resources.isEmpty, "Should have at least one resource")
 
-        if let firstResource = resources.first {
-            #expect(firstResource.uri.contains("swift"), "Resource URI should contain framework name")
-            print("   ✅ Found resource: \(firstResource.uri)")
+        // Check if any resource contains "swift" (test data may not be first in list)
+        let hasSwiftResource = resources.contains { $0.uri.contains("swift") }
+        #expect(hasSwiftResource, "Should have at least one resource with 'swift' in URI")
+        if let swiftResource = resources.first(where: { $0.uri.contains("swift") }) {
+            print("   ✅ Found resource: \(swiftResource.uri)")
         }
 
         print("   ✅ Docs provider test passed!")
@@ -244,8 +246,10 @@ struct MCPCommandTests {
 
         #expect(!resources.isEmpty, "Should have evolution proposals")
 
-        if let proposal = resources.first {
-            #expect(proposal.uri.contains("SE-"), "URI should contain SE- number")
+        // Check if any resource contains "SE-" (test data may not be first in list)
+        let hasProposal = resources.contains { $0.uri.contains("SE-") }
+        #expect(hasProposal, "Should have at least one resource with 'SE-' in URI")
+        if let proposal = resources.first(where: { $0.uri.contains("SE-") }) {
             print("   ✅ Found proposal: \(proposal.uri)")
         }
 
@@ -277,7 +281,7 @@ struct MCPCommandTests {
         let provider = DocsResourceProvider(configuration: config)
 
         // Try to read non-existent resource
-        await #expect(throws: ResourceError.self) {
+        await #expect(throws: ToolError.self) {
             _ = try await provider.readResource(uri: "apple-docs://nonexistent/file")
         }
 

--- a/Packages/Tests/CLITests/CLITests.swift
+++ b/Packages/Tests/CLITests/CLITests.swift
@@ -15,14 +15,22 @@ struct CommandRegistrationTests {
     func subcommandsRegistered() {
         let config = Cupertino.configuration
 
-        #expect(config.subcommands.count == 7)
+        #expect(config.subcommands.count == 15)
+        #expect(config.subcommands.contains { $0 == SetupCommand.self })
         #expect(config.subcommands.contains { $0 == FetchCommand.self })
         #expect(config.subcommands.contains { $0 == SaveCommand.self })
+        #expect(config.subcommands.contains { $0 == IndexCommand.self })
         #expect(config.subcommands.contains { $0 == ServeCommand.self })
         #expect(config.subcommands.contains { $0 == SearchCommand.self })
         #expect(config.subcommands.contains { $0 == ReadCommand.self })
+        #expect(config.subcommands.contains { $0 == ListFrameworksCommand.self })
+        #expect(config.subcommands.contains { $0 == ListSamplesCommand.self })
+        #expect(config.subcommands.contains { $0 == SearchSamplesCommand.self })
+        #expect(config.subcommands.contains { $0 == ReadSampleCommand.self })
+        #expect(config.subcommands.contains { $0 == ReadSampleFileCommand.self })
         #expect(config.subcommands.contains { $0 == DoctorCommand.self })
         #expect(config.subcommands.contains { $0 == CleanupCommand.self })
+        #expect(config.subcommands.contains { $0 == ReleaseCommand.self })
     }
 
     @Test("Default subcommand is ServeCommand")
@@ -64,6 +72,9 @@ struct FetchTypeTests {
             .packages,
             .packageDocs,
             .code,
+            .samples,
+            .archive,
+            .hig,
             .all,
         ]
 
@@ -85,6 +96,9 @@ struct FetchTypeTests {
             .packages,
             .packageDocs,
             .code,
+            .samples,
+            .archive,
+            .hig,
             .all,
         ]
 
@@ -106,6 +120,9 @@ struct FetchTypeTests {
             .packages,
             .packageDocs,
             .code,
+            .samples,
+            .archive,
+            .hig,
             .all,
         ]
 
@@ -132,10 +149,13 @@ struct FetchTypeTests {
     func directFetchTypes() {
         let directFetch = Cupertino.FetchType.directFetchTypes
 
-        #expect(directFetch.count == 3)
+        #expect(directFetch.count == 6)
         #expect(directFetch.contains(.packages))
         #expect(directFetch.contains(.packageDocs))
         #expect(directFetch.contains(.code))
+        #expect(directFetch.contains(.samples))
+        #expect(directFetch.contains(.archive))
+        #expect(directFetch.contains(.hig))
     }
 
     @Test("Type categorization is mutually exclusive")
@@ -148,20 +168,23 @@ struct FetchTypeTests {
 
         // All types except .all should be categorized
         let allCategorized = webCrawl.union(directFetch)
-        #expect(allCategorized.count == 6) // 3 web + 3 direct
+        #expect(allCategorized.count == 9) // 3 web + 6 direct
     }
 
     @Test("All types includes all categorized types")
     func allTypesComplete() {
         let allTypes = Cupertino.FetchType.allTypes
 
-        #expect(allTypes.count == 6)
+        #expect(allTypes.count == 9)
         #expect(allTypes.contains(.docs))
         #expect(allTypes.contains(.swift))
         #expect(allTypes.contains(.evolution))
         #expect(allTypes.contains(.packages))
         #expect(allTypes.contains(.packageDocs))
         #expect(allTypes.contains(.code))
+        #expect(allTypes.contains(.samples))
+        #expect(allTypes.contains(.archive))
+        #expect(allTypes.contains(.hig))
     }
 
     @Test("Package-docs raw value has hyphen")

--- a/Packages/Tests/CoreTests/ArchiveGuideCatalogTests.swift
+++ b/Packages/Tests/CoreTests/ArchiveGuideCatalogTests.swift
@@ -25,7 +25,7 @@ func archiveGuideCatalogRequiredGuidesIncludeCoreFrameworks() throws {
     print("   ✅ Required guides include Core framework documentation")
 }
 
-@Test("ArchiveGuideCatalog creates user file if missing")
+@Test("ArchiveGuideCatalog creates user file if missing", .serialized)
 func archiveGuideCatalogCreatesUserFileIfMissing() throws {
     let fileURL = ArchiveGuideCatalog.userSelectionsFileURL
 
@@ -57,7 +57,7 @@ func archiveGuideCatalogCreatesUserFileIfMissing() throws {
     print("   ✅ User selections file created automatically")
 }
 
-@Test("ArchiveGuideCatalog does not overwrite existing user file")
+@Test("ArchiveGuideCatalog does not overwrite existing user file", .serialized)
 func archiveGuideCatalogDoesNotOverwriteExistingFile() throws {
     let fileURL = ArchiveGuideCatalog.userSelectionsFileURL
 
@@ -79,20 +79,10 @@ func archiveGuideCatalogDoesNotOverwriteExistingFile() throws {
 
     // Create a custom user file with specific content
     let customContent = """
-    {
-      "count": 1,
-      "description": "Test file - should not be overwritten",
-      "guides": [
-        {
-          "category": "Test",
-          "framework": "TestFramework",
-          "path": "Test/Custom/Path",
-          "title": "Custom Test Guide"
-        }
-      ],
-      "lastUpdated": "2024-01-01T00:00:00Z",
-      "version": "1.0"
-    }
+    {"count":1,"description":"Test file - should not be overwritten",\
+    "guides":[{"category":"Test","framework":"TestFramework",\
+    "path":"Test/Custom/Path","title":"Custom Test Guide"}],\
+    "lastUpdated":"2024-01-01T00:00:00Z","version":"1.0"}
     """
 
     // Ensure directory exists
@@ -102,23 +92,14 @@ func archiveGuideCatalogDoesNotOverwriteExistingFile() throws {
     )
     try customContent.write(to: fileURL, atomically: true, encoding: .utf8)
 
-    // Get modification date
-    let attrs1 = try FileManager.default.attributesOfItem(atPath: fileURL.path)
-    let modDate1 = attrs1[.modificationDate] as? Date
-
     // Access essentialGuides - should NOT overwrite
     let guides = ArchiveGuideCatalog.essentialGuides
     #expect(!guides.isEmpty, "Should return guides")
 
-    // Check file wasn't modified
-    let attrs2 = try FileManager.default.attributesOfItem(atPath: fileURL.path)
-    let modDate2 = attrs2[.modificationDate] as? Date
-
-    #expect(modDate1 == modDate2, "File should not be modified if it already exists")
-
-    // Verify custom content is still there
+    // Verify custom content is still there (this is the key assertion)
     let content = try String(contentsOf: fileURL, encoding: .utf8)
     #expect(content.contains("Custom Test Guide"), "Custom content should be preserved")
+    #expect(content.contains("should not be overwritten"), "Description should be preserved")
     print("   ✅ Existing user file not overwritten")
 }
 

--- a/Packages/Tests/CoreTests/CupertinoCoreTests.swift
+++ b/Packages/Tests/CoreTests/CupertinoCoreTests.swift
@@ -385,19 +385,25 @@ func crawlerStateLoadsExistingMetadata() async throws {
 
     let metadataFile = tempDir.appendingPathComponent("metadata.json")
 
-    // Create initial metadata with some pages
+    // Create actual files that match the metadata
+    let doc1Path = tempDir.appendingPathComponent("doc1.md")
+    let doc2Path = tempDir.appendingPathComponent("doc2.md")
+    try "# Doc 1".write(to: doc1Path, atomically: true, encoding: .utf8)
+    try "# Doc 2".write(to: doc2Path, atomically: true, encoding: .utf8)
+
+    // Create initial metadata with some pages (file paths must match real files)
     var metadata = CrawlMetadata()
     metadata.pages["https://example.com/doc1"] = PageMetadata(
         url: "https://example.com/doc1",
         framework: "test",
-        filePath: "/test/doc1.md",
+        filePath: doc1Path.path,
         contentHash: "hash1",
         depth: 0
     )
     metadata.pages["https://example.com/doc2"] = PageMetadata(
         url: "https://example.com/doc2",
         framework: "test",
-        filePath: "/test/doc2.md",
+        filePath: doc2Path.path,
         contentHash: "hash2",
         depth: 1
     )

--- a/Packages/Tests/ServicesTests/ServicesTests.swift
+++ b/Packages/Tests/ServicesTests/ServicesTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+@testable import Services
+@testable import Shared
+import Testing
+
+// MARK: - Services Tests
+
+@Suite("Services Module Tests")
+struct ServicesTests {
+    // MARK: - SearchQuery Tests
+
+    @Test("SearchQuery initializes with defaults")
+    func searchQueryDefaults() {
+        let query = SearchQuery(text: "View")
+
+        #expect(query.text == "View")
+        #expect(query.source == nil)
+        #expect(query.framework == nil)
+        #expect(query.language == nil)
+        #expect(query.limit == Shared.Constants.Limit.defaultSearchLimit)
+        #expect(query.includeArchive == false)
+    }
+
+    @Test("SearchQuery clamps limit to max")
+    func searchQueryClampsLimit() {
+        let query = SearchQuery(text: "View", limit: 1000)
+
+        #expect(query.limit == Shared.Constants.Limit.maxSearchLimit)
+    }
+
+    @Test("SearchQuery accepts all parameters")
+    func searchQueryAllParams() {
+        let query = SearchQuery(
+            text: "Button",
+            source: "apple-docs",
+            framework: "swiftui",
+            language: "swift",
+            limit: 50,
+            includeArchive: true
+        )
+
+        #expect(query.text == "Button")
+        #expect(query.source == "apple-docs")
+        #expect(query.framework == "swiftui")
+        #expect(query.language == "swift")
+        #expect(query.limit == 50)
+        #expect(query.includeArchive == true)
+    }
+
+    // MARK: - SearchFilters Tests
+
+    @Test("SearchFilters detects active filters")
+    func searchFiltersActiveDetection() {
+        let noFilters = SearchFilters()
+        #expect(noFilters.hasActiveFilters == false)
+
+        let withSource = SearchFilters(source: "apple-docs")
+        #expect(withSource.hasActiveFilters == true)
+
+        let withFramework = SearchFilters(framework: "swiftui")
+        #expect(withFramework.hasActiveFilters == true)
+
+        let withLanguage = SearchFilters(language: "swift")
+        #expect(withLanguage.hasActiveFilters == true)
+    }
+
+    // MARK: - HIGQuery Tests
+
+    @Test("HIGQuery initializes with defaults")
+    func higQueryDefaults() {
+        let query = HIGQuery(text: "buttons")
+
+        #expect(query.text == "buttons")
+        #expect(query.platform == nil)
+        #expect(query.category == nil)
+        #expect(query.limit == Shared.Constants.Limit.defaultSearchLimit)
+    }
+
+    @Test("HIGQuery accepts platform and category")
+    func higQueryWithFilters() {
+        let query = HIGQuery(
+            text: "navigation",
+            platform: "iOS",
+            category: "patterns",
+            limit: 30
+        )
+
+        #expect(query.text == "navigation")
+        #expect(query.platform == "iOS")
+        #expect(query.category == "patterns")
+        #expect(query.limit == 30)
+    }
+
+    // MARK: - SampleQuery Tests
+
+    @Test("SampleQuery initializes with defaults")
+    func sampleQueryDefaults() {
+        let query = SampleQuery(text: "SwiftUI")
+
+        #expect(query.text == "SwiftUI")
+        #expect(query.framework == nil)
+        #expect(query.searchFiles == true)
+        #expect(query.limit == Shared.Constants.Limit.defaultSearchLimit)
+    }
+
+    @Test("SampleSearchResult isEmpty check")
+    func sampleSearchResultIsEmpty() {
+        let empty = SampleSearchResult(projects: [], files: [])
+        #expect(empty.isEmpty == true)
+        #expect(empty.totalCount == 0)
+    }
+}
+
+// MARK: - Format Config Tests
+
+@Suite("Format Configuration Tests")
+struct FormatConfigTests {
+    @Test("CLI default config has expected values")
+    func cliDefaultConfig() {
+        let config = SearchResultFormatConfig.cliDefault
+
+        #expect(config.showScore == false)
+        #expect(config.showWordCount == false)
+        #expect(config.showSource == true)
+        #expect(config.showSeparators == false)
+    }
+
+    @Test("MCP default config has expected values")
+    func mcpDefaultConfig() {
+        let config = SearchResultFormatConfig.mcpDefault
+
+        #expect(config.showScore == true)
+        #expect(config.showWordCount == true)
+        #expect(config.showSource == false)
+        #expect(config.showSeparators == true)
+    }
+}

--- a/Packages/Tests/TUITests/InputHandlerTests.swift
+++ b/Packages/Tests/TUITests/InputHandlerTests.swift
@@ -137,8 +137,8 @@ func inputHandlerHomeCursorBoundaries() {
     )
     #expect(homeCursor == 0, "Cursor should stay at 0")
 
-    // Move to max (2)
-    homeCursor = 2
+    // Move to max (3) - packages, library, archive, settings = 4 items
+    homeCursor = 3
     _ = InputHandler.handleInput(
         .arrowDown,
         state: state,
@@ -148,7 +148,7 @@ func inputHandlerHomeCursorBoundaries() {
         artifacts: [],
         pageSize: 10
     )
-    #expect(homeCursor == 2, "Cursor should stay at max (2)")
+    #expect(homeCursor == 3, "Cursor should stay at max (3)")
 }
 
 @MainActor

--- a/Packages/Tests/TUITests/ViewRouterTests.swift
+++ b/Packages/Tests/TUITests/ViewRouterTests.swift
@@ -29,14 +29,25 @@ func viewRouterHomeToLibraryNumber() {
 }
 
 @MainActor
-@Test("ViewRouter handles home to settings transition via number key")
-func viewRouterHomeToSettingsNumber() {
+@Test("ViewRouter handles home to archive transition via number key")
+func viewRouterHomeToArchiveNumber() {
     let state = AppState()
     state.viewMode = .home
 
     let result = ViewRouter.handleViewTransition(key: .char("3"), state: state, homeCursor: 0)
 
-    #expect(result == .settings, "Pressing '3' from home should navigate to settings")
+    #expect(result == .archive, "Pressing '3' from home should navigate to archive")
+}
+
+@MainActor
+@Test("ViewRouter handles home to settings transition via number key")
+func viewRouterHomeToSettingsNumber() {
+    let state = AppState()
+    state.viewMode = .home
+
+    let result = ViewRouter.handleViewTransition(key: .char("4"), state: state, homeCursor: 0)
+
+    #expect(result == .settings, "Pressing '4' from home should navigate to settings")
 }
 
 @MainActor
@@ -53,9 +64,13 @@ func viewRouterHomeEnterNavigation() {
     result = ViewRouter.handleViewTransition(key: .enter, state: state, homeCursor: 1)
     #expect(result == .library, "Enter with cursor at 1 should go to library")
 
-    // Cursor at 2 -> settings
+    // Cursor at 2 -> archive
     result = ViewRouter.handleViewTransition(key: .enter, state: state, homeCursor: 2)
-    #expect(result == .settings, "Enter with cursor at 2 should go to settings")
+    #expect(result == .archive, "Enter with cursor at 2 should go to archive")
+
+    // Cursor at 3 -> settings
+    result = ViewRouter.handleViewTransition(key: .enter, state: state, homeCursor: 3)
+    #expect(result == .settings, "Enter with cursor at 3 should go to settings")
 }
 
 @MainActor

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Swift-based tool to crawl, index, and serve Apple's developer documentation to
 
 Cupertino is a local, structured, AI-ready documentation system for Apple platforms. It:
 
-- **Crawls** Apple Developer documentation, Swift.org, Swift Evolution proposals, Apple Archive legacy guides, and Swift package metadata
+- **Crawls** Apple Developer documentation, Swift.org, Swift Evolution proposals, Human Interface Guidelines, Apple Archive legacy guides, and Swift package metadata
 - **Indexes** everything into a fast, searchable SQLite FTS5 database with BM25 ranking
 - **Serves** documentation to AI agents like Claude via the Model Context Protocol
 - **Provides** offline access to 138,000+ documentation pages across 263 frameworks
@@ -93,6 +93,7 @@ cupertino fetch --type package-docs  # Swift package READMEs
 cupertino fetch --type code          # Sample code from Apple (requires auth)
 cupertino fetch --type samples       # Sample code from GitHub (recommended)
 cupertino fetch --type archive       # Apple Archive programming guides
+cupertino fetch --type hig           # Human Interface Guidelines
 cupertino fetch --type all           # All types in parallel
 
 # Build indexes
@@ -246,6 +247,11 @@ A UIKit view controller that manages a SwiftUI view hierarchy.
   - Deep conceptual knowledge not in modern docs
   - Excluded from search by default (use `--include-archive`)
 
+- **Human Interface Guidelines**
+  - Apple's official design guidelines for all platforms
+  - Covers iOS, macOS, watchOS, visionOS, and tvOS
+  - Design patterns, components, foundations, and best practices
+
 ### 2. Bundled Resources
 
 Cupertino includes pre-indexed catalog data bundled directly into the application:
@@ -282,9 +288,12 @@ These catalogs are indexed during `cupertino save` and enable instant search wit
 - **Resources**: Direct access to documentation pages
   - `apple-docs://{framework}/{page}`
   - `swift-evolution://{proposal-id}`
+  - `hig://{category}/{page}`
 - **Tools**: Search and read capabilities for AI agents
   - **Documentation Tools** (requires `cupertino save`):
     - `search_docs` - Full-text search across all documentation
+    - `search_hig` - Search Human Interface Guidelines
+      - Parameters: `query` (required), `platform` (optional), `category` (optional), `limit` (optional)
     - `list_frameworks` - List available frameworks
     - `read_document` - Read document by URI with format option
       - Parameters: `uri` (required), `format` (optional: `json` or `markdown`, default: `json`)
@@ -515,7 +524,7 @@ For development setup, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Project Status
 
-**Version:** 0.3.4
+**Version:** 0.3.5
 **Status:** 🚧 Active Development
 
 - ✅ All core functionality working

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Cupertino Architecture
 
-**Version:** v0.2.7
+**Version:** v0.3.5
 **Last Updated:** 2025-12-03
 **Swift Version:** 6.2
 **Language Mode:** Swift 6 with Strict Concurrency Checking
@@ -23,7 +23,7 @@
 
 Cupertino is a Swift-based Apple documentation crawler and MCP (Model Context Protocol) server. The project uses **ExtremePackaging** architecture to organize code into focused, reusable modules.
 
-### Package Structure (v0.2.7)
+### Package Structure (v0.3.5)
 
 Cupertino uses **ExtremePackaging** architecture with 10 consolidated packages:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,800 +1,177 @@
-# Deployment Guide
+# Cupertino Deployment Guide
 
-Complete guide for deploying Cupertino via Homebrew and automating releases with GitHub Actions.
+**Version:** 0.3.5
+**Last Updated:** 2025-12-08
 
-## Table of Contents
-
-1. [Overview](#overview)
-2. [Homebrew Distribution](#homebrew-distribution)
-   - [What is Homebrew?](#what-is-homebrew)
-   - [Quick Start](#quick-start)
-   - [Creating the Formula](#creating-the-formula)
-   - [Building Bottles](#building-bottles)
-   - [Testing Locally](#testing-locally)
-   - [Publishing Options](#publishing-options)
-   - [Complete Workflow](#complete-workflow)
-   - [Best Practices](#best-practices)
-3. [CI/CD with GitHub Actions](#cicd-with-github-actions)
-   - [Build & Test Workflow](#1-build--test-workflow)
-   - [SwiftLint Workflow](#2-swiftlint-workflow)
-   - [Daily Documentation Check](#3-daily-documentation-check)
-   - [Release Workflow](#4-release-workflow)
-   - [GitHub Repository Settings](#github-repository-settings)
-   - [Automated Documentation Updates](#automated-documentation-updates-strategy)
-   - [Project Badges](#project-statistics-badges)
-4. [Release Checklist](#release-checklist)
-5. [Resources](#resources)
+This guide covers distributing Cupertino via Homebrew and GitHub releases.
 
 ---
 
-## Overview
+## Table of Contents
 
-This guide covers two key aspects of deploying Cupertino:
+1. [Installation Methods](#installation-methods)
+2. [Homebrew Distribution](#homebrew-distribution)
+3. [GitHub Releases](#github-releases)
+4. [CI/CD Setup](#cicd-setup)
+5. [Version Management](#version-management)
+6. [Release Checklist](#release-checklist)
 
-1. **Homebrew Distribution** - Package and distribute Cupertino through Homebrew, the most popular macOS package manager
-2. **GitHub Actions CI/CD** - Automate builds, tests, and releases with GitHub Actions workflows
+---
 
-Together, these enable automated releases and easy installation for end users.
+## Installation Methods
+
+### 1. One-Command Install (Recommended)
+
+```bash
+bash <(curl -sSL https://raw.githubusercontent.com/mihaelamj/cupertino/main/install.sh)
+```
+
+This downloads a pre-built, signed, and notarized universal binary.
+
+### 2. Homebrew
+
+```bash
+brew tap mihaelamj/tap
+brew install cupertino
+cupertino setup
+```
+
+### 3. Build from Source
+
+```bash
+git clone https://github.com/mihaelamj/cupertino.git
+cd cupertino
+make build
+sudo make install
+```
 
 ---
 
 ## Homebrew Distribution
 
-### What is Homebrew?
+### Tap Repository
 
-[Homebrew](https://brew.sh) is the most popular package manager for macOS. Creating a Homebrew formula allows users to install Cupertino with a single command:
+Cupertino is distributed via a custom Homebrew tap at [mihaelamj/homebrew-tap](https://github.com/mihaelamj/homebrew-tap).
 
-```bash
-brew install docsucker
+### Formula Location
+
+```
+Formula/cupertino.rb
 ```
 
-Instead of manually building from source.
-
----
-
-### Quick Start
-
-> **Note**: All `make` commands in this guide can be run from the **root directory** of the repository. A wrapper Makefile in the root delegates to `Packages/Makefile`, so you don't need to `cd Packages` first.
-
-#### Option 1: Install from Local Build
-
-```bash
-# From root directory
-make install
-
-# Or from Packages subdirectory
-cd Packages
-make install
-
-# Install to custom location
-make install PREFIX=~/.local
-```
-
-#### Option 2: Create Homebrew Tap (Recommended)
-
-Create your own Homebrew tap for easy distribution:
-
-```bash
-# 1. Create tap repository
-mkdir -p ~/homebrew-tap
-cd ~/homebrew-tap
-git init
-
-# 2. Create formula (see template below)
-mkdir -p Formula
-# Create Formula/docsucker.rb
-
-# 3. Push to GitHub
-git remote add origin https://github.com/YOUR_USERNAME/homebrew-tap.git
-git add .
-git commit -m "Add docsucker formula"
-git push -u origin main
-
-# 4. Users can now install with:
-brew tap YOUR_USERNAME/tap
-brew install docsucker
-```
-
----
-
-### Creating the Formula
-
-#### Formula Template
-
-Create `Formula/docsucker.rb`:
+### Formula Template
 
 ```ruby
 class Cupertino < Formula
   desc "Apple Documentation Crawler & MCP Server"
-  homepage "https://github.com/YOUR_USERNAME/cupertino"
-  url "https://github.com/YOUR_USERNAME/cupertino/archive/refs/tags/v1.0.0.tar.gz"
-  sha256 "SHA256_HASH_OF_TARBALL"  # Get with: shasum -a 256 tarball.tar.gz
-  license "MIT"  # Or your chosen license
-  head "https://github.com/YOUR_USERNAME/cupertino.git", branch: "main"
+  homepage "https://github.com/mihaelamj/cupertino"
+  url "https://github.com/mihaelamj/cupertino/releases/download/v0.3.5/cupertino-0.3.5-macos.tar.gz"
+  sha256 "CHECKSUM_HERE"
+  license "MIT"
 
-  # Dependencies
-  depends_on "swift" => :build
-  depends_on xcode: ["16.0", :build]
-  depends_on :macos => :sequoia  # macOS 15+
+  depends_on :macos
+  depends_on macos: :sequoia
 
   def install
-    # Build executables
-    system "swift", "build",
-           "--configuration", "release",
-           "--disable-sandbox",
-           "--build-path", ".build"
-
-    # Install binaries
-    bin.install ".build/release/docsucker"
-    bin.install ".build/release/cupertino-mcp"
-
-    # Install documentation
-    doc.install "README.md"
-    doc.install "DOCSUCKER_CLI_README.md"
-    doc.install "MCP_SERVER_README.md"
-    doc.install "TESTING_GUIDE.md"
+    bin.install "cupertino"
   end
 
   def caveats
     <<~EOS
       Cupertino has been installed!
 
-      📚 CLI Usage:
-        Download Apple documentation:
-          cupertino fetch --max-pages 15000 --output-dir ~/.docsucker/docs
+      Quick Setup:
+        cupertino setup    # Download pre-built databases
+        cupertino serve    # Start MCP server
 
-        Download Swift Evolution proposals:
-          cupertino fetch-evolution --output-dir ~/.docsucker/swift-evolution
+      Configure Claude Desktop:
+        Edit ~/Library/Application Support/Claude/claude_desktop_config.json:
+        {
+          "mcpServers": {
+            "cupertino": {
+              "command": "#{bin}/cupertino"
+            }
+          }
+        }
 
-      🤖 MCP Server Setup:
-        1. Start server:
-           cupertino-mcp serve
-
-        2. Configure Claude Desktop:
-           Edit ~/Library/Application Support/Claude/claude_desktop_config.json:
-           {
-             "mcpServers": {
-               "cupertino": {
-                 "command": "#{bin}/cupertino-mcp",
-                 "args": ["serve"]
-               }
-             }
-           }
-
-        3. Restart Claude Desktop
-
-      📖 Documentation:
-        #{doc}/README.md
-        #{doc}/DOCSUCKER_CLI_README.md
-        #{doc}/MCP_SERVER_README.md
-
-      ⚠️  Requirements:
-        - macOS 15+ (Sequoia)
-        - ~2-3 GB disk space for full Apple documentation
-        - Internet connection for initial download
+      Documentation: https://github.com/mihaelamj/cupertino
     EOS
   end
 
   test do
-    # Test CLI help
-    assert_match "Apple Documentation Crawler", shell_output("#{bin}/docsucker --help")
-    assert_match "1.0.0", shell_output("#{bin}/docsucker --version")
-
-    # Test MCP help
-    assert_match "MCP Server", shell_output("#{bin}/cupertino-mcp --help")
-    assert_match "1.0.0", shell_output("#{bin}/cupertino-mcp --version")
-
-    # Test small crawl (integration test)
-    testdir = testpath/"test-output"
-    system bin/"cupertino", "crawl",
-           "--start-url", "https://developer.apple.com/documentation/swift/array",
-           "--max-pages", "1",
-           "--max-depth", "0",
-           "--output-dir", testdir,
-           "--force"
-
-    assert_predicate testdir, :exist?, "Output directory should exist"
-
-    # Check that markdown file was created (in subdirectory)
-    markdown_files = Dir.glob("#{testdir}/**/*.md")
-    assert !markdown_files.empty?, "Should have created at least one markdown file"
+    assert_match "cupertino", shell_output("#{bin}/cupertino --help")
+    assert_match version.to_s, shell_output("#{bin}/cupertino --version")
   end
 end
 ```
 
-#### Getting the SHA256 Hash
+### Updating the Formula
 
-```bash
-# Create release archive (from root directory)
-make archive
-
-# This creates: Packages/docsucker-1.0.0-arm64-apple-darwin.tar.gz
-
-# Get SHA256
-shasum -a 256 Packages/docsucker-1.0.0-arm64-apple-darwin.tar.gz
-
-# Copy the hash into your formula
-```
-
----
-
-### Building Bottles
-
-Homebrew bottles are pre-compiled binaries for faster installation.
-
-#### Using the Makefile
-
-```bash
-# Build bottle (from root directory)
-make bottle
-
-# This creates:
-# Packages/docsucker-1.0.0.arm64_monterey.bottle.tar.gz
-
-# Get SHA256 for bottle
-shasum -a 256 Packages/docsucker-1.0.0.arm64_monterey.bottle.tar.gz
-```
-
-#### Adding Bottles to Formula
-
-```ruby
-class Cupertino < Formula
-  # ... (desc, homepage, etc.) ...
-
-  bottle do
-    root_url "https://github.com/YOUR_USERNAME/cupertino/releases/download/v1.0.0"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "BOTTLE_SHA256_HERE"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "BOTTLE_SHA256_HERE"
-    sha256 cellar: :any_skip_relocation, ventura:       "BOTTLE_SHA256_HERE"
-  end
-
-  # ... (rest of formula) ...
-end
-```
-
-#### Building Bottles for Multiple macOS Versions
-
-```bash
-# On macOS 15 (Sequoia)
-make bottle
-# → docsucker-1.0.0.arm64_sequoia.bottle.tar.gz
-
-# On macOS 14 (Sonoma)
-make bottle
-# → docsucker-1.0.0.arm64_sonoma.bottle.tar.gz
-
-# On macOS 13 (Ventura)
-make bottle
-# → docsucker-1.0.0.arm64_ventura.bottle.tar.gz
-```
-
----
-
-### Testing Locally
-
-#### Test Formula Before Publishing
-
-```bash
-# 1. Audit formula
-brew audit --new-formula Formula/docsucker.rb
-
-# 2. Style check
-brew style Formula/docsucker.rb
-
-# 3. Install from formula
-brew install --build-from-source Formula/docsucker.rb
-
-# 4. Run tests
-brew test docsucker
-
-# 5. Verify installation
-cupertino --version
-cupertino-mcp --version
-
-# 6. Test functionality
-cupertino fetch --max-pages 1 --output-dir /tmp/test-docs
-
-# 7. Uninstall
-brew uninstall docsucker
-```
-
-#### Common Issues
-
-**Issue: Swift version mismatch**
-
-```bash
-# Check Swift version
-swift --version
-
-# Update Xcode Command Line Tools
-xcode-select --install
-```
-
-**Issue: Build fails with "cannot find module"**
-
-```bash
-# Clean and rebuild
-cd Packages
-swift package clean
-brew install --build-from-source --verbose Formula/docsucker.rb
-```
-
-**Issue: Tests fail**
-
-```bash
-# Run tests manually
-cd Packages
-swift test
-
-# Check specific test
-swift test --filter testDownloadRealAppleDocPage
-```
-
----
-
-### Publishing Options
-
-#### Option 1: Personal Tap (Easiest)
-
-Create your own Homebrew tap for easy maintenance and distribution.
-
-##### Step 1: Create Tap Repository
-
-```bash
-# Create repository on GitHub: homebrew-tap
-# Clone it locally
-git clone https://github.com/YOUR_USERNAME/homebrew-tap.git
-cd homebrew-tap
-
-# Create Formula directory
-mkdir -p Formula
-```
-
-##### Step 2: Add Formula
-
-```bash
-# Copy formula
-cp /path/to/docsucker.rb Formula/
-
-# Commit
-git add Formula/docsucker.rb
-git commit -m "Add docsucker formula"
-git push
-```
-
-##### Step 3: Users Install
-
-```bash
-# Users tap your repository
-brew tap YOUR_USERNAME/tap
-
-# Install docsucker
-brew install docsucker
-
-# Update
-brew update
-brew upgrade docsucker
-```
-
-##### Step 4: Release Updates
-
-```bash
-# 1. Update version in formula
-# 2. Update URL and SHA256
-# 3. Commit and push
-git add Formula/docsucker.rb
-git commit -m "docsucker 1.1.0"
-git push
-
-# Users get updates with:
-brew update
-brew upgrade docsucker
-```
-
-#### Option 2: Submit to Homebrew Core (Advanced)
-
-Submit to official [homebrew-core](https://github.com/Homebrew/homebrew-core) for wider distribution.
-
-##### Requirements
-
-- Project must be stable and well-maintained
-- Must have a tagged release on GitHub
-- Formula must pass all audits
-- Must build bottles for all supported macOS versions
-- Must have comprehensive tests
-
-##### Process
-
-1. **Fork homebrew-core**:
+1. Build release binary:
    ```bash
-   # Fork https://github.com/Homebrew/homebrew-core on GitHub
-   git clone https://github.com/YOUR_USERNAME/homebrew-core.git
-   cd homebrew-core
+   make build
    ```
 
-2. **Create formula**:
+2. Create tarball:
    ```bash
-   # Use Homebrew's formula creator
-   brew create https://github.com/YOUR_USERNAME/cupertino/archive/refs/tags/v1.0.0.tar.gz
-
-   # Edit the generated formula
-   brew edit docsucker
+   cd Packages/.build/release
+   tar -czf cupertino-0.3.5-macos.tar.gz cupertino
    ```
 
-3. **Test thoroughly**:
+3. Calculate checksum:
    ```bash
-   brew audit --new-formula --online docsucker
-   brew style docsucker
-   brew install --build-from-source docsucker
-   brew test docsucker
-   brew linkage docsucker
+   shasum -a 256 cupertino-0.3.5-macos.tar.gz
    ```
 
-4. **Build bottles**:
+4. Update formula with new version and checksum
+
+5. Test formula:
    ```bash
-   brew install --build-bottle docsucker
-   brew bottle docsucker
+   brew install --build-from-source Formula/cupertino.rb
+   brew test cupertino
    ```
 
-5. **Submit PR**:
-   ```bash
-   git add Formula/docsucker.rb
-   git commit -m "docsucker 1.0.0 (new formula)"
-   git push origin main
+6. Commit and push to tap repository
 
-   # Create PR on GitHub
+---
+
+## GitHub Releases
+
+### Creating a Release
+
+1. **Tag the release:**
+   ```bash
+   git tag v0.3.5
+   git push origin v0.3.5
    ```
 
-6. **Wait for review** - Homebrew maintainers will review and merge if approved
+2. **Build release artifacts:**
+   ```bash
+   make build
+   cd Packages/.build/release
+   tar -czf cupertino-0.3.5-macos.tar.gz cupertino
+   ```
 
-#### Option 3: Cask for Pre-built Binaries (Alternative)
+3. **Create release on GitHub:**
+   - Go to Releases → Draft a new release
+   - Select tag v0.3.5
+   - Upload cupertino-0.3.5-macos.tar.gz
+   - Add release notes
 
-If you want to distribute pre-built binaries instead of building from source:
+### Release Artifact Structure
 
-```ruby
-cask "cupertino" do
-  version "1.0.0"
-  sha256 "SHA256_OF_ZIP"
-
-  url "https://github.com/YOUR_USERNAME/cupertino/releases/download/v#{version}/docsucker-#{version}-macos.zip"
-  name "Cupertino"
-  desc "Apple Documentation Crawler & MCP Server"
-  homepage "https://github.com/YOUR_USERNAME/cupertino"
-
-  binary "cupertino"
-  binary "cupertino-mcp"
-end
+```
+cupertino-0.3.5-macos.tar.gz
+└── cupertino              # Universal binary (arm64 + x86_64)
 ```
 
 ---
 
-### Complete Workflow
+## CI/CD Setup
 
-#### Initial Setup
+### GitHub Actions Workflow
 
-```bash
-# 1. Tag release in Git (from root directory)
-git tag -a v1.0.0 -m "Release 1.0.0"
-git push origin v1.0.0
-
-# 2. Create release archive
-make archive
-# Creates: Packages/docsucker-1.0.0-arm64-apple-darwin.tar.gz
-
-# 3. Upload to GitHub Releases
-# Go to: https://github.com/YOUR_USERNAME/cupertino/releases/new
-# - Tag: v1.0.0
-# - Title: Cupertino 1.0.0
-# - Upload: Packages/docsucker-1.0.0-arm64-apple-darwin.tar.gz
-
-# 4. Get SHA256
-shasum -a 256 Packages/docsucker-1.0.0-arm64-apple-darwin.tar.gz
-# Copy this hash
-
-# 5. Create formula
-# Create homebrew-tap repository on GitHub
-git clone https://github.com/YOUR_USERNAME/homebrew-tap.git
-cd homebrew-tap
-mkdir -p Formula
-
-# 6. Create Formula/docsucker.rb (use template above)
-# - Set URL to GitHub release tarball
-# - Set SHA256 from step 4
-
-# 7. Commit formula
-git add Formula/docsucker.rb
-git commit -m "Add docsucker 1.0.0"
-git push
-
-# 8. Test installation
-brew tap YOUR_USERNAME/tap
-brew install docsucker --build-from-source
-brew test docsucker
-
-# 9. Build and upload bottle (optional)
-brew install --build-bottle docsucker
-brew bottle docsucker
-# Upload bottle to GitHub Releases
-# Update formula with bottle SHA256
-
-# 10. Done! Users can now install with:
-brew tap YOUR_USERNAME/tap
-brew install docsucker
-```
-
-#### Release Updates
-
-```bash
-# 1. Update version in code
-# - Packages/Sources/CupertinoShared/Configuration.swift
-# - Update version to 1.1.0
-
-# 2. Commit and tag (from root directory)
-git add .
-git commit -m "Release 1.1.0"
-git tag -a v1.1.0 -m "Release 1.1.0"
-git push origin v1.1.0
-
-# 3. Create archive
-make archive
-# Creates: Packages/docsucker-1.1.0-arm64-apple-darwin.tar.gz
-
-# 4. Upload to GitHub Releases
-
-# 5. Update formula
-cd homebrew-tap
-# Update Formula/docsucker.rb:
-#   - url: v1.1.0
-#   - sha256: new hash
-git add Formula/docsucker.rb
-git commit -m "docsucker 1.1.0"
-git push
-
-# 6. Users upgrade with:
-brew update
-brew upgrade docsucker
-```
-
----
-
-### Best Practices
-
-#### Versioning
-
-- Use semantic versioning (1.0.0, 1.1.0, 2.0.0)
-- Tag releases in Git
-- Update version in code before tagging
-- Create GitHub releases for each version
-
-#### Formula Maintenance
-
-- Keep formula simple and readable
-- Test on multiple macOS versions
-- Provide helpful caveats for post-install setup
-- Include comprehensive tests
-- Document dependencies clearly
-
-#### Documentation
-
-- Maintain clear README files
-- Include installation instructions
-- Provide usage examples
-- Document MCP integration steps
-
-#### Testing
-
-```bash
-# Always test before publishing:
-brew audit --new-formula Formula/docsucker.rb
-brew style Formula/docsucker.rb
-brew install --build-from-source Formula/docsucker.rb
-brew test docsucker
-brew linkage docsucker
-
-# Test on clean system (VM or container)
-```
-
----
-
-## CI/CD with GitHub Actions
-
-Automate builds, tests, linting, and releases with GitHub Actions workflows.
-
-### 1. Build & Test Workflow
-
-**Purpose:** Build project on every push/PR to ensure it compiles
-
-**File:** `.github/workflows/build.yml`
-
-```yaml
-name: Build
-
-on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main ]
-
-jobs:
-  build:
-    name: Build on macOS
-    runs-on: macos-14  # macOS 14 (Sonoma) with Xcode 15+
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Swift
-      uses: swift-actions/setup-swift@v2
-      with:
-        swift-version: '6.2'
-
-    - name: Swift version
-      run: swift --version
-
-    - name: Build
-      run: |
-        cd Packages
-        swift build --configuration release
-
-    - name: Run tests
-      run: |
-        cd Packages
-        swift test
-
-    - name: Archive binaries (on main branch)
-      if: github.ref == 'refs/heads/main'
-      run: |
-        cd Packages
-        swift build --configuration release
-        mkdir -p artifacts
-        cp .build/release/cupertino artifacts/
-        cp .build/release/cupertino-mcp artifacts/
-
-    - name: Upload artifacts
-      if: github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v4
-      with:
-        name: cupertino-binaries
-        path: Packages/artifacts/
-```
-
----
-
-### 2. SwiftLint Workflow
-
-**Purpose:** Enforce code quality on PRs
-
-**File:** `.github/workflows/swiftlint.yml`
-
-```yaml
-name: SwiftLint
-
-on:
-  pull_request:
-    branches: [ main ]
-  push:
-    branches: [ main ]
-
-jobs:
-  swiftlint:
-    name: SwiftLint Check
-    runs-on: macos-14
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install SwiftLint
-      run: brew install swiftlint
-
-    - name: Run SwiftLint
-      run: |
-        cd Packages
-        swiftlint lint --strict
-```
-
----
-
-### 3. Daily Documentation Check
-
-**Purpose:** Automatically check for documentation updates daily
-
-**File:** `.github/workflows/daily-check.yml`
-
-```yaml
-name: Daily Docs Check
-
-on:
-  schedule:
-    # Run at 2 AM UTC daily
-    - cron: '0 2 * * *'
-  workflow_dispatch:  # Allow manual trigger
-
-jobs:
-  check-docs:
-    name: Check for Documentation Updates
-    runs-on: macos-14
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Swift
-      uses: swift-actions/setup-swift@v2
-      with:
-        swift-version: '6.2'
-
-    - name: Build cupertino
-      run: |
-        cd Packages
-        swift build --configuration release
-
-    - name: Install cupertino
-      run: |
-        sudo cp Packages/.build/release/cupertino /usr/local/bin/
-        sudo cp Packages/.build/release/cupertino-mcp /usr/local/bin/
-
-    - name: Run fast check
-      id: check
-      run: |
-        # Fast check for changes (once Phase 5b is implemented)
-        cupertino check --output /tmp/changes.json --no-delay || true
-
-        # Count changes
-        if [ -f /tmp/changes.json ]; then
-          NEW=$(jq '.new | length' /tmp/changes.json)
-          MODIFIED=$(jq '.modified | length' /tmp/changes.json)
-          echo "new=$NEW" >> $GITHUB_OUTPUT
-          echo "modified=$MODIFIED" >> $GITHUB_OUTPUT
-        else
-          echo "new=0" >> $GITHUB_OUTPUT
-          echo "modified=0" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Create issue if significant changes
-      if: steps.check.outputs.new > 50 || steps.check.outputs.modified > 100
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const new_count = ${{ steps.check.outputs.new }};
-          const modified_count = ${{ steps.check.outputs.modified }};
-
-          github.rest.issues.create({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            title: `Documentation changes detected: ${new_count} new, ${modified_count} modified`,
-            body: `
-## Documentation Update Detected
-
-**Date:** ${new Date().toISOString()}
-
-**Changes:**
-- 🆕 New pages: ${new_count}
-- ✏️ Modified pages: ${modified_count}
-
-Consider running a full update to capture these changes.
-
-\`\`\`bash
-cupertino update
-\`\`\`
-            `,
-            labels: ['documentation', 'automated']
-          });
-
-    - name: Comment on existing issues
-      if: steps.check.outputs.new > 0 || steps.check.outputs.modified > 0
-      run: |
-        echo "Found ${{ steps.check.outputs.new }} new and ${{ steps.check.outputs.modified }} modified pages"
-```
-
----
-
-### 4. Release Workflow
-
-**Purpose:** Automate releases when tags are pushed
-
-**File:** `.github/workflows/release.yml`
+Create `.github/workflows/release.yml`:
 
 ```yaml
 name: Release
@@ -802,239 +179,121 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'  # Trigger on version tags (e.g., v1.0.0)
+      - 'v*'
 
 jobs:
-  release:
-    name: Create Release
-    runs-on: macos-14
-
+  build:
+    runs-on: macos-15
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup Swift
-      uses: swift-actions/setup-swift@v2
-      with:
-        swift-version: '6.2'
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.0"
 
-    - name: Build release binaries
-      run: |
-        cd Packages
-        swift build --configuration release
+      - name: Build Release
+        run: |
+          cd Packages
+          swift build -c release
 
-    - name: Create artifacts
-      run: |
-        mkdir -p release
-        cp Packages/.build/release/cupertino release/
-        cp Packages/.build/release/cupertino-mcp release/
-        cd release
-        tar -czf cupertino-${{ github.ref_name }}-macos.tar.gz cupertino cupertino-mcp
+      - name: Create Tarball
+        run: |
+          cd Packages/.build/release
+          tar -czf cupertino-${{ github.ref_name }}-macos.tar.gz cupertino
 
-    - name: Create Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: release/cupertino-${{ github.ref_name }}-macos.tar.gz
-        generate_release_notes: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: Packages/.build/release/cupertino-${{ github.ref_name }}-macos.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ---
 
-### GitHub Repository Settings
+## Version Management
 
-#### Required Secrets
+### Version Locations
 
-None required for basic workflows. All use `GITHUB_TOKEN` which is automatically provided.
+Update version in these files when releasing:
 
-#### Branch Protection Rules
+| File | Location |
+|------|----------|
+| `Packages/Sources/Shared/Constants.swift` | `Constants.version` |
+| `README.md` | Project Status section |
+| `docs/ARCHITECTURE.md` | Header |
+| `CHANGELOG.md` | New entry at top |
 
-For `main` branch:
-- Require pull request reviews before merging
-- Require status checks to pass:
-  - Build
-  - SwiftLint
-- Require branches to be up to date before merging
+### Version Format
 
----
+Use semantic versioning: `MAJOR.MINOR.PATCH`
 
-### Automated Documentation Updates Strategy
-
-#### Option 1: Notification Only (Recommended)
-
-**What it does:**
-- Daily check for documentation changes
-- Creates GitHub issue if significant changes detected
-- User manually runs update when ready
-
-**Pros:**
-- No risk of bad data
-- User controls when to update
-- Transparent process
-
-**Cons:**
-- Requires manual intervention
-
-#### Option 2: Automated Update (Advanced)
-
-**What it does:**
-- Daily check + automatic update if changes found
-- Commits updated docs to repository
-- Creates PR for review
-
-**Implementation:**
-```yaml
-- name: Run update if changes detected
-  if: steps.check.outputs.new > 10
-  run: |
-    cupertino update --only-changed /tmp/changes.json
-    cupertino build-index
-
-- name: Create PR with updates
-  uses: peter-evans/create-pull-request@v5
-  with:
-    title: "docs: Update documentation (${{ steps.check.outputs.new }} new pages)"
-    body: |
-      Automated documentation update
-
-      - New pages: ${{ steps.check.outputs.new }}
-      - Modified pages: ${{ steps.check.outputs.modified }}
-    branch: automated-docs-update
-    commit-message: "Update Apple documentation"
-```
-
-**Pros:**
-- Fully automated
-- Always up-to-date
-
-**Cons:**
-- Requires storing docs in git (large repo size)
-- Potential for bad data if Apple docs change format
-
-**Recommendation:** Use Option 1 (notification only)
-
----
-
-### Project Statistics Badges
-
-Add badges to README.md for project visibility:
-
-```markdown
-# AppleCupertino
-
-![Swift 6.2](https://img.shields.io/badge/Swift-6.2-orange.svg)
-![Platform](https://img.shields.io/badge/Platform-macOS%2010.15%2B-blue.svg)
-![License](https://img.shields.io/badge/License-MIT-green.svg)
-![Build Status](https://github.com/mmj/cupertino/workflows/Build/badge.svg)
-![Latest Release](https://img.shields.io/github/v/release/mmj/cupertino)
-
-> Crawl and index Apple developer documentation for AI agent consumption
-```
-
-#### Dynamic Badges (Updated by Scripts)
-
-Create a script that updates badge values:
-
-```bash
-#!/bin/bash
-# .github/scripts/update-badges.sh
-
-# Count docs
-DOCS_COUNT=$(find /Volumes/Code/DeveloperExt/appledocsucker/docs -name "*.md" | wc -l | tr -d ' ')
-
-# Count samples
-SAMPLES_COUNT=$(find /Volumes/Code/DeveloperExt/appledocsucker/sample-code -name "*.zip" | wc -l | tr -d ' ')
-
-# Count proposals
-PROPOSALS_COUNT=$(find /Volumes/Code/DeveloperExt/appledocsucker/swift-evolution -name "*.md" | wc -l | tr -d ' ')
-
-# Update gist or endpoint.json for shields.io dynamic badges
-echo "{
-  \"schemaVersion\": 1,
-  \"label\": \"documentation\",
-  \"message\": \"${DOCS_COUNT}+ pages\",
-  \"color\": \"success\"
-}" > docs-badge.json
-```
-
-Then use shields.io endpoint badge:
-```markdown
-![Docs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/mmj/cupertino/main/docs-badge.json)
-```
+- **MAJOR**: Breaking changes
+- **MINOR**: New features (backwards compatible)
+- **PATCH**: Bug fixes
 
 ---
 
 ## Release Checklist
 
-Use this checklist for each release:
-
 ### Pre-Release
 
-- [ ] Update version in `Packages/Sources/CupertinoShared/Configuration.swift`
-- [ ] Update CHANGELOG.md with release notes
-- [ ] Run all tests: `cd Packages && swift test`
-- [ ] Run SwiftLint: `cd Packages && swiftlint lint --strict`
-- [ ] Build release binaries: `make archive`
-- [ ] Test installation locally
+- [ ] All tests passing: `make test`
+- [ ] No lint violations: `make lint`
+- [ ] Update version in `Constants.swift`
+- [ ] Update version in `README.md`
+- [ ] Update version in `docs/ARCHITECTURE.md`
+- [ ] Add CHANGELOG.md entry
+- [ ] Commit version changes
 
 ### Release
 
-- [ ] Commit version changes: `git commit -m "Release X.Y.Z"`
-- [ ] Tag release: `git tag -a vX.Y.Z -m "Release X.Y.Z"`
-- [ ] Push tag: `git push origin vX.Y.Z`
-- [ ] Wait for GitHub Actions to build and create release
-- [ ] Verify release artifacts on GitHub
-
-### Homebrew
-
-- [ ] Get SHA256 of release tarball
-- [ ] Update Homebrew formula (url, sha256, version)
-- [ ] Test formula: `brew install --build-from-source Formula/docsucker.rb`
-- [ ] Run formula tests: `brew test docsucker`
-- [ ] Commit formula: `git commit -m "docsucker X.Y.Z"`
-- [ ] Push to tap: `git push`
+- [ ] Tag release: `git tag v0.3.5`
+- [ ] Push tag: `git push origin v0.3.5`
+- [ ] Build: `make build`
+- [ ] Create tarball
+- [ ] Create GitHub release
+- [ ] Upload artifacts
 
 ### Post-Release
 
-- [ ] Test user installation: `brew upgrade docsucker`
-- [ ] Update documentation if needed
+- [ ] Update Homebrew formula
+- [ ] Test installation: `brew install cupertino`
+- [ ] Verify: `cupertino --version`
 - [ ] Announce release (if applicable)
-- [ ] Monitor for issues
-
-### Optional: Build Bottles
-
-- [ ] Build bottles on macOS Sequoia, Sonoma, Ventura
-- [ ] Upload bottles to GitHub Releases
-- [ ] Update formula with bottle SHA256s
-- [ ] Push updated formula
 
 ---
 
-## Resources
+## Troubleshooting
 
-### Homebrew
+### Build Fails
 
-- [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
-- [Homebrew Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae)
-- [Creating Taps](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap)
-- [Homebrew Bottles](https://docs.brew.sh/Bottles)
-- [Swift in Homebrew](https://github.com/Homebrew/homebrew-core/search?q=language%3ARuby+swift&type=code)
+```bash
+# Clean and rebuild
+make clean
+make build
+```
 
-### GitHub Actions
+### Formula Test Fails
 
-- [GitHub Actions Documentation](https://docs.github.com/en/actions)
-- [Swift Actions](https://github.com/swift-actions)
-- [Creating Releases](https://docs.github.com/en/repositories/releasing-projects-on-github)
-- [Workflow Syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)
+```bash
+# Debug formula
+brew install --verbose --debug Formula/cupertino.rb
+```
 
-### Swift & macOS
+### Binary Not Found After Install
 
-- [Swift Package Manager](https://swift.org/package-manager/)
-- [SwiftLint](https://github.com/realm/SwiftLint)
-- [Semantic Versioning](https://semver.org/)
+```bash
+# Check installation path
+which cupertino
+ls -la /usr/local/bin/cupertino
+```
 
 ---
 
-**Last updated:** 2025-11-22
-**Status:** Production deployment guide
+## See Also
+
+- [DEVELOPMENT.md](../DEVELOPMENT.md) - Development workflow
+- [ARCHITECTURE.md](ARCHITECTURE.md) - Technical architecture
+- [README.md](../README.md) - Project overview

--- a/docs/REFACTORING_ANALYSIS.md
+++ b/docs/REFACTORING_ANALYSIS.md
@@ -1,0 +1,434 @@
+# Search Code Refactoring Analysis
+
+**Date:** 2025-12-08
+**Purpose:** Identify code duplication between CLI commands and MCP tools for potential refactoring.
+
+---
+
+## Executive Summary
+
+The CLI commands and MCP tools implement **the same functionality** through different I/O channels:
+- **CLI**: ArgumentParser → stdout/stderr
+- **MCP**: JSON-RPC → CallToolResult
+
+Both use the same underlying `Search.Index` but duplicate:
+1. Parameter extraction/validation
+2. Result formatting (markdown/JSON/text)
+3. Error handling
+4. Database path resolution
+
+**Recommendation:** Extract shared logic into a `SearchService` layer.
+
+---
+
+## Detailed Analysis
+
+### 1. Functionality Mapping
+
+| Operation | CLI Command | MCP Tool | Shared Logic? |
+|-----------|-------------|----------|---------------|
+| Search docs | `SearchCommand` | `handleSearchDocs()` | **80% duplicate** |
+| Search HIG | *Missing* | `handleSearchHIG()` | N/A |
+| Read document | `ReadCommand` | `handleReadDocument()` | **70% duplicate** |
+| List frameworks | `ListFrameworksCommand` | `handleListFrameworks()` | **75% duplicate** |
+
+### 2. Code Duplication Details
+
+#### 2.1 Search Operation
+
+**CLI (`SearchCommand.swift:85-92`):**
+```swift
+let results = try await searchIndex.search(
+    query: query,
+    source: source,
+    framework: framework,
+    language: language,
+    limit: limit,
+    includeArchive: includeArchive
+)
+```
+
+**MCP (`DocumentationToolProvider.swift:95-102`):**
+```swift
+let results = try await searchIndex.search(
+    query: query,
+    source: source,
+    framework: framework,
+    language: language,
+    limit: limit,
+    includeArchive: includeArchive
+)
+```
+
+**Verdict:** Identical call - could share a service method.
+
+---
+
+#### 2.2 Markdown Formatting
+
+**CLI (`SearchCommand.swift:157-178`):**
+```swift
+private func outputMarkdown(_ results: [Search.Result]) {
+    Log.output("# Search Results for '\(query)'\n")
+    Log.output("Found \(results.count) result(s).\n")
+    for (index, result) in results.enumerated() {
+        Log.output("## \(index + 1). \(result.title)\n")
+        Log.output("- **Source:** \(result.source)")
+        Log.output("- **Framework:** \(result.framework)")
+        Log.output("- **URI:** `\(result.uri)`")
+        // ...
+    }
+}
+```
+
+**MCP (`DocumentationToolProvider.swift:104-142`):**
+```swift
+var markdown = "# Search Results for \"\(query)\"\n\n"
+markdown += "Found **\(results.count)** result\(results.count == 1 ? "" : "s"):\n\n"
+for (index, result) in results.enumerated() {
+    markdown += "## \(index + 1). \(result.title)\n\n"
+    markdown += "- **Framework:** `\(result.framework)`\n"
+    markdown += "- **URI:** `\(result.uri)`\n"
+    // ...
+}
+```
+
+**Differences:**
+| Aspect | CLI | MCP |
+|--------|-----|-----|
+| Quote style | Single `'` | Double `"` |
+| Pluralization | `result(s)` | Proper plural check |
+| Fields shown | Source, Framework, URI | Framework, URI, Score, Words |
+| Output method | `Log.output()` per line | String accumulation |
+
+**Verdict:** Similar logic with different output - extract formatter returning String.
+
+---
+
+#### 2.3 Database Path Resolution
+
+**Duplicated in 3 files:**
+
+```swift
+// SearchCommand.swift:107-112
+private func resolveSearchDbPath() -> URL {
+    if let searchDb {
+        return URL(fileURLWithPath: searchDb).expandingTildeInPath
+    }
+    return Shared.Constants.defaultSearchDatabase
+}
+
+// ReadCommand.swift:64-69
+private func resolveSearchDbPath() -> URL { /* identical */ }
+
+// ListFrameworksCommand.swift:63-68
+private func resolveSearchDbPath() -> URL { /* identical */ }
+```
+
+**Verdict:** Extract to `Shared.PathResolver.searchDatabase(custom:)`.
+
+---
+
+#### 2.4 URL Tilde Expansion
+
+**Duplicated in 3 files:**
+
+```swift
+private extension URL {
+    var expandingTildeInPath: URL {
+        if path.hasPrefix("~") {
+            let expandedPath = NSString(string: path).expandingTildeInPath
+            return URL(fileURLWithPath: expandedPath)
+        }
+        return self
+    }
+}
+```
+
+**Verdict:** Move to `Shared.Extensions.URL+Tilde.swift`.
+
+---
+
+#### 2.5 OutputFormat Enum
+
+**Duplicated in 3 files:**
+
+```swift
+// SearchCommand.swift:184-188
+enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
+    case text
+    case json
+    case markdown
+}
+
+// ListFrameworksCommand.swift:148-152
+enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
+    case text
+    case json
+    case markdown
+}
+
+// ReadCommand.swift:75-78
+enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
+    case json
+    case markdown  // Note: no text option
+}
+```
+
+**Verdict:** Create shared `CLI.OutputFormat` enum.
+
+---
+
+#### 2.6 Database Existence Check
+
+**Duplicated pattern in all CLI commands:**
+
+```swift
+guard FileManager.default.fileExists(atPath: dbPath.path) else {
+    Log.error("Search database not found at \(dbPath.path)")
+    Log.output("Run 'cupertino save' to build the search index first.")
+    throw ExitCode.failure
+}
+```
+
+**Verdict:** Extract to helper: `try CLI.requireSearchDatabase(at: dbPath)`.
+
+---
+
+#### 2.7 Search Index Lifecycle
+
+**Duplicated in all CLI commands:**
+
+```swift
+let searchIndex = try await Search.Index(dbPath: dbPath)
+defer {
+    Task {
+        await searchIndex.disconnect()
+    }
+}
+```
+
+**Verdict:** Create `withSearchIndex(at:) async throws` helper or `SearchService`.
+
+---
+
+### 3. Missing CLI Commands
+
+The MCP tool has `search_hig` but CLI has no equivalent:
+
+| MCP Tool | CLI Command | Status |
+|----------|-------------|--------|
+| `search_docs` | `search` | Exists |
+| `search_hig` | - | **Missing** |
+| `read_document` | `read` | Exists |
+| `list_frameworks` | `list-frameworks` | Exists |
+
+**Recommendation:** Add `cupertino search-hig` command or add `--hig` flag to search.
+
+---
+
+### 4. Inconsistencies
+
+| Aspect | CLI | MCP | Issue |
+|--------|-----|-----|-------|
+| Score display | Not shown | Shown | CLI should optionally show score |
+| Word count | Not shown | Shown | CLI should optionally show word count |
+| Filter display | Not shown | Shown in header | CLI should show active filters |
+| No results message | Plain text | Styled with tips | Inconsistent UX |
+| Separator | None | `---` | MCP has better visual separation |
+
+---
+
+## 5. Proposed Refactoring
+
+### 5.1 New Module: `SearchService`
+
+```
+Sources/
+├── SearchService/           # NEW
+│   ├── SearchService.swift  # Core search operations
+│   ├── Formatters/
+│   │   ├── SearchResultFormatter.swift
+│   │   ├── FrameworkListFormatter.swift
+│   │   └── DocumentFormatter.swift
+│   └── Models/
+│       └── SearchRequest.swift
+```
+
+### 5.2 SearchService API
+
+```swift
+public actor SearchService {
+    private let searchIndex: Search.Index
+
+    // Core operations
+    public func search(_ request: SearchRequest) async throws -> [Search.Result]
+    public func searchHIG(_ request: HIGSearchRequest) async throws -> [Search.Result]
+    public func readDocument(uri: String, format: DocumentFormat) async throws -> String?
+    public func listFrameworks() async throws -> [String: Int]
+
+    // Convenience
+    public static func withDatabase(
+        at path: URL?,
+        perform: (SearchService) async throws -> T
+    ) async throws -> T
+}
+```
+
+### 5.3 SearchRequest Model
+
+```swift
+public struct SearchRequest {
+    public let query: String
+    public let source: String?
+    public let framework: String?
+    public let language: String?
+    public let limit: Int
+    public let includeArchive: Bool
+
+    public init(
+        query: String,
+        source: String? = nil,
+        framework: String? = nil,
+        language: String? = nil,
+        limit: Int = 20,
+        includeArchive: Bool = false
+    )
+}
+```
+
+### 5.4 Formatter Protocol
+
+```swift
+public protocol SearchResultFormatter {
+    func format(results: [Search.Result], query: String, filters: SearchFilters) -> String
+}
+
+public struct MarkdownSearchResultFormatter: SearchResultFormatter { }
+public struct JSONSearchResultFormatter: SearchResultFormatter { }
+public struct TextSearchResultFormatter: SearchResultFormatter { }
+```
+
+### 5.5 Refactored CLI Command
+
+```swift
+struct SearchCommand: AsyncParsableCommand {
+    // ... options ...
+
+    mutating func run() async throws {
+        try await SearchService.withDatabase(at: searchDbPath) { service in
+            let request = SearchRequest(
+                query: query,
+                source: source,
+                framework: framework,
+                language: language,
+                limit: limit,
+                includeArchive: includeArchive
+            )
+
+            let results = try await service.search(request)
+            let formatter = formatter(for: format)
+            let output = formatter.format(results: results, query: query, filters: request.filters)
+            Log.output(output)
+        }
+    }
+}
+```
+
+### 5.6 Refactored MCP Tool
+
+```swift
+private func handleSearchDocs(arguments: [String: AnyCodable]?) async throws -> CallToolResult {
+    let request = try SearchRequest(from: arguments)
+    let results = try await searchService.search(request)
+
+    let formatter = MarkdownSearchResultFormatter(showScore: true, showWordCount: true)
+    let markdown = formatter.format(results: results, query: request.query, filters: request.filters)
+
+    return CallToolResult(content: [.text(TextContent(text: markdown))])
+}
+```
+
+---
+
+## 6. Shared Utilities to Extract
+
+| Current Location | New Location | Purpose |
+|------------------|--------------|---------|
+| `URL.expandingTildeInPath` (3 places) | `Shared/Extensions/URL+Tilde.swift` | Tilde expansion |
+| `resolveSearchDbPath()` (3 places) | `Shared/PathResolver.swift` | Database path resolution |
+| `OutputFormat` enum (3 places) | `CLI/OutputFormat.swift` | Output format selection |
+| Database existence check (3 places) | `CLI/DatabaseHelper.swift` | Error handling |
+| JSON encoder setup (3 places) | `Shared/JSONCoding.swift` | Consistent JSON formatting |
+
+---
+
+## 7. Priority Order
+
+1. **High Priority:**
+   - Extract `URL.expandingTildeInPath` to Shared
+   - Extract `resolveSearchDbPath()` to Shared
+   - Create shared `OutputFormat` enum
+
+2. **Medium Priority:**
+   - Create `SearchService` layer
+   - Create formatter protocol and implementations
+   - Add `search-hig` CLI command
+
+3. **Low Priority:**
+   - Unify markdown formatting between CLI and MCP
+   - Add score/wordCount display options to CLI
+   - Add filter display to CLI output
+
+---
+
+## 8. Lines of Code Estimate
+
+| Change | Lines Removed | Lines Added | Net |
+|--------|---------------|-------------|-----|
+| URL extension dedup | -30 | +15 | -15 |
+| Path resolver dedup | -24 | +20 | -4 |
+| OutputFormat dedup | -18 | +12 | -6 |
+| Database check dedup | -12 | +15 | +3 |
+| SearchService | -100 | +150 | +50 |
+| Formatters | -80 | +120 | +40 |
+| **Total** | **-264** | **+332** | **+68** |
+
+Net increase of ~68 lines, but with:
+- Single source of truth for each operation
+- Easier testing
+- Consistent behavior across CLI and MCP
+- Reduced maintenance burden
+
+---
+
+## 9. Files to Modify
+
+### Create New:
+- `Sources/Shared/Extensions/URL+Tilde.swift`
+- `Sources/Shared/PathResolver.swift`
+- `Sources/CLI/OutputFormat.swift`
+- `Sources/CLI/DatabaseHelper.swift`
+- `Sources/SearchService/SearchService.swift`
+- `Sources/SearchService/Formatters/*.swift`
+
+### Modify:
+- `Sources/CLI/Commands/SearchCommand.swift`
+- `Sources/CLI/Commands/ReadCommand.swift`
+- `Sources/CLI/Commands/ListFrameworksCommand.swift`
+- `Sources/SearchToolProvider/DocumentationToolProvider.swift`
+- `Package.swift` (add SearchService target)
+
+---
+
+## 10. Testing Impact
+
+With `SearchService` extraction:
+- Test formatters independently
+- Test service logic once (not per CLI command)
+- Mock `SearchService` in CLI/MCP tests
+- Higher test coverage with less code
+
+---
+
+*This file can be deleted after refactoring is complete.*

--- a/docs/REFACTORING_ANALYSIS.md
+++ b/docs/REFACTORING_ANALYSIS.md
@@ -1,116 +1,164 @@
-# Search Code Refactoring Analysis
+# Search & Tool Provider Refactoring Analysis
 
 **Date:** 2025-12-08
-**Purpose:** Identify code duplication between CLI commands and MCP tools for potential refactoring.
+**Purpose:** Deep analysis of code duplication between CLI commands, MCP tools, and resource providers. Design protocol-based refactoring for perfect separation of concerns.
 
 ---
 
 ## Executive Summary
 
-The CLI commands and MCP tools implement **the same functionality** through different I/O channels:
-- **CLI**: ArgumentParser → stdout/stderr
-- **MCP**: JSON-RPC → CallToolResult
+The codebase has **three parallel implementations** of similar functionality:
+1. **CLI Commands** - `SearchCommand`, `ReadCommand`, `ListFrameworksCommand`, etc.
+2. **MCP Tool Providers** - `DocumentationToolProvider`, `SampleCodeToolProvider`
+3. **MCP Resource Providers** - `DocsResourceProvider`
 
-Both use the same underlying `Search.Index` but duplicate:
-1. Parameter extraction/validation
-2. Result formatting (markdown/JSON/text)
-3. Error handling
-4. Database path resolution
+All three share the same underlying data sources (`Search.Index`, `SampleIndex.Database`) but duplicate:
+- Parameter extraction/validation
+- Result formatting
+- Error handling
+- Database/file path resolution
 
-**Recommendation:** Extract shared logic into a `SearchService` layer.
-
----
-
-## Detailed Analysis
-
-### 1. Functionality Mapping
-
-| Operation | CLI Command | MCP Tool | Shared Logic? |
-|-----------|-------------|----------|---------------|
-| Search docs | `SearchCommand` | `handleSearchDocs()` | **80% duplicate** |
-| Search HIG | *Missing* | `handleSearchHIG()` | N/A |
-| Read document | `ReadCommand` | `handleReadDocument()` | **70% duplicate** |
-| List frameworks | `ListFrameworksCommand` | `handleListFrameworks()` | **75% duplicate** |
-
-### 2. Code Duplication Details
-
-#### 2.1 Search Operation
-
-**CLI (`SearchCommand.swift:85-92`):**
-```swift
-let results = try await searchIndex.search(
-    query: query,
-    source: source,
-    framework: framework,
-    language: language,
-    limit: limit,
-    includeArchive: includeArchive
-)
-```
-
-**MCP (`DocumentationToolProvider.swift:95-102`):**
-```swift
-let results = try await searchIndex.search(
-    query: query,
-    source: source,
-    framework: framework,
-    language: language,
-    limit: limit,
-    includeArchive: includeArchive
-)
-```
-
-**Verdict:** Identical call - could share a service method.
+**Goal:** Extract shared logic into source-specific **Service** and **Formatter** protocols.
 
 ---
 
-#### 2.2 Markdown Formatting
+## Current Architecture
 
-**CLI (`SearchCommand.swift:157-178`):**
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         User Interface Layer                         │
+├─────────────────────────────────┬───────────────────────────────────┤
+│         CLI Commands            │         MCP Tools/Resources       │
+│  ┌───────────────────────────┐  │  ┌───────────────────────────┐   │
+│  │ SearchCommand             │  │  │ DocumentationToolProvider │   │
+│  │ ReadCommand               │  │  │ SampleCodeToolProvider    │   │
+│  │ ListFrameworksCommand     │  │  │ DocsResourceProvider      │   │
+│  │ SearchSamplesCommand      │  │  │ CompositeToolProvider     │   │
+│  │ ListSamplesCommand        │  │  └───────────────────────────┘   │
+│  │ ReadSampleCommand         │  │                                   │
+│  │ ReadSampleFileCommand     │  │                                   │
+│  └───────────────────────────┘  │                                   │
+├─────────────────────────────────┴───────────────────────────────────┤
+│                         Data Access Layer                            │
+│  ┌───────────────────────────┐  ┌───────────────────────────┐      │
+│  │ Search.Index              │  │ SampleIndex.Database      │      │
+│  │ (SQLite FTS5)             │  │ (SQLite FTS5)             │      │
+│  └───────────────────────────┘  └───────────────────────────┘      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Problem:** No shared service layer between CLI and MCP.
+
+---
+
+## Detailed Duplication Analysis
+
+### 1. Error Types (4 duplicates!)
+
 ```swift
-private func outputMarkdown(_ results: [Search.Result]) {
-    Log.output("# Search Results for '\(query)'\n")
-    Log.output("Found \(results.count) result(s).\n")
-    for (index, result) in results.enumerated() {
-        Log.output("## \(index + 1). \(result.title)\n")
-        Log.output("- **Source:** \(result.source)")
-        Log.output("- **Framework:** \(result.framework)")
-        Log.output("- **URI:** `\(result.uri)`")
-        // ...
-    }
+// DocumentationToolProvider.swift:288-302
+enum DocumentationToolError: Error, LocalizedError {
+    case unknownTool(String)
+    case missingArgument(String)
+    case invalidArgument(String, String)
+}
+
+// SampleCodeToolProvider.swift:311-325
+enum SampleToolError: Error, LocalizedError {
+    case unknownTool(String)
+    case missingArgument(String)
+    case invalidArgument(String, String)
+}
+
+// CompositeToolProvider.swift:63-77
+enum UnifiedToolError: Error, LocalizedError {
+    case unknownTool(String)
+    case missingArgument(String)
+    case invalidArgument(String, String)
+}
+
+// DocsResourceProvider.swift:333-349
+enum ResourceError: Error, LocalizedError {
+    case invalidURI(String)
+    case notFound(String)
+    case noDocumentation
 }
 ```
 
-**MCP (`DocumentationToolProvider.swift:104-142`):**
-```swift
-var markdown = "# Search Results for \"\(query)\"\n\n"
-markdown += "Found **\(results.count)** result\(results.count == 1 ? "" : "s"):\n\n"
-for (index, result) in results.enumerated() {
-    markdown += "## \(index + 1). \(result.title)\n\n"
-    markdown += "- **Framework:** `\(result.framework)`\n"
-    markdown += "- **URI:** `\(result.uri)`\n"
-    // ...
-}
-```
-
-**Differences:**
-| Aspect | CLI | MCP |
-|--------|-----|-----|
-| Quote style | Single `'` | Double `"` |
-| Pluralization | `result(s)` | Proper plural check |
-| Fields shown | Source, Framework, URI | Framework, URI, Score, Words |
-| Output method | `Log.output()` per line | String accumulation |
-
-**Verdict:** Similar logic with different output - extract formatter returning String.
+**Verdict:** Extract to single `ToolError` enum in Shared.
 
 ---
 
-#### 2.3 Database Path Resolution
-
-**Duplicated in 3 files:**
+### 2. Argument Extraction Pattern (repeated 15+ times)
 
 ```swift
-// SearchCommand.swift:107-112
+// Pattern repeated in every tool handler:
+guard let query = arguments?[Shared.Constants.MCP.schemaParamQuery]?.value as? String else {
+    throw SampleToolError.missingArgument(Shared.Constants.MCP.schemaParamQuery)
+}
+
+let framework = arguments?[Shared.Constants.MCP.schemaParamFramework]?.value as? String
+let defaultLimit = Shared.Constants.Limit.defaultSearchLimit
+let requestedLimit = (arguments?[Shared.Constants.MCP.schemaParamLimit]?.value as? Int) ?? defaultLimit
+let limit = min(requestedLimit, Shared.Constants.Limit.maxSearchLimit)
+```
+
+**Verdict:** Create `ArgumentExtractor` helper.
+
+---
+
+### 3. Markdown Formatting (5+ similar implementations)
+
+| Location | Function | Lines |
+|----------|----------|-------|
+| `DocumentationToolProvider` | `handleSearchDocs` | 104-142 |
+| `DocumentationToolProvider` | `handleSearchHIG` | 239-276 |
+| `DocumentationToolProvider` | `handleListFrameworks` | 155-173 |
+| `SampleCodeToolProvider` | `handleSearchSamples` | 101-156 |
+| `SampleCodeToolProvider` | `handleListSamples` | 169-191 |
+| `SampleCodeToolProvider` | `handleReadSample` | 209-247 |
+| `SearchCommand` | `outputMarkdown` | 157-178 |
+| `ListFrameworksCommand` | `outputMarkdown` | 124-141 |
+
+**All use the same markdown patterns:**
+```swift
+"# Title\n\n"
+"Found **\(count)** result(s):\n\n"
+"## \(index + 1). \(title)\n\n"
+"- **Field:** `\(value)`\n"
+"---\n\n"
+```
+
+**Verdict:** Create source-specific `ResultFormatter` protocols.
+
+---
+
+### 4. CLI/MCP Functionality Mapping
+
+| Functionality | CLI Command | MCP Tool | MCP Resource |
+|--------------|-------------|----------|--------------|
+| **Documentation** |
+| Search docs | `SearchCommand` | `search_docs` | - |
+| Search HIG | **MISSING** | `search_hig` | - |
+| Read document | `ReadCommand` | `read_document` | `readResource` |
+| List frameworks | `ListFrameworksCommand` | `list_frameworks` | - |
+| **Sample Code** |
+| Search samples | `SearchSamplesCommand` | `search_samples` | - |
+| List samples | `ListSamplesCommand` | `list_samples` | - |
+| Read sample | `ReadSampleCommand` | `read_sample` | - |
+| Read sample file | `ReadSampleFileCommand` | `read_sample_file` | - |
+
+**Missing CLI commands:**
+- `cupertino search-hig` (or `search --source hig`)
+
+---
+
+### 5. Path Resolution (6 duplicates)
+
+```swift
+// Duplicated in SearchCommand, ReadCommand, ListFrameworksCommand,
+// SearchSamplesCommand, ListSamplesCommand, ReadSampleCommand, ReadSampleFileCommand
+
 private func resolveSearchDbPath() -> URL {
     if let searchDb {
         return URL(fileURLWithPath: searchDb).expandingTildeInPath
@@ -118,22 +166,6 @@ private func resolveSearchDbPath() -> URL {
     return Shared.Constants.defaultSearchDatabase
 }
 
-// ReadCommand.swift:64-69
-private func resolveSearchDbPath() -> URL { /* identical */ }
-
-// ListFrameworksCommand.swift:63-68
-private func resolveSearchDbPath() -> URL { /* identical */ }
-```
-
-**Verdict:** Extract to `Shared.PathResolver.searchDatabase(custom:)`.
-
----
-
-#### 2.4 URL Tilde Expansion
-
-**Duplicated in 3 files:**
-
-```swift
 private extension URL {
     var expandingTildeInPath: URL {
         if path.hasPrefix("~") {
@@ -145,61 +177,12 @@ private extension URL {
 }
 ```
 
-**Verdict:** Move to `Shared.Extensions.URL+Tilde.swift`.
-
 ---
 
-#### 2.5 OutputFormat Enum
-
-**Duplicated in 3 files:**
+### 6. Database Lifecycle (7 duplicates)
 
 ```swift
-// SearchCommand.swift:184-188
-enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
-    case text
-    case json
-    case markdown
-}
-
-// ListFrameworksCommand.swift:148-152
-enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
-    case text
-    case json
-    case markdown
-}
-
-// ReadCommand.swift:75-78
-enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
-    case json
-    case markdown  // Note: no text option
-}
-```
-
-**Verdict:** Create shared `CLI.OutputFormat` enum.
-
----
-
-#### 2.6 Database Existence Check
-
-**Duplicated pattern in all CLI commands:**
-
-```swift
-guard FileManager.default.fileExists(atPath: dbPath.path) else {
-    Log.error("Search database not found at \(dbPath.path)")
-    Log.output("Run 'cupertino save' to build the search index first.")
-    throw ExitCode.failure
-}
-```
-
-**Verdict:** Extract to helper: `try CLI.requireSearchDatabase(at: dbPath)`.
-
----
-
-#### 2.7 Search Index Lifecycle
-
-**Duplicated in all CLI commands:**
-
-```swift
+// Every CLI command has this pattern:
 let searchIndex = try await Search.Index(dbPath: dbPath)
 defer {
     Task {
@@ -208,78 +191,69 @@ defer {
 }
 ```
 
-**Verdict:** Create `withSearchIndex(at:) async throws` helper or `SearchService`.
-
 ---
 
-### 3. Missing CLI Commands
-
-The MCP tool has `search_hig` but CLI has no equivalent:
-
-| MCP Tool | CLI Command | Status |
-|----------|-------------|--------|
-| `search_docs` | `search` | Exists |
-| `search_hig` | - | **Missing** |
-| `read_document` | `read` | Exists |
-| `list_frameworks` | `list-frameworks` | Exists |
-
-**Recommendation:** Add `cupertino search-hig` command or add `--hig` flag to search.
-
----
-
-### 4. Inconsistencies
-
-| Aspect | CLI | MCP | Issue |
-|--------|-----|-----|-------|
-| Score display | Not shown | Shown | CLI should optionally show score |
-| Word count | Not shown | Shown | CLI should optionally show word count |
-| Filter display | Not shown | Shown in header | CLI should show active filters |
-| No results message | Plain text | Styled with tips | Inconsistent UX |
-| Separator | None | `---` | MCP has better visual separation |
-
----
-
-## 5. Proposed Refactoring
-
-### 5.1 New Module: `SearchService`
+## Proposed Architecture
 
 ```
-Sources/
-├── SearchService/           # NEW
-│   ├── SearchService.swift  # Core search operations
-│   ├── Formatters/
-│   │   ├── SearchResultFormatter.swift
-│   │   ├── FrameworkListFormatter.swift
-│   │   └── DocumentFormatter.swift
-│   └── Models/
-│       └── SearchRequest.swift
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Interface Layer                              │
+├─────────────────────────────────┬───────────────────────────────────┤
+│         CLI Commands            │         MCP Providers              │
+│  (thin wrappers using services) │  (thin wrappers using services)   │
+├─────────────────────────────────┴───────────────────────────────────┤
+│                         Service Layer (NEW)                          │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │ protocol SearchService                                         │  │
+│  │   func search(request:) -> [SearchResult]                      │  │
+│  │   func read(uri:format:) -> String?                            │  │
+│  │   func listFrameworks() -> [String: Int]                       │  │
+│  ├───────────────────────────────────────────────────────────────┤  │
+│  │ DocsSearchService: SearchService                               │  │
+│  │ HIGSearchService: SearchService                                │  │
+│  │ SampleSearchService: SearchService                             │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+├─────────────────────────────────────────────────────────────────────┤
+│                         Formatter Layer (NEW)                        │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │ protocol ResultFormatter                                       │  │
+│  │   func format(results:query:filters:) -> String                │  │
+│  ├───────────────────────────────────────────────────────────────┤  │
+│  │ TextFormatter, JSONFormatter, MarkdownFormatter                │  │
+│  │ (per-source customization via configuration)                   │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+├─────────────────────────────────────────────────────────────────────┤
+│                         Data Access Layer                            │
+│  ┌───────────────────────────┐  ┌───────────────────────────────┐  │
+│  │ Search.Index              │  │ SampleIndex.Database          │  │
+│  └───────────────────────────┘  └───────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
 ```
 
-### 5.2 SearchService API
+---
+
+## Protocol Definitions
+
+### 1. SearchService Protocol
 
 ```swift
-public actor SearchService {
-    private let searchIndex: Search.Index
+// Sources/Services/SearchService.swift
 
-    // Core operations
-    public func search(_ request: SearchRequest) async throws -> [Search.Result]
-    public func searchHIG(_ request: HIGSearchRequest) async throws -> [Search.Result]
-    public func readDocument(uri: String, format: DocumentFormat) async throws -> String?
-    public func listFrameworks() async throws -> [String: Int]
+/// Protocol for all search operations across different sources
+public protocol SearchService: Actor {
+    associatedtype Query
+    associatedtype Result
 
-    // Convenience
-    public static func withDatabase(
-        at path: URL?,
-        perform: (SearchService) async throws -> T
-    ) async throws -> T
+    /// Execute a search query
+    func search(_ query: Query) async throws -> [Result]
+
+    /// Get document by URI
+    func read(uri: String, format: DocumentFormat) async throws -> String?
 }
-```
 
-### 5.3 SearchRequest Model
-
-```swift
-public struct SearchRequest {
-    public let query: String
+/// Common search request with source-specific extensions
+public struct SearchQuery {
+    public let text: String
     public let source: String?
     public let framework: String?
     public let language: String?
@@ -287,38 +261,395 @@ public struct SearchRequest {
     public let includeArchive: Bool
 
     public init(
-        query: String,
+        text: String,
         source: String? = nil,
         framework: String? = nil,
         language: String? = nil,
-        limit: Int = 20,
+        limit: Int = Constants.Limit.defaultSearchLimit,
         includeArchive: Bool = false
+    ) {
+        self.text = text
+        self.source = source
+        self.framework = framework
+        self.language = language
+        self.limit = min(limit, Constants.Limit.maxSearchLimit)
+        self.includeArchive = includeArchive
+    }
+}
+```
+
+### 2. Source-Specific Services
+
+```swift
+// Sources/Services/DocsSearchService.swift
+
+public actor DocsSearchService: SearchService {
+    private let index: Search.Index
+
+    public init(index: Search.Index) {
+        self.index = index
+    }
+
+    public func search(_ query: SearchQuery) async throws -> [Search.Result] {
+        try await index.search(
+            query: query.text,
+            source: query.source,
+            framework: query.framework,
+            language: query.language,
+            limit: query.limit,
+            includeArchive: query.includeArchive
+        )
+    }
+
+    public func read(uri: String, format: DocumentFormat) async throws -> String? {
+        try await index.getDocumentContent(uri: uri, format: format)
+    }
+
+    public func listFrameworks() async throws -> [String: Int] {
+        try await index.listFrameworks()
+    }
+
+    public func documentCount() async throws -> Int {
+        try await index.documentCount()
+    }
+}
+
+// Sources/Services/HIGSearchService.swift
+
+public actor HIGSearchService: SearchService {
+    private let docsService: DocsSearchService
+
+    public struct HIGQuery {
+        public let text: String
+        public let platform: String?  // iOS, macOS, etc.
+        public let category: String?  // foundations, patterns, etc.
+        public let limit: Int
+    }
+
+    public init(index: Search.Index) {
+        self.docsService = DocsSearchService(index: index)
+    }
+
+    public func search(_ query: HIGQuery) async throws -> [Search.Result] {
+        var effectiveText = query.text
+        if let platform = query.platform {
+            effectiveText += " \(platform)"
+        }
+        if let category = query.category {
+            effectiveText += " \(category)"
+        }
+
+        let searchQuery = SearchQuery(
+            text: effectiveText,
+            source: Constants.SourcePrefix.hig,
+            limit: query.limit
+        )
+
+        return try await docsService.search(searchQuery)
+    }
+
+    public func read(uri: String, format: DocumentFormat) async throws -> String? {
+        try await docsService.read(uri: uri, format: format)
+    }
+}
+
+// Sources/Services/SampleSearchService.swift
+
+public actor SampleSearchService: SearchService {
+    private let database: SampleIndex.Database
+
+    public struct SampleQuery {
+        public let text: String
+        public let framework: String?
+        public let searchFiles: Bool
+        public let limit: Int
+    }
+
+    public init(database: SampleIndex.Database) {
+        self.database = database
+    }
+
+    public func search(_ query: SampleQuery) async throws -> SampleSearchResult {
+        let projects = try await database.searchProjects(
+            query: query.text,
+            framework: query.framework,
+            limit: query.limit
+        )
+
+        var files: [SampleIndex.Database.FileSearchResult] = []
+        if query.searchFiles {
+            files = try await database.searchFiles(
+                query: query.text,
+                projectId: nil,
+                limit: query.limit
+            )
+        }
+
+        return SampleSearchResult(projects: projects, files: files)
+    }
+
+    public func readProject(id: String) async throws -> SampleIndex.Database.Project? {
+        try await database.getProject(id: id)
+    }
+
+    public func readFile(projectId: String, path: String) async throws -> SampleIndex.Database.File? {
+        try await database.getFile(projectId: projectId, path: path)
+    }
+
+    public func listProjects(framework: String?, limit: Int) async throws -> [SampleIndex.Database.Project] {
+        try await database.listProjects(framework: framework, limit: limit)
+    }
+}
+```
+
+### 3. ResultFormatter Protocol
+
+```swift
+// Sources/Services/Formatters/ResultFormatter.swift
+
+/// Protocol for formatting search results to different output formats
+public protocol ResultFormatter {
+    associatedtype Input
+    func format(_ input: Input) -> String
+}
+
+/// Configuration for search result formatting
+public struct SearchResultFormatConfig {
+    public let showScore: Bool
+    public let showWordCount: Bool
+    public let showSource: Bool
+    public let showSeparators: Bool
+    public let emptyMessage: String
+
+    public static let cliDefault = SearchResultFormatConfig(
+        showScore: false,
+        showWordCount: false,
+        showSource: true,
+        showSeparators: false,
+        emptyMessage: "No results found"
+    )
+
+    public static let mcpDefault = SearchResultFormatConfig(
+        showScore: true,
+        showWordCount: true,
+        showSource: false,
+        showSeparators: true,
+        emptyMessage: "_No results found. Try broader search terms._"
     )
 }
 ```
 
-### 5.4 Formatter Protocol
+### 4. Format-Specific Implementations
 
 ```swift
-public protocol SearchResultFormatter {
-    func format(results: [Search.Result], query: String, filters: SearchFilters) -> String
+// Sources/Services/Formatters/MarkdownFormatter.swift
+
+public struct MarkdownSearchResultFormatter: ResultFormatter {
+    private let config: SearchResultFormatConfig
+    private let query: String
+    private let filters: SearchFilters?
+
+    public init(query: String, filters: SearchFilters? = nil, config: SearchResultFormatConfig = .mcpDefault) {
+        self.query = query
+        self.filters = filters
+        self.config = config
+    }
+
+    public func format(_ results: [Search.Result]) -> String {
+        var md = "# Search Results for \"\(query)\"\n\n"
+
+        // Show active filters
+        if let filters {
+            if let source = filters.source {
+                md += "_Filtered to source: **\(source)**_\n\n"
+            }
+            if let framework = filters.framework {
+                md += "_Filtered to framework: **\(framework)**_\n\n"
+            }
+        }
+
+        md += "Found **\(results.count)** result\(results.count == 1 ? "" : "s"):\n\n"
+
+        if results.isEmpty {
+            md += config.emptyMessage
+            return md
+        }
+
+        for (index, result) in results.enumerated() {
+            md += "## \(index + 1). \(result.title)\n\n"
+            md += "- **Framework:** `\(result.framework)`\n"
+            md += "- **URI:** `\(result.uri)`\n"
+
+            if config.showScore {
+                md += "- **Score:** \(String(format: "%.2f", result.score))\n"
+            }
+            if config.showWordCount {
+                md += "- **Words:** \(result.wordCount)\n"
+            }
+
+            md += "\n\(result.summary)\n\n"
+
+            if config.showSeparators && index < results.count - 1 {
+                md += "---\n\n"
+            }
+        }
+
+        return md
+    }
 }
 
-public struct MarkdownSearchResultFormatter: SearchResultFormatter { }
-public struct JSONSearchResultFormatter: SearchResultFormatter { }
-public struct TextSearchResultFormatter: SearchResultFormatter { }
+// Sources/Services/Formatters/JSONFormatter.swift
+
+public struct JSONSearchResultFormatter: ResultFormatter {
+    public init() {}
+
+    public func format(_ results: [Search.Result]) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        guard let data = try? encoder.encode(results),
+              let json = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return json
+    }
+}
+
+// Sources/Services/Formatters/TextFormatter.swift
+
+public struct TextSearchResultFormatter: ResultFormatter {
+    private let query: String
+
+    public init(query: String) {
+        self.query = query
+    }
+
+    public func format(_ results: [Search.Result]) -> String {
+        if results.isEmpty {
+            return "No results found for '\(query)'"
+        }
+
+        var output = "Found \(results.count) result(s) for '\(query)':\n\n"
+
+        for (index, result) in results.enumerated() {
+            output += "[\(index + 1)] \(result.title)\n"
+            output += "    Source: \(result.source) | Framework: \(result.framework)\n"
+            output += "    URI: \(result.uri)\n"
+            if !result.summary.isEmpty {
+                output += "    \(result.summary)\n"
+            }
+            output += "\n"
+        }
+
+        return output
+    }
+}
 ```
 
-### 5.5 Refactored CLI Command
+### 5. Unified Tool Error
 
 ```swift
+// Sources/Shared/ToolError.swift
+
+public enum ToolError: Error, LocalizedError {
+    case unknownTool(String)
+    case missingArgument(String)
+    case invalidArgument(String, String)
+    case notFound(String)
+    case noData(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unknownTool(let name):
+            return "Unknown tool: \(name)"
+        case .missingArgument(let arg):
+            return "Missing required argument: \(arg)"
+        case .invalidArgument(let arg, let reason):
+            return "Invalid argument '\(arg)': \(reason)"
+        case .notFound(let resource):
+            return "Not found: \(resource)"
+        case .noData(let message):
+            return message
+        }
+    }
+}
+```
+
+### 6. Argument Extractor
+
+```swift
+// Sources/Shared/ArgumentExtractor.swift
+
+public struct ArgumentExtractor {
+    private let arguments: [String: AnyCodable]?
+
+    public init(_ arguments: [String: AnyCodable]?) {
+        self.arguments = arguments
+    }
+
+    public func require<T>(_ key: String) throws -> T {
+        guard let value = arguments?[key]?.value as? T else {
+            throw ToolError.missingArgument(key)
+        }
+        return value
+    }
+
+    public func optional<T>(_ key: String) -> T? {
+        arguments?[key]?.value as? T
+    }
+
+    public func optional<T>(_ key: String, default: T) -> T {
+        (arguments?[key]?.value as? T) ?? `default`
+    }
+
+    public func limit(key: String = "limit", default: Int = Constants.Limit.defaultSearchLimit) -> Int {
+        let requested = optional(key, default: `default`)
+        return min(requested, Constants.Limit.maxSearchLimit)
+    }
+}
+```
+
+---
+
+## Refactored CLI Command Example
+
+```swift
+// Sources/CLI/Commands/SearchCommand.swift
+
 struct SearchCommand: AsyncParsableCommand {
-    // ... options ...
+    static let configuration = CommandConfiguration(
+        commandName: "search",
+        abstract: "Search Apple documentation"
+    )
+
+    @Argument(help: "Search query")
+    var query: String
+
+    @Option(name: .shortAndLong, help: "Filter by source")
+    var source: String?
+
+    @Flag(name: .long, help: "Include archive docs")
+    var includeArchive: Bool = false
+
+    @Option(name: .shortAndLong, help: "Filter by framework")
+    var framework: String?
+
+    @Option(name: .shortAndLong, help: "Filter by language")
+    var language: String?
+
+    @Option(name: .long, help: "Max results")
+    var limit: Int = Constants.Limit.defaultSearchLimit
+
+    @Option(name: .long, help: "Output format")
+    var format: OutputFormat = .text
+
+    @Option(name: .long, help: "Database path")
+    var searchDb: String?
 
     mutating func run() async throws {
-        try await SearchService.withDatabase(at: searchDbPath) { service in
-            let request = SearchRequest(
-                query: query,
+        try await ServiceContainer.withDocsService(dbPath: searchDb) { service in
+            let searchQuery = SearchQuery(
+                text: query,
                 source: source,
                 framework: framework,
                 language: language,
@@ -326,108 +657,198 @@ struct SearchCommand: AsyncParsableCommand {
                 includeArchive: includeArchive
             )
 
-            let results = try await service.search(request)
-            let formatter = formatter(for: format)
-            let output = formatter.format(results: results, query: query, filters: request.filters)
+            let results = try await service.search(searchQuery)
+            let output = formatter(for: format).format(results)
             Log.output(output)
+        }
+    }
+
+    private func formatter(for format: OutputFormat) -> any ResultFormatter {
+        switch format {
+        case .text: return TextSearchResultFormatter(query: query)
+        case .json: return JSONSearchResultFormatter()
+        case .markdown: return MarkdownSearchResultFormatter(query: query, config: .cliDefault)
         }
     }
 }
 ```
 
-### 5.6 Refactored MCP Tool
+---
+
+## Refactored MCP Tool Example
 
 ```swift
-private func handleSearchDocs(arguments: [String: AnyCodable]?) async throws -> CallToolResult {
-    let request = try SearchRequest(from: arguments)
-    let results = try await searchService.search(request)
+// Sources/SearchToolProvider/DocumentationToolProvider.swift
 
-    let formatter = MarkdownSearchResultFormatter(showScore: true, showWordCount: true)
-    let markdown = formatter.format(results: results, query: request.query, filters: request.filters)
+public actor DocumentationToolProvider: ToolProvider {
+    private let docsService: DocsSearchService
+    private let higService: HIGSearchService
 
-    return CallToolResult(content: [.text(TextContent(text: markdown))])
+    public init(searchIndex: Search.Index) {
+        self.docsService = DocsSearchService(index: searchIndex)
+        self.higService = HIGSearchService(index: searchIndex)
+    }
+
+    public func callTool(name: String, arguments: [String: AnyCodable]?) async throws -> CallToolResult {
+        let args = ArgumentExtractor(arguments)
+
+        switch name {
+        case Constants.MCP.toolSearchDocs:
+            let query = SearchQuery(
+                text: try args.require("query"),
+                source: args.optional("source"),
+                framework: args.optional("framework"),
+                language: args.optional("language"),
+                limit: args.limit(),
+                includeArchive: args.optional("include_archive", default: false)
+            )
+            let results = try await docsService.search(query)
+            let formatter = MarkdownSearchResultFormatter(
+                query: query.text,
+                filters: SearchFilters(source: query.source, framework: query.framework),
+                config: .mcpDefault
+            )
+            return CallToolResult(content: [.text(TextContent(text: formatter.format(results)))])
+
+        case Constants.MCP.toolSearchHIG:
+            let query = HIGSearchService.HIGQuery(
+                text: try args.require("query"),
+                platform: args.optional("platform"),
+                category: args.optional("category"),
+                limit: args.limit()
+            )
+            let results = try await higService.search(query)
+            let formatter = HIGMarkdownFormatter(query: query)
+            return CallToolResult(content: [.text(TextContent(text: formatter.format(results)))])
+
+        // ... other tools
+        default:
+            throw ToolError.unknownTool(name)
+        }
+    }
 }
 ```
 
 ---
 
-## 6. Shared Utilities to Extract
+## New Module Structure
 
-| Current Location | New Location | Purpose |
-|------------------|--------------|---------|
-| `URL.expandingTildeInPath` (3 places) | `Shared/Extensions/URL+Tilde.swift` | Tilde expansion |
-| `resolveSearchDbPath()` (3 places) | `Shared/PathResolver.swift` | Database path resolution |
-| `OutputFormat` enum (3 places) | `CLI/OutputFormat.swift` | Output format selection |
-| Database existence check (3 places) | `CLI/DatabaseHelper.swift` | Error handling |
-| JSON encoder setup (3 places) | `Shared/JSONCoding.swift` | Consistent JSON formatting |
-
----
-
-## 7. Priority Order
-
-1. **High Priority:**
-   - Extract `URL.expandingTildeInPath` to Shared
-   - Extract `resolveSearchDbPath()` to Shared
-   - Create shared `OutputFormat` enum
-
-2. **Medium Priority:**
-   - Create `SearchService` layer
-   - Create formatter protocol and implementations
-   - Add `search-hig` CLI command
-
-3. **Low Priority:**
-   - Unify markdown formatting between CLI and MCP
-   - Add score/wordCount display options to CLI
-   - Add filter display to CLI output
-
----
-
-## 8. Lines of Code Estimate
-
-| Change | Lines Removed | Lines Added | Net |
-|--------|---------------|-------------|-----|
-| URL extension dedup | -30 | +15 | -15 |
-| Path resolver dedup | -24 | +20 | -4 |
-| OutputFormat dedup | -18 | +12 | -6 |
-| Database check dedup | -12 | +15 | +3 |
-| SearchService | -100 | +150 | +50 |
-| Formatters | -80 | +120 | +40 |
-| **Total** | **-264** | **+332** | **+68** |
-
-Net increase of ~68 lines, but with:
-- Single source of truth for each operation
-- Easier testing
-- Consistent behavior across CLI and MCP
-- Reduced maintenance burden
+```
+Sources/
+├── Services/                           # NEW MODULE
+│   ├── Package.swift
+│   ├── SearchService.swift             # Protocol
+│   ├── DocsSearchService.swift         # Implementation
+│   ├── HIGSearchService.swift          # Implementation
+│   ├── SampleSearchService.swift       # Implementation
+│   ├── ServiceContainer.swift          # Lifecycle management
+│   └── Formatters/
+│       ├── ResultFormatter.swift       # Protocol
+│       ├── MarkdownFormatter.swift
+│       ├── JSONFormatter.swift
+│       ├── TextFormatter.swift
+│       └── HIGFormatter.swift
+│
+├── Shared/
+│   ├── ToolError.swift                 # Unified error type
+│   ├── ArgumentExtractor.swift         # MCP argument helper
+│   ├── PathResolver.swift              # Database path resolution
+│   └── Extensions/
+│       └── URL+Tilde.swift             # Tilde expansion
+│
+├── CLI/
+│   ├── OutputFormat.swift              # Shared enum
+│   └── Commands/                       # Thin wrappers
+│
+└── SearchToolProvider/
+    ├── DocumentationToolProvider.swift # Thin wrapper
+    ├── SampleCodeToolProvider.swift    # Thin wrapper
+    └── CompositeToolProvider.swift     # Unchanged
+```
 
 ---
 
-## 9. Files to Modify
+## Migration Steps
 
-### Create New:
-- `Sources/Shared/Extensions/URL+Tilde.swift`
-- `Sources/Shared/PathResolver.swift`
-- `Sources/CLI/OutputFormat.swift`
-- `Sources/CLI/DatabaseHelper.swift`
-- `Sources/SearchService/SearchService.swift`
-- `Sources/SearchService/Formatters/*.swift`
+### Phase 1: Extract Shared Utilities (Low Risk)
+1. Move `URL.expandingTildeInPath` to `Shared/Extensions/`
+2. Create `Shared/PathResolver.swift`
+3. Create `Shared/ToolError.swift`
+4. Create `Shared/ArgumentExtractor.swift`
+5. Create `CLI/OutputFormat.swift`
 
-### Modify:
-- `Sources/CLI/Commands/SearchCommand.swift`
-- `Sources/CLI/Commands/ReadCommand.swift`
-- `Sources/CLI/Commands/ListFrameworksCommand.swift`
-- `Sources/SearchToolProvider/DocumentationToolProvider.swift`
-- `Package.swift` (add SearchService target)
+### Phase 2: Create Services Module (Medium Risk)
+1. Create `Services` module in Package.swift
+2. Implement `SearchService` protocol
+3. Implement `DocsSearchService`
+4. Implement `HIGSearchService`
+5. Implement `SampleSearchService`
+6. Create `ServiceContainer` for lifecycle
+
+### Phase 3: Create Formatters (Medium Risk)
+1. Implement `ResultFormatter` protocol
+2. Implement `MarkdownFormatter` with config
+3. Implement `JSONFormatter`
+4. Implement `TextFormatter`
+5. Implement `HIGFormatter`
+
+### Phase 4: Refactor CLI Commands (High Risk)
+1. Update `SearchCommand` to use services
+2. Update `ReadCommand` to use services
+3. Update `ListFrameworksCommand` to use services
+4. Update sample code commands
+5. Add `SearchHIGCommand` or `--hig` flag
+
+### Phase 5: Refactor MCP Providers (High Risk)
+1. Update `DocumentationToolProvider`
+2. Update `SampleCodeToolProvider`
+3. Simplify `DocsResourceProvider`
 
 ---
 
-## 10. Testing Impact
+## Benefits
 
-With `SearchService` extraction:
-- Test formatters independently
-- Test service logic once (not per CLI command)
-- Mock `SearchService` in CLI/MCP tests
-- Higher test coverage with less code
+| Metric | Before | After |
+|--------|--------|-------|
+| Error enum duplicates | 4 | 1 |
+| Path resolution duplicates | 6 | 1 |
+| Markdown formatting duplicates | 8+ | 3 (per format) |
+| Argument extraction duplicates | 15+ | 1 helper |
+| Lines to test search logic | 400+ | ~100 |
+| New features (add source) | Touch 5+ files | Touch 1 service |
+
+---
+
+## Test Strategy
+
+```swift
+// Tests/ServicesTests/DocsSearchServiceTests.swift
+
+@Test("Search returns results for valid query")
+func testSearch() async throws {
+    let index = try await TestHelpers.createTestIndex()
+    let service = DocsSearchService(index: index)
+
+    let results = try await service.search(SearchQuery(text: "View"))
+
+    #expect(results.count > 0)
+    #expect(results[0].title.contains("View"))
+}
+
+// Tests/ServicesTests/FormatterTests.swift
+
+@Test("Markdown formatter produces valid output")
+func testMarkdownFormatter() {
+    let results = [TestHelpers.mockSearchResult()]
+    let formatter = MarkdownSearchResultFormatter(query: "test", config: .mcpDefault)
+
+    let output = formatter.format(results)
+
+    #expect(output.contains("# Search Results"))
+    #expect(output.contains("## 1."))
+    #expect(output.contains("**Score:**"))
+}
+```
 
 ---
 

--- a/docs/artifacts/README.md
+++ b/docs/artifacts/README.md
@@ -21,6 +21,7 @@ All Cupertino artifacts are stored under:
 | [swift-org/](folders/swift-org/) | Crawled Swift.org documentation | [README](folders/swift-org/) + [metadata.json](folders/docs/metadata.json.md) |
 | [swift-evolution/](folders/swift-evolution/) | Swift Evolution proposals | [README](folders/swift-evolution/) + [metadata.json](folders/docs/metadata.json.md) |
 | [archive/](folders/archive/) | Apple Archive programming guides | [README](folders/archive/) |
+| [hig/](folders/hig/) | Human Interface Guidelines | [README](folders/hig/) |
 | [sample-code/](folders/sample-code/) | Apple sample code ZIP files | [README](folders/sample-code/) + [.auth-cookies.json](folders/sample-code/.auth-cookies.json.md) |
 | [packages/](folders/packages/) | Swift package metadata | [README](folders/packages/) + [swift-packages-with-stars.json](folders/packages/swift-packages-with-stars.json.md) + [checkpoint.json](folders/packages/checkpoint.json.md) |
 | [search.db](folders/search.db.md) | FTS5 search index for documentation | File documentation |
@@ -41,8 +42,10 @@ All Cupertino artifacts are stored under:
 ├── swift-evolution/        # Swift Evolution Proposals
 │   ├── metadata.json
 │   └── proposals/
-└── archive/                # Apple Archive Guides (legacy)
-    └── [guide folders]/    # TP30001066/, TP40004514/, etc.
+├── archive/                # Apple Archive Guides (legacy)
+│   └── [guide folders]/    # TP30001066/, TP40004514/, etc.
+└── hig/                    # Human Interface Guidelines
+    └── [category folders]/ # foundations/, patterns/, etc.
 ```
 
 ### Fetch Artifacts
@@ -73,6 +76,7 @@ All Cupertino artifacts are stored under:
 | `cupertino fetch --type swift` | Markdown files + metadata | `~/.cupertino/swift-org/` |
 | `cupertino fetch --type evolution` | Proposal files + metadata | `~/.cupertino/swift-evolution/` |
 | `cupertino fetch --type archive` | Markdown files | `~/.cupertino/archive/` |
+| `cupertino fetch --type hig` | Markdown files | `~/.cupertino/hig/` |
 | `cupertino fetch --type code` | ZIP files + checkpoint | `~/.cupertino/sample-code/` |
 | `cupertino fetch --type samples` | Git clone (606 projects) | `~/.cupertino/sample-code/cupertino-sample-code/` |
 | `cupertino fetch --type packages` | Package data + checkpoint | `~/.cupertino/packages/` |

--- a/docs/artifacts/folders/docs/README.md
+++ b/docs/artifacts/folders/docs/README.md
@@ -90,7 +90,7 @@ docs/storekit/documentation_storekit_product_subscriptionoffer_signature.md
 cupertino save --docs-dir ~/.cupertino/docs
 
 # Use with MCP
-cupertino-mcp serve
+cupertino
 ```
 
 ### Read Directly

--- a/docs/artifacts/folders/hig/README.md
+++ b/docs/artifacts/folders/hig/README.md
@@ -1,0 +1,187 @@
+# hig/ - Human Interface Guidelines
+
+Apple Human Interface Guidelines from developer.apple.com/design/human-interface-guidelines.
+
+## Location
+
+**Default**: `~/.cupertino/hig/`
+
+## Created By
+
+```bash
+cupertino fetch --type hig
+```
+
+## Structure
+
+```
+~/.cupertino/hig/
+├── foundations/
+│   ├── accessibility.md
+│   ├── app-icons.md
+│   ├── color.md
+│   ├── dark-mode.md
+│   ├── layout.md
+│   ├── materials.md
+│   ├── motion.md
+│   ├── sf-symbols.md
+│   ├── typography.md
+│   └── ...
+├── patterns/
+│   ├── drag-and-drop.md
+│   ├── entering-data.md
+│   ├── file-management.md
+│   ├── loading.md
+│   ├── modality.md
+│   ├── navigation.md
+│   ├── onboarding.md
+│   ├── searching.md
+│   ├── settings.md
+│   └── ...
+├── components/
+│   ├── buttons.md
+│   ├── collections.md
+│   ├── menus.md
+│   ├── navigation-bars.md
+│   ├── pickers.md
+│   ├── progress-indicators.md
+│   ├── segmented-controls.md
+│   ├── sliders.md
+│   ├── tab-bars.md
+│   ├── text-fields.md
+│   ├── toggles.md
+│   └── ...
+├── technologies/
+│   ├── app-intents.md
+│   ├── apple-pay.md
+│   ├── carplay.md
+│   ├── game-center.md
+│   ├── healthkit.md
+│   ├── homekit.md
+│   ├── live-activities.md
+│   ├── siri.md
+│   ├── storekit.md
+│   ├── widgets.md
+│   └── ...
+├── inputs/
+│   ├── apple-pencil.md
+│   ├── digital-crown.md
+│   ├── game-controllers.md
+│   ├── keyboards.md
+│   ├── pointing-devices.md
+│   ├── spatial-interactions.md
+│   └── ...
+└── platforms/
+    ├── ios/
+    ├── macos/
+    ├── watchos/
+    ├── visionos/
+    └── tvos/
+```
+
+## Contents
+
+### Category Folders
+Each top-level folder represents a HIG category:
+- **foundations/** - Core design principles
+- **patterns/** - Common UX patterns
+- **components/** - UI controls and views
+- **technologies/** - Platform features and integrations
+- **inputs/** - Input devices and methods
+- **platforms/** - Platform-specific guidelines
+
+### Markdown Files
+- Converted from Apple's JavaScript-rendered HIG pages
+- YAML front matter with metadata
+- Full content preserved
+
+### YAML Front Matter Example
+```yaml
+---
+title: "Buttons"
+category: "components"
+platforms:
+  - iOS
+  - macOS
+  - watchOS
+  - visionOS
+  - tvOS
+source: hig
+url: https://developer.apple.com/design/human-interface-guidelines/buttons
+---
+```
+
+## Categories
+
+| Category | Description | Examples |
+|----------|-------------|----------|
+| Foundations | Core design principles | Color, typography, icons, motion |
+| Patterns | Common UX patterns | Navigation, onboarding, modality |
+| Components | UI controls and views | Buttons, pickers, text fields |
+| Technologies | Platform features | Siri, HealthKit, CarPlay |
+| Inputs | Input methods | Touch, Apple Pencil, keyboard |
+
+## Platforms
+
+| Platform | Description |
+|----------|-------------|
+| iOS | iPhone and iPad guidelines |
+| macOS | Mac application guidelines |
+| watchOS | Apple Watch guidelines |
+| visionOS | Apple Vision Pro guidelines |
+| tvOS | Apple TV guidelines |
+
+## Size
+
+- **~200+ markdown files**
+- **~20-50 MB total**
+
+## Search Behavior
+
+HIG documentation is **included in search by default** (unlike archive).
+
+### Search All Documentation
+```bash
+cupertino search "buttons"
+```
+
+### Search HIG Only
+```bash
+cupertino search "navigation patterns" --source hig
+```
+
+### MCP Tool Usage
+```json
+{
+  "name": "search_hig",
+  "arguments": {
+    "query": "buttons",
+    "platform": "iOS",
+    "category": "components"
+  }
+}
+```
+
+## Use Cases
+
+- **Design decisions** - Understand Apple's design philosophy
+- **Component guidelines** - Learn proper control usage
+- **Platform conventions** - Match platform expectations
+- **Accessibility** - Implement inclusive design
+- **App Store preparation** - Meet design requirements
+
+## Why HIG?
+
+Human Interface Guidelines are essential for:
+- Building apps that feel native on Apple platforms
+- Understanding platform-specific design patterns
+- Implementing accessible, inclusive interfaces
+- Preparing apps for App Store review
+- Making informed design decisions
+
+## Notes
+
+- Content requires WKWebView crawling (JavaScript-rendered)
+- Guidelines updated regularly by Apple
+- Some content varies by platform
+- Great complement to API documentation

--- a/docs/artifacts/folders/search.db.md
+++ b/docs/artifacts/folders/search.db.md
@@ -16,32 +16,126 @@ cupertino save
 
 - **Fast Full-Text Search** - Sub-second queries across thousands of pages
 - **BM25 Ranking** - Relevance-based result ordering
+- **Source Filtering** - Search within specific documentation sources
 - **Framework Filtering** - Search within specific frameworks
 - **Snippet Generation** - Show matching context
 - **MCP Integration** - Power AI documentation search
 
-## Database Structure
+## Database Schema
 
-SQLite database with FTS5 virtual table:
+### Main FTS5 Table
 
 ```sql
-CREATE VIRTUAL TABLE documents USING fts5(
-    title,           -- Page title
-    content,         -- Full page content
-    framework,       -- Framework name
-    url,             -- Source URL
-    path,            -- File path
-    tokenize = 'porter unicode61'
+CREATE VIRTUAL TABLE docs_fts USING fts5(
+    uri,        -- Unique identifier (e.g., apple-docs://swiftui/View)
+    source,     -- Source type (apple-docs, swift-evolution, hig, etc.)
+    framework,  -- Framework or category (swiftui, foundation, components)
+    language,   -- Programming language (swift, objc)
+    title,      -- Page title
+    content,    -- Full page content (searchable)
+    summary,    -- First paragraph or description
+    tokenize='porter unicode61'
 );
 ```
 
-## Fields
+### Metadata Table
 
-- **title** - Page title (e.g., "Array - Swift Standard Library")
-- **content** - Full Markdown content
-- **framework** - Framework name (e.g., "swift", "swiftui")
-- **url** - Original documentation URL
-- **path** - Local file path
+```sql
+CREATE TABLE docs_metadata (
+    uri TEXT PRIMARY KEY,
+    source TEXT NOT NULL DEFAULT 'apple-docs',
+    framework TEXT NOT NULL,
+    language TEXT NOT NULL DEFAULT 'swift',
+    file_path TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    last_crawled INTEGER NOT NULL,
+    word_count INTEGER NOT NULL,
+    source_type TEXT DEFAULT 'apple',
+    package_id INTEGER,
+    json_data TEXT
+);
+```
+
+### Tokenizer
+
+- **`porter`** - Porter stemming algorithm (search "running" finds "run", "runs", "running")
+- **`unicode61`** - Unicode-aware tokenization (handles international characters)
+
+## Source Types
+
+All 8 documentation sources are indexed into the same `docs_fts` table:
+
+### 1. Apple Documentation (`apple-docs`)
+
+| Field | Example |
+|-------|---------|
+| URI | `apple-docs://swiftui/View` |
+| Source | `apple-docs` |
+| Framework | `swiftui`, `foundation`, `uikit`, etc. |
+| Path | `~/.cupertino/docs/{framework}/*.json` |
+
+### 2. Swift Evolution (`swift-evolution`)
+
+| Field | Example |
+|-------|---------|
+| URI | `swift-evolution://SE-0306` |
+| Source | `swift-evolution` |
+| Framework | `NULL` |
+| Path | `~/.cupertino/swift-evolution/SE-*.md` |
+
+### 3. Swift.org (`swift-org`)
+
+| Field | Example |
+|-------|---------|
+| URI | `swift-org://concurrency` |
+| Source | `swift-org` |
+| Framework | `NULL` |
+| Path | `~/.cupertino/swift-org/*.md` |
+
+### 4. Swift Book (`swift-book`)
+
+| Field | Example |
+|-------|---------|
+| URI | `swift-book://closures` |
+| Source | `swift-book` |
+| Framework | `NULL` |
+| Path | `~/.cupertino/swift-org/swift-book/*.md` |
+
+### 5. Apple Archive (`apple-archive`)
+
+| Field | Example |
+|-------|---------|
+| URI | `apple-archive://TP40014097/about-views` |
+| Source | `apple-archive` |
+| Framework | From YAML front matter (e.g., `QuartzCore`) |
+| Path | `~/.cupertino/archive/{guideUID}/*.md` |
+
+### 6. Human Interface Guidelines (`hig`)
+
+| Field | Example |
+|-------|---------|
+| URI | `hig://components/buttons` |
+| Source | `hig` |
+| Framework | Category (`foundations`, `patterns`, `components`, `inputs`, `technologies`) |
+| Path | `~/.cupertino/hig/{category}/*.md` |
+
+### 7. Sample Code (`apple-sample-code`)
+
+| Field | Example |
+|-------|---------|
+| URI | `apple-sample-code://BuildingAGreatMacApp` |
+| Source | `apple-sample-code` |
+| Framework | `swiftui`, `uikit`, etc. |
+| Path | Bundled in `swift-sample-code-catalog.json` |
+
+### 8. Swift Packages (`packages`)
+
+| Field | Example |
+|-------|---------|
+| URI | `packages://apple/swift-nio` |
+| Source | `packages` |
+| Framework | `NULL` |
+| Path | Bundled in `swift-packages-catalog.json` |
 
 ## Size
 
@@ -55,46 +149,80 @@ Typically ~10-20% of source documentation size:
 
 ## Usage
 
-### Query with SQL
+### CLI Search
+
 ```bash
-# Search for "async"
-sqlite3 ~/.cupertino/search.db "SELECT title, framework FROM documents WHERE documents MATCH 'async' LIMIT 10"
+# Search all sources
+cupertino search "async"
 
-# Search within SwiftUI
-sqlite3 ~/.cupertino/search.db "SELECT title FROM documents WHERE documents MATCH 'view' AND framework = 'swiftui' LIMIT 10"
+# Search specific source
+cupertino search "buttons" --source hig
 
-# Get snippets
-sqlite3 ~/.cupertino/search.db "SELECT snippet(documents, 1, '<b>', '</b>', '...', 32) FROM documents WHERE documents MATCH 'concurrency'"
+# Search specific framework
+cupertino search "View" --framework swiftui
+
+# Combine filters
+cupertino search "animation" --source apple-docs --framework swiftui
 ```
 
-### Use with MCP
+### Query with SQL
+
+```bash
+# Search for "async" across all sources
+sqlite3 ~/.cupertino/search.db \
+  "SELECT uri, title, source FROM docs_fts WHERE docs_fts MATCH 'async' LIMIT 10"
+
+# Search within HIG only
+sqlite3 ~/.cupertino/search.db \
+  "SELECT uri, title FROM docs_fts WHERE docs_fts MATCH 'buttons' AND source = 'hig' LIMIT 10"
+
+# Search SwiftUI framework
+sqlite3 ~/.cupertino/search.db \
+  "SELECT uri, title FROM docs_fts WHERE docs_fts MATCH 'view' AND framework = 'swiftui' LIMIT 10"
+
+# Get snippets with highlighting
+sqlite3 ~/.cupertino/search.db \
+  "SELECT snippet(docs_fts, 5, '<b>', '</b>', '...', 32) FROM docs_fts WHERE docs_fts MATCH 'concurrency'"
+```
+
+### MCP Server
+
 ```bash
 # Start MCP server (uses search.db automatically)
-cupertino-mcp serve
+cupertino
 ```
 
-The MCP server provides search capabilities to AI assistants like Claude.
-
-### Use in Swift
-```swift
-import CupertinoSearch
-
-let searchIndex = SearchIndex(databasePath: URL(fileURLWithPath: "~/.cupertino/search.db"))
-let results = try await searchIndex.search(query: "async await")
-```
+The MCP server provides `search_docs` and `search_hig` tools to AI assistants.
 
 ## Search Features
 
 ### Full-Text Search
-- Searches across all content
+- Searches across title, content, and summary
 - Supports phrase queries: `"exact phrase"`
 - Boolean operators: `term1 AND term2`, `term1 OR term2`
 - Prefix search: `asyn*` matches "async", "asynchronous"
 
+### Porter Stemming
+- `running` matches `run`, `runs`, `running`, `ran`
+- `documentation` matches `document`, `docs`
+- Improves recall without exact matching
+
 ### BM25 Ranking
 - Relevance-based result ordering
 - Term frequency and inverse document frequency
-- Better results than simple matching
+- Source-based boosting (apple-docs ranked higher)
+
+### Source Filtering
+```sql
+-- Only HIG results
+WHERE source = 'hig'
+
+-- Multiple sources
+WHERE source IN ('apple-docs', 'hig')
+
+-- Exclude packages
+WHERE source != 'packages'
+```
 
 ### Framework Filtering
 ```sql
@@ -105,20 +233,14 @@ WHERE framework = 'swiftui'
 WHERE framework IN ('swift', 'foundation')
 ```
 
-### Snippets
-```sql
--- Show matching context with highlighting
-snippet(documents, 1, '<mark>', '</mark>', '...', 32)
-```
-
 ## Rebuilding Index
 
 ```bash
-# Clear and rebuild from scratch
+# Clear and rebuild from scratch (recommended)
 cupertino save --clear
 
-# Update with new documentation
-cupertino save --no-clear
+# Rebuild with specific directories
+cupertino save --docs-dir ~/my-docs --evolution-dir ~/proposals
 ```
 
 ## Customizing Location
@@ -126,6 +248,9 @@ cupertino save --no-clear
 ```bash
 # Use custom database path
 cupertino save --search-db ./my-search.db
+
+# Search with custom database
+cupertino search "query" --search-db ./my-search.db
 ```
 
 ## Technical Details
@@ -134,18 +259,13 @@ cupertino save --search-db ./my-search.db
 - **Tokenizer**: Porter stemming + Unicode61
 - **Format**: Standard SQLite database file
 - **Compatibility**: Any SQLite 3.9.0+ client
-- **Performance**: Optimized for fast queries on large datasets
-
-## Used By
-
-- `cupertino-mcp serve` - MCP server for AI integration
-- Direct SQL queries
-- Custom search applications via CupertinoSearch library
+- **Performance**: Sub-100ms queries on 50k+ documents
+- **Thread Safety**: Safe for concurrent reads
 
 ## Notes
 
 - Standard SQLite file - can be queried with any SQLite tool
 - FTS5 provides production-grade full-text search
-- Rebuilding is fast (minutes for full Apple docs)
+- Rebuilding is fast (~2-5 minutes for full documentation)
 - Can be backed up like any SQLite database
-- Thread-safe for concurrent reads
+- Delete and run `cupertino save` to rebuild from scratch

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -7,7 +7,7 @@ CLI commands for the Cupertino documentation server.
 | Command | Description |
 |---------|-------------|
 | [setup](setup/) | **Download pre-built databases from GitHub (fastest)** |
-| [fetch](fetch/) | Download documentation from Apple, Swift Evolution, Swift.org, and Apple Archive |
+| [fetch](fetch/) | Download documentation from Apple, Swift Evolution, Swift.org, HIG, and Apple Archive |
 | [save](save/) | Build FTS5 search index from downloaded documentation |
 | [index](index/) | Index sample code for full-text search |
 | [serve](serve/) | Start MCP server for AI agent access |
@@ -32,6 +32,7 @@ cupertino serve
 # Or download documentation manually
 cupertino fetch --type docs
 cupertino fetch --type evolution
+cupertino fetch --type hig
 cupertino fetch --type archive
 
 # Build search index (from local files)
@@ -80,7 +81,8 @@ cupertino serve
 # 1. Download documentation (takes time)
 cupertino fetch --type docs --max-pages 15000
 cupertino fetch --type evolution
-cupertino fetch --type archive  # Legacy programming guides
+cupertino fetch --type hig       # Human Interface Guidelines
+cupertino fetch --type archive   # Legacy programming guides
 
 # 2. Build search index
 cupertino save

--- a/docs/commands/fetch/README.md
+++ b/docs/commands/fetch/README.md
@@ -29,6 +29,7 @@ The `fetch` command is the unified fetching command that handles both web crawli
   - `code` - Apple Sample Code (direct download from Apple, requires auth)
   - `samples` - Apple Sample Code (git clone from GitHub, recommended)
   - `archive` - Apple Archive guides (legacy programming guides)
+  - `hig` - Human Interface Guidelines (web crawl)
   - `all` - All types in parallel
 
 ### Web Crawl Options
@@ -90,6 +91,12 @@ cupertino fetch --type archive
 # Fetches: Core Animation, Core Graphics, Core Text, etc.
 ```
 
+### Fetch Human Interface Guidelines
+```bash
+cupertino fetch --type hig
+# Fetches: Design guidelines for iOS, macOS, watchOS, visionOS, tvOS
+```
+
 ### Custom Web Crawl
 ```bash
 cupertino fetch --start-url https://developer.apple.com/documentation/swiftui \
@@ -116,6 +123,7 @@ Default locations:
 - **swift**: `~/.cupertino/swift-org/`
 - **evolution**: `~/.cupertino/swift-evolution/`
 - **archive**: `~/.cupertino/archive/`
+- **hig**: `~/.cupertino/hig/`
 
 Output files:
 - **Markdown files** - Converted documentation pages

--- a/docs/commands/fetch/option (--)/type (=value)/hig.md
+++ b/docs/commands/fetch/option (--)/type (=value)/hig.md
@@ -1,0 +1,234 @@
+# --type hig
+
+Fetch Apple Human Interface Guidelines
+
+## Synopsis
+
+```bash
+cupertino fetch --type hig
+```
+
+## Description
+
+Downloads Apple's Human Interface Guidelines (HIG) from developer.apple.com. These guidelines provide design principles, patterns, and best practices for building apps across all Apple platforms.
+
+## Data Source
+
+**Apple Human Interface Guidelines** - https://developer.apple.com/design/human-interface-guidelines/
+
+## Output
+
+Creates Markdown files with YAML front matter:
+- Organized by category and platform
+- Design patterns and principles preserved
+- Platform and category metadata included
+
+## Default Settings
+
+| Setting | Value |
+|---------|-------|
+| Output Directory | `~/.cupertino/hig` |
+| Source | Apple Human Interface Guidelines |
+| Fetch Method | Web crawling with WKWebView |
+| Authentication | Not required |
+| Estimated Size | ~200+ pages |
+
+## Examples
+
+### Fetch All HIG Content
+```bash
+cupertino fetch --type hig
+```
+
+### Resume Interrupted Download
+```bash
+cupertino fetch --type hig --resume
+```
+
+### Force Re-download
+```bash
+cupertino fetch --type hig --force
+```
+
+### Custom Output Directory
+```bash
+cupertino fetch --type hig --output-dir ./hig-docs
+```
+
+## Output Structure
+
+```
+~/.cupertino/hig/
+├── foundations/
+│   ├── accessibility.md
+│   ├── app-icons.md
+│   ├── branding.md
+│   ├── color.md
+│   ├── dark-mode.md
+│   ├── icons.md
+│   ├── images.md
+│   ├── layout.md
+│   ├── materials.md
+│   ├── motion.md
+│   ├── right-to-left.md
+│   ├── sf-symbols.md
+│   ├── typography.md
+│   └── ...
+├── patterns/
+│   ├── accessing-private-data.md
+│   ├── collaboration.md
+│   ├── drag-and-drop.md
+│   ├── entering-data.md
+│   ├── file-management.md
+│   ├── live-viewing-apps.md
+│   ├── loading.md
+│   ├── managing-accounts.md
+│   ├── modality.md
+│   ├── multitasking.md
+│   ├── onboarding.md
+│   ├── searching.md
+│   ├── settings.md
+│   ├── undo-and-redo.md
+│   └── ...
+├── components/
+│   ├── buttons.md
+│   ├── collections.md
+│   ├── disclosure-controls.md
+│   ├── labels.md
+│   ├── menus.md
+│   ├── page-controls.md
+│   ├── pickers.md
+│   ├── progress-indicators.md
+│   ├── segmented-controls.md
+│   ├── sliders.md
+│   ├── steppers.md
+│   ├── tables.md
+│   ├── text-fields.md
+│   ├── toggles.md
+│   └── ...
+├── technologies/
+│   ├── airplay.md
+│   ├── app-intents.md
+│   ├── apple-pay.md
+│   ├── carplay.md
+│   ├── game-center.md
+│   ├── healthkit.md
+│   ├── homekit.md
+│   ├── imessage.md
+│   ├── live-activities.md
+│   ├── maps.md
+│   ├── photos.md
+│   ├── siri.md
+│   ├── storekit.md
+│   ├── wallet.md
+│   ├── widgets.md
+│   └── ...
+├── inputs/
+│   ├── apple-pencil.md
+│   ├── digital-crown.md
+│   ├── eyes.md
+│   ├── game-controllers.md
+│   ├── gyro-and-accelerometer.md
+│   ├── keyboards.md
+│   ├── pointing-devices.md
+│   ├── siri-remote.md
+│   ├── spatial-interactions.md
+│   └── ...
+└── platforms/
+    ├── ios/
+    ├── macos/
+    ├── watchos/
+    ├── visionos/
+    └── tvos/
+```
+
+## Categories
+
+| Category | Description |
+|----------|-------------|
+| Foundations | Core design principles (color, typography, icons, etc.) |
+| Patterns | Common interaction and UX patterns |
+| Components | UI controls and views |
+| Technologies | Platform-specific features and integrations |
+| Inputs | Input devices and interaction methods |
+
+## Platforms
+
+| Platform | Description |
+|----------|-------------|
+| iOS | iPhone and iPad design guidelines |
+| macOS | Mac application guidelines |
+| watchOS | Apple Watch design guidelines |
+| visionOS | Apple Vision Pro spatial computing |
+| tvOS | Apple TV application guidelines |
+
+## YAML Front Matter
+
+Each file includes metadata:
+
+```yaml
+---
+title: "Buttons"
+category: "components"
+platforms:
+  - iOS
+  - macOS
+  - watchOS
+  - visionOS
+  - tvOS
+source: hig
+url: https://developer.apple.com/design/human-interface-guidelines/buttons
+---
+```
+
+## Search Integration
+
+HIG documentation is included in search by default:
+
+### Search All Documentation
+```bash
+cupertino search "buttons"
+```
+
+### Search HIG Only
+```bash
+cupertino search "navigation" --source hig
+```
+
+### Using MCP Tool
+AI agents can use the `search_hig` tool for targeted HIG searches with platform and category filters.
+
+## Performance
+
+| Metric | Value |
+|--------|-------|
+| Download time | 10-30 minutes |
+| Incremental update | Minutes (only changed) |
+| Total storage | ~20-50 MB |
+| Pages | ~200+ markdown files |
+
+## Use Cases
+
+- Understanding Apple design principles
+- Learning UI component best practices
+- Platform-specific design requirements
+- Accessibility implementation guidance
+- Design system consistency
+- App Store review preparation
+
+## Why HIG Documentation?
+
+Human Interface Guidelines are essential for:
+- **Design consistency** - Match Apple platform conventions
+- **User expectations** - Build familiar, intuitive interfaces
+- **App Store approval** - Meet design requirements for review
+- **Accessibility** - Implement inclusive design patterns
+- **Cross-platform** - Understand platform differences
+
+## Notes
+
+- HIG content is regularly updated by Apple
+- Some guidelines vary by platform
+- Included in default search results
+- Use `--source hig` for HIG-only searches
+- Great reference for both designers and developers

--- a/docs/commands/fetch/option (--)/type.md
+++ b/docs/commands/fetch/option (--)/type.md
@@ -21,7 +21,10 @@ Specifies which documentation source to fetch. Each type targets a different dat
 | `evolution` | Swift Evolution proposals |
 | `packages` | Swift package metadata |
 | `package-docs` | Swift package READMEs |
-| `code` | Apple sample code projects |
+| `code` | Apple sample code (from Apple, requires auth) |
+| `samples` | Apple sample code (from GitHub, recommended) |
+| `archive` | Apple Archive legacy programming guides |
+| `hig` | Human Interface Guidelines |
 | `all` | All types in parallel |
 
 ## Default
@@ -53,7 +56,10 @@ cupertino fetch --type all
 - [evolution](type%20(=value)/evolution.md) - Swift Evolution proposals
 - [packages](type%20(=value)/packages.md) - Swift package metadata
 - [package-docs](type%20(=value)/package-docs.md) - Swift package READMEs
-- [code](type%20(=value)/code.md) - Apple sample code
+- [code](type%20(=value)/code.md) - Apple sample code (from Apple)
+- samples - Apple sample code (from GitHub)
+- [archive](type%20(=value)/archive.md) - Apple Archive legacy guides
+- [hig](type%20(=value)/hig.md) - Human Interface Guidelines
 - [all](type%20(=value)/all.md) - All documentation types
 
 ## Notes

--- a/docs/commands/read/README.md
+++ b/docs/commands/read/README.md
@@ -189,6 +189,18 @@ swift-org://<path>
 ```
 Example: `swift-org://swift-org_documentation_articles_value-and-reference-types`
 
+### Human Interface Guidelines
+```
+hig://<category>/<page>
+```
+Example: `hig://components/buttons`
+
+### Apple Archive
+```
+apple-archive://<guide>/<page>
+```
+Example: `apple-archive://TP40014097/about-views`
+
 ## Error Handling
 
 ### Document Not Found

--- a/docs/commands/save/option (--)/remote/README.md
+++ b/docs/commands/save/option (--)/remote/README.md
@@ -36,6 +36,7 @@ The `--remote` flag enables **instant setup** by streaming pre-crawled documenta
 | evolution | `swift-evolution/` | Swift Evolution proposals |
 | archive | `archive/` | Legacy Apple programming guides |
 | swiftOrg | `swift-org/` | Swift.org documentation |
+| hig | `hig/` | Human Interface Guidelines |
 | packages | `packages/` | Package READMEs |
 
 ### State File
@@ -44,7 +45,7 @@ Progress is saved to `~/.cupertino/remote-save-state.json` for resume support:
 
 ```json
 {
-  "version": "0.2.7",
+  "version": "0.3.5",
   "started": "2025-12-04T12:00:00Z",
   "phase": "docs",
   "phasesCompleted": [],

--- a/docs/commands/search/README.md
+++ b/docs/commands/search/README.md
@@ -34,13 +34,14 @@ cupertino search "Observable macro"
 Filter results by documentation source.
 
 **Type:** String
-**Values:** `apple-docs`, `swift-evolution`, `swift-org`, `swift-book`, `packages`, `apple-sample-code`, `apple-archive`
+**Values:** `apple-docs`, `swift-evolution`, `swift-org`, `swift-book`, `packages`, `apple-sample-code`, `apple-archive`, `hig`
 
 **Example:**
 ```bash
 cupertino search "concurrency" --source swift-evolution
 cupertino search "View" --source apple-docs
 cupertino search "CALayer" --source apple-archive
+cupertino search "buttons" --source hig
 ```
 
 ### --include-archive

--- a/docs/commands/search/option (--)/source (=value)/hig.md
+++ b/docs/commands/search/option (--)/source (=value)/hig.md
@@ -1,0 +1,102 @@
+# hig
+
+Human Interface Guidelines source
+
+## Synopsis
+
+```bash
+cupertino search <query> --source hig
+```
+
+## Description
+
+Filters search results to only include Apple Human Interface Guidelines. These are Apple's official design guidelines for building apps across all Apple platforms.
+
+## Content
+
+- **Design foundations** (color, typography, icons, layout)
+- **UI patterns** (navigation, onboarding, modality)
+- **Components** (buttons, pickers, text fields, etc.)
+- **Technologies** (Siri, HealthKit, CarPlay, etc.)
+- **Input methods** (touch, Apple Pencil, keyboard)
+- **Platform-specific** guidelines for iOS, macOS, watchOS, visionOS, tvOS
+
+## Typical Size
+
+- **~200+ pages** indexed
+- **~20-50 MB** on disk
+- Updated as Apple releases new guidelines
+
+## Examples
+
+### Search for Component Guidelines
+```bash
+cupertino search "buttons" --source hig
+```
+
+### Search for Design Patterns
+```bash
+cupertino search "navigation" --source hig
+```
+
+### Search for Platform Guidelines
+```bash
+cupertino search "visionOS spatial" --source hig
+```
+
+### Search for Accessibility
+```bash
+cupertino search "VoiceOver accessibility" --source hig
+```
+
+## URI Format
+
+Results use the `hig://` URI scheme:
+
+```
+hig://{category}/{page}
+```
+
+Examples:
+- `hig://components/buttons`
+- `hig://patterns/navigation`
+- `hig://foundations/color`
+- `hig://technologies/siri`
+
+## How to Populate
+
+```bash
+# Fetch all HIG content (10-30 minutes)
+cupertino fetch --type hig
+
+# Build index
+cupertino save
+```
+
+## Categories
+
+| Category | Content |
+|----------|---------|
+| Foundations | Color, typography, icons, layout, motion |
+| Patterns | Navigation, onboarding, modality, searching |
+| Components | Buttons, pickers, text fields, sliders |
+| Technologies | Siri, HealthKit, CarPlay, Apple Pay |
+| Inputs | Touch, Apple Pencil, keyboard, game controllers |
+
+## Platforms Covered
+
+| Platform | Description |
+|----------|-------------|
+| iOS | iPhone and iPad guidelines |
+| macOS | Mac application guidelines |
+| watchOS | Apple Watch guidelines |
+| visionOS | Apple Vision Pro spatial computing |
+| tvOS | Apple TV guidelines |
+
+## Notes
+
+- Fetched from developer.apple.com/design/human-interface-guidelines
+- Requires WKWebView crawling (JavaScript-rendered content)
+- Always included in default search (not excluded like archive)
+- Also available via dedicated `search_hig` MCP tool
+- Great for design decisions and App Store preparation

--- a/docs/commands/search/option (--)/source.md
+++ b/docs/commands/search/option (--)/source.md
@@ -23,6 +23,8 @@ Filters search results to only include documents from the specified documentatio
 | `swift-book` | The Swift Programming Language book |
 | `packages` | Swift package metadata |
 | `apple-sample-code` | Apple sample code projects |
+| `hig` | Human Interface Guidelines |
+| `apple-archive` | Apple Archive programming guides |
 
 ## Default
 
@@ -45,6 +47,11 @@ cupertino search "async" --source swift-evolution
 cupertino search "closures" -s swift-book
 ```
 
+### Search Human Interface Guidelines
+```bash
+cupertino search "buttons" --source hig
+```
+
 ## Value Details
 
 - [apple-docs](source%20(=value)/apple-docs.md) - Apple Developer Documentation
@@ -53,6 +60,8 @@ cupertino search "closures" -s swift-book
 - [swift-book](source%20(=value)/swift-book.md) - The Swift Programming Language book
 - [packages](source%20(=value)/packages.md) - Swift package metadata
 - [apple-sample-code](source%20(=value)/apple-sample-code.md) - Apple sample code projects
+- [hig](source%20(=value)/hig.md) - Human Interface Guidelines
+- [apple-archive](source%20(=value)/apple-archive.md) - Apple Archive programming guides
 
 ## Combining with Other Filters
 

--- a/docs/commands/serve/README.md
+++ b/docs/commands/serve/README.md
@@ -139,9 +139,19 @@ Full-text search across all documentation.
 
 **Parameters:**
 - `query` (required): Search keywords
-- `source` (optional): Filter by source (apple-docs, swift-book, swift-org, swift-evolution, packages)
+- `source` (optional): Filter by source (apple-docs, swift-book, swift-org, swift-evolution, packages, hig, apple-archive)
 - `framework` (optional): Filter by framework name
 - `language` (optional): Filter by language (swift, objc)
+- `limit` (optional): Max results (default: 20, max: 100)
+
+### search_hig
+
+Search Human Interface Guidelines with platform and category filters.
+
+**Parameters:**
+- `query` (required): Search keywords
+- `platform` (optional): Filter by platform (iOS, macOS, watchOS, visionOS, tvOS)
+- `category` (optional): Filter by category (foundations, patterns, components, inputs, technologies)
 - `limit` (optional): Max results (default: 20, max: 100)
 
 ### list_frameworks

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -9,6 +9,7 @@ Cupertino provides these MCP tools for AI agents to search and read documentatio
 | Tool | Description |
 |------|-------------|
 | [search_docs](search_docs/) | Full-text search across all indexed documentation |
+| [search_hig](search_hig/) | Search Human Interface Guidelines with platform/category filters |
 | [list_frameworks](list_frameworks/) | List available frameworks with document counts |
 | [read_document](read_document/) | Read a document by URI in JSON or Markdown format |
 

--- a/docs/tools/list_frameworks/README.md
+++ b/docs/tools/list_frameworks/README.md
@@ -110,4 +110,5 @@ If total documents is 0, run `cupertino save` to build the index.
 ## See Also
 
 - [search_docs](../search_docs/) - Search documentation
+- [search_hig](../search_hig/) - Search Human Interface Guidelines
 - [read_document](../read_document/) - Read document content

--- a/docs/tools/read_document/README.md
+++ b/docs/tools/read_document/README.md
@@ -31,12 +31,19 @@ Document URI from search results.
 **Schemes:**
 - `apple-docs://` - Apple Developer documentation
 - `swift-evolution://` - Swift Evolution proposals
+- `swift-book://` - The Swift Programming Language book
+- `swift-org://` - Swift.org documentation
+- `hig://` - Human Interface Guidelines
+- `apple-archive://` - Apple Archive legacy programming guides
+- `packages://` - Swift package documentation
 
 **Examples:**
 - `apple-docs://swiftui/documentation_swiftui_view`
 - `apple-docs://swift/documentation_swift_actor`
 - `swift-evolution://SE-0001`
 - `swift-evolution://SE-0302`
+- `hig://components/buttons`
+- `apple-archive://TP40014097/about-views`
 
 ### format (optional)
 
@@ -213,4 +220,5 @@ If the URI format is incorrect:
 ## See Also
 
 - [search_docs](../search_docs/) - Search for documents
+- [search_hig](../search_hig/) - Search Human Interface Guidelines
 - [list_frameworks](../list_frameworks/) - List available frameworks

--- a/docs/tools/search_docs/README.md
+++ b/docs/tools/search_docs/README.md
@@ -53,6 +53,7 @@ Filter results to a specific documentation source.
 - `"swift-org"` - Swift.org documentation
 - `"swift-evolution"` - Swift Evolution proposals
 - `"packages"` - Swift Package documentation
+- `"hig"` - Human Interface Guidelines
 - `"apple-archive"` - Apple Archive legacy programming guides
 
 ### framework (optional)
@@ -231,5 +232,6 @@ A type whose mutable state is protected from concurrent access...
 
 ## See Also
 
+- [search_hig](../search_hig/) - Search Human Interface Guidelines
 - [read_document](../read_document/) - Read document content by URI
 - [list_frameworks](../list_frameworks/) - List available frameworks

--- a/docs/tools/search_hig/README.md
+++ b/docs/tools/search_hig/README.md
@@ -1,0 +1,236 @@
+# search_hig
+
+Search Apple Human Interface Guidelines for design principles and UI patterns.
+
+## Synopsis
+
+```json
+{
+  "name": "search_hig",
+  "arguments": {
+    "query": "buttons",
+    "platform": "iOS",
+    "category": "components",
+    "limit": 10
+  }
+}
+```
+
+## Description
+
+Searches the Human Interface Guidelines (HIG) index using SQLite FTS5 with BM25 ranking. Returns a ranked list of matching design guidelines with URIs that can be used with `read_document` to retrieve full content.
+
+This tool is optimized for design-related queries and supports HIG-specific filters like platform and category.
+
+## Parameters
+
+### query (required)
+
+Search keywords to find in HIG documentation.
+
+**Type:** String
+
+**Examples:**
+- `"buttons"` - Find button design guidelines
+- `"navigation patterns"` - Find navigation UX patterns
+- `"dark mode"` - Find dark mode design guidelines
+- `"accessibility"` - Find accessibility guidelines
+
+**Search Tips:**
+- Use design terminology for better results
+- Platform-specific terms help narrow results (e.g., "sidebar macOS")
+- Component names return focused results (e.g., "picker", "toggle")
+
+### platform (optional)
+
+Filter results to a specific Apple platform.
+
+**Type:** String
+
+**Default:** None (searches all platforms)
+
+**Values:**
+- `"iOS"` - iPhone and iPad guidelines
+- `"macOS"` - Mac application guidelines
+- `"watchOS"` - Apple Watch guidelines
+- `"visionOS"` - Apple Vision Pro spatial computing
+- `"tvOS"` - Apple TV guidelines
+
+### category (optional)
+
+Filter results to a specific HIG category.
+
+**Type:** String
+
+**Default:** None (searches all categories)
+
+**Values:**
+- `"foundations"` - Core design principles (color, typography, icons)
+- `"patterns"` - Common interaction and UX patterns
+- `"components"` - UI controls and views
+- `"technologies"` - Platform-specific features (Siri, HealthKit, etc.)
+- `"inputs"` - Input devices and interaction methods
+
+### limit (optional)
+
+Maximum number of results to return.
+
+**Type:** Integer
+
+**Default:** 20
+
+**Maximum:** 100
+
+## Response
+
+Returns markdown-formatted search results:
+
+```markdown
+# HIG Search Results for "buttons"
+
+Found **8** guidelines:
+
+## 1. Buttons
+
+- **URI:** `hig://components/buttons`
+- **Score:** 15.32
+
+A button initiates an instantaneous action. Versatile and highly customizable, buttons give people simple, familiar ways to do tasks in your app...
+
+---
+
+## 2. Toggle buttons
+
+- **URI:** `hig://components/toggle-buttons`
+- **Score:** 12.18
+...
+```
+
+### Result Fields
+
+| Field | Description |
+|-------|-------------|
+| URI | Document identifier for use with `read_document` |
+| Score | BM25 relevance score (higher = more relevant) |
+| Summary | Brief excerpt from the guideline |
+
+## Examples
+
+### Basic Search
+
+```json
+{
+  "query": "buttons"
+}
+```
+
+### Platform-Filtered Search
+
+```json
+{
+  "query": "navigation",
+  "platform": "iOS"
+}
+```
+
+### Category-Filtered Search
+
+```json
+{
+  "query": "color",
+  "category": "foundations"
+}
+```
+
+### Combined Filters
+
+```json
+{
+  "query": "sidebar",
+  "platform": "macOS",
+  "category": "components",
+  "limit": 5
+}
+```
+
+### Accessibility Guidelines
+
+```json
+{
+  "query": "accessibility VoiceOver",
+  "category": "foundations"
+}
+```
+
+## Common Use Cases
+
+### Finding UI Component Guidelines
+
+```json
+{"query": "text fields"}
+{"query": "pickers"}
+{"query": "navigation bars"}
+{"query": "tab bars"}
+```
+
+### Finding Design Patterns
+
+```json
+{"query": "onboarding"}
+{"query": "modality sheets"}
+{"query": "drag and drop"}
+{"query": "searching"}
+```
+
+### Platform-Specific Design
+
+```json
+{"query": "menu bar", "platform": "macOS"}
+{"query": "complications", "platform": "watchOS"}
+{"query": "spatial interactions", "platform": "visionOS"}
+{"query": "focus navigation", "platform": "tvOS"}
+```
+
+### Accessibility Implementation
+
+```json
+{"query": "VoiceOver support"}
+{"query": "Dynamic Type"}
+{"query": "reduce motion"}
+{"query": "color contrast"}
+```
+
+### App Store Preparation
+
+```json
+{"query": "app icons requirements"}
+{"query": "launch screen"}
+{"query": "privacy best practices"}
+```
+
+## Comparison with search_docs
+
+| Feature | search_hig | search_docs |
+|---------|-----------|-------------|
+| Purpose | Design guidelines | API documentation |
+| Content | UX patterns, design principles | Code reference, APIs |
+| Filters | platform, category | source, framework, language |
+| Best for | Design decisions | Implementation details |
+
+Use `search_hig` when you need:
+- Design guidance and best practices
+- UI component appearance and behavior
+- Platform-specific conventions
+- Accessibility requirements
+
+Use `search_docs` when you need:
+- API reference and method signatures
+- Code examples and implementation
+- Technical specifications
+- Framework documentation
+
+## See Also
+
+- [search_docs](../search_docs/) - Search all documentation
+- [read_document](../read_document/) - Read document content by URI
+- [list_frameworks](../list_frameworks/) - List available frameworks


### PR DESCRIPTION
## Summary

  - Add Human Interface Guidelines support with `fetch --type hig` and `search_hig` MCP tool
  - Add framework aliases for better search (249 aliases - search by import name, display name, or variations)
  - Fix Swift.org indexer to handle JSON files correctly
  - Fix Swift.org base URL (`docs.swift.org` → `www.swift.org/documentation/`)
  - Default Swift Evolution to only accepted/implemented proposals

  ## Issues Closed

  Closes #69, #91, #92, #93, #94