### PR TITLE
feat: add platform availability filtering for all Apple platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 0.6.0 (2025-12-12)
+
+### Added
+- **Platform Availability Support** (#99)
+  - `cupertino fetch --type availability` - Fetch platform version data for all docs
+  - Availability tracked for all sources: apple-docs, sample-code, archive, swift-evolution, swift-book, hig
+  - Search filtering by `--min-ios`, `--min-macos`, `--min-tvos`, `--min-watchos`, `--min-visionos` (CLI and MCP `search_docs` tool)
+  - `save` command now warns if docs don't have availability data
+  - Schema v7: availability columns in docs_metadata and sample_code_metadata
+
+### Availability Sources
+| Source | Strategy |
+|--------|----------|
+| apple-docs | API fetch + fallbacks |
+| sample-code | Derives from framework |
+| apple-archive | Derives from framework |
+| swift-evolution | Swift version mapping |
+| swift-book/hig | Universal (all platforms) |
+
+### Documentation
+- Added `docs/commands/search/option (--)/min-ios.md`
+- Added `docs/commands/search/option (--)/min-macos.md`
+- Added `docs/commands/search/option (--)/min-tvos.md`
+- Added `docs/commands/search/option (--)/min-watchos.md`
+- Added `docs/commands/search/option (--)/min-visionos.md`
+- Updated search command docs with availability filtering options
+
+### Related Issues
+- Closes #99
+
+---
+
 ## 0.5.0 (2025-12-11)
 
 **Why minor bump?** The `cupertino release` command was removed from the public CLI. Users who had scripts calling `cupertino release` will need to update them. This is a breaking change for maintainer workflows.

--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -24,6 +24,7 @@ let macOSOnlyProducts: [Product] = [
     .singleTargetLibrary("SampleIndex"),
     .singleTargetLibrary("Services"),
     .singleTargetLibrary("Resources"),
+    .singleTargetLibrary("Availability"),
     .singleTargetLibrary("MCPSupport"),
     .singleTargetLibrary("SearchToolProvider"),
     .singleTargetLibrary("MCPClient"),
@@ -178,6 +179,15 @@ let targets: [Target] = {
         dependencies: ["RemoteSync", "TestSupport"]
     )
 
+    let availabilityTarget = Target.target(
+        name: "Availability",
+        dependencies: []
+    )
+    let availabilityTestsTarget = Target.testTarget(
+        name: "AvailabilityTests",
+        dependencies: ["Availability", "TestSupport"]
+    )
+
     let cliTarget = Target.executableTarget(
         name: "CLI",
         dependencies: [
@@ -189,6 +199,7 @@ let targets: [Target] = {
             "Services",
             "Logging",
             "RemoteSync",
+            "Availability",
             // MCP dependencies (for mcp serve command)
             "MCP",
             "MCPSupport",
@@ -296,6 +307,8 @@ let targets: [Target] = {
         mcpClientTestsTarget,
         remoteSyncTarget,
         remoteSyncTestsTarget,
+        availabilityTarget,
+        availabilityTestsTarget,
         testSupportTarget,
         cliTarget,
         tuiTarget,

--- a/Packages/Sources/Availability/Availability.swift
+++ b/Packages/Sources/Availability/Availability.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Namespace for availability-related types
+public enum Availability {
+    // Namespace root - types defined in extensions
+}

--- a/Packages/Sources/Availability/AvailabilityError.swift
+++ b/Packages/Sources/Availability/AvailabilityError.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+// MARK: - Availability Errors
+
+/// Errors that can occur during availability fetching
+public enum AvailabilityError: Error, LocalizedError, Sendable {
+    /// Network request failed
+    case networkError(Error)
+
+    /// Request timed out
+    case timeout
+
+    /// API returned 404 (symbol not found)
+    case notFound(String)
+
+    /// Invalid response from API
+    case invalidResponse
+
+    /// Rate limited by API
+    case rateLimited
+
+    /// No documentation directory found
+    case noDocumentationFound
+
+    /// Failed to parse JSON
+    case jsonParseError(Error)
+
+    /// Failed to write updated file
+    case writeError(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+        case .timeout:
+            return "Request timed out"
+        case .notFound(let symbol):
+            return "Symbol not found: \(symbol)"
+        case .invalidResponse:
+            return "Invalid response from Apple API"
+        case .rateLimited:
+            return "Rate limited by Apple API"
+        case .noDocumentationFound:
+            return "No documentation directory found"
+        case .jsonParseError(let error):
+            return "JSON parse error: \(error.localizedDescription)"
+        case .writeError(let error):
+            return "Failed to write file: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Packages/Sources/Availability/AvailabilityFetcher.swift
+++ b/Packages/Sources/Availability/AvailabilityFetcher.swift
@@ -1,0 +1,619 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// MARK: - Availability Fetcher
+
+// swiftlint:disable type_body_length
+// Justification: AvailabilityFetcher is a self-contained actor that handles availability data fetching.
+// It manages API calls, caching, fallback strategies, and statistics tracking as a cohesive unit.
+// Splitting would fragment the actor's state management and reduce thread-safety guarantees.
+
+/// Fetches platform availability data from Apple's API and updates existing documentation JSONs
+public actor AvailabilityFetcher {
+    // MARK: - Configuration
+
+    /// Configuration for the availability fetcher
+    public struct Configuration: Sendable {
+        /// Maximum concurrent requests
+        public let concurrency: Int
+
+        /// Request timeout in seconds
+        public let timeout: TimeInterval
+
+        /// Whether to skip documents that already have availability
+        public let skipExisting: Bool
+
+        /// Base URL for Apple's tutorials/data API
+        public let apiBaseURL: String
+
+        public init(
+            concurrency: Int = 50,
+            timeout: TimeInterval = 1.0,
+            skipExisting: Bool = false,
+            apiBaseURL: String = "https://developer.apple.com/tutorials/data/documentation"
+        ) {
+            self.concurrency = concurrency
+            self.timeout = timeout
+            self.skipExisting = skipExisting
+            self.apiBaseURL = apiBaseURL
+        }
+
+        /// Default configuration
+        public static let `default` = Configuration()
+
+        /// Fast configuration for quick updates
+        public static let fast = Configuration(
+            concurrency: 100,
+            timeout: 0.5,
+            skipExisting: true
+        )
+    }
+
+    // MARK: - Properties
+
+    private let docsDirectory: URL
+    private let configuration: Configuration
+    private let urlSession: URLSession
+
+    /// Cache of framework-level availability for inheritance
+    private var frameworkAvailabilityCache: [String: [PlatformAvailability]] = [:]
+
+    /// Cache of all document availability (populated in pass 1, used in pass 2 for articles)
+    private var documentAvailabilityCache: [String: [PlatformAvailability]] = [:]
+
+    // MARK: - Initialization
+
+    public init(
+        docsDirectory: URL,
+        configuration: Configuration = .default
+    ) {
+        self.docsDirectory = docsDirectory
+        self.configuration = configuration
+
+        // Configure URLSession with timeout
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = configuration.timeout
+        config.timeoutIntervalForResource = configuration.timeout * 2
+        config.httpMaximumConnectionsPerHost = configuration.concurrency
+        urlSession = URLSession(configuration: config)
+    }
+
+    // MARK: - Public API
+
+    /// Fetch availability data and update all documentation JSONs
+    public func fetch(
+        onProgress: (@Sendable (AvailabilityProgress) -> Void)? = nil
+    ) async throws -> AvailabilityStatistics {
+        var stats = AvailabilityStatistics(startTime: Date())
+
+        // Discover all frameworks
+        let frameworks = try discoverFrameworks()
+        guard !frameworks.isEmpty else {
+            throw AvailabilityError.noDocumentationFound
+        }
+
+        // Collect all JSON files
+        let allFiles = try collectJSONFiles(from: frameworks)
+        stats.totalDocuments = allFiles.count
+        stats.frameworksProcessed = frameworks.count
+
+        // Process files with concurrency
+        try await processFiles(
+            allFiles,
+            stats: &stats,
+            onProgress: onProgress
+        )
+
+        stats.endTime = Date()
+        return stats
+    }
+
+    // MARK: - Private Methods - Discovery
+
+    private func discoverFrameworks() throws -> [String] {
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: docsDirectory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+
+        return contents.compactMap { url -> String? in
+            let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory
+            return isDirectory == true ? url.lastPathComponent : nil
+        }.sorted()
+    }
+
+    private func collectJSONFiles(from frameworks: [String]) throws -> [(framework: String, file: URL)] {
+        var files: [(String, URL)] = []
+
+        for framework in frameworks {
+            let frameworkDir = docsDirectory.appendingPathComponent(framework)
+            let contents = try FileManager.default.contentsOfDirectory(
+                at: frameworkDir,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+
+            for file in contents where file.pathExtension == "json" {
+                files.append((framework, file))
+            }
+        }
+
+        return files
+    }
+
+    // MARK: - Private Methods - Processing
+
+    private func processFiles(
+        _ files: [(framework: String, file: URL)],
+        stats: inout AvailabilityStatistics,
+        onProgress: (@Sendable (AvailabilityProgress) -> Void)?
+    ) async throws {
+        // Phase 1: Cache framework root availability
+        await cacheFrameworkAvailability(from: files)
+
+        // Phase 2: First pass - process API docs (non-articles) and cache their availability
+        // This populates documentAvailabilityCache for article reference lookups
+        let (apiDocs, articles) = separateAPIDocsAndArticles(files)
+
+        let batchSize = configuration.concurrency
+        var completed = 0
+        var successful = 0
+        var failed = 0
+        var filesWithNoAvailability: [String] = []
+
+        // Process API docs first
+        for batch in stride(from: 0, to: apiDocs.count, by: batchSize) {
+            let endIndex = min(batch + batchSize, apiDocs.count)
+            let batchFiles = Array(apiDocs[batch..<endIndex])
+
+            await withTaskGroup(of: ProcessResult.self) { group in
+                for (framework, file) in batchFiles {
+                    group.addTask {
+                        await self.processFile(file, framework: framework, isArticle: false)
+                    }
+                }
+
+                for await result in group {
+                    completed += 1
+                    updateStats(
+                        result: result,
+                        stats: &stats,
+                        successful: &successful,
+                        failed: &failed,
+                        filesWithNoAvailability: &filesWithNoAvailability
+                    )
+
+                    reportProgress(
+                        result: result,
+                        completed: completed,
+                        total: files.count,
+                        successful: successful,
+                        failed: failed,
+                        onProgress: onProgress
+                    )
+                }
+            }
+        }
+
+        // Phase 3: Second pass - process articles with reference lookup
+        for batch in stride(from: 0, to: articles.count, by: batchSize) {
+            let endIndex = min(batch + batchSize, articles.count)
+            let batchFiles = Array(articles[batch..<endIndex])
+
+            await withTaskGroup(of: ProcessResult.self) { group in
+                for (framework, file) in batchFiles {
+                    group.addTask {
+                        await self.processFile(file, framework: framework, isArticle: true)
+                    }
+                }
+
+                for await result in group {
+                    completed += 1
+                    updateStats(
+                        result: result,
+                        stats: &stats,
+                        successful: &successful,
+                        failed: &failed,
+                        filesWithNoAvailability: &filesWithNoAvailability
+                    )
+
+                    reportProgress(
+                        result: result,
+                        completed: completed,
+                        total: files.count,
+                        successful: successful,
+                        failed: failed,
+                        onProgress: onProgress
+                    )
+                }
+            }
+        }
+
+        // Store files with no availability for logging (limit to first 100)
+        stats.filesWithNoAvailability = Array(filesWithNoAvailability.prefix(100))
+    }
+
+    /// Separate files into API docs and articles based on document kind
+    private func separateAPIDocsAndArticles(
+        _ files: [(framework: String, file: URL)]
+    ) -> (apiDocs: [(framework: String, file: URL)], articles: [(framework: String, file: URL)]) {
+        var apiDocs: [(String, URL)] = []
+        var articles: [(String, URL)] = []
+
+        for (framework, file) in files {
+            if let data = try? Data(contentsOf: file),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let kind = json["kind"] as? String,
+               kind == "article" {
+                articles.append((framework, file))
+            } else {
+                apiDocs.append((framework, file))
+            }
+        }
+
+        return (apiDocs, articles)
+    }
+
+    private func updateStats(
+        result: ProcessResult,
+        stats: inout AvailabilityStatistics,
+        successful: inout Int,
+        failed: inout Int,
+        filesWithNoAvailability: inout [String]
+    ) {
+        switch result.status {
+        case .updated:
+            stats.updatedDocuments += 1
+            stats.successfulFetches += 1
+            successful += 1
+        case .inherited:
+            stats.inheritedFromParent += 1
+            stats.updatedDocuments += 1
+            successful += 1
+        case .derivedFromReferences:
+            stats.derivedFromReferences += 1
+            stats.updatedDocuments += 1
+            successful += 1
+        case .markedEmpty:
+            stats.markedEmpty += 1
+            filesWithNoAvailability.append("\(result.framework)/\(result.filename)")
+        case .skipped:
+            stats.skippedDocuments += 1
+        case .failed:
+            stats.failedFetches += 1
+            failed += 1
+        case .notApplicable:
+            stats.skippedDocuments += 1
+        }
+    }
+
+    private func reportProgress(
+        result: ProcessResult,
+        completed: Int,
+        total: Int,
+        successful: Int,
+        failed: Int,
+        onProgress: (@Sendable (AvailabilityProgress) -> Void)?
+    ) {
+        if let onProgress {
+            let progress = AvailabilityProgress(
+                currentDocument: result.filename,
+                completed: completed,
+                total: total,
+                successful: successful,
+                failed: failed,
+                currentFramework: result.framework
+            )
+            onProgress(progress)
+        }
+    }
+
+    /// Cache framework-level availability by processing root documentation files
+    private func cacheFrameworkAvailability(from files: [(framework: String, file: URL)]) async {
+        // Find framework root files (e.g., documentation_swiftui.json)
+        let frameworkRoots = files.filter { framework, file in
+            let filename = file.deletingPathExtension().lastPathComponent
+            return filename == "documentation_\(framework)"
+        }
+
+        // Process framework roots to cache their availability
+        for (framework, file) in frameworkRoots {
+            if let data = try? Data(contentsOf: file),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let availabilityArray = json["availability"] as? [[String: Any]] {
+                let platforms = availabilityArray.compactMap { dict -> PlatformAvailability? in
+                    guard let name = dict["name"] as? String else { return nil }
+                    return PlatformAvailability(
+                        name: name,
+                        introducedAt: dict["introducedAt"] as? String,
+                        deprecated: dict["deprecated"] as? Bool ?? false,
+                        deprecatedAt: dict["deprecatedAt"] as? String,
+                        unavailable: dict["unavailable"] as? Bool ?? false,
+                        beta: dict["beta"] as? Bool ?? false
+                    )
+                }
+                if !platforms.isEmpty {
+                    frameworkAvailabilityCache[framework] = platforms
+                }
+            }
+        }
+    }
+
+    private func processFile(
+        _ fileURL: URL,
+        framework: String,
+        isArticle: Bool
+    ) async -> ProcessResult {
+        let filename = fileURL.lastPathComponent
+
+        // Load existing JSON
+        guard let data = try? Data(contentsOf: fileURL),
+              var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return ProcessResult(status: .failed, filename: filename, framework: framework)
+        }
+
+        // Check if already has availability (if skipExisting is enabled)
+        if configuration.skipExisting,
+           let existingAvailability = json["availability"] as? [[String: Any]],
+           !existingAvailability.isEmpty {
+            return ProcessResult(status: .skipped, filename: filename, framework: framework)
+        }
+
+        // Extract URL to build API path
+        guard let urlString = json["url"] as? String,
+              let docURL = URL(string: urlString)
+        else {
+            return ProcessResult(status: .notApplicable, filename: filename, framework: framework)
+        }
+
+        // Build API URL from doc URL
+        // https://developer.apple.com/documentation/SwiftUI/View
+        // -> https://developer.apple.com/tutorials/data/documentation/swiftui/view.json
+        let apiURL = buildAPIURL(from: docURL)
+
+        // Fetch availability from API
+        var availability = await fetchAvailability(from: apiURL)
+        var inherited = false
+        var derivedFromRefs = false
+
+        // Fallback 1: If API failed or returned empty, try parsing @available from local content
+        if availability == nil || availability!.isEmpty {
+            availability = AvailabilityInfo.extractFromJSONContent(data)
+        }
+
+        // Fallback 2: For articles, derive from referenced APIs
+        if isArticle, availability == nil || availability!.isEmpty {
+            if let derived = deriveAvailabilityFromReferences(json: json) {
+                availability = derived
+                derivedFromRefs = true
+            }
+        }
+
+        // Fallback 3: If still no availability, try inheriting from framework
+        if availability == nil || availability!.isEmpty,
+           let frameworkPlatforms = frameworkAvailabilityCache[framework] {
+            availability = AvailabilityInfo(platforms: frameworkPlatforms)
+            inherited = true
+        }
+
+        // Determine the final status and what to write
+        let finalStatus: ProcessResult.Status
+        let platformsToWrite: [[String: Any]]
+
+        if let availability, !availability.isEmpty {
+            // We have availability data
+            platformsToWrite = availability.platforms.map { platform in
+                var dict: [String: Any] = [
+                    "name": platform.name,
+                    "deprecated": platform.deprecated,
+                    "unavailable": platform.unavailable,
+                    "beta": platform.beta,
+                ]
+                if let introduced = platform.introducedAt {
+                    dict["introducedAt"] = introduced
+                }
+                if let deprecatedAt = platform.deprecatedAt {
+                    dict["deprecatedAt"] = deprecatedAt
+                }
+                return dict
+            }
+            if derivedFromRefs {
+                finalStatus = .derivedFromReferences
+            } else if inherited {
+                finalStatus = .inherited
+            } else {
+                finalStatus = .updated
+            }
+
+            // Cache availability for this document (for article reference lookups)
+            let cacheKey = docURL.path.lowercased()
+            cacheDocumentAvailability(key: cacheKey, platforms: availability.platforms)
+        } else {
+            // Fallback 4: Mark with empty availability to indicate we checked
+            platformsToWrite = []
+            finalStatus = .markedEmpty
+        }
+
+        // Update JSON with availability (even if empty)
+        json["availability"] = platformsToWrite
+
+        // Write updated JSON
+        do {
+            let updatedData = try JSONSerialization.data(
+                withJSONObject: json,
+                options: [.prettyPrinted, .sortedKeys]
+            )
+            try updatedData.write(to: fileURL)
+            return ProcessResult(status: finalStatus, filename: filename, framework: framework)
+        } catch {
+            return ProcessResult(status: .failed, filename: filename, framework: framework)
+        }
+    }
+
+    /// Cache document availability for reference lookups
+    private func cacheDocumentAvailability(key: String, platforms: [PlatformAvailability]) {
+        documentAvailabilityCache[key] = platforms
+    }
+
+    /// Derive availability from doc:// references in article content
+    private func deriveAvailabilityFromReferences(json: [String: Any]) -> AvailabilityInfo? {
+        guard let rawMarkdown = json["rawMarkdown"] as? String else { return nil }
+
+        // Extract doc:// references from markdown
+        // Pattern: [doc://com.apple.storekit/documentation/StoreKit/Transaction]
+        // or: [doc://com.apple.documentation/documentation/Foundation/URL]
+        let docRefPattern = #"doc://[^/]+/documentation/([^\]]+)"#
+        guard let regex = try? NSRegularExpression(pattern: docRefPattern, options: []) else {
+            return nil
+        }
+
+        let range = NSRange(rawMarkdown.startIndex..., in: rawMarkdown)
+        let matches = regex.matches(in: rawMarkdown, options: [], range: range)
+
+        var allPlatforms: [[PlatformAvailability]] = []
+
+        for match in matches {
+            guard let pathRange = Range(match.range(at: 1), in: rawMarkdown) else { continue }
+            let refPath = String(rawMarkdown[pathRange]).lowercased()
+
+            // Build the full path for cache lookup
+            let cacheKey = "/documentation/\(refPath)"
+
+            if let platforms = documentAvailabilityCache[cacheKey], !platforms.isEmpty {
+                allPlatforms.append(platforms)
+            }
+        }
+
+        guard !allPlatforms.isEmpty else { return nil }
+
+        // Compute most restrictive availability (highest minimum version per platform)
+        return computeMostRestrictiveAvailability(from: allPlatforms)
+    }
+
+    /// Compute the most restrictive availability from multiple sources
+    /// Uses the highest minimum version for each platform
+    private func computeMostRestrictiveAvailability(
+        from sources: [[PlatformAvailability]]
+    ) -> AvailabilityInfo? {
+        var platformVersions: [String: (version: String, deprecated: Bool, beta: Bool)] = [:]
+
+        for platforms in sources {
+            for platform in platforms where !platform.unavailable {
+                guard let version = platform.introducedAt else { continue }
+
+                if let existing = platformVersions[platform.name] {
+                    // Keep the higher (more restrictive) version
+                    if Self.isVersion(version, greaterThan: existing.version) {
+                        platformVersions[platform.name] = (
+                            version,
+                            platform.deprecated || existing.deprecated,
+                            platform.beta || existing.beta
+                        )
+                    }
+                } else {
+                    platformVersions[platform.name] = (version, platform.deprecated, platform.beta)
+                }
+            }
+        }
+
+        guard !platformVersions.isEmpty else { return nil }
+
+        let platforms = platformVersions.map { name, info in
+            PlatformAvailability(
+                name: name,
+                introducedAt: info.version,
+                deprecated: info.deprecated,
+                deprecatedAt: nil,
+                unavailable: false,
+                beta: info.beta
+            )
+        }
+
+        return AvailabilityInfo(platforms: platforms)
+    }
+
+    /// Compare version strings - returns true if lhs > rhs
+    private static func isVersion(_ lhs: String, greaterThan rhs: String) -> Bool {
+        let lhsComponents = lhs.split(separator: ".").compactMap { Int($0) }
+        let rhsComponents = rhs.split(separator: ".").compactMap { Int($0) }
+
+        for idx in 0..<max(lhsComponents.count, rhsComponents.count) {
+            let lhsValue = idx < lhsComponents.count ? lhsComponents[idx] : 0
+            let rhsValue = idx < rhsComponents.count ? rhsComponents[idx] : 0
+
+            if lhsValue > rhsValue { return true }
+            if lhsValue < rhsValue { return false }
+        }
+        return false // Equal versions
+    }
+
+    private func buildAPIURL(from docURL: URL) -> URL {
+        // Extract path after /documentation/
+        let path = docURL.path.lowercased()
+        let apiPath: String
+
+        if path.hasPrefix("/documentation/") {
+            apiPath = String(path.dropFirst("/documentation/".count))
+        } else {
+            apiPath = path
+        }
+
+        return URL(string: "\(configuration.apiBaseURL)/\(apiPath).json")!
+    }
+
+    private func fetchAvailability(from url: URL) async -> AvailabilityInfo? {
+        do {
+            let (data, response) = try await urlSession.data(from: url)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return nil
+            }
+
+            guard httpResponse.statusCode == 200 else {
+                return nil
+            }
+
+            let decoder = JSONDecoder()
+            let apiResponse = try decoder.decode(Availability.APIResponse.self, from: data)
+
+            guard let platforms = apiResponse.metadata?.platforms else {
+                return nil
+            }
+
+            let availability = platforms.map { $0.toPlatformAvailability() }
+            return AvailabilityInfo(platforms: availability)
+        } catch {
+            // Network error or JSON parse error - return nil to mark as failed
+            return nil
+        }
+    }
+}
+
+// MARK: - Process Result
+
+private struct ProcessResult: Sendable {
+    enum Status: Sendable {
+        case updated // Availability fetched from API or parsed from @available
+        case inherited // Inherited from parent/framework
+        case derivedFromReferences // Derived from doc:// references (articles)
+        case markedEmpty // Checked but no availability found, marked with empty array
+        case skipped // Already has availability (when skipExisting is true)
+        case failed // JSON parsing or write error
+        case notApplicable // No URL to fetch from
+    }
+
+    let status: Status
+    let filename: String
+    let framework: String
+
+    init(status: Status, filename: String, framework: String) {
+        self.status = status
+        self.filename = filename
+        self.framework = framework
+    }
+}

--- a/Packages/Sources/Availability/AvailabilityProgress.swift
+++ b/Packages/Sources/Availability/AvailabilityProgress.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+// MARK: - Availability Fetch Progress
+
+/// Progress information for availability fetching
+public struct AvailabilityProgress: Sendable {
+    /// Current document being processed
+    public let currentDocument: String
+
+    /// Number of documents processed
+    public let completed: Int
+
+    /// Total documents to process
+    public let total: Int
+
+    /// Number of successful fetches
+    public let successful: Int
+
+    /// Number of failed fetches
+    public let failed: Int
+
+    /// Current framework being processed
+    public let currentFramework: String
+
+    public init(
+        currentDocument: String,
+        completed: Int,
+        total: Int,
+        successful: Int,
+        failed: Int,
+        currentFramework: String
+    ) {
+        self.currentDocument = currentDocument
+        self.completed = completed
+        self.total = total
+        self.successful = successful
+        self.failed = failed
+        self.currentFramework = currentFramework
+    }
+
+    /// Progress percentage (0-100)
+    public var percentage: Double {
+        guard total > 0 else { return 0 }
+        return (Double(completed) / Double(total)) * 100.0
+    }
+}

--- a/Packages/Sources/Availability/AvailabilityStatistics.swift
+++ b/Packages/Sources/Availability/AvailabilityStatistics.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+// MARK: - Availability Fetch Statistics
+
+/// Statistics for availability fetch operation
+public struct AvailabilityStatistics: Sendable {
+    /// Total documents scanned
+    public var totalDocuments: Int = 0
+
+    /// Documents that had availability updated
+    public var updatedDocuments: Int = 0
+
+    /// Documents where availability fetch was successful
+    public var successfulFetches: Int = 0
+
+    /// Documents where availability fetch failed (timeouts, 404s, etc.)
+    public var failedFetches: Int = 0
+
+    /// Documents skipped (already have availability or not applicable)
+    public var skippedDocuments: Int = 0
+
+    /// Documents that inherited availability from parent/framework
+    public var inheritedFromParent: Int = 0
+
+    /// Articles that derived availability from referenced APIs
+    public var derivedFromReferences: Int = 0
+
+    /// Documents marked with empty availability (checked but none found)
+    public var markedEmpty: Int = 0
+
+    /// Number of frameworks processed
+    public var frameworksProcessed: Int = 0
+
+    /// Files that had no availability after all fallbacks (for logging)
+    public var filesWithNoAvailability: [String] = []
+
+    /// Start time of the operation
+    public var startTime: Date?
+
+    /// End time of the operation
+    public var endTime: Date?
+
+    public init(
+        totalDocuments: Int = 0,
+        updatedDocuments: Int = 0,
+        successfulFetches: Int = 0,
+        failedFetches: Int = 0,
+        skippedDocuments: Int = 0,
+        inheritedFromParent: Int = 0,
+        derivedFromReferences: Int = 0,
+        markedEmpty: Int = 0,
+        frameworksProcessed: Int = 0,
+        filesWithNoAvailability: [String] = [],
+        startTime: Date? = nil,
+        endTime: Date? = nil
+    ) {
+        self.totalDocuments = totalDocuments
+        self.updatedDocuments = updatedDocuments
+        self.successfulFetches = successfulFetches
+        self.failedFetches = failedFetches
+        self.skippedDocuments = skippedDocuments
+        self.inheritedFromParent = inheritedFromParent
+        self.derivedFromReferences = derivedFromReferences
+        self.markedEmpty = markedEmpty
+        self.frameworksProcessed = frameworksProcessed
+        self.filesWithNoAvailability = filesWithNoAvailability
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+
+    /// Duration of the operation in seconds
+    public var duration: TimeInterval? {
+        guard let start = startTime, let end = endTime else {
+            return nil
+        }
+        return end.timeIntervalSince(start)
+    }
+
+    /// Success rate as percentage
+    public var successRate: Double {
+        let attempted = successfulFetches + failedFetches
+        guard attempted > 0 else { return 0 }
+        return (Double(successfulFetches) / Double(attempted)) * 100.0
+    }
+}

--- a/Packages/Sources/Availability/PlatformAvailability.swift
+++ b/Packages/Sources/Availability/PlatformAvailability.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+// MARK: - Platform Availability
+
+/// Represents platform availability information for an API symbol
+/// Matches Apple's /tutorials/data/documentation API response format
+public struct PlatformAvailability: Codable, Sendable, Hashable {
+    /// Platform name (iOS, macOS, watchOS, etc.)
+    public let name: String
+
+    /// Version when this API was introduced (e.g., "13.0", "10.15")
+    public let introducedAt: String?
+
+    /// Whether this API is deprecated
+    public let deprecated: Bool
+
+    /// Version when this API was deprecated (if applicable)
+    public let deprecatedAt: String?
+
+    /// Whether this API is unavailable on this platform
+    public let unavailable: Bool
+
+    /// Whether this API is in beta
+    public let beta: Bool
+
+    public init(
+        name: String,
+        introducedAt: String? = nil,
+        deprecated: Bool = false,
+        deprecatedAt: String? = nil,
+        unavailable: Bool = false,
+        beta: Bool = false
+    ) {
+        self.name = name
+        self.introducedAt = introducedAt
+        self.deprecated = deprecated
+        self.deprecatedAt = deprecatedAt
+        self.unavailable = unavailable
+        self.beta = beta
+    }
+}
+
+// MARK: - API Response Models
+
+extension Availability {
+    /// Response from Apple's /tutorials/data/documentation API
+    struct APIResponse: Codable, Sendable {
+        let metadata: Metadata?
+
+        struct Metadata: Codable, Sendable {
+            let platforms: [PlatformInfo]?
+        }
+
+        struct PlatformInfo: Codable, Sendable {
+            let name: String
+            let introducedAt: String?
+            let deprecated: Bool?
+            let deprecatedAt: String?
+            let unavailable: Bool?
+            let beta: Bool?
+
+            func toPlatformAvailability() -> PlatformAvailability {
+                PlatformAvailability(
+                    name: name,
+                    introducedAt: introducedAt,
+                    deprecated: deprecated ?? false,
+                    deprecatedAt: deprecatedAt,
+                    unavailable: unavailable ?? false,
+                    beta: beta ?? false
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Availability Info
+
+/// Complete availability information for a documentation page
+public struct AvailabilityInfo: Codable, Sendable, Hashable {
+    /// Platform availability array
+    public let platforms: [PlatformAvailability]
+
+    /// When the availability was fetched
+    public let fetchedAt: Date
+
+    public init(platforms: [PlatformAvailability], fetchedAt: Date = Date()) {
+        self.platforms = platforms
+        self.fetchedAt = fetchedAt
+    }
+
+    /// Empty availability (no data available)
+    public static let empty = AvailabilityInfo(platforms: [])
+
+    /// Check if availability data exists
+    public var isEmpty: Bool {
+        platforms.isEmpty
+    }
+
+    /// Minimum iOS version required (nil if not available on iOS)
+    public var minimumiOS: String? {
+        platforms.first { $0.name == "iOS" && !$0.unavailable }?.introducedAt
+    }
+
+    /// Minimum macOS version required (nil if not available on macOS)
+    public var minimumMacOS: String? {
+        platforms.first { $0.name == "macOS" && !$0.unavailable }?.introducedAt
+    }
+
+    /// Check if deprecated on any platform
+    public var isDeprecated: Bool {
+        platforms.contains { $0.deprecated }
+    }
+
+    /// Check if in beta on any platform
+    public var isBeta: Bool {
+        platforms.contains { $0.beta }
+    }
+}
+
+// MARK: - @available Annotation Parser
+
+extension AvailabilityInfo {
+    /// Parse availability from @available annotations in Swift code
+    /// Example: @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    public static func parseFromAnnotation(_ content: String) -> AvailabilityInfo? {
+        // Match @available(iOS 13.0, macOS 10.15, *) pattern
+        let pattern = #"@available\s*\(\s*([^)]+)\s*\)"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []),
+              let match = regex.firstMatch(
+                  in: content,
+                  options: [],
+                  range: NSRange(content.startIndex..., in: content)
+              ),
+              let range = Range(match.range(at: 1), in: content)
+        else {
+            return nil
+        }
+
+        let annotationContent = String(content[range])
+        var platforms: [PlatformAvailability] = []
+
+        // Split by comma and parse each platform
+        let parts = annotationContent.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+
+        for part in parts {
+            // Skip wildcard
+            if part == "*" { continue }
+
+            // Parse "iOS 13.0" or "macOS 10.15" or "deprecated" etc.
+            let components = part.split(separator: " ", maxSplits: 1)
+
+            if components.count >= 1 {
+                let platformName = normalizePlatformName(String(components[0]))
+                let version = components.count >= 2 ? String(components[1]) : nil
+
+                // Skip modifiers like "deprecated", "unavailable", "introduced"
+                let modifiers = ["deprecated", "unavailable", "introduced", "obsoleted", "message", "renamed"]
+                if modifiers.contains(platformName.lowercased()) { continue }
+
+                // Check for deprecated/unavailable modifiers
+                let isDeprecated = part.lowercased().contains("deprecated")
+                let isUnavailable = part.lowercased().contains("unavailable")
+
+                platforms.append(PlatformAvailability(
+                    name: platformName,
+                    introducedAt: version,
+                    deprecated: isDeprecated,
+                    deprecatedAt: nil,
+                    unavailable: isUnavailable,
+                    beta: false
+                ))
+            }
+        }
+
+        return platforms.isEmpty ? nil : AvailabilityInfo(platforms: platforms)
+    }
+
+    /// Normalize platform names to match Apple's API format
+    private static func normalizePlatformName(_ name: String) -> String {
+        switch name.lowercased() {
+        case "ios": return "iOS"
+        case "ipados": return "iPadOS"
+        case "macos", "osx": return "macOS"
+        case "tvos": return "tvOS"
+        case "watchos": return "watchOS"
+        case "visionos": return "visionOS"
+        case "maccatalyst", "macCatalyst": return "Mac Catalyst"
+        default: return name
+        }
+    }
+
+    /// Try to extract availability from JSON content (rawMarkdown, codeExamples, declaration)
+    public static func extractFromJSONContent(_ jsonData: Data) -> AvailabilityInfo? {
+        // Try to parse as dictionary
+        guard let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+            return nil
+        }
+
+        // Check rawMarkdown first
+        if let rawMarkdown = json["rawMarkdown"] as? String,
+           let availability = parseFromAnnotation(rawMarkdown) {
+            return availability
+        }
+
+        // Check declaration
+        if let declaration = json["declaration"] as? [String: Any],
+           let code = declaration["code"] as? String,
+           let availability = parseFromAnnotation(code) {
+            return availability
+        }
+
+        // Check code examples
+        if let codeExamples = json["codeExamples"] as? [[String: Any]] {
+            for example in codeExamples {
+                if let code = example["code"] as? String,
+                   let availability = parseFromAnnotation(code) {
+                    return availability
+                }
+            }
+        }
+
+        return nil
+    }
+}

--- a/Packages/Sources/CLI/Commands/SearchCommand.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand.swift
@@ -52,6 +52,36 @@ struct SearchCommand: AsyncParsableCommand {
 
     @Option(
         name: .long,
+        help: "Filter to APIs available on iOS version (e.g., 13.0, 15.0)"
+    )
+    var minIos: String?
+
+    @Option(
+        name: .long,
+        help: "Filter to APIs available on macOS version (e.g., 10.15, 12.0)"
+    )
+    var minMacos: String?
+
+    @Option(
+        name: .long,
+        help: "Filter to APIs available on tvOS version (e.g., 13.0, 15.0)"
+    )
+    var minTvos: String?
+
+    @Option(
+        name: .long,
+        help: "Filter to APIs available on watchOS version (e.g., 6.0, 8.0)"
+    )
+    var minWatchos: String?
+
+    @Option(
+        name: .long,
+        help: "Filter to APIs available on visionOS version (e.g., 1.0, 2.0)"
+    )
+    var minVisionos: String?
+
+    @Option(
+        name: .long,
         help: "Path to search database"
     )
     var searchDb: String?
@@ -71,7 +101,12 @@ struct SearchCommand: AsyncParsableCommand {
                 framework: framework,
                 language: language,
                 limit: limit,
-                includeArchive: includeArchive
+                includeArchive: includeArchive,
+                minimumiOS: minIos,
+                minimumMacOS: minMacos,
+                minimumTvOS: minTvos,
+                minimumWatchOS: minWatchos,
+                minimumVisionOS: minVisionos
             ))
         }
 
@@ -86,7 +121,16 @@ struct SearchCommand: AsyncParsableCommand {
         case .markdown:
             let formatter = MarkdownSearchResultFormatter(
                 query: query,
-                filters: SearchFilters(source: source, framework: framework, language: language),
+                filters: SearchFilters(
+                    source: source,
+                    framework: framework,
+                    language: language,
+                    minimumiOS: minIos,
+                    minimumMacOS: minMacos,
+                    minimumTvOS: minTvos,
+                    minimumWatchOS: minWatchos,
+                    minimumVisionOS: minVisionos
+                ),
                 config: .cliDefault
             )
             Log.output(formatter.format(results))

--- a/Packages/Sources/CLI/SupportingTypes.swift
+++ b/Packages/Sources/CLI/SupportingTypes.swift
@@ -15,6 +15,7 @@ extension Cupertino {
         case samples
         case archive
         case hig
+        case availability
         case all
 
         var displayName: String {
@@ -28,6 +29,7 @@ extension Cupertino {
             case .samples: return "Sample Code (GitHub)"
             case .archive: return Shared.Constants.DisplayName.archive
             case .hig: return Shared.Constants.DisplayName.humanInterfaceGuidelines
+            case .availability: return "API Availability Data"
             case .all: return Shared.Constants.DisplayName.allDocs
             }
         }
@@ -43,6 +45,7 @@ extension Cupertino {
             case .samples: return "" // Git clone from GitHub
             case .archive: return Shared.Constants.BaseURL.appleArchive
             case .hig: return Shared.Constants.BaseURL.appleHIG
+            case .availability: return "" // Updates existing docs
             case .all: return "" // N/A - fetches all types sequentially
             }
         }
@@ -82,6 +85,8 @@ extension Cupertino {
                 return "\(homeDir)/\(baseDir)/\(Shared.Constants.Directory.archive)"
             case .hig:
                 return "\(homeDir)/\(baseDir)/\(Shared.Constants.Directory.hig)"
+            case .availability:
+                return "\(homeDir)/\(baseDir)/\(Shared.Constants.Directory.docs)"
             case .all:
                 return "\(homeDir)/\(baseDir)"
             }
@@ -92,7 +97,7 @@ extension Cupertino {
         }
 
         static var directFetchTypes: [FetchType] {
-            [.packages, .packageDocs, .code, .samples, .archive, .hig]
+            [.packages, .packageDocs, .code, .samples, .archive, .hig, .availability]
         }
 
         static var allTypes: [FetchType] {

--- a/Packages/Sources/Core/AppleArchiveCrawler.swift
+++ b/Packages/Sources/Core/AppleArchiveCrawler.swift
@@ -4,6 +4,11 @@ import Shared
 
 // MARK: - Apple Archive Crawler
 
+// swiftlint:disable type_body_length function_body_length
+// Justification: AppleArchiveCrawler handles the complete lifecycle of crawling Apple's legacy docs.
+// It manages HTML fetching, parsing, markdown conversion, and hierarchical page navigation.
+// The guide parsing function is complex due to handling multiple HTML structures from different eras.
+
 /// Crawls Apple's archived documentation (static HTML pages)
 /// These are the pre-2016 guides that are no longer updated but still valuable
 extension Core {

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -5,13 +5,11 @@ import Shared
 
 // MARK: - Documentation Crawler
 
-// swiftlint:disable function_body_length
+// swiftlint:disable function_body_length type_body_length
 // Justification: This class implements the core web crawling engine with WKWebView integration.
 // It manages: page navigation, URL queue processing, change detection, content extraction,
 // progress tracking, session persistence, and navigation delegation. The crawling logic is
 // inherently stateful and requires coordinating multiple async operations in sequence.
-// Function body length: 67 lines
-// Disabling: function_body_length (50 line limit for main crawl loop)
 
 /// Main crawler for Apple documentation using WKWebView
 extension Core {

--- a/Packages/Sources/Core/Transformers/HTMLToMarkdown.swift
+++ b/Packages/Sources/Core/Transformers/HTMLToMarkdown.swift
@@ -6,7 +6,7 @@ import WebKit
 
 // MARK: - HTML to Markdown Converter
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 // Justification: This file contains a comprehensive HTML-to-Markdown converter
 // with specialized handling for documentation pages. The conversion logic includes:
 // - Content extraction from various HTML structures (main, article, body)

--- a/Packages/Sources/Core/Transformers/MarkdownToStructuredPage.swift
+++ b/Packages/Sources/Core/Transformers/MarkdownToStructuredPage.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Shared
 
+// swiftlint:disable type_body_length
+// Justification: MarkdownToStructuredPage is a comprehensive parser for Apple documentation markdown.
+// It handles: YAML frontmatter, section detection, code blocks, tables, links, and nested structures.
+// The parsing logic must handle many edge cases from Apple's varied documentation formats.
+
 /// Converts Apple documentation markdown files to StructuredDocumentationPage
 public enum MarkdownToStructuredPage {
     // MARK: - Public API

--- a/Packages/Sources/MockAIAgent/main.swift
+++ b/Packages/Sources/MockAIAgent/main.swift
@@ -3,6 +3,11 @@ import MCP
 
 // MARK: - Mock AI Agent
 
+// swiftlint:disable type_body_length
+// Justification: MCPClient actor implements a complete MCP client for testing.
+// It handles: process management, JSON-RPC communication, request/response formatting, and demo flows.
+// The actor maintains state across multiple async operations for the test session.
+
 /// A mock AI agent that demonstrates how to send MCP requests to an MCP server
 /// This helps visualize the complete MCP request/response cycle with full JSON logging
 

--- a/Packages/Sources/Services/DocsSearchService.swift
+++ b/Packages/Sources/Services/DocsSearchService.swift
@@ -22,14 +22,88 @@ public actor DocsSearchService: SearchService {
     // MARK: - SearchService Protocol
 
     public func search(_ query: SearchQuery) async throws -> [Search.Result] {
-        try await index.search(
+        // Fetch more results if filtering by version (to account for filtering)
+        let hasVersionFilter = query.minimumiOS != nil || query.minimumMacOS != nil ||
+            query.minimumTvOS != nil || query.minimumWatchOS != nil ||
+            query.minimumVisionOS != nil
+        let fetchLimit = hasVersionFilter
+            ? min(query.limit * 3, Shared.Constants.Limit.maxSearchLimit)
+            : query.limit
+
+        var results = try await index.search(
             query: query.text,
             source: query.source,
             framework: query.framework,
             language: query.language,
-            limit: query.limit,
+            limit: fetchLimit,
             includeArchive: query.includeArchive
         )
+
+        // Apply version filters if specified
+        if let minimumiOS = query.minimumiOS {
+            results = results.filter { result in
+                guard let resultVersion = result.minimumiOS else {
+                    return false
+                }
+                return Self.isVersion(resultVersion, lessThanOrEqualTo: minimumiOS)
+            }
+        }
+
+        if let minimumMacOS = query.minimumMacOS {
+            results = results.filter { result in
+                guard let resultVersion = result.minimumMacOS else {
+                    return false
+                }
+                return Self.isVersion(resultVersion, lessThanOrEqualTo: minimumMacOS)
+            }
+        }
+
+        if let minimumTvOS = query.minimumTvOS {
+            results = results.filter { result in
+                guard let resultVersion = result.minimumTvOS else {
+                    return false
+                }
+                return Self.isVersion(resultVersion, lessThanOrEqualTo: minimumTvOS)
+            }
+        }
+
+        if let minimumWatchOS = query.minimumWatchOS {
+            results = results.filter { result in
+                guard let resultVersion = result.minimumWatchOS else {
+                    return false
+                }
+                return Self.isVersion(resultVersion, lessThanOrEqualTo: minimumWatchOS)
+            }
+        }
+
+        if let minimumVisionOS = query.minimumVisionOS {
+            results = results.filter { result in
+                guard let resultVersion = result.minimumVisionOS else {
+                    return false
+                }
+                return Self.isVersion(resultVersion, lessThanOrEqualTo: minimumVisionOS)
+            }
+        }
+
+        // Trim to requested limit after filtering
+        return Array(results.prefix(query.limit))
+    }
+
+    /// Compare version strings (e.g., "13.0" vs "15.0")
+    /// Returns true if lhs <= rhs (API was introduced before or at target version)
+    private static func isVersion(_ lhs: String, lessThanOrEqualTo rhs: String) -> Bool {
+        let lhsComponents = lhs.split(separator: ".").compactMap { Int($0) }
+        let rhsComponents = rhs.split(separator: ".").compactMap { Int($0) }
+
+        // Compare component by component
+        for idx in 0..<max(lhsComponents.count, rhsComponents.count) {
+            let lhsValue = idx < lhsComponents.count ? lhsComponents[idx] : 0
+            let rhsValue = idx < rhsComponents.count ? rhsComponents[idx] : 0
+
+            if lhsValue < rhsValue { return true }
+            if lhsValue > rhsValue { return false }
+        }
+        return true // Equal versions
     }
 
     public func read(uri: String, format: Search.Index.DocumentFormat) async throws -> String? {

--- a/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
@@ -34,6 +34,21 @@ public struct MarkdownSearchResultFormatter: ResultFormatter {
             if let language = filters.language {
                 md += "_Filtered to language: **\(language)**_\n\n"
             }
+            if let minimumiOS = filters.minimumiOS {
+                md += "_Filtered to iOS: **\(minimumiOS)+**_\n\n"
+            }
+            if let minimumMacOS = filters.minimumMacOS {
+                md += "_Filtered to macOS: **\(minimumMacOS)+**_\n\n"
+            }
+            if let minimumTvOS = filters.minimumTvOS {
+                md += "_Filtered to tvOS: **\(minimumTvOS)+**_\n\n"
+            }
+            if let minimumWatchOS = filters.minimumWatchOS {
+                md += "_Filtered to watchOS: **\(minimumWatchOS)+**_\n\n"
+            }
+            if let minimumVisionOS = filters.minimumVisionOS {
+                md += "_Filtered to visionOS: **\(minimumVisionOS)+**_\n\n"
+            }
         }
 
         md += "Found **\(results.count)** result\(results.count == 1 ? "" : "s"):\n\n"

--- a/Packages/Sources/Services/SearchService.swift
+++ b/Packages/Sources/Services/SearchService.swift
@@ -33,6 +33,11 @@ public struct SearchQuery: Sendable {
     public let language: String?
     public let limit: Int
     public let includeArchive: Bool
+    public let minimumiOS: String?
+    public let minimumMacOS: String?
+    public let minimumTvOS: String?
+    public let minimumWatchOS: String?
+    public let minimumVisionOS: String?
 
     public init(
         text: String,
@@ -40,7 +45,12 @@ public struct SearchQuery: Sendable {
         framework: String? = nil,
         language: String? = nil,
         limit: Int = Shared.Constants.Limit.defaultSearchLimit,
-        includeArchive: Bool = false
+        includeArchive: Bool = false,
+        minimumiOS: String? = nil,
+        minimumMacOS: String? = nil,
+        minimumTvOS: String? = nil,
+        minimumWatchOS: String? = nil,
+        minimumVisionOS: String? = nil
     ) {
         self.text = text
         self.source = source
@@ -48,6 +58,11 @@ public struct SearchQuery: Sendable {
         self.language = language
         self.limit = min(limit, Shared.Constants.Limit.maxSearchLimit)
         self.includeArchive = includeArchive
+        self.minimumiOS = minimumiOS
+        self.minimumMacOS = minimumMacOS
+        self.minimumTvOS = minimumTvOS
+        self.minimumWatchOS = minimumWatchOS
+        self.minimumVisionOS = minimumVisionOS
     }
 }
 
@@ -58,15 +73,36 @@ public struct SearchFilters: Sendable {
     public let source: String?
     public let framework: String?
     public let language: String?
+    public let minimumiOS: String?
+    public let minimumMacOS: String?
+    public let minimumTvOS: String?
+    public let minimumWatchOS: String?
+    public let minimumVisionOS: String?
 
-    public init(source: String? = nil, framework: String? = nil, language: String? = nil) {
+    public init(
+        source: String? = nil,
+        framework: String? = nil,
+        language: String? = nil,
+        minimumiOS: String? = nil,
+        minimumMacOS: String? = nil,
+        minimumTvOS: String? = nil,
+        minimumWatchOS: String? = nil,
+        minimumVisionOS: String? = nil
+    ) {
         self.source = source
         self.framework = framework
         self.language = language
+        self.minimumiOS = minimumiOS
+        self.minimumMacOS = minimumMacOS
+        self.minimumTvOS = minimumTvOS
+        self.minimumWatchOS = minimumWatchOS
+        self.minimumVisionOS = minimumVisionOS
     }
 
     /// Check if any filters are active
     public var hasActiveFilters: Bool {
-        source != nil || framework != nil || language != nil
+        source != nil || framework != nil || language != nil ||
+            minimumiOS != nil || minimumMacOS != nil || minimumTvOS != nil ||
+            minimumWatchOS != nil || minimumVisionOS != nil
     }
 }

--- a/Packages/Sources/Shared/ArgumentExtractor.swift
+++ b/Packages/Sources/Shared/ArgumentExtractor.swift
@@ -98,4 +98,39 @@ public struct ArgumentExtractor: Sendable {
     ) -> Bool {
         optional(key, default: false)
     }
+
+    /// Extract min_ios version filter
+    public func minIOS(
+        key: String = Shared.Constants.MCP.schemaParamMinIOS
+    ) -> String? {
+        optional(key)
+    }
+
+    /// Extract min_macos version filter
+    public func minMacOS(
+        key: String = Shared.Constants.MCP.schemaParamMinMacOS
+    ) -> String? {
+        optional(key)
+    }
+
+    /// Extract min_tvos version filter
+    public func minTvOS(
+        key: String = Shared.Constants.MCP.schemaParamMinTvOS
+    ) -> String? {
+        optional(key)
+    }
+
+    /// Extract min_watchos version filter
+    public func minWatchOS(
+        key: String = Shared.Constants.MCP.schemaParamMinWatchOS
+    ) -> String? {
+        optional(key)
+    }
+
+    /// Extract min_visionos version filter
+    public func minVisionOS(
+        key: String = Shared.Constants.MCP.schemaParamMinVisionOS
+    ) -> String? {
+        optional(key)
+    }
 }

--- a/Packages/Sources/Shared/Constants.swift
+++ b/Packages/Sources/Shared/Constants.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - Cupertino Constants
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 // Justification: Shared.Constants serves as central configuration hub for the entire application.
 // Contains directory names, file names, URL patterns, limits, delays, and MCP configuration.
 // Splitting would scatter related constants and reduce discoverability.
@@ -144,7 +144,7 @@ extension Shared {
             public static let userAgent = "CupertinoCrawler/1.0"
 
             /// Current version
-            public static let version = "0.5.0"
+            public static let version = "0.6.0"
         }
 
         // MARK: - Display Names
@@ -466,7 +466,12 @@ extension Shared {
             Returns a ranked list of relevant documents with URIs that can be read using resources/read. \
             Optional parameters: source (apple-docs, swift-evolution, swift-org, swift-book, apple-archive, hig), \
             framework (e.g. swiftui, foundation), include_archive (bool, includes legacy Apple Archive guides \
-            like Core Animation Programming Guide - useful for foundational concepts not in modern docs).
+            like Core Animation Programming Guide - useful for foundational concepts not in modern docs), \
+            min_ios (filter to APIs available on iOS version, e.g. "13.0"), \
+            min_macos (filter to APIs available on macOS version, e.g. "10.15"), \
+            min_tvos (filter to APIs available on tvOS version, e.g. "13.0"), \
+            min_watchos (filter to APIs available on watchOS version, e.g. "6.0"), \
+            min_visionos (filter to APIs available on visionOS version, e.g. "1.0").
             """
 
             /// List frameworks tool description
@@ -559,6 +564,21 @@ extension Shared {
 
             /// JSON Schema parameter: search_files
             public static let schemaParamSearchFiles = "search_files"
+
+            /// JSON Schema parameter: min_ios
+            public static let schemaParamMinIOS = "min_ios"
+
+            /// JSON Schema parameter: min_macos
+            public static let schemaParamMinMacOS = "min_macos"
+
+            /// JSON Schema parameter: min_tvos
+            public static let schemaParamMinTvOS = "min_tvos"
+
+            /// JSON Schema parameter: min_watchos
+            public static let schemaParamMinWatchOS = "min_watchos"
+
+            /// JSON Schema parameter: min_visionos
+            public static let schemaParamMinVisionOS = "min_visionos"
 
             /// Format value: json
             public static let formatValueJSON = "json"

--- a/Packages/Sources/TUI/PackageCurator.swift
+++ b/Packages/Sources/TUI/PackageCurator.swift
@@ -3,6 +3,11 @@ import Foundation
 import Resources
 import Shared
 
+// swiftlint:disable type_body_length function_body_length
+// Justification: PackageCuratorApp is a self-contained CLI tool for curating Swift packages.
+// The main() function orchestrates a complex multi-stage workflow that is clearer as a single flow.
+// Splitting would fragment the workflow logic without meaningful improvement.
+
 @main
 struct PackageCuratorApp {
     @MainActor

--- a/Packages/Sources/TUI/Routing/InputHandler.swift
+++ b/Packages/Sources/TUI/Routing/InputHandler.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+// swiftlint:disable type_body_length
+// Justification: InputHandler processes all keyboard input for the TUI application.
+// It handles: navigation, selection, filtering, pagination, and view-specific actions.
+// The switch statement covers all input cases for consistent keyboard handling.
+
 /// Result of input handling - either continue running, quit, or request render
 enum InputResult {
     case continueRunning

--- a/Packages/Tests/AvailabilityTests/AvailabilityTests.swift
+++ b/Packages/Tests/AvailabilityTests/AvailabilityTests.swift
@@ -1,0 +1,575 @@
+import Availability
+import Foundation
+import Testing
+
+// MARK: - Platform Availability Tests
+
+@Suite("PlatformAvailability Tests")
+struct PlatformAvailabilityTests {
+    @Test("Initialize with all parameters")
+    func fullInitialization() {
+        let availability = PlatformAvailability(
+            name: "iOS",
+            introducedAt: "13.0",
+            deprecated: true,
+            deprecatedAt: "17.0",
+            unavailable: false,
+            beta: false
+        )
+
+        #expect(availability.name == "iOS")
+        #expect(availability.introducedAt == "13.0")
+        #expect(availability.deprecated == true)
+        #expect(availability.deprecatedAt == "17.0")
+        #expect(availability.unavailable == false)
+        #expect(availability.beta == false)
+    }
+
+    @Test("Initialize with minimal parameters")
+    func minimalInitialization() {
+        let availability = PlatformAvailability(name: "macOS")
+
+        #expect(availability.name == "macOS")
+        #expect(availability.introducedAt == nil)
+        #expect(availability.deprecated == false)
+        #expect(availability.deprecatedAt == nil)
+        #expect(availability.unavailable == false)
+        #expect(availability.beta == false)
+    }
+
+    @Test("Hashable conformance")
+    func hashable() {
+        let iosAvailability = PlatformAvailability(name: "iOS", introducedAt: "13.0")
+        let iosAvailabilityCopy = PlatformAvailability(name: "iOS", introducedAt: "13.0")
+        let macOSAvailability = PlatformAvailability(name: "macOS", introducedAt: "10.15")
+
+        #expect(iosAvailability == iosAvailabilityCopy)
+        #expect(iosAvailability != macOSAvailability)
+        #expect(iosAvailability.hashValue == iosAvailabilityCopy.hashValue)
+    }
+
+    @Test("Codable round-trip")
+    func codable() throws {
+        let original = PlatformAvailability(
+            name: "iOS",
+            introducedAt: "15.0",
+            deprecated: false,
+            deprecatedAt: nil,
+            unavailable: false,
+            beta: true
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(PlatformAvailability.self, from: data)
+
+        #expect(decoded == original)
+    }
+}
+
+// MARK: - Availability Info Tests
+
+@Suite("AvailabilityInfo Tests")
+struct AvailabilityInfoTests {
+    @Test("Empty availability")
+    func testEmpty() {
+        let empty = AvailabilityInfo.empty
+
+        #expect(empty.isEmpty == true)
+        #expect(empty.platforms.isEmpty == true)
+        #expect(empty.minimumiOS == nil)
+        #expect(empty.minimumMacOS == nil)
+        #expect(empty.isDeprecated == false)
+        #expect(empty.isBeta == false)
+    }
+
+    @Test("Non-empty availability")
+    func nonEmpty() {
+        let platforms = [
+            PlatformAvailability(name: "iOS", introducedAt: "13.0"),
+            PlatformAvailability(name: "macOS", introducedAt: "10.15"),
+        ]
+        let info = AvailabilityInfo(platforms: platforms)
+
+        #expect(info.isEmpty == false)
+        #expect(info.platforms.count == 2)
+    }
+
+    @Test("Minimum iOS version")
+    func testMinimumiOS() {
+        let platforms = [
+            PlatformAvailability(name: "iOS", introducedAt: "14.0"),
+            PlatformAvailability(name: "macOS", introducedAt: "11.0"),
+        ]
+        let info = AvailabilityInfo(platforms: platforms)
+
+        #expect(info.minimumiOS == "14.0")
+    }
+
+    @Test("Minimum macOS version")
+    func testMinimumMacOS() {
+        let platforms = [
+            PlatformAvailability(name: "iOS", introducedAt: "15.0"),
+            PlatformAvailability(name: "macOS", introducedAt: "12.0"),
+        ]
+        let info = AvailabilityInfo(platforms: platforms)
+
+        #expect(info.minimumMacOS == "12.0")
+    }
+
+    @Test("iOS unavailable returns nil")
+    func unavailableiOS() {
+        let platforms = [
+            PlatformAvailability(name: "iOS", introducedAt: "13.0", unavailable: true),
+            PlatformAvailability(name: "macOS", introducedAt: "10.15"),
+        ]
+        let info = AvailabilityInfo(platforms: platforms)
+
+        #expect(info.minimumiOS == nil)
+        #expect(info.minimumMacOS == "10.15")
+    }
+
+    @Test("Deprecation check - deprecated")
+    func isDeprecatedTrue() {
+        let platforms = [
+            PlatformAvailability(name: "iOS", introducedAt: "10.0", deprecated: true),
+            PlatformAvailability(name: "macOS", introducedAt: "10.12"),
+        ]
+        let info = AvailabilityInfo(platforms: platforms)
+
+        #expect(info.isDeprecated == true)
+    }
+
+    @Test("Deprecation check - not deprecated")
+    func isDeprecatedFalse() {
+        let platforms = [
+            PlatformAvailability(name: "iOS", introducedAt: "15.0"),
+            PlatformAvailability(name: "macOS", introducedAt: "12.0"),
+        ]
+        let info = AvailabilityInfo(platforms: platforms)
+
+        #expect(info.isDeprecated == false)
+    }
+
+    @Test("Beta check - in beta")
+    func isBetaTrue() {
+        let platforms = [
+            PlatformAvailability(name: "visionOS", introducedAt: "1.0", beta: true),
+        ]
+        let info = AvailabilityInfo(platforms: platforms)
+
+        #expect(info.isBeta == true)
+    }
+
+    @Test("Beta check - not in beta")
+    func isBetaFalse() {
+        let platforms = [
+            PlatformAvailability(name: "iOS", introducedAt: "17.0"),
+        ]
+        let info = AvailabilityInfo(platforms: platforms)
+
+        #expect(info.isBeta == false)
+    }
+
+    @Test("Codable round-trip")
+    func testCodable() throws {
+        let platforms = [
+            PlatformAvailability(name: "iOS", introducedAt: "16.0"),
+            PlatformAvailability(name: "watchOS", introducedAt: "9.0"),
+        ]
+        let original = AvailabilityInfo(platforms: platforms)
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(AvailabilityInfo.self, from: data)
+
+        #expect(decoded.platforms.count == original.platforms.count)
+        #expect(decoded.minimumiOS == original.minimumiOS)
+    }
+}
+
+// MARK: - Availability Statistics Tests
+
+@Suite("AvailabilityStatistics Tests")
+struct AvailabilityStatisticsTests {
+    @Test("Default initialization")
+    func defaultInit() {
+        let stats = AvailabilityStatistics()
+
+        #expect(stats.totalDocuments == 0)
+        #expect(stats.updatedDocuments == 0)
+        #expect(stats.successfulFetches == 0)
+        #expect(stats.failedFetches == 0)
+        #expect(stats.skippedDocuments == 0)
+        #expect(stats.frameworksProcessed == 0)
+        #expect(stats.startTime == nil)
+        #expect(stats.endTime == nil)
+        #expect(stats.duration == nil)
+    }
+
+    @Test("Duration calculation")
+    func testDuration() {
+        let start = Date()
+        let end = start.addingTimeInterval(120)
+
+        let stats = AvailabilityStatistics(
+            startTime: start,
+            endTime: end
+        )
+
+        #expect(stats.duration == 120)
+    }
+
+    @Test("Duration nil when no end time")
+    func durationNilNoEnd() {
+        let stats = AvailabilityStatistics(startTime: Date())
+
+        #expect(stats.duration == nil)
+    }
+
+    @Test("Duration nil when no start time")
+    func durationNilNoStart() {
+        let stats = AvailabilityStatistics(endTime: Date())
+
+        #expect(stats.duration == nil)
+    }
+
+    @Test("Success rate calculation - all successful")
+    func successRateAllSuccess() {
+        var stats = AvailabilityStatistics()
+        stats.successfulFetches = 100
+        stats.failedFetches = 0
+
+        #expect(stats.successRate == 100.0)
+    }
+
+    @Test("Success rate calculation - mixed")
+    func successRateMixed() {
+        var stats = AvailabilityStatistics()
+        stats.successfulFetches = 75
+        stats.failedFetches = 25
+
+        #expect(stats.successRate == 75.0)
+    }
+
+    @Test("Success rate calculation - all failed")
+    func successRateAllFailed() {
+        var stats = AvailabilityStatistics()
+        stats.successfulFetches = 0
+        stats.failedFetches = 50
+
+        #expect(stats.successRate == 0.0)
+    }
+
+    @Test("Success rate calculation - no attempts")
+    func successRateNoAttempts() {
+        let stats = AvailabilityStatistics()
+
+        #expect(stats.successRate == 0.0)
+    }
+}
+
+// MARK: - Availability Progress Tests
+
+@Suite("AvailabilityProgress Tests")
+struct AvailabilityProgressTests {
+    @Test("Progress percentage calculation")
+    func testPercentage() {
+        let progress = AvailabilityProgress(
+            currentDocument: "test.json",
+            completed: 50,
+            total: 100,
+            successful: 45,
+            failed: 5,
+            currentFramework: "SwiftUI"
+        )
+
+        #expect(progress.percentage == 50.0)
+    }
+
+    @Test("Progress percentage - zero total")
+    func percentageZeroTotal() {
+        let progress = AvailabilityProgress(
+            currentDocument: "test.json",
+            completed: 0,
+            total: 0,
+            successful: 0,
+            failed: 0,
+            currentFramework: "SwiftUI"
+        )
+
+        #expect(progress.percentage == 0.0)
+    }
+
+    @Test("Progress percentage - 100%")
+    func percentageFull() {
+        let progress = AvailabilityProgress(
+            currentDocument: "last.json",
+            completed: 200,
+            total: 200,
+            successful: 190,
+            failed: 10,
+            currentFramework: "Foundation"
+        )
+
+        #expect(progress.percentage == 100.0)
+    }
+
+    @Test("Progress stores all values")
+    func allValues() {
+        let progress = AvailabilityProgress(
+            currentDocument: "view.json",
+            completed: 10,
+            total: 50,
+            successful: 8,
+            failed: 2,
+            currentFramework: "UIKit"
+        )
+
+        #expect(progress.currentDocument == "view.json")
+        #expect(progress.completed == 10)
+        #expect(progress.total == 50)
+        #expect(progress.successful == 8)
+        #expect(progress.failed == 2)
+        #expect(progress.currentFramework == "UIKit")
+    }
+}
+
+// MARK: - Availability Error Tests
+
+@Suite("AvailabilityError Tests")
+struct AvailabilityErrorTests {
+    @Test("Network error description")
+    func testNetworkError() {
+        let userInfo = [NSLocalizedDescriptionKey: "Connection failed"]
+        let underlyingError = NSError(domain: "test", code: -1, userInfo: userInfo)
+        let error = AvailabilityError.networkError(underlyingError)
+
+        #expect(error.errorDescription?.contains("Network error") == true)
+        #expect(error.errorDescription?.contains("Connection failed") == true)
+    }
+
+    @Test("Timeout error description")
+    func timeoutError() {
+        let error = AvailabilityError.timeout
+
+        #expect(error.errorDescription == "Request timed out")
+    }
+
+    @Test("Not found error description")
+    func notFoundError() {
+        let error = AvailabilityError.notFound("SwiftUI/View")
+
+        #expect(error.errorDescription?.contains("not found") == true)
+        #expect(error.errorDescription?.contains("SwiftUI/View") == true)
+    }
+
+    @Test("Invalid response error description")
+    func invalidResponseError() {
+        let error = AvailabilityError.invalidResponse
+
+        #expect(error.errorDescription == "Invalid response from Apple API")
+    }
+
+    @Test("Rate limited error description")
+    func rateLimitedError() {
+        let error = AvailabilityError.rateLimited
+
+        #expect(error.errorDescription == "Rate limited by Apple API")
+    }
+
+    @Test("No documentation found error description")
+    func noDocumentationFoundError() {
+        let error = AvailabilityError.noDocumentationFound
+
+        #expect(error.errorDescription == "No documentation directory found")
+    }
+
+    @Test("JSON parse error description")
+    func jSONParseError() {
+        let underlyingError = NSError(domain: "JSON", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"])
+        let error = AvailabilityError.jsonParseError(underlyingError)
+
+        #expect(error.errorDescription?.contains("JSON parse error") == true)
+    }
+
+    @Test("Write error description")
+    func testWriteError() {
+        let userInfo = [NSLocalizedDescriptionKey: "Permission denied"]
+        let underlyingError = NSError(domain: "File", code: 2, userInfo: userInfo)
+        let error = AvailabilityError.writeError(underlyingError)
+
+        #expect(error.errorDescription?.contains("Failed to write file") == true)
+    }
+}
+
+// MARK: - Availability Fetcher Configuration Tests
+
+@Suite("AvailabilityFetcher.Configuration Tests")
+struct AvailabilityFetcherConfigurationTests {
+    @Test("Default configuration values")
+    func defaultConfig() {
+        let config = AvailabilityFetcher.Configuration.default
+
+        #expect(config.concurrency == 50)
+        #expect(config.timeout == 1.0)
+        #expect(config.skipExisting == false)
+        #expect(config.apiBaseURL == "https://developer.apple.com/tutorials/data/documentation")
+    }
+
+    @Test("Fast configuration values")
+    func fastConfig() {
+        let config = AvailabilityFetcher.Configuration.fast
+
+        #expect(config.concurrency == 100)
+        #expect(config.timeout == 0.5)
+        #expect(config.skipExisting == true)
+    }
+
+    @Test("Custom configuration")
+    func customConfig() {
+        let config = AvailabilityFetcher.Configuration(
+            concurrency: 25,
+            timeout: 2.0,
+            skipExisting: true,
+            apiBaseURL: "https://custom.api.com"
+        )
+
+        #expect(config.concurrency == 25)
+        #expect(config.timeout == 2.0)
+        #expect(config.skipExisting == true)
+        #expect(config.apiBaseURL == "https://custom.api.com")
+    }
+}
+
+// MARK: - @available Annotation Parser Tests
+
+@Suite("AvailabilityInfo Annotation Parser Tests")
+struct AvailabilityAnnotationParserTests {
+    @Test("Parse simple @available annotation")
+    func parseSimpleAnnotation() {
+        let code = "@available(iOS 13.0, macOS 10.15, *)"
+        let result = AvailabilityInfo.parseFromAnnotation(code)
+
+        #expect(result != nil)
+        #expect(result?.platforms.count == 2)
+        #expect(result?.minimumiOS == "13.0")
+        #expect(result?.minimumMacOS == "10.15")
+    }
+
+    @Test("Parse multiple platforms")
+    func parseMultiplePlatforms() {
+        let code = "@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)"
+        let result = AvailabilityInfo.parseFromAnnotation(code)
+
+        #expect(result != nil)
+        #expect(result?.platforms.count == 5)
+        #expect(result?.minimumiOS == "18.0")
+        #expect(result?.minimumMacOS == "15.0")
+    }
+
+    @Test("Parse annotation with extra whitespace")
+    func parseWithWhitespace() {
+        let code = "@available(  iOS 16.0 ,  macOS 13.0  , * )"
+        let result = AvailabilityInfo.parseFromAnnotation(code)
+
+        #expect(result != nil)
+        #expect(result?.minimumiOS == "16.0")
+        #expect(result?.minimumMacOS == "13.0")
+    }
+
+    @Test("Parse annotation in code block")
+    func parseInCodeBlock() {
+        let code = """
+        import SwiftUI
+
+        @available(iOS 17.0, macOS 14.0, *)
+        struct MyView: View {
+            var body: some View {
+                Text("Hello")
+            }
+        }
+        """
+        let result = AvailabilityInfo.parseFromAnnotation(code)
+
+        #expect(result != nil)
+        #expect(result?.minimumiOS == "17.0")
+        #expect(result?.minimumMacOS == "14.0")
+    }
+
+    @Test("No annotation returns nil")
+    func noAnnotation() {
+        let code = "struct MyView: View { }"
+        let result = AvailabilityInfo.parseFromAnnotation(code)
+
+        #expect(result == nil)
+    }
+
+    @Test("Platform name normalization")
+    func platformNormalization() {
+        let code = "@available(ios 15.0, MACOS 12.0, watchos 8.0, *)"
+        let result = AvailabilityInfo.parseFromAnnotation(code)
+
+        #expect(result != nil)
+        // Check normalized names
+        let platformNames = result?.platforms.map(\.name) ?? []
+        #expect(platformNames.contains("iOS"))
+        #expect(platformNames.contains("macOS"))
+        #expect(platformNames.contains("watchOS"))
+    }
+
+    @Test("Extract from JSON rawMarkdown")
+    func extractFromJSON() throws {
+        let json: [String: Any] = [
+            "title": "Test",
+            "rawMarkdown": """
+            # Test
+            ```swift
+            @available(iOS 16.0, macOS 13.0, *)
+            func test() { }
+            ```
+            """,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let result = AvailabilityInfo.extractFromJSONContent(data)
+
+        #expect(result != nil)
+        #expect(result?.minimumiOS == "16.0")
+    }
+
+    @Test("Extract from JSON declaration")
+    func extractFromDeclaration() throws {
+        let json: [String: Any] = [
+            "title": "Test",
+            "declaration": [
+                "code": "@available(iOS 15.0, *)\nfunc test() { }",
+                "language": "swift",
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let result = AvailabilityInfo.extractFromJSONContent(data)
+
+        #expect(result != nil)
+        #expect(result?.minimumiOS == "15.0")
+    }
+
+    @Test("Extract from JSON code examples")
+    func extractFromCodeExamples() throws {
+        let json: [String: Any] = [
+            "title": "Test",
+            "codeExamples": [
+                ["code": "@available(iOS 17.0, macOS 14.0, *)\nstruct Example { }"],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let result = AvailabilityInfo.extractFromJSONContent(data)
+
+        #expect(result != nil)
+        #expect(result?.minimumiOS == "17.0")
+        #expect(result?.minimumMacOS == "14.0")
+    }
+}

--- a/Packages/Tests/CLITests/CLITests.swift
+++ b/Packages/Tests/CLITests/CLITests.swift
@@ -148,13 +148,14 @@ struct FetchTypeTests {
     func directFetchTypes() {
         let directFetch = Cupertino.FetchType.directFetchTypes
 
-        #expect(directFetch.count == 6)
+        #expect(directFetch.count == 7)
         #expect(directFetch.contains(.packages))
         #expect(directFetch.contains(.packageDocs))
         #expect(directFetch.contains(.code))
         #expect(directFetch.contains(.samples))
         #expect(directFetch.contains(.archive))
         #expect(directFetch.contains(.hig))
+        #expect(directFetch.contains(.availability))
     }
 
     @Test("Type categorization is mutually exclusive")
@@ -167,14 +168,14 @@ struct FetchTypeTests {
 
         // All types except .all should be categorized
         let allCategorized = webCrawl.union(directFetch)
-        #expect(allCategorized.count == 9) // 3 web + 6 direct
+        #expect(allCategorized.count == 10) // 3 web + 7 direct
     }
 
     @Test("All types includes all categorized types")
     func allTypesComplete() {
         let allTypes = Cupertino.FetchType.allTypes
 
-        #expect(allTypes.count == 9)
+        #expect(allTypes.count == 10)
         #expect(allTypes.contains(.docs))
         #expect(allTypes.contains(.swift))
         #expect(allTypes.contains(.evolution))
@@ -184,6 +185,7 @@ struct FetchTypeTests {
         #expect(allTypes.contains(.samples))
         #expect(allTypes.contains(.archive))
         #expect(allTypes.contains(.hig))
+        #expect(allTypes.contains(.availability))
     }
 
     @Test("Package-docs raw value has hyphen")

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ cupertino fetch --type code          # Sample code from Apple (requires auth)
 cupertino fetch --type samples       # Sample code from GitHub (recommended)
 cupertino fetch --type archive       # Apple Archive programming guides
 cupertino fetch --type hig           # Human Interface Guidelines
+cupertino fetch --type availability  # Platform availability data
 cupertino fetch --type all           # All types in parallel
 
 # Build indexes
@@ -281,6 +282,7 @@ These catalogs are indexed during `cupertino save` and enable instant search wit
 - **Features**:
   - Porter stemming (e.g., "running" matches "run")
   - Framework filtering
+  - Platform availability filtering (iOS/macOS version)
   - Snippet generation
   - Sub-100ms query performance
 - **Size**: ~1.9GB index for full documentation (234,000+ documents across 287 frameworks)
@@ -295,6 +297,7 @@ These catalogs are indexed during `cupertino save` and enable instant search wit
 - **Tools**: Search and read capabilities for AI agents
   - **Documentation Tools** (requires `cupertino save`):
     - `search_docs` - Full-text search across all documentation
+      - Parameters: `query` (required), `source`, `framework`, `min_ios`, `min_macos`, `include_archive`, `limit` (all optional)
     - `search_hig` - Search Human Interface Guidelines
       - Parameters: `query` (required), `platform` (optional), `category` (optional), `limit` (optional)
     - `list_frameworks` - List available frameworks
@@ -530,7 +533,7 @@ For development setup, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Project Status
 
-**Version:** 0.5.0
+**Version:** 0.6.0
 **Status:** 🚧 Active Development
 
 - ✅ All core functionality working

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Cupertino Deployment Guide
 
-**Version:** 0.5.0
+**Version:** 0.6.0
 **Last Updated:** 2025-12-10
 
 This guide covers the complete release process for Cupertino.

--- a/docs/artifacts/README.md
+++ b/docs/artifacts/README.md
@@ -80,6 +80,7 @@ All Cupertino artifacts are stored under:
 | `cupertino fetch --type code` | ZIP files + checkpoint | `~/.cupertino/sample-code/` |
 | `cupertino fetch --type samples` | Git clone (606 projects) | `~/.cupertino/sample-code/cupertino-sample-code/` |
 | `cupertino fetch --type packages` | Package data + checkpoint | `~/.cupertino/packages/` |
+| `cupertino fetch --type availability` | Updates JSON with availability | `~/.cupertino/docs/*.json` |
 | `cupertino save` | Documentation search database | `~/.cupertino/search.db` |
 | `cupertino index` | Sample code search database | `~/.cupertino/samples.db` |
 

--- a/docs/artifacts/folders/docs/README.md
+++ b/docs/artifacts/folders/docs/README.md
@@ -106,6 +106,33 @@ open ~/.cupertino/docs/swiftui/view/index.md
 cupertino fetch --type docs --output-dir ./my-apple-docs
 ```
 
+## Availability Data
+
+After running `cupertino fetch --type availability`, JSON files are updated with platform availability:
+
+```json
+{
+  "title": "View",
+  "url": "...",
+  "availability": [
+    {"name": "iOS", "introducedAt": "13.0", "deprecated": false, "beta": false},
+    {"name": "macOS", "introducedAt": "10.15", "deprecated": false, "beta": false}
+  ]
+}
+```
+
+This enables:
+- Filtering search results by minimum OS version
+- Identifying deprecated APIs
+- Tracking platform support
+
+**Recommended workflow:**
+```bash
+cupertino fetch --type docs         # Fetch documentation
+cupertino fetch --type availability # Add availability data
+cupertino save                       # Build search index
+```
+
 ## Notes
 
 - Framework folders match URL structure

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -45,6 +45,7 @@ cupertino serve
 cupertino search "SwiftUI View" --limit 10
 cupertino search "async" --source swift-evolution
 cupertino search "Core Animation" --include-archive
+cupertino search "Observable" --min-ios 17.0  # Filter by iOS version
 
 # Read full document
 cupertino read "apple-docs://swiftui/documentation_swiftui_view" --format markdown
@@ -83,10 +84,13 @@ cupertino fetch --type evolution
 cupertino fetch --type hig       # Human Interface Guidelines
 cupertino fetch --type archive   # Legacy programming guides
 
-# 2. Build search index
+# 2. Fetch availability data (adds iOS/macOS version info)
+cupertino fetch --type availability
+
+# 3. Build search index
 cupertino save
 
-# 3. Start server or use CLI
+# 4. Start server or use CLI
 cupertino serve  # For MCP/AI agents
 cupertino search "your query"  # For CLI usage
 ```

--- a/docs/commands/fetch/option (--)/type (=value)/availability.md
+++ b/docs/commands/fetch/option (--)/type (=value)/availability.md
@@ -1,0 +1,189 @@
+# --type availability
+
+Fetch platform availability data for Apple documentation
+
+## Synopsis
+
+```bash
+cupertino fetch --type availability
+```
+
+## Description
+
+Fetches platform availability information (minimum iOS, macOS, tvOS, watchOS, visionOS versions) for all Apple documentation. This data is used to enable filtering search results by OS version.
+
+**Important:** Run this before `cupertino save` to ensure sample-code and apple-archive get availability data (they derive it from framework docs).
+
+## Data Source
+
+**Apple Tutorials API** - `https://developer.apple.com/tutorials/data/documentation/{path}.json`
+
+Returns platform metadata for each documentation page including:
+- Minimum supported version per platform
+- Deprecation status
+- Beta status
+
+## Output
+
+Updates existing JSON files in `~/.cupertino/docs/` with an `availability` array:
+
+```json
+{
+  "title": "View",
+  "url": "...",
+  "availability": [
+    {"name": "iOS", "introducedAt": "13.0", "deprecated": false, "beta": false},
+    {"name": "macOS", "introducedAt": "10.15", "deprecated": false, "beta": false},
+    {"name": "tvOS", "introducedAt": "13.0", "deprecated": false, "beta": false},
+    {"name": "watchOS", "introducedAt": "6.0", "deprecated": false, "beta": false},
+    {"name": "visionOS", "introducedAt": "1.0", "deprecated": false, "beta": false}
+  ]
+}
+```
+
+## Default Settings
+
+| Setting | Value |
+|---------|-------|
+| Input Directory | `~/.cupertino/docs` |
+| Concurrent Requests | 50 |
+| Request Timeout | 1 second |
+| Method | Direct API fetch |
+| Authentication | Not required |
+
+## Options
+
+### --force
+
+Re-fetch availability for all documents, even those that already have data.
+
+```bash
+cupertino fetch --type availability --force
+```
+
+### --fast
+
+Use aggressive settings for faster fetching:
+- 100 concurrent requests
+- 0.5 second timeout
+- Skips documents that already have availability
+
+```bash
+cupertino fetch --type availability --fast
+```
+
+### Combined
+
+```bash
+cupertino fetch --type availability --force --fast
+```
+
+## Fallback Strategy
+
+When the API returns 404 or times out, availability is derived using fallbacks:
+
+1. **Parent Document** - Inherit from parent documentation page
+2. **Framework** - Use framework's root availability
+3. **Referenced APIs** - For articles, derive from APIs mentioned in content
+4. **Empty Marker** - Mark as checked but no availability found
+
+## Examples
+
+### Initial Fetch
+
+```bash
+# First, fetch docs
+cupertino fetch --type docs
+
+# Then, fetch availability
+cupertino fetch --type availability
+
+# Finally, build index with availability
+cupertino save
+```
+
+### Update Availability Only
+
+```bash
+cupertino fetch --type availability --force
+cupertino save
+```
+
+### Fast Mode for Large Datasets
+
+```bash
+cupertino fetch --type availability --fast
+```
+
+## Performance
+
+| Metric | Default | Fast Mode |
+|--------|---------|-----------|
+| Concurrent requests | 50 | 100 |
+| Timeout | 1s | 0.5s |
+| Estimated time | 30-60 min | 15-30 min |
+| Success rate | ~92% | ~85% |
+
+## Statistics
+
+After fetching, shows statistics:
+
+```
+Availability fetch complete:
+   Total documents: 233,462
+   Updated: 145,312
+   Successful fetches: 140,000
+   Failed fetches: 5,312
+   Inherited from parent: 50,000
+   Derived from references: 30,000
+   Frameworks processed: 250
+   Duration: 45:23
+   Success rate: 92.5%
+```
+
+## Availability Sources
+
+When availability is indexed, the source is tracked:
+
+| Source | Description |
+|--------|-------------|
+| `api` | Direct from Apple's API |
+| `parent` | Inherited from parent document |
+| `framework` | Inherited from framework root |
+| `references` | Derived from referenced APIs (articles) |
+| `empty` | Checked but none found |
+
+## Dependencies
+
+**Requires docs to be fetched first:**
+
+```bash
+cupertino fetch --type docs   # Must run first
+cupertino fetch --type availability
+```
+
+**Other sources derive availability during indexing:**
+
+| Source | Derives From |
+|--------|--------------|
+| sample-code | Framework docs |
+| apple-archive | Framework docs |
+| swift-evolution | Swift version in status |
+| swift-book | Universal (all platforms) |
+| hig | Universal (all platforms) |
+
+## Use Cases
+
+- Filter search results by minimum iOS/macOS version
+- Identify deprecated APIs
+- Find beta APIs
+- Target specific OS versions for development
+- Track API availability across platforms
+
+## Notes
+
+- Only updates `~/.cupertino/docs/` (apple-docs source)
+- Other sources get availability during `cupertino save`
+- ~5% of URLs return 404 (internal/deprecated APIs)
+- Collection pages have no platforms (expected)
+- Run before `save` for best results

--- a/docs/commands/fetch/option (--)/type.md
+++ b/docs/commands/fetch/option (--)/type.md
@@ -25,6 +25,7 @@ Specifies which documentation source to fetch. Each type targets a different dat
 | `samples` | Apple sample code (from GitHub, recommended) |
 | `archive` | Apple Archive legacy programming guides |
 | `hig` | Human Interface Guidelines |
+| `availability` | Platform availability data for docs |
 | `all` | All types in parallel |
 
 ## Default
@@ -60,6 +61,7 @@ cupertino fetch --type all
 - samples - Apple sample code (from GitHub)
 - [archive](type%20(=value)/archive.md) - Apple Archive legacy guides
 - [hig](type%20(=value)/hig.md) - Human Interface Guidelines
+- [availability](type%20(=value)/availability.md) - Platform availability data
 - [all](type%20(=value)/all.md) - All documentation types
 
 ## Notes

--- a/docs/commands/search/README.md
+++ b/docs/commands/search/README.md
@@ -98,6 +98,76 @@ cupertino search "Array" --limit 5
 cupertino search "SwiftUI" --limit 50
 ```
 
+### --min-ios
+
+Filter results to APIs available on a specific iOS version or earlier.
+
+**Type:** String (version number, e.g., `13.0`, `15.0`, `17.0`)
+
+Only returns documents that have availability data and were introduced at or before the specified version.
+
+**Example:**
+```bash
+cupertino search "Combine" --min-ios 13.0
+cupertino search "Observable" --min-ios 17.0 --framework swiftui
+```
+
+### --min-macos
+
+Filter results to APIs available on a specific macOS version or earlier.
+
+**Type:** String (version number, e.g., `10.15`, `12.0`, `14.0`)
+
+Only returns documents that have availability data and were introduced at or before the specified version.
+
+**Example:**
+```bash
+cupertino search "Combine" --min-macos 10.15
+cupertino search "SwiftData" --min-macos 14.0
+```
+
+### --min-tvos
+
+Filter results to APIs available on a specific tvOS version or earlier.
+
+**Type:** String (version number, e.g., `13.0`, `15.0`, `17.0`)
+
+Only returns documents that have availability data and were introduced at or before the specified version.
+
+**Example:**
+```bash
+cupertino search "animation" --min-tvos 13.0
+cupertino search "player" --min-tvos 15.0 --framework avfoundation
+```
+
+### --min-watchos
+
+Filter results to APIs available on a specific watchOS version or earlier.
+
+**Type:** String (version number, e.g., `6.0`, `8.0`, `10.0`)
+
+Only returns documents that have availability data and were introduced at or before the specified version.
+
+**Example:**
+```bash
+cupertino search "health" --min-watchos 6.0
+cupertino search "workout" --min-watchos 8.0 --framework healthkit
+```
+
+### --min-visionos
+
+Filter results to APIs available on a specific visionOS version or earlier.
+
+**Type:** String (version number, e.g., `1.0`, `2.0`)
+
+Only returns documents that have availability data and were introduced at or before the specified version.
+
+**Example:**
+```bash
+cupertino search "immersive" --min-visionos 1.0
+cupertino search "spatial" --min-visionos 1.0 --framework realitykit
+```
+
 ### --search-db
 
 Path to the search database file.

--- a/docs/commands/search/option (--)/min-ios.md
+++ b/docs/commands/search/option (--)/min-ios.md
@@ -1,0 +1,59 @@
+# --min-ios
+
+Filter search results to APIs available on a specific iOS version or earlier.
+
+## Synopsis
+
+```bash
+cupertino search <query> --min-ios <version>
+```
+
+## Description
+
+Filters search results to only include APIs that were introduced at or before the specified iOS version. This is useful when you need to find APIs compatible with a specific iOS deployment target.
+
+Only returns documents that have availability data. Documents without availability information are excluded from filtered results.
+
+## Values
+
+Version string in `MAJOR.MINOR` format:
+
+- `13.0` - iOS 13.0+
+- `14.0` - iOS 14.0+
+- `15.0` - iOS 15.0+
+- `16.0` - iOS 16.0+
+- `17.0` - iOS 17.0+
+- `18.0` - iOS 18.0+
+
+## Examples
+
+### Find APIs available on iOS 13+
+
+```bash
+cupertino search "Combine" --min-ios 13.0
+```
+
+### Find SwiftUI APIs available on iOS 17+
+
+```bash
+cupertino search "Observable" --min-ios 17.0 --framework swiftui
+```
+
+### Combined with macOS filter
+
+```bash
+cupertino search "async await" --min-ios 15.0 --min-macos 12.0
+```
+
+## Notes
+
+- Only documents with availability data are included in filtered results
+- The filter checks if the API was **introduced** at or before the version (not deprecated)
+- Use with `--framework` for more precise results
+- Availability data comes from `cupertino fetch --type availability`
+
+## See Also
+
+- [min-macos](min-macos.md) - Filter by macOS version
+- [framework](framework.md) - Filter by framework
+- [source](source.md) - Filter by documentation source

--- a/docs/commands/search/option (--)/min-macos.md
+++ b/docs/commands/search/option (--)/min-macos.md
@@ -1,0 +1,59 @@
+# --min-macos
+
+Filter search results to APIs available on a specific macOS version or earlier.
+
+## Synopsis
+
+```bash
+cupertino search <query> --min-macos <version>
+```
+
+## Description
+
+Filters search results to only include APIs that were introduced at or before the specified macOS version. This is useful when you need to find APIs compatible with a specific macOS deployment target.
+
+Only returns documents that have availability data. Documents without availability information are excluded from filtered results.
+
+## Values
+
+Version string in `MAJOR.MINOR` format:
+
+- `10.15` - macOS Catalina+
+- `11.0` - macOS Big Sur+
+- `12.0` - macOS Monterey+
+- `13.0` - macOS Ventura+
+- `14.0` - macOS Sonoma+
+- `15.0` - macOS Sequoia+
+
+## Examples
+
+### Find APIs available on macOS Catalina+
+
+```bash
+cupertino search "Combine" --min-macos 10.15
+```
+
+### Find SwiftData APIs (macOS 14+)
+
+```bash
+cupertino search "SwiftData" --min-macos 14.0
+```
+
+### Combined with iOS filter
+
+```bash
+cupertino search "async await" --min-ios 15.0 --min-macos 12.0
+```
+
+## Notes
+
+- Only documents with availability data are included in filtered results
+- The filter checks if the API was **introduced** at or before the version (not deprecated)
+- Use with `--framework` for more precise results
+- Availability data comes from `cupertino fetch --type availability`
+
+## See Also
+
+- [min-ios](min-ios.md) - Filter by iOS version
+- [framework](framework.md) - Filter by framework
+- [source](source.md) - Filter by documentation source

--- a/docs/commands/search/option (--)/min-tvos.md
+++ b/docs/commands/search/option (--)/min-tvos.md
@@ -1,0 +1,52 @@
+# --min-tvos
+
+Filter search results to APIs available on or before a specific tvOS version.
+
+## Usage
+
+```bash
+cupertino search "animation" --min-tvos 13.0
+```
+
+## Description
+
+The `--min-tvos` option filters search results to only show documentation for APIs that were introduced in the specified tvOS version or earlier. This is useful when developing for older tvOS versions and you need to ensure API compatibility.
+
+## Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `VERSION` | String | Yes | tvOS version number (e.g., "13.0", "15.0") |
+
+## Examples
+
+```bash
+# Find APIs available on tvOS 13.0 or earlier
+cupertino search "animation" --min-tvos 13.0
+
+# Combine with framework filter
+cupertino search "player" --framework avfoundation --min-tvos 15.0
+
+# Combine with multiple platform filters
+cupertino search "view" --min-ios 15.0 --min-tvos 15.0
+```
+
+## MCP Tool Usage
+
+When using via MCP, use the `min_tvos` parameter:
+
+```json
+{
+  "name": "search_docs",
+  "arguments": {
+    "query": "animation",
+    "min_tvos": "13.0"
+  }
+}
+```
+
+## Notes
+
+- Results without tvOS availability information are excluded when this filter is active
+- Version comparison is semantic (e.g., "13.0" < "13.1" < "14.0")
+- Can be combined with other platform filters (`--min-ios`, `--min-macos`, `--min-watchos`, `--min-visionos`)

--- a/docs/commands/search/option (--)/min-visionos.md
+++ b/docs/commands/search/option (--)/min-visionos.md
@@ -1,0 +1,52 @@
+# --min-visionos
+
+Filter search results to APIs available on or before a specific visionOS version.
+
+## Usage
+
+```bash
+cupertino search "immersive" --min-visionos 1.0
+```
+
+## Description
+
+The `--min-visionos` option filters search results to only show documentation for APIs that were introduced in the specified visionOS version or earlier. This is useful when developing for Apple Vision Pro and you need to ensure API compatibility.
+
+## Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `VERSION` | String | Yes | visionOS version number (e.g., "1.0", "2.0") |
+
+## Examples
+
+```bash
+# Find APIs available on visionOS 1.0 (initial release)
+cupertino search "immersive" --min-visionos 1.0
+
+# Combine with framework filter
+cupertino search "spatial" --framework realitykit --min-visionos 1.0
+
+# Combine with multiple platform filters
+cupertino search "view" --min-ios 17.0 --min-visionos 1.0
+```
+
+## MCP Tool Usage
+
+When using via MCP, use the `min_visionos` parameter:
+
+```json
+{
+  "name": "search_docs",
+  "arguments": {
+    "query": "immersive",
+    "min_visionos": "1.0"
+  }
+}
+```
+
+## Notes
+
+- Results without visionOS availability information are excluded when this filter is active
+- visionOS 1.0 was released with Apple Vision Pro in 2024
+- Can be combined with other platform filters (`--min-ios`, `--min-macos`, `--min-tvos`, `--min-watchos`)

--- a/docs/commands/search/option (--)/min-watchos.md
+++ b/docs/commands/search/option (--)/min-watchos.md
@@ -1,0 +1,52 @@
+# --min-watchos
+
+Filter search results to APIs available on or before a specific watchOS version.
+
+## Usage
+
+```bash
+cupertino search "health" --min-watchos 6.0
+```
+
+## Description
+
+The `--min-watchos` option filters search results to only show documentation for APIs that were introduced in the specified watchOS version or earlier. This is useful when developing for older watchOS versions and you need to ensure API compatibility.
+
+## Arguments
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `VERSION` | String | Yes | watchOS version number (e.g., "6.0", "8.0") |
+
+## Examples
+
+```bash
+# Find APIs available on watchOS 6.0 or earlier
+cupertino search "health" --min-watchos 6.0
+
+# Combine with framework filter
+cupertino search "workout" --framework healthkit --min-watchos 7.0
+
+# Combine with multiple platform filters
+cupertino search "notification" --min-ios 15.0 --min-watchos 8.0
+```
+
+## MCP Tool Usage
+
+When using via MCP, use the `min_watchos` parameter:
+
+```json
+{
+  "name": "search_docs",
+  "arguments": {
+    "query": "health",
+    "min_watchos": "6.0"
+  }
+}
+```
+
+## Notes
+
+- Results without watchOS availability information are excluded when this filter is active
+- Version comparison is semantic (e.g., "6.0" < "6.2" < "7.0")
+- Can be combined with other platform filters (`--min-ios`, `--min-macos`, `--min-tvos`, `--min-visionos`)

--- a/docs/tools/search_docs/README.md
+++ b/docs/tools/search_docs/README.md
@@ -11,6 +11,7 @@ Full-text search across all indexed documentation.
     "query": "Actors Swift concurrency",
     "source": "apple-docs",
     "framework": "swift",
+    "min_ios": "13.0",
     "limit": 10
   }
 }
@@ -83,6 +84,36 @@ Filter results by programming language.
 - `"swift"` - Swift documentation
 - `"objc"` - Objective-C documentation
 
+### min_ios (optional)
+
+Filter to APIs available on the specified iOS version or earlier.
+
+**Type:** String
+
+**Default:** None (no version filtering)
+
+**Examples:**
+- `"13.0"` - APIs available on iOS 13.0+
+- `"15.0"` - APIs available on iOS 15.0+
+- `"17.0"` - APIs available on iOS 17.0+ (e.g., Observable, SwiftData)
+
+**Note:** Only returns documents that have availability data and were introduced at or before the specified version.
+
+### min_macos (optional)
+
+Filter to APIs available on the specified macOS version or earlier.
+
+**Type:** String
+
+**Default:** None (no version filtering)
+
+**Examples:**
+- `"10.15"` - APIs available on macOS Catalina+
+- `"12.0"` - APIs available on macOS Monterey+
+- `"14.0"` - APIs available on macOS Sonoma+
+
+**Note:** Only returns documents that have availability data and were introduced at or before the specified version.
+
 ### limit (optional)
 
 Maximum number of results to return.
@@ -118,6 +149,7 @@ Found **15** results:
 
 - **Framework:** `swift`
 - **URI:** `apple-docs://swift/documentation_swift_actor`
+- **Availability:** iOS 13.0+, macOS 10.15+
 - **Score:** 12.45
 - **Words:** 1,234
 
@@ -135,6 +167,7 @@ A type whose mutable state is protected from concurrent access...
 |-------|-------------|
 | Framework | The framework containing this document |
 | URI | Document identifier for use with `read_document` |
+| Availability | Platform versions (iOS, macOS, etc.) when available |
 | Score | BM25 relevance score (higher = more relevant) |
 | Words | Document word count |
 | Summary | Brief excerpt from the document |
@@ -201,6 +234,35 @@ A type whose mutable state is protected from concurrent access...
 {
   "query": "CALayer",
   "source": "apple-archive"
+}
+```
+
+### Filter by iOS Version
+
+```json
+{
+  "query": "Observable",
+  "min_ios": "17.0"
+}
+```
+
+### Filter by macOS Version
+
+```json
+{
+  "query": "SwiftData",
+  "min_macos": "14.0"
+}
+```
+
+### Combined Version Filter
+
+```json
+{
+  "query": "async await",
+  "framework": "swift",
+  "min_ios": "15.0",
+  "min_macos": "12.0"
 }
 ```
 


### PR DESCRIPTION
  - Add platform availability filtering for all 5 Apple platforms (iOS, macOS, tvOS, watchOS, visionOS)
  - Implement `cupertino fetch --type availability` to fetch API availability data from Apple's documentation API
  - Add `--min-ios`, `--min-macos`, `--min-tvos`, `--min-watchos`, `--min-visionos` filters to CLI search and MCP tools