### PR TITLE
fix: Show informative message in doctor when using pre-built database

### DIFF
--- a/Packages/Sources/CLI/Commands/DoctorCommand.swift
+++ b/Packages/Sources/CLI/Commands/DoctorCommand.swift
@@ -80,6 +80,7 @@ struct DoctorCommand: AsyncParsableCommand {
         let docsURL = URL(fileURLWithPath: docsDir).expandingTildeInPath
         let evolutionURL = URL(fileURLWithPath: evolutionDir).expandingTildeInPath
         let higURL = Shared.Constants.defaultHIGDirectory
+        let searchDBURL = URL(fileURLWithPath: searchDB).expandingTildeInPath
 
         var hasIssues = false
 
@@ -88,7 +89,18 @@ struct DoctorCommand: AsyncParsableCommand {
         // Check docs directory
         if FileManager.default.fileExists(atPath: docsURL.path) {
             let count = countMarkdownFiles(in: docsURL)
-            Log.output("   ✓ Apple docs: \(docsURL.path) (\(count) files)")
+            if count == 0 && FileManager.default.fileExists(atPath: searchDBURL.path) {
+                // Docs folder exists but is empty, and we have a database - likely using setup command
+                Log.output("   ✓ Apple docs: using pre-built database")
+            } else if count > 0 {
+                Log.output("   ✓ Apple docs: \(docsURL.path) (\(count) files)")
+            } else {
+                Log.output("   ⚠  Apple docs: \(docsURL.path) (0 files)")
+                Log.output("     → Run: cupertino fetch --type docs")
+            }
+        } else if FileManager.default.fileExists(atPath: searchDBURL.path) {
+            // No docs folder but database exists - using pre-built database from setup
+            Log.output("   ✓ Apple docs: using pre-built database")
         } else {
             Log.output("   ✗ Apple docs: \(docsURL.path) (not found)")
             Log.output("     → Run: cupertino fetch --type docs")


### PR DESCRIPTION
## Summary

Implements #68

When users run `cupertino setup` to download the pre-built database directly, the doctor command would show `0 files` for Apple docs which could confuse users:

```
📚 Documentation Directories
   ✓ Apple docs: /Users/mmj/.cupertino/docs (0 files)
```

This is actually expected behavior since `setup` downloads the pre-built database without storing raw documentation files.

## Changes

Updated `checkDocumentationDirectories()` in `DoctorCommand.swift` to detect when the pre-built database is being used:

1. If docs folder has 0 files AND search database exists → "using pre-built database"
2. If docs folder doesn't exist AND search database exists → "using pre-built database"
3. Otherwise, show the normal file count or warning

## Before

```
📚 Documentation Directories
   ✓ Apple docs: /Users/mmj/.cupertino/docs (0 files)
```

## After

```
📚 Documentation Directories
   ✓ Apple docs: using pre-built database
```

This makes it clear to users that the setup is working correctly even without raw documentation files.