### PR TITLE
docs(claude.md): refresh active focus to v1.0.1 (post-First-Light state)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,19 +2,29 @@
 
 ## Active focus
 
-[#183 — bugs → recrawl → vector → tutor](https://github.com/mihaelamj/cupertino/issues/183) (Phase 1: close 6 open bugs)
+[#183 — bugs → recrawl → vector → tutor](https://github.com/mihaelamj/cupertino/issues/183). v1.0.0 "First Light" shipped 2026-05-05; current focus is the v1.0.1 bug-fix release.
 
-## Phase 1 (now): close all open bugs
+## v1.0.1 (in flight): close priority-high bugs
 
-All 6 open bugs are tagged `priority: high` and assigned to milestone [#1](https://github.com/mihaelamj/cupertino/milestone/1). Work on the existing branch `fix/all-open-bugs-2026-04`. One commit per bug. Open one PR when all six are closed.
+6 open bugs assigned to milestone [v1.0.1 (#7)](https://github.com/mihaelamj/cupertino/milestone/7), plus 1 carried over from the v1.0.0 milestone:
 
-Bug list: https://github.com/mihaelamj/cupertino/issues?q=is%3Aopen+is%3Aissue+label%3Abug
+- [#199](https://github.com/mihaelamj/cupertino/issues/199) — contentHash and id are non-deterministic
+- [#200](https://github.com/mihaelamj/cupertino/issues/200) — URL canonicalization (case + dash/underscore)
+- [#202](https://github.com/mihaelamj/cupertino/issues/202) — Crawler missed page-wide references dict
+- [#203](https://github.com/mihaelamj/cupertino/issues/203) — Crawler HTML fallback link extraction
+- [#237](https://github.com/mihaelamj/cupertino/issues/237) — search --source samples fails when search.db is locked
+- [#238](https://github.com/mihaelamj/cupertino/issues/238) — Sample search FTS5 query AND-joins
+- [#107](https://github.com/mihaelamj/cupertino/issues/107) (still on v1.0.0 milestone) — `fetch --type package-docs` does not read selected-packages.json
 
-Recommended order (smallest first): #110 → #107 → #161 → #168 → #6 → #181.
+Closed during the v1.0.1 work so far: [#261](https://github.com/mihaelamj/cupertino/issues/261) `cupertino search --source packages` returned 0 results (fixed by [#262](https://github.com/mihaelamj/cupertino/pull/262)).
+
+Live bug list: https://github.com/mihaelamj/cupertino/issues?q=is%3Aopen+is%3Aissue+label%3Abug
+
+Workflow: trunk-based development. Branch from `main` per bug (`fix/<issue>-<topic>`), PR to `main`, squash merge. Auto-delete-on-merge is enabled. When all v1.0.1 bugs are merged on main, cut a `release/v1.0.1` branch, finalize CHANGELOG, tag, ship the database bundle. No long-lived feature branches.
 
 ## Phase 2 onwards
 
-See #183. Do not start Phase 2 until Phase 1 ships.
+See #183. v1.1+ design and academic research review live in `mihaela-blog-ideas/cupertino/research/`. The diagnostic block in MCP responses (Phase 2.1) is the keystone for everything that follows; do not start it until v1.0.1 ships.
 
 ## Conventions
 


### PR DESCRIPTION
Refreshes `CLAUDE.md` so the project-instructions file matches reality after v1.0.0 shipped. Three things were stale:

1. **"Phase 1 (now): close 6 open bugs"** was pre-v1.0.0 framing. v1.0.0 "First Light" shipped 2026-05-05; current focus is the v1.0.1 bug-fix release.
2. **"Work on the existing branch `fix/all-open-bugs-2026-04`"** referenced a branch that doesn't exist. The repo is now on trunk-based development (one `fix/<issue>-<topic>` branch per bug, PR to `main`, squash-merge, auto-delete-on-merge enabled).
3. **The recommended-order list** (`#110 → #107 → #161 → #168 → #6 → #181`) named issues that were already closed in v1.0.0.

New active-focus section:

- 6 bugs on the v1.0.1 milestone (#199, #200, #202, #203, #237, #238)
- 1 carry-over from v1.0.0 (#107)
- Closed during the v1.0.1 work so far: #261 (fixed by #262)
- Workflow paragraph: trunk-based, branch-per-bug, squash-merge, cut a `release/v1.0.1` branch when bugs are done
- Phase 2 paragraph: points at the v1.1+ research review in `mihaela-blog-ideas/cupertino/research/` and names the diagnostic block (Phase 2.1) as the keystone of v1.1+, deferred until v1.0.1 ships

Doc-only change. No code touched.
