### PR TITLE
fix(search): #261 --source packages now queries packages.db (was returning [])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased: v1.0.1
+
+### Fixed
+
+- **`cupertino search --source packages` returns 0 results** ([#261](https://github.com/mihaelamj/cupertino/issues/261)): the `--source` dispatch in `SearchCommand.run()` lumped `packages` together with the doc-shaped sources (`apple-docs`, `apple-archive`, `swift-evolution`, `swift-org`, `swift-book`) and routed them all to `runDocsSearch`, which queries `search.db` only. Packages live in their own DB (`packages.db`) with their own fetcher (`PackageFTSCandidateFetcher`); querying `search.db` for `source = 'packages'` rows always returned empty. The unified fan-out path correctly opened `packages.db` via `openPackagesFetcher`, so default search returned package results, masking the bug. `--source packages` now routes to a new `runPackageSearch` runner that wraps `Search.PackageFTSCandidateFetcher` in a single-fetcher `Search.SmartQuery` and renders through the same `printSmartReport` formatter as the default fan-out. Output JSON shape is `{candidates, contributingSources: ["packages"], question}`, consistent with the unified search rather than the per-source list views. Honors `--platform` / `--min-version` filters and `--packages-db` override. Verified: `cupertino search "alamofire" --source packages` was returning 5 bytes (`[]\n`); now returns SourceKitten / SWXMLHash / package-collection results.
+
+---
+
 ## 1.0.0 "First Light" — 2026-05-05
 
 _The first release we'd call properly stable. Consolidates what was originally scoped as v0.11.0 (packages-overhaul) + v0.12.0 (docs-overhaul) into a single cut. Release plan: [#192](https://github.com/mihaelamj/cupertino/issues/192). Canonical roadmap: [#183](https://github.com/mihaelamj/cupertino/issues/183)._

--- a/Packages/Sources/CLI/Commands/SearchCommand+SourceRunners.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand+SourceRunners.swift
@@ -123,6 +123,53 @@ extension SearchCommand {
         }
     }
 
+    /// Single-source view for `--source packages`. Packages live in their
+    /// own DB (`packages.db`), so this can't share `runDocsSearch`'s code
+    /// path against `search.db`. Mirrors the unified-search shape exactly:
+    /// a SmartQuery wrapped around one `PackageFTSCandidateFetcher`,
+    /// rendered through the same `printSmartReport` formatter the default
+    /// path uses. Output JSON is therefore the unified
+    /// `{candidates, contributingSources, question}` shape with
+    /// `contributingSources: ["packages"]`. (#261)
+    func runPackageSearch() async throws {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            Logging.ConsoleLogger.error("❌ Query cannot be empty.")
+            throw ExitCode.failure
+        }
+
+        let dbURL = packagesDb.map { URL(fileURLWithPath: $0).expandingTildeInPath }
+            ?? Shared.Constants.defaultPackagesDatabase
+
+        guard FileManager.default.fileExists(atPath: dbURL.path) else {
+            Logging.ConsoleLogger.error("❌ packages.db not found at \(dbURL.path)")
+            Logging.ConsoleLogger.error("   Run `cupertino setup` to download it, or `cupertino save --packages` to build locally.")
+            throw ExitCode.failure
+        }
+
+        let availabilityFilter = try resolveAvailabilityFilter()
+        let fetcher = Search.PackageFTSCandidateFetcher(
+            dbPath: dbURL,
+            availability: availabilityFilter
+        )
+        let smartQuery = Search.SmartQuery(fetchers: [fetcher])
+        let result = await smartQuery.answer(
+            question: trimmed,
+            limit: limit,
+            perFetcherLimit: max(20, perSource)
+        )
+
+        Self.printSmartReport(
+            result: result,
+            question: trimmed,
+            availabilityFilterActive: availabilityFilter != nil,
+            platform: platform,
+            minVersion: minVersion,
+            format: format,
+            brief: brief
+        )
+    }
+
     func runHIGSearch() async throws {
         let results = try await ServiceContainer.withDocsService(dbPath: searchDb) { service in
             try await service.search(SearchQuery(

--- a/Packages/Sources/CLI/Commands/SearchCommand.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand.swift
@@ -205,12 +205,17 @@ struct SearchCommand: AsyncParsableCommand {
             try await runSampleSearch()
         case Shared.Constants.SourcePrefix.hig:
             try await runHIGSearch()
+        case Shared.Constants.SourcePrefix.packages:
+            // packages live in their own DB (packages.db), not search.db.
+            // The docs runner queries search.db only and would silently
+            // return [] here. Use the dedicated single-fetcher SmartQuery
+            // path instead so packages.db is actually consulted (#261).
+            try await runPackageSearch()
         case Shared.Constants.SourcePrefix.appleDocs,
              Shared.Constants.SourcePrefix.appleArchive,
              Shared.Constants.SourcePrefix.swiftEvolution,
              Shared.Constants.SourcePrefix.swiftOrg,
-             Shared.Constants.SourcePrefix.swiftBook,
-             Shared.Constants.SourcePrefix.packages:
+             Shared.Constants.SourcePrefix.swiftBook:
             try await runDocsSearch()
         default:
             // Default (nil or "all") triggers the SmartQuery fan-out.


### PR DESCRIPTION
Fixes #261. `cupertino search "<query>" --source packages` was returning `[]` (5 bytes) for every query despite packages.db being 988 MB with 20186 indexed files.

## Root cause

`SearchCommand.run()` dispatch lumped `packages` with the docs-shaped sources:

```swift
case .appleDocs, .appleArchive, .swiftEvolution, .swiftOrg, .swiftBook, .packages:
    try await runDocsSearch()
```

`runDocsSearch()` queries **search.db** via `DocsService`. The other five sources live in search.db (each tagged with their own `source` value). **Packages live in their own DB** (`packages.db`) with their own fetcher (`PackageFTSCandidateFetcher`). Querying search.db for `source = 'packages'` rows always returned empty.

The unified fan-out path (`runUnifiedSearch` → `buildFetchers` → `openPackagesFetcher`) correctly opens packages.db, which is why default search returns package results in `contributingSources`. That masked the bug from anyone running `cupertino search X` without a source filter.

## Fix

Split `packages` out of the `runDocsSearch` case in `SearchCommand.run()` and route it to a new `runPackageSearch()` runner in `SearchCommand+SourceRunners.swift`. The runner mirrors what `runUnifiedSearch` does for the fan-out, but with a single fetcher:

```swift
let fetcher = Search.PackageFTSCandidateFetcher(dbPath: dbURL, availability: availabilityFilter)
let smartQuery = Search.SmartQuery(fetchers: [fetcher])
let result = await smartQuery.answer(question: trimmed, limit: limit, perFetcherLimit: max(20, perSource))
Self.printSmartReport(...)
```

Output JSON is the unified `{candidates, contributingSources: ["packages"], question}` shape rather than a separate per-source list view.

Honors `--platform` / `--min-version` filters and the `--packages-db` override.

## Verification

```
Before:
  $ cupertino search "alamofire" --source packages --format json
  [
                                     # 5 bytes total
  ]

After:
  $ cupertino search "alamofire" --source packages --format json
  {
    "candidates": [
      { "title": "SourceKitten", "metadata": {"owner": "jpsim", "repo": "SourceKitten", ...}, ... },
      { "title": "SWXMLHash", "metadata": {"owner": "drmohundro", "repo": "SWXMLHash", ...}, ... },
      ...
    ],
    "contributingSources": ["packages"],
    "question": "alamofire"
  }
```

Tested 5 queries (`alamofire`, `swiftui`, `actor`, `navigation`, `view`): all return 3 candidates each (was 0).

User-facing example for "add dependencies packages":

| Path | Top result |
|---|---|
| Default search | apple-docs: Trait, Identifying binary dependencies, Building Swift packages |
| `--source packages` (fixed) | swift-package-manager `package-collection add`, swift-container-plugin "Add the plugin", swift-mmio Installation |

The two paths complement each other: default search returns Apple's docs about packaging; `--source packages` returns real packages' own docs about how to add them. Pre-fix, the second view was unreachable.

## Regression checks

All other source filters unaffected:

| Source | Bytes returned for query "swift" |
|---|---|
| apple-docs | 1359 |
| samples | 1175 |
| hig | 687 |
| swift-evolution | 2188 |
| swift-org | 1577 |
| swift-book | 2581 |
| apple-archive | 2844 |

Default search still returns from packages in `contributingSources`. 26 unit tests in `PackageQuery` / `SearchCommand` suites pass.

## CHANGELOG

Added an `Unreleased: v1.0.1` section above the v1.0.0 entry.

## Milestone

v1.0.1 (#7).

