### PR TITLE
fix(crawler): canonicalize Apple documentation URLs

### DIFF
--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -66,8 +66,9 @@ extension Core {
                 // Restore state
                 visited = savedSession.visited
                 queue = savedSession.queue.compactMap { queued in
-                    guard let url = URL(string: queued.url) else { return nil }
-                    return (url: url, depth: queued.depth)
+                    guard let url = URL(string: queued.url),
+                          let normalized = URLUtilities.normalize(url) else { return nil }
+                    return (url: normalized, depth: queued.depth)
                 }
 
                 // Restore or initialize stats
@@ -97,15 +98,19 @@ extension Core {
                     do {
                         logInfo("📋 Fetching technology index for complete framework coverage...")
                         let frameworkURLs = try await TechnologiesIndexFetcher.fetchFrameworkURLs()
-                        queue = frameworkURLs.map { (url: $0, depth: 0) }
+                        queue = frameworkURLs.compactMap { url in
+                            URLUtilities.normalize(url).map { (url: $0, depth: 0) }
+                        }
                         logInfo("   ✅ Seeded queue with \(frameworkURLs.count) framework root URLs")
                     } catch {
                         logInfo("   ⚠️ Failed to fetch technology index: \(error.localizedDescription)")
                         logInfo("   ⚠️ Falling back to start URL only")
-                        queue = [(url: configuration.startURL, depth: 0)]
+                        let startURL = URLUtilities.normalize(configuration.startURL) ?? configuration.startURL
+                        queue = [(url: startURL, depth: 0)]
                     }
                 } else {
-                    queue = [(url: configuration.startURL, depth: 0)]
+                    let startURL = URLUtilities.normalize(configuration.startURL) ?? configuration.startURL
+                    queue = [(url: startURL, depth: 0)]
                 }
 
                 logInfo("🚀 Starting new crawl")
@@ -415,7 +420,14 @@ extension Core {
                 return false
             }
 
-            return !visited.contains(normalized.absoluteString)
+            let normalizedString = normalized.absoluteString
+            guard !visited.contains(normalizedString) else {
+                return false
+            }
+
+            return !queue.contains { queuedURL, _ in
+                URLUtilities.normalize(queuedURL)?.absoluteString == normalizedString
+            }
         }
 
         // MARK: - Logging

--- a/Packages/Sources/Search/SearchIndexBuilder.swift
+++ b/Packages/Sources/Search/SearchIndexBuilder.swift
@@ -213,7 +213,7 @@ extension Search {
             logInfo("📂 Scanning directory for documentation (no metadata.json)...")
 
             // Recursively find all .json and .md files (JSON preferred over MD)
-            let docFiles = try findDocFiles(in: docsDirectory)
+            let docFiles = try deduplicateDocFilesByCanonicalURL(findDocFiles(in: docsDirectory))
 
             guard !docFiles.isEmpty else {
                 logInfo("⚠️  No documentation files found in \(docsDirectory.path)")
@@ -227,11 +227,12 @@ extension Search {
 
             for (index, file) in docFiles.enumerated() {
                 // Extract framework from path: docs/{framework}/...
-                guard let framework = extractFrameworkFromPath(file, relativeTo: docsDirectory) else {
+                guard let rawFramework = extractFrameworkFromPath(file, relativeTo: docsDirectory) else {
                     logError("Could not extract framework from path: \(file.path) (relative to \(docsDirectory.path))")
                     skipped += 1
                     continue
                 }
+                let framework = canonicalPathComponent(rawFramework)
 
                 // Always work with StructuredDocumentationPage
                 let structuredPage: StructuredDocumentationPage
@@ -278,7 +279,8 @@ extension Search {
                 }
 
                 // Generate URI: apple-docs://{framework}/{filename}
-                let filename = file.deletingPathExtension().lastPathComponent
+                let filename = URLUtilities.normalize(structuredPage.url)?.lastPathComponent
+                    ?? canonicalPathComponent(file.deletingPathExtension().lastPathComponent)
                 let uri = "apple-docs://\(framework)/\(filename)"
 
                 // Index using indexStructuredDocument (Apple docs from /docs folder)
@@ -361,6 +363,56 @@ extension Search {
             }
 
             return docFiles
+        }
+
+        private func deduplicateDocFilesByCanonicalURL(_ files: [URL]) throws -> [URL] {
+            var newestByURL: [String: (file: URL, crawledAt: Date)] = [:]
+
+            for file in files {
+                guard let canonicalURL = canonicalDocumentationURL(for: file) else {
+                    continue
+                }
+
+                let crawledAt = documentationCrawledAt(for: file) ?? .distantPast
+                if let existing = newestByURL[canonicalURL], existing.crawledAt >= crawledAt {
+                    continue
+                }
+
+                newestByURL[canonicalURL] = (file, crawledAt)
+            }
+
+            let keptFiles = Set(newestByURL.values.map(\.file))
+            return files.filter { keptFiles.contains($0) }
+        }
+
+        private func canonicalDocumentationURL(for file: URL) -> String? {
+            if file.pathExtension.lowercased() == "json",
+               let data = try? Data(contentsOf: file),
+               let page = try? JSONDecoder().decode(StructuredDocumentationPage.self, from: data) {
+                return URLUtilities.normalize(page.url)?.absoluteString
+            }
+
+            guard let rawFramework = extractFrameworkFromPath(file, relativeTo: docsDirectory) else {
+                return nil
+            }
+
+            let framework = canonicalPathComponent(rawFramework)
+            let filename = canonicalPathComponent(file.deletingPathExtension().lastPathComponent)
+            return "https://developer.apple.com/documentation/\(framework)/\(filename)"
+        }
+
+        private func documentationCrawledAt(for file: URL) -> Date? {
+            if file.pathExtension.lowercased() == "json",
+               let data = try? Data(contentsOf: file),
+               let page = try? JSONDecoder().decode(StructuredDocumentationPage.self, from: data) {
+                return page.crawledAt
+            }
+
+            return try? file.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+        }
+
+        private func canonicalPathComponent(_ component: String) -> String {
+            component.lowercased().replacingOccurrences(of: "_", with: "-")
         }
 
         private func findMarkdownFiles(in directory: URL) throws -> [URL] {

--- a/Packages/Sources/Shared/Models.swift
+++ b/Packages/Sources/Shared/Models.swift
@@ -747,6 +747,15 @@ public enum URLUtilities {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         components?.fragment = nil
         components?.query = nil
+
+        if components?.host == "developer.apple.com",
+           let path = components?.path,
+           path.hasPrefix("/documentation/") {
+            components?.path = path
+                .lowercased()
+                .replacingOccurrences(of: "_", with: "-")
+        }
+
         return components?.url
     }
 

--- a/Packages/Tests/CoreTests/CrawlerTests.swift
+++ b/Packages/Tests/CoreTests/CrawlerTests.swift
@@ -69,6 +69,31 @@ struct CrawlerTests {
         #expect(!normalized!.absoluteString.contains("?"))
     }
 
+    @Test("URLUtilities normalize lowercases Apple documentation paths")
+    func urlNormalizeLowercasesAppleDocumentationPaths() throws {
+        let uppercase = URL(string: "https://developer.apple.com/documentation/Cinematic/CNAssetInfo-2ata2")!
+        let lowercase = URL(string: "https://developer.apple.com/documentation/cinematic/cnassetinfo-2ata2")!
+
+        #expect(URLUtilities.normalize(uppercase) == URLUtilities.normalize(lowercase))
+        #expect(URLUtilities.normalize(uppercase)?.path == "/documentation/cinematic/cnassetinfo-2ata2")
+    }
+
+    @Test("URLUtilities normalize canonicalizes Apple documentation underscores")
+    func urlNormalizeCanonicalizesAppleDocumentationUnderscores() throws {
+        let dashed = URL(string: "https://developer.apple.com/documentation/professional-video-applications/fxplug")!
+        let underscored = URL(string: "https://developer.apple.com/documentation/professional_video_applications/fxplug")!
+
+        #expect(URLUtilities.normalize(dashed) == URLUtilities.normalize(underscored))
+        #expect(URLUtilities.normalize(underscored)?.path == "/documentation/professional-video-applications/fxplug")
+    }
+
+    @Test("URLUtilities normalize preserves method disambiguator dashes")
+    func urlNormalizePreservesMethodDisambiguatorDashes() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/Cinematic/CNAssetInfo-2ata2")!
+
+        #expect(URLUtilities.normalize(url)?.lastPathComponent == "cnassetinfo-2ata2")
+    }
+
     // MARK: - Framework Extraction Tests
 
     @Test("URLUtilities extracts framework from Apple docs URL")


### PR DESCRIPTION
Apple doc links with different path casing, or the old underscore framework form, normalized to different strings. That let the crawler enqueue the same page multiple times and let directory indexing produce separate framework/URI entries for the same content.

`URLUtilities.normalize()` now lowercases Apple documentation paths and maps underscores to dashes. The crawler normalizes restored, seeded, and newly discovered queue entries before de-duping; directory indexing canonicalizes framework/URI keys and keeps the newest duplicate by `crawledAt`.

Tests:
- `swift test --package-path Packages --filter 'CrawlerTests/urlNormalize'`
- `swift test --package-path Packages --filter 'SearchTests'`
- `swift build --package-path Packages -c release --arch arm64`

Full `swift test --package-path Packages` still fails in existing MCP integration tests waiting for server responses, then crashes with `Index out of range`.

Fixes #200
