### PR TITLE
fix: crawler session resume, complete framework coverage, and synonyms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@
 
 ---
 
+## 0.10.0 (2026-03-13)
+
+### Added
+- Framework synonyms: search using common alternate names (e.g., "nfc" → CoreNFC, "bluetooth" → CoreBluetooth, "shareplay" → GroupActivities)
+- Seed framework discovery from Apple's technologies.json for complete coverage
+- Agent skill for stateless CLI usage (#167, thanks @tijs)
+- Database v0.9.0: 320,771 documents across 443 frameworks (+18k docs, +136 frameworks)
+
+### Changed
+- Case-insensitive framework matching across all search functions
+- Reduced default request delay from 0.5s to 0.05s for faster crawling
+
+### Fixed
+- Crawler session resume now validates startURL before resuming
+- Case-insensitive URL prefix matching in shouldVisit
+- Link enqueue before skip check — incremental re-crawls now discover new child pages
+- Case-insensitive framework queries in searchByKind and searchSampleCode
+
 ## 0.9.0 (2025-12-31)
 
 ### Changed

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -88,8 +88,25 @@ extension Core {
                     stats = CrawlStatistics(startTime: startTime)
                 }
 
-                // Initialize queue
-                queue = [(url: configuration.startURL, depth: 0)]
+                // Initialize queue — seed from technologies.json for Apple docs root
+                let isAppleDocs = configuration.startURL.host?.contains("developer.apple.com") == true
+                let isDocsRoot = configuration.startURL.path == "/documentation"
+                    || configuration.startURL.path == "/documentation/"
+
+                if isAppleDocs && isDocsRoot {
+                    do {
+                        logInfo("📋 Fetching technology index for complete framework coverage...")
+                        let frameworkURLs = try await TechnologiesIndexFetcher.fetchFrameworkURLs()
+                        queue = frameworkURLs.map { (url: $0, depth: 0) }
+                        logInfo("   ✅ Seeded queue with \(frameworkURLs.count) framework root URLs")
+                    } catch {
+                        logInfo("   ⚠️ Failed to fetch technology index: \(error.localizedDescription)")
+                        logInfo("   ⚠️ Falling back to start URL only")
+                        queue = [(url: configuration.startURL, depth: 0)]
+                    }
+                } else {
+                    queue = [(url: configuration.startURL, depth: 0)]
+                }
 
                 logInfo("🚀 Starting new crawl")
             }

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -53,29 +53,35 @@ extension Core {
         public func crawl(onProgress: (@Sendable (CrawlProgress) -> Void)? = nil) async throws -> CrawlStatistics {
             self.onProgress = onProgress
 
-            // Check for resumable session
-            let hasActiveSession = await state.hasActiveSession()
-            if hasActiveSession {
+            // Check for resumable session (must match current start URL)
+            let savedSession = await state.getSavedSession()
+            let canResume = savedSession != nil
+                && savedSession!.isActive
+                && savedSession!.startURL == configuration.startURL.absoluteString
+            if canResume, let savedSession {
                 logInfo("🔄 Found resumable session!")
-                if let savedSession = await state.getSavedSession() {
-                    logInfo("   Resuming from \(savedSession.visited.count) visited URLs")
-                    logInfo("   Queue has \(savedSession.queue.count) pending URLs")
+                logInfo("   Resuming from \(savedSession.visited.count) visited URLs")
+                logInfo("   Queue has \(savedSession.queue.count) pending URLs")
 
-                    // Restore state
-                    visited = savedSession.visited
-                    queue = savedSession.queue.compactMap { queued in
-                        guard let url = URL(string: queued.url) else { return nil }
-                        return (url: url, depth: queued.depth)
-                    }
+                // Restore state
+                visited = savedSession.visited
+                queue = savedSession.queue.compactMap { queued in
+                    guard let url = URL(string: queued.url) else { return nil }
+                    return (url: url, depth: queued.depth)
+                }
 
-                    // Restore or initialize stats
-                    await state.updateStatistics { stats in
-                        if stats.startTime == nil {
-                            stats.startTime = savedSession.sessionStartTime
-                        }
+                // Restore or initialize stats
+                await state.updateStatistics { stats in
+                    if stats.startTime == nil {
+                        stats.startTime = savedSession.sessionStartTime
                     }
                 }
             } else {
+                // Clear stale session if start URL doesn't match
+                if savedSession != nil {
+                    logInfo("⚠️ Ignoring saved session (different start URL)")
+                    await state.clearSessionState()
+                }
                 // Initialize stats for new crawl
                 let startTime = Date()
                 await state.updateStatistics { stats in

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -403,9 +403,9 @@ extension Core {
         }
 
         private func shouldVisit(url: URL) -> Bool {
-            // Check if URL starts with allowed prefixes
-            let urlString = url.absoluteString
-            guard configuration.allowedPrefixes.contains(where: { urlString.hasPrefix($0) }) else {
+            // Check if URL starts with allowed prefixes (case-insensitive)
+            let urlString = url.absoluteString.lowercased()
+            guard configuration.allowedPrefixes.contains(where: { urlString.hasPrefix($0.lowercased()) }) else {
                 return false
             }
 

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -277,6 +277,14 @@ extension Core {
                 filePath: jsonFilePath
             )
 
+            // Enqueue discovered links before any early returns
+            // so child pages are always discovered even when content is unchanged
+            if depth < configuration.maxDepth {
+                for link in links where shouldVisit(url: link) {
+                    queue.append((url: link, depth: depth + 1))
+                }
+            }
+
             if !shouldRecrawl {
                 logInfo("   ⏩ No changes detected, skipping")
                 await state.updateStatistics { $0.skippedPages += 1 }
@@ -320,13 +328,6 @@ extension Core {
             }
 
             await state.updateStatistics { $0.totalPages += 1 }
-
-            // Enqueue discovered links
-            if depth < configuration.maxDepth {
-                for link in links where shouldVisit(url: link) {
-                    queue.append((url: link, depth: depth + 1))
-                }
-            }
 
             // Notify progress
             if let onProgress {

--- a/Packages/Sources/Core/TechnologiesIndexFetcher.swift
+++ b/Packages/Sources/Core/TechnologiesIndexFetcher.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Shared
+
+// MARK: - Technologies Index Fetcher
+
+/// Fetches all framework URLs from Apple's technology index (technologies.json)
+/// Used to seed the crawler queue for complete framework coverage.
+/// See: https://github.com/mihaelamj/cupertino/issues/160
+public enum TechnologiesIndexFetcher {
+    private static let indexURL = URL(
+        string: "https://developer.apple.com/tutorials/data/documentation/technologies.json"
+    )!
+
+    /// Fetch all active framework root URLs from Apple's technology index
+    public static func fetchFrameworkURLs() async throws -> [URL] {
+        let (data, response) = try await URLSession.shared.data(from: indexURL)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200
+        else {
+            throw TechnologiesIndexError.fetchFailed
+        }
+
+        return try parseFrameworkURLs(from: data)
+    }
+
+    private static func parseFrameworkURLs(from data: Data) throws -> [URL] {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sections = json["sections"] as? [[String: Any]]
+        else {
+            throw TechnologiesIndexError.invalidFormat
+        }
+
+        var urls: [URL] = []
+
+        for section in sections {
+            if let technologies = section["technologies"] as? [[String: Any]] {
+                urls.append(contentsOf: extractURLs(from: technologies))
+            }
+
+            if let groups = section["groups"] as? [[String: Any]] {
+                for group in groups {
+                    if let technologies = group["technologies"] as? [[String: Any]] {
+                        urls.append(contentsOf: extractURLs(from: technologies))
+                    }
+                }
+            }
+        }
+
+        return urls
+    }
+
+    private static func extractURLs(from technologies: [[String: Any]]) -> [URL] {
+        technologies.compactMap { tech -> URL? in
+            guard let destination = tech["destination"] as? [String: Any],
+                  let identifier = destination["identifier"] as? String,
+                  let isActive = destination["isActive"] as? Bool,
+                  isActive
+            else {
+                return nil
+            }
+
+            return convertIdentifierToURL(identifier)
+        }
+    }
+
+    private static func convertIdentifierToURL(_ identifier: String) -> URL? {
+        guard identifier.hasPrefix("doc://"),
+              let range = identifier.range(of: "/documentation/")
+        else {
+            return nil
+        }
+
+        let path = String(identifier[range.lowerBound...]).lowercased()
+        return URL(string: "https://developer.apple.com\(path)")
+    }
+}
+
+// MARK: - Error Types
+
+public enum TechnologiesIndexError: Error, LocalizedError {
+    case fetchFailed
+    case invalidFormat
+
+    public var errorDescription: String? {
+        switch self {
+        case .fetchFailed: return "Failed to fetch technologies.json"
+        case .invalidFormat: return "Invalid technologies.json format"
+        }
+    }
+}

--- a/Packages/Sources/Search/SearchIndex.swift
+++ b/Packages/Sources/Search/SearchIndex.swift
@@ -27,7 +27,7 @@ extension Search {
         /// - 7: Previous version
         /// - 8: Added attributes column to docs_structured for @attribute indexing
         /// - 9: Added doc_symbols, doc_imports tables for SwiftSyntax AST indexing (#81)
-        public static let schemaVersion: Int32 = 9
+        public static let schemaVersion: Int32 = 10
 
         private var database: OpaquePointer?
         private let dbPath: URL
@@ -165,6 +165,25 @@ extension Search {
 
             // Version 8 -> 9: New tables created with IF NOT EXISTS in createTables()
             // No explicit migration needed for doc_symbols, doc_symbols_fts, doc_imports
+
+            if currentVersion < 10 {
+                // Version 9 -> 10: Added synonyms column to framework_aliases
+                try await migrateToVersion10()
+            }
+        }
+
+        private func migrateToVersion10() async throws {
+            guard let database else {
+                throw SearchError.databaseNotInitialized
+            }
+
+            let sql = "ALTER TABLE framework_aliases ADD COLUMN synonyms TEXT;"
+
+            var errorPointer: UnsafeMutablePointer<CChar>?
+            defer { sqlite3_free(errorPointer) }
+
+            // Ignore error if column already exists
+            sqlite3_exec(database, sql, nil, nil, &errorPointer)
         }
 
         private func migrateToVersion7() async throws {
@@ -344,10 +363,12 @@ extension Search {
             -- identifier: appintents (lowercase, URL path, folder name)
             -- import_name: AppIntents (CamelCase, Swift import statement)
             -- display_name: App Intents (human-readable, from JSON module field)
+            -- synonyms: comma-separated alternate names (e.g., "nfc" for corenfc)
             CREATE TABLE IF NOT EXISTS framework_aliases (
                 identifier TEXT PRIMARY KEY,
                 import_name TEXT NOT NULL,
-                display_name TEXT NOT NULL
+                display_name TEXT NOT NULL,
+                synonyms TEXT
             );
 
             CREATE INDEX IF NOT EXISTS idx_alias_import ON framework_aliases(import_name);
@@ -3471,6 +3492,30 @@ extension Search {
             _ = sqlite3_step(statement)
         }
 
+        /// Update synonyms for an existing framework alias
+        /// - Parameters:
+        ///   - identifier: The framework identifier (e.g., "corenfc")
+        ///   - synonyms: Comma-separated alternate names (e.g., "nfc")
+        public func updateFrameworkSynonyms(identifier: String, synonyms: String) async throws {
+            guard let database else {
+                throw SearchError.databaseNotInitialized
+            }
+
+            let sql = "UPDATE framework_aliases SET synonyms = ? WHERE identifier = ?;"
+
+            var statement: OpaquePointer?
+            defer { sqlite3_finalize(statement) }
+
+            guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+                return
+            }
+
+            sqlite3_bind_text(statement, 1, (synonyms as NSString).utf8String, -1, nil)
+            sqlite3_bind_text(statement, 2, (identifier as NSString).utf8String, -1, nil)
+
+            _ = sqlite3_step(statement)
+        }
+
         /// Resolve any framework input (identifier, import name, or display name) to identifier
         /// - Parameter input: Any of the three forms (e.g., "appintents", "AppIntents", "App Intents")
         /// - Returns: The identifier form (e.g., "appintents"), or nil if not found
@@ -3516,6 +3561,25 @@ extension Search {
             if sqlite3_step(statement) == SQLITE_ROW,
                let ptr = sqlite3_column_text(statement, 0) {
                 return String(cString: ptr)
+            }
+
+            // Third try: match on synonyms (comma-separated alternate names)
+            let synonymSql = """
+            SELECT identifier FROM framework_aliases
+            WHERE synonyms IS NOT NULL
+            AND (',' || LOWER(synonyms) || ',') LIKE '%,' || ? || ',%'
+            LIMIT 1;
+            """
+
+            var synStmt: OpaquePointer?
+            defer { sqlite3_finalize(synStmt) }
+
+            if sqlite3_prepare_v2(database, synonymSql, -1, &synStmt, nil) == SQLITE_OK {
+                sqlite3_bind_text(synStmt, 1, (normalizedInput as NSString).utf8String, -1, nil)
+                if sqlite3_step(synStmt) == SQLITE_ROW,
+                   let ptr = sqlite3_column_text(synStmt, 0) {
+                    return String(cString: ptr)
+                }
             }
 
             // Fallback: return normalized input (might be a valid framework not in alias table yet)

--- a/Packages/Sources/Search/SearchIndex.swift
+++ b/Packages/Sources/Search/SearchIndex.swift
@@ -822,7 +822,7 @@ extension Search {
             sqlite3_bind_text(statement, 1, (query as NSString).utf8String, -1, nil)
 
             if let framework {
-                sqlite3_bind_text(statement, 2, (framework as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(statement, 2, (framework.lowercased() as NSString).utf8String, -1, nil)
                 sqlite3_bind_int(statement, 3, Int32(limit))
             } else {
                 sqlite3_bind_int(statement, 2, Int32(limit))
@@ -1611,7 +1611,7 @@ extension Search {
 
             var paramIndex: Int32 = 2
             if let framework {
-                sqlite3_bind_text(statement, paramIndex, (framework as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(statement, paramIndex, (framework.lowercased() as NSString).utf8String, -1, nil)
                 paramIndex += 1
             }
             sqlite3_bind_int(statement, paramIndex, Int32(limit))

--- a/Packages/Sources/Search/SearchIndexBuilder.swift
+++ b/Packages/Sources/Search/SearchIndexBuilder.swift
@@ -88,8 +88,46 @@ extension Search {
             // Index Swift Packages catalog
             try await indexPackagesCatalog(onProgress: onProgress)
 
+            // Register framework synonyms for common alternate names
+            try await registerFrameworkSynonyms()
+
             let count = try await searchIndex.documentCount()
             logInfo("✅ Search index built: \(count) documents")
+        }
+
+        /// Register synonyms so common alternate names resolve to the correct framework
+        private func registerFrameworkSynonyms() async throws {
+            let synonyms: [(identifier: String, synonyms: String)] = [
+                ("corenfc", "nfc"),
+                ("journalingsuggestions", "journaling"),
+                ("corebluetooth", "bluetooth"),
+                ("corelocation", "location"),
+                ("coredata", "data"),
+                ("coremotion", "motion"),
+                ("coregraphics", "graphics"),
+                ("coreimage", "imageprocessing"),
+                ("coremedia", "media"),
+                ("coreaudio", "audio"),
+                ("coreml", "ml,machinelearning"),
+                ("corespotlight", "spotlight"),
+                ("coretext", "text"),
+                ("corevideo", "video"),
+                ("corehaptics", "haptics"),
+                ("corewlan", "wifi,wlan"),
+                ("coretelephony", "telephony"),
+                ("metalperformanceshadersgraph", "mpsgraph"),
+                ("avfoundation", "av"),
+                ("scenekit", "scene"),
+                ("spritekit", "sprite"),
+                ("groupactivities", "shareplay"),
+            ]
+
+            for entry in synonyms {
+                try await searchIndex.updateFrameworkSynonyms(
+                    identifier: entry.identifier,
+                    synonyms: entry.synonyms
+                )
+            }
         }
 
         // MARK: - Private Methods

--- a/Packages/Sources/Shared/Configuration.swift
+++ b/Packages/Sources/Shared/Configuration.swift
@@ -22,7 +22,7 @@ extension Shared {
             maxDepth: Int = 15,
             outputDirectory: URL = Shared.Constants.defaultDocsDirectory,
             logFile: URL? = nil,
-            requestDelay: TimeInterval = 0.5,
+            requestDelay: TimeInterval = 0.05,
             retryAttempts: Int = 3,
             useJSONAPI: Bool = false
         ) {

--- a/Packages/Sources/Shared/Constants.swift
+++ b/Packages/Sources/Shared/Constants.swift
@@ -159,10 +159,10 @@ extension Shared {
             public static let version = "0.9.1"
 
             /// Database version - separate from CLI version, only bump when schema/content changes
-            public static let databaseVersion = "0.8.2"
+            public static let databaseVersion = "0.9.0"
 
             /// Approximate database zip file size for progress display when Content-Length is unknown.
-            /// NOTE: Update this after each database release (current: v0.8.2 ~400MB)
+            /// NOTE: Update this after each database release (current: v0.9.0 ~400MB)
             public static let approximateZipSize: Int64 = 400 * 1024 * 1024
         }
 

--- a/Packages/Sources/Shared/Constants.swift
+++ b/Packages/Sources/Shared/Constants.swift
@@ -156,7 +156,7 @@ extension Shared {
             public static let userAgent = "CupertinoCrawler/1.0"
 
             /// Current version
-            public static let version = "0.9.1"
+            public static let version = "0.10.0"
 
             /// Database version - separate from CLI version, only bump when schema/content changes
             public static let databaseVersion = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ For development setup, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Project Status
 
-**Version:** 0.9.1
+**Version:** 0.10.0
 **Status:** 🚧 Active Development
 
 - ✅ All core functionality working

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Cupertino Deployment Guide
 
-**Version:** 0.9.1
+**Version:** 0.10.0
 **Last Updated:** 2025-12-12
 
 This guide covers the complete release process for Cupertino.


### PR DESCRIPTION
## Summary

Fixes #159, fixes #160 — missing Apple framework documentation.

### Crawler fixes (5 bugs)
- **Session resume validation**: Crawler now validates startURL before resuming a session
- **Complete framework discovery**: Seed from Apple's technologies.json (385+ frameworks vs ~20 from BFS)
- **Case-insensitive URL prefix matching**: Apple's JSON API returns mixed-case paths
- **Link enqueue before skip check**: Incremental re-crawls now discover new child pages
- **Case-insensitive framework queries**: Fixed `searchByKind()` and `searchSampleCode()`

### New features
- **Framework synonyms**: Search using common names — "nfc"→CoreNFC, "bluetooth"→CoreBluetooth, "shareplay"→GroupActivities, "journaling"→JournalingSuggestions, and 18 more
- **Schema v10**: Added `synonyms` column to `framework_aliases` with migration

### Database v0.9.0
- 320,771 documents (was 302,424 — +18,347)
- 443 frameworks (was 307 — +136 new)
- Uploaded to [cupertino-docs releases](https://github.com/mihaelamj/cupertino-docs/releases/tag/v0.9.0)

### Community contributions included in this release
- #167 — Add agent skill for stateless CLI usage (thanks @tijs)
- #169 — Add Claude Code plugin with marketplace manifest (thanks @gpambrozio)
- #162 — Add CONTRIBUTING.md with Swift-only policy (thanks @William-Laverty)
- #133 — Update Claude Code link in README (thanks @lwdupont)

## Test plan
- [x] All synonym resolutions verified
- [x] Case-insensitive framework queries verified
- [x] New DB strictly larger than old DB in every table
- [x] search, list-frameworks, sample code search all work
- [x] Database v0.9.0 uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)