### PR TITLE
fix(cli): #242 reap stale sibling cupertino serve processes at startup

### DIFF
--- a/Packages/Sources/CLI/Commands/ServeCommand.swift
+++ b/Packages/Sources/CLI/Commands/ServeCommand.swift
@@ -38,6 +38,12 @@ struct ServeCommand: AsyncParsableCommand {
     )
 
     mutating func run() async throws {
+        // Reap any sibling `cupertino serve` processes of the same binary
+        // before we bind stdio. MCP host config reloads (Claude Desktop,
+        // Cursor, etc.) leave orphan servers behind otherwise — they pin
+        // SQLite read locks and stack RAM usage. (#242)
+        ServeReaper.reapSiblings()
+
         if isatty(STDOUT_FILENO) == 0 {
             Log.disableConsole()
         }

--- a/Packages/Sources/CLI/Commands/ServeReaper.swift
+++ b/Packages/Sources/CLI/Commands/ServeReaper.swift
@@ -30,7 +30,16 @@ enum ServeReaper {
 
         for entry in listProcesses() {
             guard entry.pid != ownPID else { continue }
-            guard isServeSubcommand(entry.commandLine) else { continue }
+            // Subcommand check uses the real argv from the kernel
+            // (sysctl KERN_PROCARGS2). The joined command line that ps
+            // outputs is fundamentally ambiguous when paths or args
+            // contain spaces or the substring 'cupertino' (--base-dir
+            // /Users/me/.cupertino-dev, --search-db /tmp/cupertino.db,
+            // /Applications/My Tools/cupertino, …).
+            guard let argv = argvOf(pid: entry.pid),
+                  argv.count >= 2,
+                  argv[1] == "serve"
+            else { continue }
             guard let entryPath = pathOf(pid: entry.pid),
                   entryPath == ownPath
             else { continue }
@@ -96,27 +105,87 @@ enum ServeReaper {
         let commandLine: String
     }
 
-    /// Detects whether a command line's first subcommand (argv[1]) is
-    /// `serve`. Robust against binary paths that contain spaces
-    /// (`/Applications/My Tools/cupertino serve` and similar) by anchoring
-    /// on the last occurrence of `cupertino` in the command line — the
-    /// binary basename always ends in that token, so whatever follows is
-    /// argv[1]. Word-boundary check at the end, so `server-foo` and
-    /// `serves` do NOT match.
-    static func isServeSubcommand(_ commandLine: String) -> Bool {
-        let trimmed = commandLine.trimmingCharacters(in: .whitespaces)
-        // Anchor on the LAST `cupertino` in the line. Using `.backwards`
-        // ensures we don't get fooled when an outer directory in the path
-        // happens to contain `cupertino` (e.g.
-        // `/Volumes/cupertino-build/cupertino serve`).
-        guard let cupertinoRange = trimmed.range(of: "cupertino", options: .backwards) else {
-            return false
+    /// Read argv of `pid` via `sysctl(KERN_PROCARGS2)`. Returns nil if the
+    /// process has exited or we lack permission to query it.
+    ///
+    /// Earlier revisions tried to parse the joined command line that
+    /// `ps -o command=` produces, but that loses argv boundaries
+    /// irrecoverably: paths with spaces, args whose values contain the
+    /// substring `cupertino` (`--search-db /tmp/cupertino.db`,
+    /// `--base-dir ~/.cupertino-dev`), and combinations of both all
+    /// defeat any heuristic. The kernel knows the actual argv vector;
+    /// asking for it directly is the only correct answer.
+    private static func argvOf(pid: pid_t) -> [String]? {
+        var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+        var size: Int = 0
+
+        // Probe for the buffer size first.
+        guard mib.withUnsafeMutableBufferPointer({ ptr in
+            sysctl(ptr.baseAddress, 3, nil, &size, nil, 0)
+        }) == 0, size > 0 else { return nil }
+
+        var buffer = [UInt8](repeating: 0, count: size)
+        guard mib.withUnsafeMutableBufferPointer({ mibPtr in
+            buffer.withUnsafeMutableBufferPointer { bufPtr in
+                sysctl(mibPtr.baseAddress, 3, bufPtr.baseAddress, &size, nil, 0)
+            }
+        }) == 0 else { return nil }
+
+        // sysctl may have written less than the probed size; trim.
+        return parseProcargs2(Array(buffer.prefix(size)))
+    }
+
+    /// Pure parser for the `KERN_PROCARGS2` byte layout. xnu format:
+    ///
+    ///     [argc: int32 host-endian]
+    ///     [exec_path: null-terminated string]
+    ///     [zero or more NUL bytes for alignment]
+    ///     [argv[0]: null-terminated]
+    ///     [argv[1]: null-terminated]
+    ///     ...
+    ///     [argv[argc-1]: null-terminated]
+    ///     [envp[0]: null-terminated]   (ignored)
+    ///     ...
+    ///
+    /// Internal so unit tests can build synthetic buffers.
+    static func parseProcargs2(_ buffer: [UInt8]) -> [String]? {
+        guard buffer.count >= 4 else { return nil }
+
+        var argc: Int32 = 0
+        withUnsafeMutableBytes(of: &argc) { argcBytes in
+            for i in 0..<4 {
+                argcBytes[i] = buffer[i]
+            }
         }
-        let afterBinary = trimmed[cupertinoRange.upperBound...]
-            .drop(while: { $0 == " " })
-        guard !afterBinary.isEmpty else { return false }
-        let firstToken = afterBinary.prefix(while: { $0 != " " })
-        return firstToken == "serve"
+        guard argc > 0 else { return nil }
+
+        var offset = 4
+
+        // Skip the canonical exec_path string.
+        while offset < buffer.count && buffer[offset] != 0 {
+            offset += 1
+        }
+        // Skip the NUL terminator + any alignment padding NULs.
+        while offset < buffer.count && buffer[offset] == 0 {
+            offset += 1
+        }
+
+        // Read `argc` null-terminated strings starting from here.
+        var argv: [String] = []
+        var stringStart = offset
+        while offset < buffer.count && argv.count < Int(argc) {
+            if buffer[offset] == 0 {
+                let bytes = Array(buffer[stringStart..<offset])
+                guard let s = String(bytes: bytes, encoding: .utf8) else {
+                    return nil
+                }
+                argv.append(s)
+                stringStart = offset + 1
+            }
+            offset += 1
+        }
+
+        return argv.count == Int(argc) ? argv : nil
     }
 
     /// Parses `ps -ax -o pid=,etime=,command=` output into Entry records.

--- a/Packages/Sources/CLI/Commands/ServeReaper.swift
+++ b/Packages/Sources/CLI/Commands/ServeReaper.swift
@@ -96,21 +96,26 @@ enum ServeReaper {
         let commandLine: String
     }
 
-    /// Detects whether a command line's first subcommand (token after the
-    /// binary path) is `serve`. Word-boundary check, so a command like
-    /// `cupertino server-something` would NOT match (defensive against
-    /// future subcommands containing the substring "serve").
+    /// Detects whether a command line's first subcommand (argv[1]) is
+    /// `serve`. Robust against binary paths that contain spaces
+    /// (`/Applications/My Tools/cupertino serve` and similar) by anchoring
+    /// on the last occurrence of `cupertino` in the command line — the
+    /// binary basename always ends in that token, so whatever follows is
+    /// argv[1]. Word-boundary check at the end, so `server-foo` and
+    /// `serves` do NOT match.
     static func isServeSubcommand(_ commandLine: String) -> Bool {
-        // Skip past the binary token. Use Substring slicing rather than
-        // .split() so we don't lose argv-with-spaces edge cases.
         let trimmed = commandLine.trimmingCharacters(in: .whitespaces)
-        guard let firstSpace = trimmed.firstIndex(of: " ") else {
-            return false // no subcommand at all
+        // Anchor on the LAST `cupertino` in the line. Using `.backwards`
+        // ensures we don't get fooled when an outer directory in the path
+        // happens to contain `cupertino` (e.g.
+        // `/Volumes/cupertino-build/cupertino serve`).
+        guard let cupertinoRange = trimmed.range(of: "cupertino", options: .backwards) else {
+            return false
         }
-        let afterBinary = trimmed[trimmed.index(after: firstSpace)...]
-            .trimmingCharacters(in: .whitespaces)
-        // First token after binary must be exactly `serve`.
-        let firstToken = afterBinary.split(separator: " ", maxSplits: 1).first ?? ""
+        let afterBinary = trimmed[cupertinoRange.upperBound...]
+            .drop(while: { $0 == " " })
+        guard !afterBinary.isEmpty else { return false }
+        let firstToken = afterBinary.prefix(while: { $0 != " " })
         return firstToken == "serve"
     }
 

--- a/Packages/Sources/CLI/Commands/ServeReaper.swift
+++ b/Packages/Sources/CLI/Commands/ServeReaper.swift
@@ -1,0 +1,158 @@
+import Darwin
+import Foundation
+
+/// Reap stale sibling `cupertino serve` processes at startup. (#242)
+///
+/// MCP hosts (Claude Desktop, Cursor, etc.) launch a fresh server every
+/// reload of their MCP config and don't always clean up the previous one.
+/// Without this reap pass, multiple servers stack up holding file
+/// descriptors, SQLite read connections, and stdio handles, making
+/// `cupertino save` fail more often with "database is locked" and
+/// burning RAM (a few hundred MB per server once the AST cache warms).
+///
+/// Conservative scope by design:
+/// - Only reaps processes whose absolute binary path equals our own
+///   (resolved via `proc_pidpath` + `realpath`). Different installs
+///   coexist (brew + dev, multiple `--base-dir` setups per #211).
+/// - Only reaps processes whose first subcommand is `serve`. Concurrent
+///   `cupertino save` / `fetch` survive.
+/// - Skips own PID.
+/// - SIGTERM, then SIGKILL after `gracePeriod` if still alive.
+/// - Logs one line per reap to stderr (so it doesn't corrupt the JSON-RPC
+///   stream on stdout when the host is talking to us via pipe).
+enum ServeReaper {
+    /// Grace period between SIGTERM and SIGKILL.
+    static let gracePeriod: TimeInterval = 2.0
+
+    static func reapSiblings() {
+        guard let ownPath = currentExecutablePath() else { return }
+        let ownPID = getpid()
+
+        for entry in listProcesses() {
+            guard entry.pid != ownPID else { continue }
+            guard isServeSubcommand(entry.commandLine) else { continue }
+            guard let entryPath = pathOf(pid: entry.pid),
+                  entryPath == ownPath
+            else { continue }
+            reap(pid: entry.pid, elapsed: entry.elapsed)
+        }
+    }
+
+    // MARK: - Reap mechanics
+
+    private static func reap(pid: pid_t, elapsed: String) {
+        guard kill(pid, SIGTERM) == 0 else { return }
+        FileHandle.standardError.write(
+            Data("🧹 Reaped stale serve process PID=\(pid) (running \(elapsed))\n".utf8)
+        )
+
+        let deadline = Date().addingTimeInterval(gracePeriod)
+        while Date() < deadline {
+            if kill(pid, 0) != 0 { return } // gone
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+
+        // Still alive after grace window — force.
+        if kill(pid, 0) == 0 {
+            _ = kill(pid, SIGKILL)
+        }
+    }
+
+    // MARK: - Path resolution
+
+    /// Resolved absolute path of the currently running binary.
+    private static func currentExecutablePath() -> String? {
+        var size: UInt32 = 4096
+        var buf = [CChar](repeating: 0, count: Int(size))
+        guard _NSGetExecutablePath(&buf, &size) == 0 else { return nil }
+        return resolveSymlinks(in: String(cString: buf))
+    }
+
+    /// Resolved absolute path of the binary running as `pid`, or nil if
+    /// the process has exited or we lack permission to query it.
+    private static func pathOf(pid: pid_t) -> String? {
+        // PROC_PIDPATHINFO_MAXSIZE is `4 * MAXPATHLEN` per
+        // <sys/proc_info.h>; the macro doesn't auto-import into Swift.
+        let bufLen = 4 * 1024
+        var buf = [CChar](repeating: 0, count: bufLen)
+        let result = proc_pidpath(pid, &buf, UInt32(bufLen))
+        guard result > 0 else { return nil }
+        return resolveSymlinks(in: String(cString: buf))
+    }
+
+    private static func resolveSymlinks(in path: String) -> String {
+        path.withCString { cpath in
+            guard let resolved = realpath(cpath, nil) else { return path }
+            defer { free(resolved) }
+            return String(cString: resolved)
+        }
+    }
+
+    // MARK: - ps parsing (testable surface)
+
+    struct Entry: Equatable {
+        let pid: pid_t
+        let elapsed: String
+        let commandLine: String
+    }
+
+    /// Detects whether a command line's first subcommand (token after the
+    /// binary path) is `serve`. Word-boundary check, so a command like
+    /// `cupertino server-something` would NOT match (defensive against
+    /// future subcommands containing the substring "serve").
+    static func isServeSubcommand(_ commandLine: String) -> Bool {
+        // Skip past the binary token. Use Substring slicing rather than
+        // .split() so we don't lose argv-with-spaces edge cases.
+        let trimmed = commandLine.trimmingCharacters(in: .whitespaces)
+        guard let firstSpace = trimmed.firstIndex(of: " ") else {
+            return false // no subcommand at all
+        }
+        let afterBinary = trimmed[trimmed.index(after: firstSpace)...]
+            .trimmingCharacters(in: .whitespaces)
+        // First token after binary must be exactly `serve`.
+        let firstToken = afterBinary.split(separator: " ", maxSplits: 1).first ?? ""
+        return firstToken == "serve"
+    }
+
+    /// Parses `ps -ax -o pid=,etime=,command=` output into Entry records.
+    /// Public for unit testability; not part of the runtime API.
+    static func parsePsOutput(_ output: String) -> [Entry] {
+        var entries: [Entry] = []
+        for line in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            let parts = trimmed.split(
+                separator: " ",
+                maxSplits: 2,
+                omittingEmptySubsequences: true
+            )
+            guard parts.count == 3,
+                  let pid = pid_t(parts[0])
+            else { continue }
+            entries.append(Entry(
+                pid: pid,
+                elapsed: String(parts[1]),
+                commandLine: String(parts[2])
+            ))
+        }
+        return entries
+    }
+
+    private static func listProcesses() -> [Entry] {
+        let task = Foundation.Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/ps")
+        task.arguments = ["-ax", "-o", "pid=,etime=,command="]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+        do {
+            try task.run()
+            task.waitUntilExit()
+        } catch {
+            return []
+        }
+        guard let data = try? pipe.fileHandleForReading.readToEnd(),
+              let output = String(data: data, encoding: .utf8)
+        else { return [] }
+        return parsePsOutput(output)
+    }
+}

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeReaperTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeReaperTests.swift
@@ -89,4 +89,29 @@ struct ServeReaperTests {
         #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino"))
         #expect(!ServeReaper.isServeSubcommand(""))
     }
+
+    // MARK: - Path-with-spaces edge cases (codex review on #267)
+
+    @Test("handles binary paths that contain spaces")
+    func binaryPathWithSpaces() {
+        // Real-world cases the previous implementation got wrong:
+        #expect(ServeReaper.isServeSubcommand("/Applications/My Tools/cupertino serve"))
+        #expect(ServeReaper.isServeSubcommand("/tmp/My Tools/cupertino serve"))
+        #expect(ServeReaper.isServeSubcommand("/Users/me/Dev Builds/cupertino serve"))
+        #expect(ServeReaper.isServeSubcommand("/Applications/My App/bin/cupertino serve --x"))
+        // Negative: serve missing
+        #expect(!ServeReaper.isServeSubcommand("/Applications/My Tools/cupertino save"))
+        #expect(!ServeReaper.isServeSubcommand("/Applications/My Tools/cupertino"))
+    }
+
+    @Test("handles outer directories named like the binary (cupertino-build / cupertino-suffix)")
+    func directoryNameContainsBinaryName() {
+        // Anchoring on the LAST occurrence of `cupertino` so a directory
+        // earlier in the path that happens to contain the substring does
+        // not throw the parser off.
+        #expect(ServeReaper.isServeSubcommand("/Volumes/cupertino-build/cupertino serve"))
+        #expect(ServeReaper.isServeSubcommand("/Apps/cupertino-suffix/cupertino serve"))
+        #expect(ServeReaper.isServeSubcommand("/path/cupertino/cupertino serve"))
+        #expect(!ServeReaper.isServeSubcommand("/Volumes/cupertino-build/cupertino save"))
+    }
 }

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeReaperTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeReaperTests.swift
@@ -3,9 +3,20 @@ import Foundation
 import Testing
 
 // Unit coverage for the testable surface of `ServeReaper` (#242).
-// The runtime reap loop (kill / proc_pidpath / spawning ps) is exercised
-// only by manual / staging verification — this suite covers the pure
-// string parsing that decides which processes are reap candidates.
+// The runtime reap loop (kill / proc_pidpath / spawning ps / sysctl)
+// is exercised only by manual / staging verification — this suite
+// covers the pure parsing layers that decide which processes get
+// reaped:
+//
+//   - `parsePsOutput` (PID + elapsed-time extraction from ps output)
+//   - `parseProcargs2` (argv extraction from the kernel-format byte
+//     buffer that `sysctl(KERN_PROCARGS2)` returns)
+//
+// Earlier revisions tried to detect the `serve` subcommand by parsing
+// the joined command line that `ps -o command=` outputs. That layer
+// got patched twice and still missed real-world failures because the
+// joined string loses argv boundaries irrecoverably. The kernel knows
+// the truth; we now ask it.
 
 @Suite("ServeReaper parsing")
 struct ServeReaperTests {
@@ -62,56 +73,145 @@ struct ServeReaperTests {
         #expect(entries.isEmpty)
     }
 
-    // MARK: - isServeSubcommand
+    // MARK: - parseProcargs2 (kernel argv buffer)
 
-    @Test("identifies serve as the subcommand")
-    func recognizesServe() {
-        #expect(ServeReaper.isServeSubcommand("/usr/local/bin/cupertino serve"))
-        #expect(ServeReaper.isServeSubcommand("/usr/local/bin/cupertino serve --search-db /tmp/x"))
-        #expect(ServeReaper.isServeSubcommand("cupertino serve"))
+    @Test("parses a typical KERN_PROCARGS2 buffer")
+    func parsesTypicalProcargs2() {
+        let buf = buildProcargs2(
+            execPath: "/usr/local/bin/cupertino",
+            argv: ["/usr/local/bin/cupertino", "serve"]
+        )
+        #expect(ServeReaper.parseProcargs2(buf) == [
+            "/usr/local/bin/cupertino",
+            "serve",
+        ])
     }
 
-    @Test("rejects non-serve subcommands so save/fetch survive (#242 acceptance)")
-    func rejectsOthers() {
-        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino save"))
-        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino fetch --type docs"))
-        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino doctor"))
+    @Test("preserves argument values containing 'cupertino' (regression for codex review on #267)")
+    func argValuesContainCupertino() {
+        // The realistic case codex flagged: --search-db /tmp/cupertino.db
+        // The previous string-anchored matcher resolved to `.db` and missed
+        // the process. Argv-based parsing returns the actual vector so
+        // argv[1] is unambiguously `serve` regardless of what later args
+        // contain.
+        let cases: [[String]] = [
+            ["/usr/local/bin/cupertino", "serve", "--search-db", "/tmp/cupertino.db"],
+            ["/usr/local/bin/cupertino", "serve", "--base-dir", "/Users/me/.cupertino-dev"],
+            [
+                "/Applications/My Tools/cupertino", "serve",
+                "--search-db", "/tmp/cupertino-search.db",
+            ],
+        ]
+        for argv in cases {
+            let buf = buildProcargs2(execPath: argv[0], argv: argv)
+            #expect(ServeReaper.parseProcargs2(buf) == argv)
+        }
     }
 
-    @Test("does not match word-prefix collisions (server-foo / serves)")
-    func wordBoundary() {
-        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino server-something"))
-        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino serves"))
-    }
-
-    @Test("rejects bare commands with no subcommand")
-    func bareBinary() {
-        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino"))
-        #expect(!ServeReaper.isServeSubcommand(""))
-    }
-
-    // MARK: - Path-with-spaces edge cases (codex review on #267)
-
-    @Test("handles binary paths that contain spaces")
+    @Test("handles binary paths that contain spaces (regression for first codex review on #267)")
     func binaryPathWithSpaces() {
-        // Real-world cases the previous implementation got wrong:
-        #expect(ServeReaper.isServeSubcommand("/Applications/My Tools/cupertino serve"))
-        #expect(ServeReaper.isServeSubcommand("/tmp/My Tools/cupertino serve"))
-        #expect(ServeReaper.isServeSubcommand("/Users/me/Dev Builds/cupertino serve"))
-        #expect(ServeReaper.isServeSubcommand("/Applications/My App/bin/cupertino serve --x"))
-        // Negative: serve missing
-        #expect(!ServeReaper.isServeSubcommand("/Applications/My Tools/cupertino save"))
-        #expect(!ServeReaper.isServeSubcommand("/Applications/My Tools/cupertino"))
+        let buf = buildProcargs2(
+            execPath: "/Applications/My Tools/cupertino",
+            argv: ["/Applications/My Tools/cupertino", "serve"]
+        )
+        let argv = ServeReaper.parseProcargs2(buf)
+        #expect(argv == ["/Applications/My Tools/cupertino", "serve"])
     }
 
-    @Test("handles outer directories named like the binary (cupertino-build / cupertino-suffix)")
-    func directoryNameContainsBinaryName() {
-        // Anchoring on the LAST occurrence of `cupertino` so a directory
-        // earlier in the path that happens to contain the substring does
-        // not throw the parser off.
-        #expect(ServeReaper.isServeSubcommand("/Volumes/cupertino-build/cupertino serve"))
-        #expect(ServeReaper.isServeSubcommand("/Apps/cupertino-suffix/cupertino serve"))
-        #expect(ServeReaper.isServeSubcommand("/path/cupertino/cupertino serve"))
-        #expect(!ServeReaper.isServeSubcommand("/Volumes/cupertino-build/cupertino save"))
+    @Test("handles arbitrary alignment padding between exec_path and argv[0]")
+    func alignmentPadding() {
+        // xnu pads exec_path's NUL terminator out to an alignment boundary.
+        // We don't know the exact alignment ahead of time; the parser
+        // should tolerate any number of trailing NULs before argv[0].
+        for padding in [0, 1, 3, 7, 15] {
+            let buf = buildProcargs2(
+                execPath: "/usr/local/bin/cupertino",
+                argv: ["cupertino", "serve"],
+                padding: padding
+            )
+            let argv = ServeReaper.parseProcargs2(buf)
+            #expect(argv == ["cupertino", "serve"], "padding=\(padding)")
+        }
     }
+
+    @Test("ignores envp following argv (does not read past argc strings)")
+    func ignoresEnvironment() {
+        let buf = buildProcargs2(
+            execPath: "/usr/local/bin/cupertino",
+            argv: ["cupertino", "serve"],
+            envp: ["HOME=/Users/me", "PATH=/usr/bin:/bin"]
+        )
+        let argv = ServeReaper.parseProcargs2(buf)
+        #expect(argv == ["cupertino", "serve"])
+    }
+
+    @Test("rejects buffers that are too short")
+    func rejectsTooShort() {
+        #expect(ServeReaper.parseProcargs2([]) == nil)
+        #expect(ServeReaper.parseProcargs2([0, 0, 0]) == nil)
+    }
+
+    @Test("rejects argc=0 buffers (no argv to inspect)")
+    func rejectsZeroArgc() {
+        let buf: [UInt8] = [0, 0, 0, 0] + Array("/usr/local/bin/cupertino\0".utf8)
+        #expect(ServeReaper.parseProcargs2(buf) == nil)
+    }
+
+    @Test("returns nil when buffer truncates mid-argv")
+    func truncatedBuffer() {
+        // Build a buffer claiming argc=3 but supplying only 2 strings.
+        var buf: [UInt8] = []
+        var argc = Int32(3)
+        withUnsafeBytes(of: &argc) { buf.append(contentsOf: $0) }
+        buf.append(contentsOf: "/usr/local/bin/cupertino\0".utf8)
+        buf.append(contentsOf: "cupertino\0".utf8)
+        buf.append(contentsOf: "serve\0".utf8)
+        // Only 2 strings provided; parser should return nil.
+        #expect(ServeReaper.parseProcargs2(buf) == nil)
+    }
+}
+
+// MARK: - Test fixture helpers
+
+/// Builds a synthetic `KERN_PROCARGS2` byte buffer in the xnu format the
+/// real `sysctl` returns. Layout per xnu `bsd/kern/kern_sysctl.c`:
+///
+///     [argc: int32 host-endian]
+///     [exec_path: null-terminated]
+///     [`padding` extra NUL bytes for alignment]
+///     [argv[0]: null-terminated]
+///     ...
+///     [argv[argc-1]: null-terminated]
+///     [envp[0]: null-terminated]
+///     ...
+private func buildProcargs2(
+    execPath: String,
+    argv: [String],
+    padding: Int = 0,
+    envp: [String] = []
+) -> [UInt8] {
+    var buffer: [UInt8] = []
+    var argc = Int32(argv.count)
+
+    withUnsafeBytes(of: &argc) { bytes in
+        buffer.append(contentsOf: bytes)
+    }
+
+    buffer.append(contentsOf: execPath.utf8)
+    buffer.append(0)
+    for _ in 0..<padding {
+        buffer.append(0)
+    }
+
+    for arg in argv {
+        buffer.append(contentsOf: arg.utf8)
+        buffer.append(0)
+    }
+
+    for env in envp {
+        buffer.append(contentsOf: env.utf8)
+        buffer.append(0)
+    }
+
+    return buffer
 }

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeReaperTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeReaperTests.swift
@@ -1,0 +1,92 @@
+@testable import CLI
+import Foundation
+import Testing
+
+// Unit coverage for the testable surface of `ServeReaper` (#242).
+// The runtime reap loop (kill / proc_pidpath / spawning ps) is exercised
+// only by manual / staging verification — this suite covers the pure
+// string parsing that decides which processes are reap candidates.
+
+@Suite("ServeReaper parsing")
+struct ServeReaperTests {
+    // MARK: - parsePsOutput
+
+    @Test("parses a typical ps -ax -o pid=,etime=,command= line")
+    func parsesTypicalLine() throws {
+        let output = "12345     1-02:30:45 /usr/local/bin/cupertino serve\n"
+        let entries = ServeReaper.parsePsOutput(output)
+        #expect(entries.count == 1)
+        let entry = try #require(entries.first)
+        #expect(entry.pid == 12345)
+        #expect(entry.elapsed == "1-02:30:45")
+        #expect(entry.commandLine == "/usr/local/bin/cupertino serve")
+    }
+
+    @Test("preserves command-line arguments after the binary path")
+    func preservesArgs() throws {
+        let output = "98765   00:30 /opt/homebrew/bin/cupertino serve --search-db /tmp/x\n"
+        let entry = try #require(ServeReaper.parsePsOutput(output).first)
+        #expect(entry.commandLine == "/opt/homebrew/bin/cupertino serve --search-db /tmp/x")
+    }
+
+    @Test("handles multiple lines and skips blank lines")
+    func multipleLines() {
+        let output = """
+            12345 00:30 /usr/local/bin/cupertino serve
+
+            54321 1:20 /usr/local/bin/cupertino save
+
+            99999 02:00 /bin/bash -c whatever
+            """
+        let entries = ServeReaper.parsePsOutput(output)
+        #expect(entries.count == 3)
+        #expect(entries.map(\.pid) == [12345, 54321, 99999])
+    }
+
+    @Test("skips lines without a parseable pid")
+    func skipsMalformed() throws {
+        let output = """
+            not-a-pid 00:30 /usr/local/bin/cupertino serve
+            12345 00:10 /usr/local/bin/cupertino serve
+            """
+        let entries = ServeReaper.parsePsOutput(output)
+        #expect(entries.count == 1)
+        let entry = try #require(entries.first)
+        #expect(entry.pid == 12345)
+    }
+
+    @Test("skips lines with too few fields")
+    func skipsShortLines() {
+        let output = "12345\n12345 00:10\n"
+        let entries = ServeReaper.parsePsOutput(output)
+        #expect(entries.isEmpty)
+    }
+
+    // MARK: - isServeSubcommand
+
+    @Test("identifies serve as the subcommand")
+    func recognizesServe() {
+        #expect(ServeReaper.isServeSubcommand("/usr/local/bin/cupertino serve"))
+        #expect(ServeReaper.isServeSubcommand("/usr/local/bin/cupertino serve --search-db /tmp/x"))
+        #expect(ServeReaper.isServeSubcommand("cupertino serve"))
+    }
+
+    @Test("rejects non-serve subcommands so save/fetch survive (#242 acceptance)")
+    func rejectsOthers() {
+        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino save"))
+        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino fetch --type docs"))
+        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino doctor"))
+    }
+
+    @Test("does not match word-prefix collisions (server-foo / serves)")
+    func wordBoundary() {
+        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino server-something"))
+        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino serves"))
+    }
+
+    @Test("rejects bare commands with no subcommand")
+    func bareBinary() {
+        #expect(!ServeReaper.isServeSubcommand("/usr/local/bin/cupertino"))
+        #expect(!ServeReaper.isServeSubcommand(""))
+    }
+}


### PR DESCRIPTION
Fixes #242. Reap stale sibling `cupertino serve` processes at startup.

## Symptom

Right now on the dev machine:

```
PID    ELAPSED       COMMAND
30543  1-09:19:04    /Applications/Claude.app/Contents/Helpers/disclaimer /opt/homebrew/bin/cupertino serve
30544  1-09:19:04    /opt/homebrew/bin/cupertino serve
52191  50:00         /opt/homebrew/bin/cupertino serve
43329  04:07:16      /opt/homebrew/bin/cupertino serve
```

Four stale `cupertino serve` instances, the oldest 4+ hours old. All held SQLite read connections to `search.db` / `samples.db` / `packages.db`, pinning file descriptors and stacking ~hundreds of MB RAM each once the AST cache warms. They also make `cupertino save` more likely to fail with `database is locked`.

## Root cause

MCP hosts (Claude Desktop, Cursor, etc.) launch a fresh `cupertino serve` every config reload but don't always reap the previous one when the previous host instance crashes or restarts. cupertino itself never noticed the orphan.

## Fix

`ServeCommand.run()` now calls `ServeReaper.reapSiblings()` before binding stdio:

1. Resolves own binary via `_NSGetExecutablePath` + `realpath`.
2. Lists processes via `ps -ax -o pid=,etime=,command=`.
3. For each candidate: gets its real binary path via `proc_pidpath` + `realpath`, compares against own. Skip on mismatch.
4. Verifies first subcommand is exactly `serve` (word-boundary check, so `cupertino save` survives, and a hypothetical `cupertino server-foo` would NOT match).
5. Skips own PID.
6. `SIGTERM`, 2s grace, `SIGKILL` if still alive.
7. Logs one line per reap to stderr (so it doesn't corrupt JSON-RPC stdout when an MCP host is talking via pipe).

## Acceptance verified per #242

- ✅ Two `cupertino serve` invocations of the same binary in succession leave only one alive (new reaps old).
- ✅ Two cupertino servers from different binary paths (brew + dev) coexist (different `realpath` → skip).
- ✅ Concurrent `cupertino save` / `fetch` is NOT reaped (subcommand check rejects them).
- ✅ One stderr line per reap so the user can see what happened.

## Tests

9 unit tests in `ServeReaperTests`:

- `parsePsOutput` correctness (typical, with-args, multi-line, malformed pid, too-few-fields)
- `isServeSubcommand` correctness (recognizes serve, rejects save/fetch/doctor, rejects `server-foo`/`serves` word-boundary collisions, rejects bare command, rejects empty)

The runtime kill loop (kill / proc_pidpath / forking ps) is covered only by manual / staging verification — unit-testing actual `fork` + `kill` would be flaky in CI for marginal value.

## Out of scope (per #242)

- Background watchdog mode that periodically reaps. Startup-time reap is enough; orphans only stack on host relaunch.
- Reaping non-serve cupertino processes. Save / fetch are rarer and have legitimate long-running cases.
- Cross-user reap. `ps` already filters to the calling user.
- WAL journal mode (#236) — broader fix for the lock-collision class, separate ticket.

## Milestone

v1.0.1.

## Files

- `Packages/Sources/CLI/Commands/ServeReaper.swift` — new (180 lines)
- `Packages/Sources/CLI/Commands/ServeCommand.swift` — single-call addition at the top of `run()`
- `Packages/Tests/CLICommandTests/ServeTests/ServeReaperTests.swift` — new (9 tests)
