### PR TITLE
fix(search): normalize underscore→dash in sub-page URI segments (#285)

### DIFF
--- a/Packages/Sources/Shared/Models.swift
+++ b/Packages/Sources/Shared/Models.swift
@@ -872,14 +872,16 @@ public enum URLUtilities {
     // be left untouched.
     private static func normalizeDocPath(_ path: String) -> String {
         var parts = path.components(separatedBy: "/")
-        guard let docIdx = parts.firstIndex(of: "documentation") else {
-            return path
-        }
-        let normalizeFromIdx = docIdx + 2  // skip "documentation" + framework slug
-        for i in normalizeFromIdx..<parts.count {
-            parts[i] = String(parts[i].map { $0 == "_" ? "-" : $0 })
-        }
-        return parts.joined(separator: "/")
+        guard let docIdx = parts.firstIndex(of: "documentation"),
+              docIdx + 2 < parts.count else { return path }
+
+        let normalizeFromIdx = docIdx + 2
+        return parts
+            .enumerated()
+            .map { index, part in
+                index >= normalizeFromIdx ? String(part.map { $0 == "_" ? "-" : $0 }) : part
+            }
+            .joined(separator: "/")
     }
 
     /// Extract framework name from documentation URL (Apple or Swift.org)

--- a/Packages/Sources/Shared/Models.swift
+++ b/Packages/Sources/Shared/Models.swift
@@ -873,7 +873,7 @@ public enum URLUtilities {
         }
         let normalizeFromIdx = docIdx + 2  // skip "documentation" + framework slug
         for i in normalizeFromIdx..<parts.count {
-            parts[i] = parts[i].replacingOccurrences(of: "_", with: "-")
+            parts[i] = String(parts[i].map { $0 == "_" ? "-" : $0 })
         }
         return parts.joined(separator: "/")
     }

--- a/Packages/Sources/Shared/Models.swift
+++ b/Packages/Sources/Shared/Models.swift
@@ -842,16 +842,20 @@ public enum HashUtilities {
 
 /// Utilities for URL manipulation
 public enum URLUtilities {
-    /// Normalize a URL: strip fragment and query, lowercase the path, and
-    /// collapse underscore → dash in sub-page path segments within
-    /// /documentation/ paths (depth ≥ 3, i.e. everything after the framework
-    /// slug). Framework-level slugs at depth 2 are intentionally preserved
-    /// because at least two Apple frameworks (`installer_js`,
+    /// Returns a normalized copy of `url` with fragment and query stripped,
+    /// path lowercased, and underscores replaced with dashes in sub-page
+    /// segments within `/documentation/` paths.
+    ///
+    /// Applies underscore-to-dash replacement only to path segments at depth
+    /// ≥ 3 (sub-page level). Framework slugs at depth 2 are preserved because
+    /// at least two Apple frameworks (`installer_js`,
     /// `professional_video_applications`) use underscores canonically and
-    /// their dash forms return 404. The sub-page axis is safe to normalize
-    /// because Apple's docs server 301-redirects all underscore sub-page
-    /// slugs to their dash equivalents, resolving the 31 duplicate URI
+    /// their dash forms return 404. This resolves the 31 duplicate URI
     /// clusters in search.db (#285).
+    ///
+    /// - Parameter url: The URL to normalize.
+    /// - Returns: The normalized URL, or `nil` if `url` cannot be decomposed
+    ///   into URL components.
     public static func normalize(_ url: URL) -> URL? {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         components?.fragment = nil

--- a/Packages/Sources/Shared/Models.swift
+++ b/Packages/Sources/Shared/Models.swift
@@ -842,23 +842,40 @@ public enum HashUtilities {
 
 /// Utilities for URL manipulation
 public enum URLUtilities {
-    /// Normalize a URL: strip fragment and query, lowercase the path.
-    /// Apple's docs server is case-insensitive on the path
-    /// (`/documentation/Cinematic/CNAssetInfo-2ata2` and the all-lowercase
-    /// form return the same content), so dedup logic must treat them as one
-    /// page (#200). Dash-vs-underscore framework variants
-    /// (`professional-video-applications` ↔ `professional_video_applications`)
-    /// are NOT collapsed here because at least one Apple framework
-    /// (`installer_js`) legitimately uses underscore in its path; that axis
-    /// is handled at the search-index save layer instead.
+    /// Normalize a URL: strip fragment and query, lowercase the path, and
+    /// collapse underscore → dash in sub-page path segments within
+    /// /documentation/ paths (depth ≥ 3, i.e. everything after the framework
+    /// slug). Framework-level slugs at depth 2 are intentionally preserved
+    /// because at least two Apple frameworks (`installer_js`,
+    /// `professional_video_applications`) use underscores canonically and
+    /// their dash forms return 404. The sub-page axis is safe to normalize
+    /// because Apple's docs server 301-redirects all underscore sub-page
+    /// slugs to their dash equivalents, resolving the 31 duplicate URI
+    /// clusters in search.db (#285).
     public static func normalize(_ url: URL) -> URL? {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         components?.fragment = nil
         components?.query = nil
         if let path = components?.path {
-            components?.path = path.lowercased()
+            components?.path = normalizeDocPath(path.lowercased())
         }
         return components?.url
+    }
+
+    // Replace underscores with dashes in sub-page path segments only.
+    // Framework slugs at depth 2 after /documentation/ use underscores
+    // canonically (installer_js, professional_video_applications) and must
+    // be left untouched.
+    private static func normalizeDocPath(_ path: String) -> String {
+        var parts = path.components(separatedBy: "/")
+        guard let docIdx = parts.firstIndex(of: "documentation") else {
+            return path
+        }
+        let normalizeFromIdx = docIdx + 2  // skip "documentation" + framework slug
+        for i in normalizeFromIdx..<parts.count {
+            parts[i] = parts[i].replacingOccurrences(of: "_", with: "-")
+        }
+        return parts.joined(separator: "/")
     }
 
     /// Extract framework name from documentation URL (Apple or Swift.org)

--- a/Packages/Tests/CoreTests/CrawlerTests.swift
+++ b/Packages/Tests/CoreTests/CrawlerTests.swift
@@ -149,6 +149,16 @@ struct CrawlerTests {
         #expect(normalized?.path == "/documentation/swiftui/some-method")
     }
 
+    @Test("URLUtilities normalize does not crash on /documentation with no framework slug")
+    func urlNormalizeHandlesDocumentationOnlyPath() throws {
+        // Regression: normalizeDocPath used to trap with "Range requires lowerBound <= upperBound"
+        // when documentation was found but had fewer than 2 following path segments.
+        let url = URL(string: "https://developer.apple.com/documentation")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation")
+    }
+
     // MARK: - Framework Extraction Tests
 
     @Test("URLUtilities extracts framework from Apple docs URL")

--- a/Packages/Tests/CoreTests/CrawlerTests.swift
+++ b/Packages/Tests/CoreTests/CrawlerTests.swift
@@ -107,12 +107,15 @@ struct CrawlerTests {
         #expect(normalized?.path == "/documentation/corelocation/getting-heading-and-course-information")
     }
 
-    @Test("URLUtilities normalize preserves installer_js framework slug but normalizes sub-page underscore")
+    @Test("URLUtilities normalize preserves framework slug at depth 2 and normalizes sub-page underscore")
     func urlNormalizePreservesFrameworkSlugNormalizesSubpage() throws {
-        let url = URL(string: "https://developer.apple.com/documentation/installer_js/some_class")!
+        // driverkit/driverkit_constants is one of the 31 duplicate-cluster pairs from #285.
+        // The framework slug "driverkit" at depth 2 must be left untouched;
+        // only "driverkit_constants" at depth 3 is collapsed to dashes.
+        let url = URL(string: "https://developer.apple.com/documentation/driverkit/driverkit_constants")!
         let normalized = URLUtilities.normalize(url)
 
-        #expect(normalized?.path == "/documentation/installer_js/some-class")
+        #expect(normalized?.path == "/documentation/driverkit/driverkit-constants")
     }
 
     @Test("URLUtilities normalize converts underscores at multiple sub-page depths")

--- a/Packages/Tests/CoreTests/CrawlerTests.swift
+++ b/Packages/Tests/CoreTests/CrawlerTests.swift
@@ -99,6 +99,56 @@ struct CrawlerTests {
         #expect(try !#require(normalized?.absoluteString.contains("installer-js")))
     }
 
+    @Test("URLUtilities normalize converts underscore sub-page slug to dash")
+    func urlNormalizeConvertsUnderscoreSubpageToDash() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/corelocation/getting_heading_and_course_information")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/corelocation/getting-heading-and-course-information")
+    }
+
+    @Test("URLUtilities normalize preserves installer_js framework slug but normalizes sub-page underscore")
+    func urlNormalizePreservesFrameworkSlugNormalizesSubpage() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/installer_js/some_class")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/installer_js/some-class")
+    }
+
+    @Test("URLUtilities normalize converts underscores at multiple sub-page depths")
+    func urlNormalizeConvertsUnderscoresAtMultipleDepths() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/swiftui/some_class/some_method")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/swiftui/some-class/some-method")
+    }
+
+    @Test("URLUtilities normalize does not touch non-documentation URL underscores")
+    func urlNormalizeDoesNotTouchNonDocsPaths() throws {
+        let url = URL(string: "https://developer.apple.com/videos/play/wwdc2023/10_video")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/videos/play/wwdc2023/10_video")
+    }
+
+    @Test("URLUtilities normalize strips fragment and query and collapses sub-page underscore")
+    func urlNormalizeStripsFragmentQueryAndNormalizesUnderscore() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/swiftui/some_method?foo=1#bar")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/swiftui/some-method")
+        #expect(normalized?.query == nil)
+        #expect(normalized?.fragment == nil)
+    }
+
+    @Test("URLUtilities normalize lowercases before collapsing underscore to dash")
+    func urlNormalizeLowercasesBeforeCollapsingUnderscore() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/SwiftUI/Some_Method")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/swiftui/some-method")
+    }
+
     // MARK: - Framework Extraction Tests
 
     @Test("URLUtilities extracts framework from Apple docs URL")


### PR DESCRIPTION
## Summary

- Adds underscore→dash normalization in `URLUtilities.normalize()` for path segments at depth ≥ 3 within `/documentation/` paths, fixing the 31 duplicate URI clusters (62 rows) in `search.db` reported in #285.
- Framework slugs at depth 2 are intentionally preserved — `installer_js` and `professional_video_applications` use underscores canonically and their dash forms return 404 on Apple's server.
- Adds a private `normalizeDocPath(_:)` helper that splits on `/`, finds the `documentation` segment, and applies `replacingOccurrences(of: "_", with: "-")` only from depth ≥ 3 onwards.
- Updates the `normalize()` docstring to remove the outdated "NOT collapsed here / handled at the search-index save layer" caveat.
- Adds 6 regression tests covering: sub-page normalization, framework slug preservation, multi-level paths, non-docs URLs, fragment/query stripping with underscores, and uppercase→lowercase→dash pipeline.

## Files Changed

- `Packages/Sources/Shared/Models.swift` — `URLUtilities.normalize()` + new `normalizeDocPath(_:)`
- `Packages/Tests/CoreTests/CrawlerTests.swift` — 6 new `@Test` cases

## Post-merge Action Required

A `search.db` re-index is required after deployment to remove the 62 existing stale rows with mixed dash/underscore URI variants. Recommended approach: delete and re-index `search.db` (cleanest, no merge logic needed).

## Test plan

- [x] `swift build` — 0 errors
- [x] `swift test --filter CrawlerTests` — 67 tests pass (including all 6 new normalize tests + existing installer_js safety test)
- [x] `swift test --filter URLUtilitiesFilenameTests` — 10 tests pass

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)