### PR TITLE
docs: add CONTRIBUTING.md with Swift-only policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to Cupertino
+
+Thank you for your interest in contributing to Cupertino!
+
+## Swift Native
+
+**Cupertino is a Swift-native project. This is a priority and a prerogative.**
+
+Many MCP servers are written in Node.js or Python. Cupertino takes a different path — we're built for Apple developers, using Apple's language, with Apple's tooling.
+
+We will only accept contributions in:
+- ✅ Swift source code
+- ✅ Swift Package Manager for dependencies
+- ✅ Shell scripts for build/install automation
+
+We will **not** accept:
+- ❌ Node.js / JavaScript / TypeScript
+- ❌ Python
+- ❌ Other languages or runtimes
+
+**No exceptions.** If you can't solve something in Swift, someone else can.
+
+This keeps the project lean, consistent, and true to its mission.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork locally
+3. Create a feature branch: `git checkout -b feature/your-feature`
+4. Make your changes
+5. Test your changes thoroughly
+6. Commit with clear messages
+7. Push to your fork
+8. Open a Pull Request
+
+## Code Style
+
+- Follow Swift conventions and best practices
+- Use meaningful variable and function names
+- Add documentation comments for public APIs
+- Keep functions focused and concise
+
+## Pull Requests
+
+- Keep PRs focused on a single change
+- Write a clear description of what your PR does
+- Reference any related issues
+- Be responsive to feedback
+
+## Questions?
+
+Open an issue if you have questions or need guidance.


### PR DESCRIPTION
## Summary
Closes #90

Added a CONTRIBUTING.md file that clearly states Cupertino's Swift-native philosophy.

## Contents
- Swift-native policy statement
- Accepted contribution types (Swift, SPM, shell scripts)
- Explicitly rejected contribution types (Node.js, Python, etc.)
- Getting started guide
- Code style guidelines
- PR guidelines

## Motivation
As the project grows, this helps set clear expectations for potential contributors about the project's Swift-native philosophy.