### PR TITLE
feat(crawler): #203 HTML fallback link augmentation in auto mode

### DIFF
--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -282,6 +282,20 @@ extension Core {
             if useJSON {
                 do {
                     (structuredPage, markdown, links) = try await loadPageViaJSON(url: url, depth: depth)
+                    // Augment JSON-extracted links with HTML anchor tags when enabled. (#203)
+                    // Catches ~9,600 URLs that Apple's DocC JSON references dict omits.
+                    // Skipped in .jsonOnly mode (speed-critical) and when explicitly disabled.
+                    if configuration.htmlLinkAugmentation, mode == .auto {
+                        if let html = try? await loadPage(url: url) {
+                            let htmlLinks = autoreleasepool { extractLinks(from: html, baseURL: url) }
+                            let seen = Set(links.map(\.absoluteString))
+                            let added = htmlLinks.filter { !seen.contains($0.absoluteString) }
+                            if !added.isEmpty {
+                                logInfo("   🔗 HTML augmentation: +\(added.count) links")
+                                links += added
+                            }
+                        }
+                    }
                 } catch {
                     if mode == .jsonOnly {
                         // No fallback in pure JSON-only mode — propagate.

--- a/Packages/Sources/Shared/Configuration.swift
+++ b/Packages/Sources/Shared/Configuration.swift
@@ -24,6 +24,11 @@ extension Shared {
         public let requestDelay: TimeInterval
         public let retryAttempts: Int
         public let discoveryMode: DiscoveryMode
+        /// When true, the crawler fetches page HTML after a successful JSON API call and
+        /// unions the HTML anchor-tag links with the JSON-extracted links. Catches ~9,600
+        /// URLs that Apple's DocC JSON references dict omits. No-op in `.jsonOnly` mode.
+        /// Defaults to true; set to false for speed-critical crawls. (#203)
+        public let htmlLinkAugmentation: Bool
 
         public init(
             startURL: URL = URL(string: Shared.Constants.BaseURL.appleDeveloperDocs)!,
@@ -34,7 +39,8 @@ extension Shared {
             logFile: URL? = nil,
             requestDelay: TimeInterval = 0.05,
             retryAttempts: Int = 3,
-            discoveryMode: DiscoveryMode = .auto
+            discoveryMode: DiscoveryMode = .auto,
+            htmlLinkAugmentation: Bool = true
         ) {
             self.startURL = startURL
 
@@ -69,13 +75,14 @@ extension Shared {
             self.requestDelay = requestDelay
             self.retryAttempts = retryAttempts
             self.discoveryMode = discoveryMode
+            self.htmlLinkAugmentation = htmlLinkAugmentation
         }
 
         /// Custom decoder so legacy config JSON without `discoveryMode` still
         /// loads cleanly — defaults to `.auto`. Encode is auto-synthesized.
         private enum CodingKeys: String, CodingKey {
             case startURL, allowedPrefixes, maxPages, maxDepth, outputDirectory
-            case logFile, requestDelay, retryAttempts, discoveryMode
+            case logFile, requestDelay, retryAttempts, discoveryMode, htmlLinkAugmentation
         }
 
         public init(from decoder: any Decoder) throws {
@@ -89,6 +96,7 @@ extension Shared {
             requestDelay = try container.decode(TimeInterval.self, forKey: .requestDelay)
             retryAttempts = try container.decode(Int.self, forKey: .retryAttempts)
             discoveryMode = try container.decodeIfPresent(DiscoveryMode.self, forKey: .discoveryMode) ?? .auto
+            htmlLinkAugmentation = try container.decodeIfPresent(Bool.self, forKey: .htmlLinkAugmentation) ?? true
         }
 
         /// Load configuration from JSON file

--- a/Packages/Tests/CoreTests/CrawlerTests.swift
+++ b/Packages/Tests/CoreTests/CrawlerTests.swift
@@ -349,4 +349,64 @@ struct CrawlerTests {
         #expect(jsonURL != nil)
         #expect(jsonURL?.absoluteString == "https://developer.apple.com/tutorials/data/documentation/accelerate/lapack-functions.json")
     }
+
+    // MARK: - htmlLinkAugmentation Configuration Tests (#203)
+
+    @Test("CrawlerConfiguration htmlLinkAugmentation defaults to true")
+    func htmlLinkAugmentationDefaultsToTrue() throws {
+        let config = Shared.CrawlerConfiguration(
+            startURL: try #require(URL(string: "https://developer.apple.com/documentation")),
+            outputDirectory: FileManager.default.temporaryDirectory
+        )
+        #expect(config.htmlLinkAugmentation == true)
+    }
+
+    @Test("CrawlerConfiguration htmlLinkAugmentation can be set to false")
+    func htmlLinkAugmentationCanBeDisabled() throws {
+        let config = Shared.CrawlerConfiguration(
+            startURL: try #require(URL(string: "https://developer.apple.com/documentation")),
+            outputDirectory: FileManager.default.temporaryDirectory,
+            htmlLinkAugmentation: false
+        )
+        #expect(config.htmlLinkAugmentation == false)
+    }
+
+    @Test("CrawlerConfiguration decodes legacy JSON without htmlLinkAugmentation as true")
+    func htmlLinkAugmentationDecodesLegacyJSON() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let json = """
+        {
+            "startURL": "https://developer.apple.com/documentation",
+            "allowedPrefixes": ["https://developer.apple.com/documentation"],
+            "maxPages": 100,
+            "maxDepth": 15,
+            "outputDirectory": "\(tempDir.path)",
+            "requestDelay": 0.05,
+            "retryAttempts": 3
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let config = try JSONDecoder().decode(Shared.CrawlerConfiguration.self, from: data)
+        #expect(config.htmlLinkAugmentation == true)
+    }
+
+    @Test("CrawlerConfiguration decodes htmlLinkAugmentation false from JSON")
+    func htmlLinkAugmentationDecodesExplicitFalse() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let json = """
+        {
+            "startURL": "https://developer.apple.com/documentation",
+            "allowedPrefixes": ["https://developer.apple.com/documentation"],
+            "maxPages": 100,
+            "maxDepth": 15,
+            "outputDirectory": "\(tempDir.path)",
+            "requestDelay": 0.05,
+            "retryAttempts": 3,
+            "htmlLinkAugmentation": false
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let config = try JSONDecoder().decode(Shared.CrawlerConfiguration.self, from: data)
+        #expect(config.htmlLinkAugmentation == false)
+    }
 }


### PR DESCRIPTION
## Summary

- Implements HTML fallback link augmentation for issue #203 (VIG-192)
- After a successful JSON API fetch in `auto` discovery mode, the crawler now also fetches the rendered HTML via WKWebView and unions anchor-tag links with JSON-extracted links
- Restores discovery of ~9,600 URLs that Apple's DocC JSON references dict omits (operator overloads like `.!=(_:_:)`, legacy numeric-ID paths like `/iokit/.../1559770-...`, REST API sub-paths)
- New `htmlLinkAugmentation: Bool = true` config flag allows opting out for speed-critical crawls
- No-op in `.jsonOnly` and `.webViewOnly` modes

## Changes

- `Packages/Sources/Shared/Configuration.swift` — add `htmlLinkAugmentation: Bool = true` to `CrawlerConfiguration` with `decodeIfPresent` for backwards-compatible JSON config loading
- `Packages/Sources/Core/Crawler.swift` — add HTML augmentation union block in `crawlPage()` after JSON success, guarded by `mode == .auto && configuration.htmlLinkAugmentation`
- `Packages/Tests/CoreTests/CrawlerTests.swift` — 4 new unit tests: default value, explicit disable, and legacy JSON decoding (both with and without the field)

## Test plan

- [ ] `swift test --filter htmlLinkAugmentation` — 4 tests pass
- [ ] `swift build` — clean build, no errors
- [ ] Live smoke crawl on `https://developer.apple.com/documentation/webkitjs` in `.auto` mode confirms link count parity with `.webViewOnly` baseline (T-E1 from Linda's QA plan)
- [ ] Spot-check `https://developer.apple.com/documentation/accelerate/simd_float2x4` confirms operator overload URLs discovered (T-E2)

## Notes

Augmentation uses the existing `webPageFetcher` (WKWebView); the fetch is guarded with `try?` so a timeout or network error degrades gracefully to JSON-only links. The `autoreleasepool` wrapper on `extractLinks` follows the existing pattern in the file for memory safety on long crawls.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)