### PR TITLE
Add agent skill for stateless CLI usage

### DIFF
--- a/.claude/skills/cupertino/SKILL.md
+++ b/.claude/skills/cupertino/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: cupertino
+description: Search and read Apple developer documentation including SwiftUI, UIKit, Foundation, and 300+ frameworks. Use when the user asks about Apple APIs, iOS/macOS development, Swift syntax, or needs to look up Apple documentation.
+license: MIT
+compatibility: Requires macOS 13+, pre-built database via 'cupertino setup'
+metadata:
+  author: mihaelamj
+  version: "1.0"
+allowed-tools: Bash(cupertino:*)
+---
+
+# Cupertino - Apple Documentation Search
+
+Search 300,000+ Apple developer documentation pages offline.
+
+## Setup
+
+First-time setup (downloads ~2.4GB database):
+```bash
+cupertino setup
+```
+
+## Commands
+
+### Search Documentation
+Search across all sources (apple-docs, samples, hig, swift-evolution, swift-org, swift-book, packages):
+```bash
+cupertino search "SwiftUI View" --format json
+```
+
+Filter by source:
+```bash
+cupertino search "async await" --source swift-evolution --format json
+cupertino search "NavigationStack" --source apple-docs --format json
+cupertino search "button styles" --source samples --format json
+cupertino search "button guidelines" --source hig --format json
+```
+
+Filter by framework:
+```bash
+cupertino search "@Observable" --framework swiftui --format json
+```
+
+### Read a Document
+Retrieve full document content by URI:
+```bash
+cupertino read "apple-docs://swiftui/documentation_swiftui_view" --format json
+cupertino read "apple-docs://swiftui/documentation_swiftui_view" --format markdown
+```
+
+### List Frameworks
+List all indexed frameworks with document counts:
+```bash
+cupertino list-frameworks --format json
+```
+
+### List Sample Projects
+Browse indexed Apple sample code projects:
+```bash
+cupertino list-samples --format json
+cupertino list-samples --framework swiftui --format json
+```
+
+### Read Sample Code
+Read a sample project or specific file:
+```bash
+cupertino read-sample "foodtrucksampleapp" --format json
+cupertino read-sample-file "foodtrucksampleapp" "FoodTruckApp.swift" --format json
+```
+
+## Sources
+
+| Source | Description |
+|--------|-------------|
+| `apple-docs` | Official Apple documentation (301,000+ pages) |
+| `swift-evolution` | Swift Evolution proposals |
+| `hig` | Human Interface Guidelines |
+| `samples` | Apple sample code projects |
+| `swift-org` | Swift.org documentation |
+| `swift-book` | The Swift Programming Language book |
+| `apple-archive` | Legacy guides (Core Animation, Quartz 2D, KVO/KVC) |
+| `packages` | Swift package documentation |
+
+## Output Formats
+
+All commands support `--format` with these options:
+- `text` - Human-readable output (default for most commands)
+- `json` - Structured JSON for parsing
+- `markdown` - Formatted markdown
+
+## Example JSON Output
+
+```json
+{
+  "results": [
+    {
+      "uri": "apple-docs://swiftui/documentation_swiftui_vstack",
+      "title": "VStack",
+      "framework": "SwiftUI",
+      "summary": "A view that arranges its children vertically",
+      "source": "apple-docs"
+    }
+  ],
+  "count": 1,
+  "query": "VStack"
+}
+```
+
+## Tips
+
+- Use `--source` to narrow searches to a specific documentation source
+- Use `--framework` to filter by framework (e.g., swiftui, foundation, uikit)
+- Use `--limit` to control the number of results returned
+- URIs from search results can be used directly with `cupertino read`

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,8 @@ fastlane/test_output
 # Custom folders used in ExtremePackaging
 Stage/
 Tasks/.build/
-.claude/
+.claude/*
+!.claude/skills/
 
 # Build artefacts (global)
 Build/

--- a/README.md
+++ b/README.md
@@ -278,6 +278,90 @@ Add to `opencode.jsonc`:
 
 > **Note:** All examples use `/opt/homebrew/bin/cupertino` (Homebrew on Apple Silicon). Use `/usr/local/bin/cupertino` for Intel Macs or manual installs. Run `which cupertino` to find your path.
 
+### Use as an Agent Skill (No Server Required)
+
+Cupertino can also be used as a stateless CLI skill without running an MCP server. This is useful for agents that support the [Agent Skills](https://agentskills.io) specification.
+
+**Prerequisites:**
+
+Install cupertino and download the databases first:
+```bash
+# Install via Homebrew or from source (see Installation above)
+cupertino setup
+```
+
+**Option A: Install with OpenSkills (Recommended)**
+
+[OpenSkills](https://github.com/numman-ali/openskills) is a universal skills loader that works with Claude Code, Cursor, Windsurf, Aider, and other AI coding agents.
+
+```bash
+# Install the cupertino skill from GitHub
+npx openskills install mihaelamj/cupertino
+
+# Sync to update AGENTS.md
+npx openskills sync
+```
+
+For global installation (available in all projects):
+```bash
+npx openskills install mihaelamj/cupertino --global
+```
+
+For multi-agent setups (installs to `.agent/skills/` instead of `.claude/skills/`):
+```bash
+npx openskills install mihaelamj/cupertino --universal
+```
+
+**Option B: Manual Installation**
+
+Copy the skill definition to your project or global skills directory:
+```bash
+# Clone this repo
+git clone https://github.com/mihaelamj/cupertino.git
+
+# For a single project
+mkdir -p .claude/skills/cupertino
+cp cupertino/.claude/skills/cupertino/SKILL.md .claude/skills/cupertino/
+
+# Or for global use with Claude Code
+mkdir -p ~/.claude/skills/cupertino
+cp cupertino/.claude/skills/cupertino/SKILL.md ~/.claude/skills/cupertino/
+```
+
+**How It Works:**
+
+The skill uses the CLI directly with JSON output, no server process needed:
+
+```bash
+# Search documentation
+cupertino search "SwiftUI View" --format json
+
+# Filter by source
+cupertino search "NavigationStack" --source apple-docs --format json
+cupertino search "button styles" --source samples --format json
+
+# Read a document
+cupertino read "apple-docs://swiftui/documentation_swiftui_view" --format json
+
+# List frameworks
+cupertino list-frameworks --format json
+
+# List sample projects
+cupertino list-samples --framework swiftui --format json
+```
+
+All commands support `--format json` for structured output that agents can parse.
+
+**Available Sources:**
+- `apple-docs` - Official Apple documentation (301,000+ pages)
+- `samples` - Apple sample code projects
+- `hig` - Human Interface Guidelines
+- `swift-evolution` - Swift Evolution proposals
+- `swift-org` - Swift.org documentation
+- `swift-book` - The Swift Programming Language book
+- `apple-archive` - Legacy programming guides
+- `packages` - Swift package documentation
+
 ### What You Get
 
 Once configured, Claude Desktop can search your local documentation:


### PR DESCRIPTION
## Summary

Adds support for using Cupertino as a stateless [Agent Skill](https://agentskills.io) — no MCP server required. AI coding agents get direct access to Apple documentation search via CLI commands with JSON output.

- Adds `.claude/skills/cupertino/SKILL.md` skill definition
- Adds "Use as an Agent Skill" section to README with installation instructions
- Updates `.gitignore` to allow `.claude/skills/` through

No changes to existing MCP functionality.

Closes #166