### PR TITLE
fix(search): #200 dedupe case-axis URL variants in crawler queue + indexer

### DIFF
--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -73,8 +73,9 @@ extension Core {
                 // Restore state
                 visited = savedSession.visited
                 queue = savedSession.queue.compactMap { queued in
-                    guard let url = URL(string: queued.url) else { return nil }
-                    return (url: url, depth: queued.depth)
+                    guard let url = URL(string: queued.url),
+                          let normalized = URLUtilities.normalize(url) else { return nil }
+                    return (url: normalized, depth: queued.depth)
                 }
                 // Rebuild the enqueued-URL set from the restored queue so the
                 // dedup at enqueue is correct after resume. Schema-compatible:
@@ -108,15 +109,19 @@ extension Core {
                     do {
                         logInfo("📋 Fetching technology index for complete framework coverage...")
                         let frameworkURLs = try await TechnologiesIndexFetcher.fetchFrameworkURLs()
-                        queue = frameworkURLs.map { (url: $0, depth: 0) }
+                        queue = frameworkURLs.compactMap { url in
+                            URLUtilities.normalize(url).map { (url: $0, depth: 0) }
+                        }
                         logInfo("   ✅ Seeded queue with \(frameworkURLs.count) framework root URLs")
                     } catch {
                         logInfo("   ⚠️ Failed to fetch technology index: \(error.localizedDescription)")
                         logInfo("   ⚠️ Falling back to start URL only")
-                        queue = [(url: configuration.startURL, depth: 0)]
+                        let startURL = URLUtilities.normalize(configuration.startURL) ?? configuration.startURL
+                        queue = [(url: startURL, depth: 0)]
                     }
                 } else {
-                    queue = [(url: configuration.startURL, depth: 0)]
+                    let startURL = URLUtilities.normalize(configuration.startURL) ?? configuration.startURL
+                    queue = [(url: startURL, depth: 0)]
                 }
 
                 logInfo("🚀 Starting new crawl")
@@ -480,7 +485,14 @@ extension Core {
                 return false
             }
 
-            return !visited.contains(normalized.absoluteString)
+            let normalizedString = normalized.absoluteString
+            guard !visited.contains(normalizedString) else {
+                return false
+            }
+
+            return !queue.contains { queuedURL, _ in
+                URLUtilities.normalize(queuedURL)?.absoluteString == normalizedString
+            }
         }
 
         // MARK: - Logging

--- a/Packages/Sources/Search/SearchIndexBuilder.swift
+++ b/Packages/Sources/Search/SearchIndexBuilder.swift
@@ -385,7 +385,7 @@ extension Search {
             return docFiles
         }
 
-        private func deduplicateDocFilesByCanonicalURL(_ files: [URL]) throws -> [URL] {
+        internal func deduplicateDocFilesByCanonicalURL(_ files: [URL]) throws -> [URL] {
             var newestByURL: [String: (file: URL, crawledAt: Date)] = [:]
 
             for file in files {
@@ -405,10 +405,23 @@ extension Search {
             return files.filter { keptFiles.contains($0) }
         }
 
-        private func canonicalDocumentationURL(for file: URL) -> String? {
-            if file.pathExtension.lowercased() == "json",
-               let data = try? Data(contentsOf: file),
-               let page = try? JSONDecoder().decode(StructuredDocumentationPage.self, from: data) {
+        /// Read and decode a saved StructuredDocumentationPage. Configures the
+        /// decoder with `.iso8601` to match how `cupertino fetch` writes
+        /// `crawledAt`; without this the decode silently fails on every real
+        /// Apple-doc JSON file and the dedup primary path becomes dead code.
+        /// See `indexStructuredDocument` for the canonical decoder config.
+        internal func loadStructuredPage(from file: URL) -> StructuredDocumentationPage? {
+            guard file.pathExtension.lowercased() == "json",
+                  let data = try? Data(contentsOf: file) else {
+                return nil
+            }
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return try? decoder.decode(StructuredDocumentationPage.self, from: data)
+        }
+
+        internal func canonicalDocumentationURL(for file: URL) -> String? {
+            if let page = loadStructuredPage(from: file) {
                 return URLUtilities.normalize(page.url)?.absoluteString
             }
 
@@ -421,10 +434,8 @@ extension Search {
             return "https://developer.apple.com/documentation/\(framework)/\(filename)"
         }
 
-        private func documentationCrawledAt(for file: URL) -> Date? {
-            if file.pathExtension.lowercased() == "json",
-               let data = try? Data(contentsOf: file),
-               let page = try? JSONDecoder().decode(StructuredDocumentationPage.self, from: data) {
+        internal func documentationCrawledAt(for file: URL) -> Date? {
+            if let page = loadStructuredPage(from: file) {
                 return page.crawledAt
             }
 

--- a/Packages/Sources/Search/SearchIndexBuilder.swift
+++ b/Packages/Sources/Search/SearchIndexBuilder.swift
@@ -212,8 +212,9 @@ extension Search {
 
             logInfo("📂 Scanning directory for documentation (no metadata.json)...")
 
-            // Recursively find all .json and .md files (JSON preferred over MD)
-            let docFiles = try Self.findDocFiles(in: docsDirectory)
+            // Recursively find all .json and .md files (JSON preferred over MD).
+            // The dedup helper collapses case-axis duplicates by canonical URL.
+            let docFiles = try deduplicateDocFilesByCanonicalURL(Self.findDocFiles(in: docsDirectory))
 
             guard !docFiles.isEmpty else {
                 logInfo("⚠️  No documentation files found in \(docsDirectory.path)")
@@ -227,11 +228,12 @@ extension Search {
 
             for (index, file) in docFiles.enumerated() {
                 // Extract framework from path: docs/{framework}/...
-                guard let framework = extractFrameworkFromPath(file, relativeTo: docsDirectory) else {
+                guard let rawFramework = extractFrameworkFromPath(file, relativeTo: docsDirectory) else {
                     logError("Could not extract framework from path: \(file.path) (relative to \(docsDirectory.path))")
                     skipped += 1
                     continue
                 }
+                let framework = canonicalPathComponent(rawFramework)
 
                 // Always work with StructuredDocumentationPage
                 let structuredPage: StructuredDocumentationPage
@@ -278,7 +280,8 @@ extension Search {
                 }
 
                 // Generate URI: apple-docs://{framework}/{filename}
-                let filename = file.deletingPathExtension().lastPathComponent
+                let filename = URLUtilities.normalize(structuredPage.url)?.lastPathComponent
+                    ?? canonicalPathComponent(file.deletingPathExtension().lastPathComponent)
                 let uri = "apple-docs://\(framework)/\(filename)"
 
                 // Index using indexStructuredDocument (Apple docs from /docs folder)
@@ -380,6 +383,61 @@ extension Search {
             }
 
             return docFiles
+        }
+
+        private func deduplicateDocFilesByCanonicalURL(_ files: [URL]) throws -> [URL] {
+            var newestByURL: [String: (file: URL, crawledAt: Date)] = [:]
+
+            for file in files {
+                guard let canonicalURL = canonicalDocumentationURL(for: file) else {
+                    continue
+                }
+
+                let crawledAt = documentationCrawledAt(for: file) ?? .distantPast
+                if let existing = newestByURL[canonicalURL], existing.crawledAt >= crawledAt {
+                    continue
+                }
+
+                newestByURL[canonicalURL] = (file, crawledAt)
+            }
+
+            let keptFiles = Set(newestByURL.values.map(\.file))
+            return files.filter { keptFiles.contains($0) }
+        }
+
+        private func canonicalDocumentationURL(for file: URL) -> String? {
+            if file.pathExtension.lowercased() == "json",
+               let data = try? Data(contentsOf: file),
+               let page = try? JSONDecoder().decode(StructuredDocumentationPage.self, from: data) {
+                return URLUtilities.normalize(page.url)?.absoluteString
+            }
+
+            guard let rawFramework = extractFrameworkFromPath(file, relativeTo: docsDirectory) else {
+                return nil
+            }
+
+            let framework = canonicalPathComponent(rawFramework)
+            let filename = canonicalPathComponent(file.deletingPathExtension().lastPathComponent)
+            return "https://developer.apple.com/documentation/\(framework)/\(filename)"
+        }
+
+        private func documentationCrawledAt(for file: URL) -> Date? {
+            if file.pathExtension.lowercased() == "json",
+               let data = try? Data(contentsOf: file),
+               let page = try? JSONDecoder().decode(StructuredDocumentationPage.self, from: data) {
+                return page.crawledAt
+            }
+
+            return try? file.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+        }
+
+        /// Lowercase-only canonicalization. Mirrors `URLUtilities.normalize`
+        /// which deliberately does NOT collapse underscore→dash because
+        /// at least one Apple framework (`installer_js`) legitimately uses
+        /// underscore in its path and Apple does not redirect from the dash
+        /// form (verified: `documentation/installer-js` returns 404).
+        private func canonicalPathComponent(_ component: String) -> String {
+            component.lowercased()
         }
 
         private func findMarkdownFiles(in directory: URL) throws -> [URL] {

--- a/Packages/Tests/CoreTests/CrawlerTests.swift
+++ b/Packages/Tests/CoreTests/CrawlerTests.swift
@@ -69,6 +69,36 @@ struct CrawlerTests {
         #expect(try !#require(normalized?.absoluteString.contains("?")))
     }
 
+    @Test("URLUtilities normalize lowercases Apple documentation paths")
+    func urlNormalizeLowercasesAppleDocumentationPaths() throws {
+        let uppercase = URL(string: "https://developer.apple.com/documentation/Cinematic/CNAssetInfo-2ata2")!
+        let lowercase = URL(string: "https://developer.apple.com/documentation/cinematic/cnassetinfo-2ata2")!
+
+        #expect(URLUtilities.normalize(uppercase) == URLUtilities.normalize(lowercase))
+        #expect(URLUtilities.normalize(uppercase)?.path == "/documentation/cinematic/cnassetinfo-2ata2")
+    }
+
+    @Test("URLUtilities normalize preserves method disambiguator dashes")
+    func urlNormalizePreservesMethodDisambiguatorDashes() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/Cinematic/CNAssetInfo-2ata2")!
+
+        #expect(URLUtilities.normalize(url)?.lastPathComponent == "cnassetinfo-2ata2")
+    }
+
+    @Test("URLUtilities normalize keeps underscores intact (installer_js safety)")
+    func urlNormalizePreservesUnderscoresInPath() throws {
+        // Apple does not redirect /documentation/installer-js to
+        // /documentation/installer_js — the dash form returns 404. A naive
+        // underscore→dash collapse in URLUtilities would silently break the
+        // entire installer_js framework on every crawl. Verify we never make
+        // that change.
+        let url = URL(string: "https://developer.apple.com/documentation/installer_js/license")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/installer_js/license")
+        #expect(try !#require(normalized?.absoluteString.contains("installer-js")))
+    }
+
     // MARK: - Framework Extraction Tests
 
     @Test("URLUtilities extracts framework from Apple docs URL")

--- a/Packages/Tests/SearchTests/IndexBuilderDeduplicationTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderDeduplicationTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+@testable import Search
+import Shared
+import Testing
+
+// Regression coverage for `Search.IndexBuilder.deduplicateDocFilesByCanonicalURL`
+// (#200). The dedup helper reads `crawledAt` out of saved
+// `StructuredDocumentationPage` JSON files to break ties between case-axis
+// URL duplicates. If the JSON decoder isn't configured with `.iso8601` the
+// decode silently fails, the helper falls back to filesystem mtime, and
+// dedup picks the wrong file when mtime and crawledAt diverge (e.g. after
+// a corpus copy or git checkout that shuffles mtimes).
+
+@Suite("Search.IndexBuilder.deduplicateDocFilesByCanonicalURL (#200)", .serialized)
+struct IndexBuilderDeduplicationTests {
+    @Test("Two files with same canonical URL: keeps the one with newer crawledAt even when its mtime is older")
+    func keepsNewestByCrawledAtNotMtime() async throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cupertino-dedup-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let docsDir = tempRoot.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docsDir, withIntermediateDirectories: true)
+
+        // Two distinct on-disk files that both point to the same canonical
+        // Apple URL via their `page.url` field. This simulates the real
+        // production case where successive crawls or a URL-canonicalization
+        // change left two on-disk copies of the same page (e.g. underscore
+        // vs dash framework variants pre-fix). Distinct filenames so the test
+        // is FS-case-insensitivity-independent (macOS HFS+ default would
+        // otherwise collapse them before dedup runs).
+        let sharedCanonicalURL = URL(string: "https://developer.apple.com/documentation/swiftui/list")!
+
+        let older = try writeFixtureDoc(
+            url: sharedCanonicalURL,
+            crawledAt: Date(timeIntervalSince1970: 1_700_000_000),
+            into: docsDir,
+            framework: "swiftui",
+            name: "list"
+        )
+        let newer = try writeFixtureDoc(
+            url: sharedCanonicalURL,
+            crawledAt: Date(timeIntervalSince1970: 1_800_000_000),
+            into: docsDir,
+            framework: "swiftui",
+            name: "list-copy"
+        )
+
+        // Sabotage filesystem mtime: bump the older file's mtime to be newer
+        // than the actually-newer file's mtime. If dedup falls back to mtime
+        // (i.e. the JSON decode silently fails because `.iso8601` isn't set),
+        // it would now incorrectly keep `older`. With `.iso8601` working,
+        // dedup reads `crawledAt` from the JSON directly and keeps `newer`.
+        let inFuture = Date().addingTimeInterval(86_400)
+        try FileManager.default.setAttributes(
+            [.modificationDate: inFuture],
+            ofItemAtPath: older.path
+        )
+
+        let dbPath = tempRoot.appendingPathComponent("search.db")
+        let index = try await Search.Index(dbPath: dbPath)
+        let builder = Search.IndexBuilder(
+            searchIndex: index,
+            metadata: nil,
+            docsDirectory: docsDir,
+            indexSampleCode: false
+        )
+
+        let result = try await builder.deduplicateDocFilesByCanonicalURL([older, newer])
+        #expect(result == [newer])
+    }
+
+    @Test("Single file with no duplicates passes through unchanged")
+    func singleFilePassesThrough() async throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cupertino-dedup-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let docsDir = tempRoot.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docsDir, withIntermediateDirectories: true)
+
+        let file = try writeFixtureDoc(
+            url: URL(string: "https://developer.apple.com/documentation/swiftui/list")!,
+            crawledAt: Date(),
+            into: docsDir,
+            framework: "swiftui",
+            name: "list"
+        )
+
+        let dbPath = tempRoot.appendingPathComponent("search.db")
+        let index = try await Search.Index(dbPath: dbPath)
+        let builder = Search.IndexBuilder(
+            searchIndex: index,
+            metadata: nil,
+            docsDirectory: docsDir,
+            indexSampleCode: false
+        )
+
+        let result = try await builder.deduplicateDocFilesByCanonicalURL([file])
+        #expect(result == [file])
+    }
+
+    @Test("Distinct canonical URLs both survive (no false-positive dedup)")
+    func distinctURLsBothSurvive() async throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cupertino-dedup-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let docsDir = tempRoot.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docsDir, withIntermediateDirectories: true)
+
+        let listView = try writeFixtureDoc(
+            url: URL(string: "https://developer.apple.com/documentation/swiftui/list")!,
+            crawledAt: Date(),
+            into: docsDir,
+            framework: "swiftui",
+            name: "list"
+        )
+        let textField = try writeFixtureDoc(
+            url: URL(string: "https://developer.apple.com/documentation/swiftui/textfield")!,
+            crawledAt: Date(),
+            into: docsDir,
+            framework: "swiftui",
+            name: "textfield"
+        )
+
+        let dbPath = tempRoot.appendingPathComponent("search.db")
+        let index = try await Search.Index(dbPath: dbPath)
+        let builder = Search.IndexBuilder(
+            searchIndex: index,
+            metadata: nil,
+            docsDirectory: docsDir,
+            indexSampleCode: false
+        )
+
+        let result = try await builder.deduplicateDocFilesByCanonicalURL([listView, textField])
+        #expect(Set(result) == Set([listView, textField]))
+    }
+
+    @Test("loadStructuredPage: decoder is configured with .iso8601 (regression for codex review on #264)")
+    func loadStructuredPageDecodesIso8601() async throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cupertino-dedup-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let docsDir = tempRoot.appendingPathComponent("docs")
+        try FileManager.default.createDirectory(at: docsDir, withIntermediateDirectories: true)
+
+        let knownDate = Date(timeIntervalSince1970: 1_750_000_000)
+        let file = try writeFixtureDoc(
+            url: URL(string: "https://developer.apple.com/documentation/swiftui/view")!,
+            crawledAt: knownDate,
+            into: docsDir,
+            framework: "swiftui",
+            name: "view"
+        )
+
+        let dbPath = tempRoot.appendingPathComponent("search.db")
+        let index = try await Search.Index(dbPath: dbPath)
+        let builder = Search.IndexBuilder(
+            searchIndex: index,
+            metadata: nil,
+            docsDirectory: docsDir,
+            indexSampleCode: false
+        )
+
+        let page = try #require(await builder.loadStructuredPage(from: file))
+        #expect(page.crawledAt == knownDate)
+        // canonicalDocumentationURL should also use the page.url branch, not
+        // the path-based fallback. Asserting it returns the lowercased Apple URL.
+        let canonical = await builder.canonicalDocumentationURL(for: file)
+        #expect(canonical == "https://developer.apple.com/documentation/swiftui/view")
+    }
+}
+
+private func writeFixtureDoc(
+    url: URL,
+    crawledAt: Date,
+    into directory: URL,
+    framework: String,
+    name: String
+) throws -> URL {
+    let frameworkDir = directory.appendingPathComponent(framework)
+    try FileManager.default.createDirectory(at: frameworkDir, withIntermediateDirectories: true)
+
+    let page = StructuredDocumentationPage(
+        url: url,
+        title: "Sample",
+        kind: .struct,
+        source: .appleJSON,
+        abstract: nil,
+        declaration: nil,
+        overview: nil,
+        sections: [],
+        codeExamples: [],
+        language: nil,
+        crawledAt: crawledAt,
+        contentHash: "test-hash-\(UUID().uuidString)"
+    )
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(page)
+
+    let fileURL = frameworkDir.appendingPathComponent("\(name).json")
+    try data.write(to: fileURL)
+    return fileURL
+}


### PR DESCRIPTION
Closes #200. Cherry-picks the safe parts of @imwyvern's PR #201 (opened 2026-04-28, conflicted with main after v1.0.0). The full PR couldn't merge as-is because its `URLUtilities.normalize` underscore→dash collapse would break the `installer_js` framework. Verified: Apple does not redirect `installer-js` to `installer_js`; the dash form returns 404. Main's existing `4ec49ba` had already documented this constraint and landed lowercase-only normalization.

## What we keep from #201

- **Crawler queue normalization** on session restore, fresh framework-index seed, and start-URL fallback. Newly enqueued URLs additionally check against a normalized-form match in the queue, so case-flip duplicates don't re-enter the queue.
- **`SearchIndexBuilder.deduplicateDocFilesByCanonicalURL`**: at index-build time, when two on-disk JSON pages share a canonical URL after normalization, keep the one with the newest `crawledAt`. Reads the URL from the page JSON when available; falls back to filesystem mtime.
- **`canonicalDocumentationURL`** helper: derives the canonical URL string from either the page JSON (preferred) or path-based reconstruction.
- **`canonicalPathComponent`** helper: lowercase-only (the underscore→dash replacement was removed; comment explains the `installer_js` reasoning).
- **URI generation in `indexStructuredDocument`** now prefers `URLUtilities.normalize(structuredPage.url)?.lastPathComponent`, falls back to `canonicalPathComponent`. Aligns the `apple-docs://` URI shape with the canonical URL form.
- **Tests**: `URLUtilities normalize lowercases Apple documentation paths`, `URLUtilities normalize preserves method disambiguator dashes`.

## What we drop from #201

- `URLUtilities.normalize` underscore→dash collapse (would break `installer_js`).
- Test asserting underscore→dash collapse (conflicts with the design).

## What we add

- Test `URLUtilities normalize keeps underscores intact (installer_js safety)`: locks in the design decision and prevents regression. Asserts both that the path retains the underscore and that the resulting absoluteString never contains `installer-js`.

## Re-crawl required?

No. Re-index only.

The fix runs at `cupertino save` time, reading the existing 319k on-disk files. Estimated ~30-60 min for a full re-index (AST extraction is the slow part). The output is a fresh `search.db` with canonical URIs. v1.0.1 should ship the re-built `search.db` in the distribution bundle.

## URI shape change (intentional)

This changes the `apple-docs://` URI shape from mixed-case to lowercase. Searches still work (BM25 doesn't care). Existing search.db built with v1.0.0 will have uppercase URIs that don't `cupertino read` cleanly after the fix lands; one re-index resolves it. Distribution will need a fresh search.db for v1.0.1.

## Pre-existing gap (not in scope)

Crawler uses the request URL as storage key, not `response.url` after redirect-following. So when Apple migrates a framework (e.g., `professional_video_applications` → `professional-video-applications`), URLSession follows the redirect and fetches the dash-form content, but cupertino still stores it under the underscore-form key. That's a pre-existing bug unrelated to this PR. Filing as a follow-up to address with `response.url` storage and a regression test.

## Verification

- `swift build -c debug` → clean
- `swift test` → 1202 tests in 130 suites pass
- 6 URL-related tests pass: query removal, fragment removal, trailing slash, lowercase Apple paths, method disambiguator preservation, **underscore preservation (new)**
- `cupertino` CLI commands unchanged

## Attribution

@imwyvern (Wesley) authored the original work in #201. The crawler queue dedup, SearchIndexBuilder dedup helpers, URI generation alignment, and the case-axis tests are his. The commit credits him as Co-author. Closing #201 with a comment pointing here.
