### PR TITLE
fix(core): #284 skip HTTP error templates in WebView fallback

### DIFF
--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -313,6 +313,12 @@ extension Core {
                     // JSON API failed, fall back to HTML
                     logInfo("   ⚠️ JSON API unavailable, using HTML fallback")
                     let html = try await loadPage(url: url)
+                    if HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) {
+                        logInfo("   ⛔ HTTP error template detected, skipping (#284)")
+                        await state.updateStatistics { $0.errors += 1 }
+                        await state.updateStatistics { $0.totalPages += 1 }
+                        return
+                    }
                     (markdown, links, structuredPage) = autoreleasepool {
                         (
                             HTMLToMarkdown.convert(html, url: url),
@@ -324,6 +330,12 @@ extension Core {
             } else {
                 // No JSON endpoint available, use HTML directly
                 let html = try await loadPage(url: url)
+                if HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) {
+                    logInfo("   ⛔ HTTP error template detected, skipping (#284)")
+                    await state.updateStatistics { $0.errors += 1 }
+                    await state.updateStatistics { $0.totalPages += 1 }
+                    return
+                }
                 (markdown, links, structuredPage) = autoreleasepool {
                     (
                         HTMLToMarkdown.convert(html, url: url),

--- a/Packages/Sources/Core/Transformers/HTMLToMarkdown.swift
+++ b/Packages/Sources/Core/Transformers/HTMLToMarkdown.swift
@@ -112,6 +112,69 @@ public struct HTMLToMarkdown: ContentTransformer, @unchecked Sendable {
             lowercased.contains("javascript is required")
     }
 
+    // MARK: - Error-page detection (#284)
+
+    /// Returns true if `html` looks like an HTTP error response template
+    /// (Apple's CDN sometimes serves a styled 403/404/502 page with HTTP
+    /// 200 status, which then gets indexed as if it were documentation).
+    /// Used by the crawler's WebView fallback as a defense-in-depth check
+    /// before saving the page. The JSON API path already filters by
+    /// HTTP status code, so this gate fires only on rendered-HTML inputs.
+    public static func looksLikeHTTPErrorPage(html: String) -> Bool {
+        guard let title = extractTitle(from: html) else {
+            // No title means we'll skip via the existing nil-title gate; let
+            // that path handle it rather than double-counting.
+            return false
+        }
+        return looksLikeHTTPErrorPage(title: title, html: html)
+    }
+
+    /// Pure decision over a pre-extracted `title` + the surrounding `html`.
+    /// Split out so unit tests can exercise the rule against synthetic
+    /// inputs without round-tripping through the full HTML title-extractor.
+    static func looksLikeHTTPErrorPage(title: String, html: String) -> Bool {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Direct prefix: "403 Forbidden", "502 Bad Gateway", etc.
+        // The space/end-anchor matches the issue spec so a real Apple page
+        // titled "404 Not Found · Apple Developer Documentation" still trips
+        // it, while "Routing404" or "Error404Type" do not.
+        if trimmed.range(of: #"^(403|404|429|500|502|503|504)(\s|$)"#, options: .regularExpression) != nil {
+            return true
+        }
+
+        // Defense-in-depth: a very short rendered body whose title contains
+        // a known error phrase. The issue spec calls for a content-body
+        // word-count (not the converted-markdown word-count, which would
+        // include the front-matter overhead `convert()` always emits).
+        let errorPhrases = ["Forbidden", "Bad Gateway", "Not Found", "Service Unavailable", "Gateway Timeout"]
+        let containsErrorPhrase = errorPhrases.contains { trimmed.contains($0) }
+        if containsErrorPhrase, countBodyWords(in: html) < 10 {
+            return true
+        }
+
+        return false
+    }
+
+    /// Approximate body word-count for the error-page heuristic. Strips
+    /// HTML tags + entities from the `<body>` region (or the whole input
+    /// if no body tag), then counts whitespace-separated tokens. Cheap
+    /// enough to run on every WebView fallback page; the only consumer is
+    /// `looksLikeHTTPErrorPage`.
+    private static func countBodyWords(in html: String) -> Int {
+        let body: String
+        let bodyOptions: NSString.CompareOptions = [.regularExpression, .caseInsensitive]
+        if let range = html.range(of: #"<body[^>]*>(.*?)</body>"#, options: bodyOptions) {
+            body = String(html[range])
+        } else {
+            body = html
+        }
+        let stripped = body
+            .replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "&[a-z0-9#]+;", with: " ", options: bodyOptions)
+        return stripped.split(whereSeparator: { $0.isWhitespace }).count
+    }
+
     private static func extractMainContent(from html: String) -> String {
         // Try to extract main content area - need dotMatchesLineSeparators for multiline content
         let options: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]

--- a/Packages/Tests/CoreTests/HTMLToMarkdownErrorPageDetectionTests.swift
+++ b/Packages/Tests/CoreTests/HTMLToMarkdownErrorPageDetectionTests.swift
@@ -1,0 +1,109 @@
+@testable import Core
+import Foundation
+import Testing
+
+// Coverage for the `HTMLToMarkdown.looksLikeHTTPErrorPage(...)` helper
+// added in #284. The helper gates the crawler's WebView fallback path
+// from persisting Apple's CDN-served error templates as if they were
+// documentation pages. The shipped v1.0.2 search.db carries 68 such
+// poison rows (23 × 403 + 45 × 502) that this helper would have caught
+// at crawl time.
+
+@Suite("HTMLToMarkdown.looksLikeHTTPErrorPage (#284)")
+struct HTMLToMarkdownErrorPageDetectionTests {
+    // MARK: HTTP-status-prefix titles
+
+    @Test("'403 Forbidden' title trips the gate")
+    func detectsForbidden() {
+        let html = "<html><head><title>403 Forbidden</title></head><body><p>Forbidden.</p></body></html>"
+        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == true)
+    }
+
+    @Test("'502 Bad Gateway' title trips the gate")
+    func detectsBadGateway() {
+        let html = "<html><head><title>502 Bad Gateway</title></head><body><p>Server error.</p></body></html>"
+        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == true)
+    }
+
+    @Test(
+        "All status-prefix codes from the issue spec trip the gate",
+        arguments: [
+            "403 Forbidden",
+            "404 Not Found",
+            "429 Too Many Requests",
+            "500 Internal Server Error",
+            "502 Bad Gateway",
+            "503 Service Unavailable",
+            "504 Gateway Timeout",
+        ]
+    )
+    func detectsAllStatusPrefixes(title: String) {
+        let html = "<html><head><title>\(title)</title></head><body><p>err</p></body></html>"
+        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == true)
+    }
+
+    // MARK: Real Apple titles that LOOK error-adjacent must NOT trip
+
+    @Test("Real Apple symbol page named '...Forbidden...' is not flagged")
+    func realForbiddenSymbolNotFlagged() {
+        // From the v1.0.2 audit: there are legitimate Apple symbol pages
+        // like UIDropOperation.forbidden, MTRAccessControlAccessRestriction-
+        // Type.attributeAccessForbidden, etc. None match the status-prefix
+        // regex AND they all carry a real documentation body, so word-count
+        // pushes them above the 10-word threshold.
+        let html = """
+        <html><head><title>UIDropOperation.forbidden | Apple Developer Documentation</title></head>
+        <body>
+        <h1>UIDropOperation.forbidden</h1>
+        <p>The drag operation is not permitted at the destination, so a stop
+        glyph is rendered next to the cursor while the drag is over the view.
+        Use this case when the receiver cannot accept the dragged content but
+        wants to communicate that constraint visually.</p>
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == false)
+    }
+
+    @Test("Real Apple symbol page named 'Routing404Type' is not flagged")
+    func numericInTitleNotFlagged() {
+        let html = """
+        <html><head><title>Routing404Type | Apple Developer Documentation</title></head>
+        <body><h1>Routing404Type</h1>
+        <p>A type that represents the specific kind of 404 routing error
+        observed in the request. Used by the routing layer to differentiate
+        legitimate not-found cases from misconfigured routes.</p></body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == false)
+    }
+
+    // MARK: word-count defense-in-depth
+
+    @Test("Short body + 'Service Unavailable' phrase trips the defense-in-depth gate")
+    func shortBodyServiceUnavailableTrips() {
+        let html = "<html><head><title>Service Unavailable</title></head><body><p>Try again later.</p></body></html>"
+        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == true)
+    }
+
+    @Test("Long body containing 'Bad Gateway' phrase in title is NOT flagged once it has real content")
+    func longBodyOverridesPhraseHeuristic() {
+        // If Apple ever ships a real doc page with one of the error phrases
+        // in the title, the word-count threshold should keep us from
+        // incorrectly skipping it.
+        let body = String(repeating: "word ", count: 50) // 50 whitespace-separated tokens
+        let html = "<html><head><title>Handling Bad Gateway Responses</title></head><body><p>\(body)</p></body></html>"
+        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == false)
+    }
+
+    // MARK: degenerate inputs
+
+    @Test("Title-less HTML returns false (the existing nil-title gate handles it)")
+    func noTitleReturnsFalse() {
+        let html = "<html><body><p>Just a body, no head, no title.</p></body></html>"
+        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == false)
+    }
+
+    @Test("Empty HTML returns false")
+    func emptyHTMLReturnsFalse() {
+        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: "") == false)
+    }
+}


### PR DESCRIPTION
## What

Closes #284. Adds a defense-in-depth gate at the crawler boundary so Apple's CDN-served HTTP error templates (403/404/429/500/502/503/504) stop landing in `docs_structured` as if they were real documentation.

## Why

Audit of the v1.0.2 bundle (post-#283 reindex):

```sql
SELECT title, COUNT(*) FROM docs_structured
WHERE title IN ('403 Forbidden', '502 Bad Gateway')
GROUP BY title;
-- 403 Forbidden   | 23
-- 502 Bad Gateway | 45
```

68 poisoned rows. Sample URLs are mostly Swift built-in operator-overload pages (403s) and AudioToolbox / AVRouting / Tabletopkit / Kernel symbols (502s). Apple's docs server returns these errors *consistently*, so #283's reindex didn't help — the WebView fallback rendered them at HTTP 200 and we persisted them.

## How

- `HTMLToMarkdown.looksLikeHTTPErrorPage(html:)` — public static helper. Returns `true` when the extracted title matches `^(403|404|429|500|502|503|504)(\\s|$)`, OR when the title contains `Forbidden` / `Bad Gateway` / `Not Found` / `Service Unavailable` / `Gateway Timeout` AND the rendered body has fewer than 10 whitespace-separated tokens.
- Body word-count is computed against the `<body>` region of the raw HTML (with tags + entities stripped), **not** against `convert()` output. `convert()` always emits a small front-matter block (`source:`, `crawled:`) that would push short error templates above the threshold and silently disable the heuristic.
- `Crawler.swift`'s two HTML fallback sites (post-JSON-API-failure and no-JSON-endpoint) call the helper after fetching HTML and before any persistence. On a hit: log with the `#284` tag, bump `CrawlStatistics.errors` + `totalPages`, return early — no JSON write, no markdown write, no metadata entry, no link enqueue.

The JSON API path already gates on `statusCode == 200` and is unaffected.

## Scope

- **No schema change.** `docs_structured` layout unchanged.
- **No version bump.** `databaseVersion` and `schemaVersion` unchanged. The post-#284 binary is fully compatible with the v1.0.2 bundle.
- **No migration.** The 68 existing poison rows stay in the v1.0.2 bundle until some future bundle release. This fix prevents new poison from being added during subsequent crawls.

## Tests

New: `Tests/CoreTests/HTMLToMarkdownErrorPageDetectionTests.swift` — 9 cases / 1 suite:
- 7-case parameterized pin of every status-prefix code from the spec
- positive cases for `403 Forbidden` / `502 Bad Gateway`
- negative cases for legitimate Apple symbol pages whose title contains `Forbidden` (`UIDropOperation.forbidden`) or the digits `404` (`Routing404Type`) — both must NOT be flagged
- defense-in-depth: short body + `Service Unavailable` phrase trips; long body + `Bad Gateway` phrase doesn't
- degenerate inputs (no title, empty html) return false

## Verification

- `swift build` clean
- `swift test`: **1252 → 1261 tests / 140 → 141 suites pass**
- pre-commit `SwiftLint` + `SwiftFormat` pass

## Side note (out of scope)

`Crawler.swift:23` carries a dotted-type IUO (`webPageFetcher: WKWebCrawler.WKWebContentFetcher!`) that PR #288's force-unwrap audit regex didn't catch (regex was simple-type only). Flagging here for a future cleanup; not addressing in this PR.