### PR TITLE
reduced unknown number

### DIFF
--- a/Packages/Sources/Shared/Models.swift
+++ b/Packages/Sources/Shared/Models.swift
@@ -395,18 +395,18 @@ public struct StructuredDocumentationPage: Codable, Sendable, Identifiable, Hash
             return .macro
         }
 
-        // Type declarations
-        if decl.hasPrefix("protocol ") { return .protocol }
-        if decl.hasPrefix("struct ") { return .struct }
-        if decl.hasPrefix("class ") { return .class }
-        if decl.hasPrefix("enum ") { return .enum }
-        if decl.hasPrefix("actor ") { return .class } // actors are class-like
+        // Type declarations (handle modifiers like public, final, open, etc.)
+        if decl.hasPrefix("protocol ") || decl.contains(" protocol ") { return .protocol }
+        if decl.hasPrefix("struct ") || decl.contains(" struct ") { return .struct }
+        if decl.hasPrefix("class ") || decl.contains(" class ") { return .class }
+        if decl.hasPrefix("enum ") || decl.contains(" enum ") { return .enum }
+        if decl.hasPrefix("actor ") || decl.contains(" actor ") { return .class } // actors are class-like
 
         // Enum cases (often appear as separate docs)
-        if decl.hasPrefix("case ") { return .enum }
+        if decl.hasPrefix("case ") || decl.contains(" case ") { return .enum }
 
         // Associated types (protocol requirements)
-        if decl.hasPrefix("associatedtype ") { return .typeAlias }
+        if decl.hasPrefix("associatedtype ") || decl.contains(" associatedtype ") { return .typeAlias }
 
         // Properties (var/let) - including static
         if decl.hasPrefix("var ") || decl.hasPrefix("let ") { return .property }
@@ -419,18 +419,23 @@ public struct StructuredDocumentationPage: Codable, Sendable, Identifiable, Hash
 
         // Methods and initializers
         if decl.hasPrefix("func ") || decl.contains(" func ") { return .method }
-        if decl.hasPrefix("init(") || decl.contains(" init(") || decl.contains(" init<") { return .method }
+        // Initializers: init(, init?(, init!(, init<T>
+        if decl.hasPrefix("init(") || decl.hasPrefix("init?") || decl.hasPrefix("init!") || decl.hasPrefix("init<") { return .method }
+        if decl.contains(" init(") || decl.contains(" init?") || decl.contains(" init!") || decl.contains(" init<") { return .method }
         if decl.hasPrefix("deinit") { return .method }
         if decl.hasPrefix("static func ") || decl.hasPrefix("class func ") { return .method }
 
-        // Type aliases
-        if decl.hasPrefix("typealias ") { return .typeAlias }
+        // REST API types (OpenAPI object declarations)
+        if decl.hasPrefix("object ") { return .struct }
+
+        // Type aliases (can have public/internal modifiers)
+        if decl.hasPrefix("typealias ") || decl.contains(" typealias ") { return .typeAlias }
 
         // Operators
         if decl.hasPrefix("operator ") || decl.contains(" operator ") { return .operator }
-        if decl.hasPrefix("prefix ") || decl.hasPrefix("postfix ") || decl.hasPrefix("infix ") {
-            return .operator
-        }
+        if decl.hasPrefix("prefix ") || decl.contains(" prefix ") { return .operator }
+        if decl.hasPrefix("postfix ") || decl.contains(" postfix ") { return .operator }
+        if decl.hasPrefix("infix ") || decl.contains(" infix ") { return .operator }
 
         // Still unknown after all heuristics
         return .unknown

--- a/Packages/Tests/SharedTests/ModelsTests.swift
+++ b/Packages/Tests/SharedTests/ModelsTests.swift
@@ -426,3 +426,189 @@ func structuredPageInferredKindPreservesExisting() {
     // Should preserve original .method, not infer .struct
     #expect(page.inferredKind == Kind.method)
 }
+
+// MARK: - Modifier Prefix Handling Tests
+
+@Test("StructuredDocumentationPage inferredKind detects public struct")
+func structuredPageInferredKindPublicStruct() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "MyStruct",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "public struct MyStruct"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.struct)
+}
+
+@Test("StructuredDocumentationPage inferredKind detects final class")
+func structuredPageInferredKindFinalClass() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "FinalClass",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "final class FinalClass"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.class)
+}
+
+@Test("StructuredDocumentationPage inferredKind detects open class")
+func structuredPageInferredKindOpenClass() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "OpenClass",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "open class OpenClass"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.class)
+}
+
+@Test("StructuredDocumentationPage inferredKind detects nonisolated func")
+func structuredPageInferredKindNonisolatedFunc() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "doWork",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "nonisolated func doWork()"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.method)
+}
+
+@Test("StructuredDocumentationPage inferredKind detects public actor")
+func structuredPageInferredKindPublicActor() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "MyActor",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "public actor MyActor"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.class)
+}
+
+@Test("StructuredDocumentationPage inferredKind detects public typealias")
+func structuredPageInferredKindPublicTypealias() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "Handler",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "public typealias Handler = () -> Void"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.typeAlias)
+}
+
+@Test("StructuredDocumentationPage inferredKind detects indirect enum")
+func structuredPageInferredKindIndirectEnum() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "Tree",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "indirect enum Tree<T>"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.enum)
+}
+
+// MARK: - Failable/Generic Initializer Tests
+
+@Test("StructuredDocumentationPage inferredKind detects failable init?")
+func structuredPageInferredKindFailableInit() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "init(mimeType:conformingTo:)",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "init?(mimeType: String, conformingTo supertype: UTType = .data)"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.method)
+}
+
+@Test("StructuredDocumentationPage inferredKind detects implicitly unwrapped init!")
+func structuredPageInferredKindIUOInit() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "init(contentURL:)",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "init!(contentURL url: URL!)"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.method)
+}
+
+@Test("StructuredDocumentationPage inferredKind detects generic init<T>")
+func structuredPageInferredKindGenericInit() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "init(controlPoints:creationDate:)",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "init<T>(controlPoints: T, creationDate: Date) where T : Sequence"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.method)
+}
+
+@Test("StructuredDocumentationPage inferredKind detects convenience init?")
+func structuredPageInferredKindConvenienceFailableInit() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "init(mimeType:)",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "convenience init?(mimeType: String)"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.method)
+}
+
+// MARK: - REST API Types
+
+@Test("StructuredDocumentationPage inferredKind detects object as struct")
+func structuredPageInferredKindObject() {
+    let page = Page(
+        url: URL(string: "https://example.com")!,
+        title: "ErrorResponse",
+        kind: .unknown,
+        source: .appleJSON,
+        declaration: Page.Declaration(
+            code: "object ErrorResponse"
+        )
+    )
+
+    #expect(page.inferredKind == Kind.struct)
+}


### PR DESCRIPTION
## Summary

  - Improved kind inference for declarations with modifier prefixes (`public`, `final`, `open`, `nonisolated`, `indirect`)
  - Added support for failable/generic initializers (`init?`, `init!`, `init<T>`)
  - Classified REST API `object` declarations as structs

  ## Results

  | Metric | Before | After | Change |
  |--------|--------|-------|--------|
  | Unknown docs | 12,536 | 3,881 | **-69%** |

  ## Test plan

  - [x] Added 12 new tests for modifier and initializer patterns
  - [x] All 645 tests passing

  Closes #87