### PR TITLE
fix(search): #284 indexer-side defense — refuse to index HTTP error templates

### DIFF
--- a/Packages/Sources/Search/SearchIndexBuilder.swift
+++ b/Packages/Sources/Search/SearchIndexBuilder.swift
@@ -292,6 +292,23 @@ extension Search {
                     jsonString = json
                 }
 
+                // Defense-in-depth: refuse to index any page whose title looks
+                // like an HTTP error template (502 Bad Gateway, 403 Forbidden,
+                // etc.). The crawler-side filter (#284 / PR #289) catches
+                // these at fetch time, but stray poison files can land on disk
+                // via mid-flight rsync from a pre-#284 binary, restored
+                // backups, or hand-edited corpora. Skipping at index time
+                // keeps the bundle clean by construction regardless of how
+                // the file got onto disk.
+                if Self.titleLooksLikeHTTPErrorTemplate(structuredPage.title) {
+                    logError(
+                        "⛔ Skipping HTTP-error-template page (#284 indexer defense): " +
+                            "title=\(structuredPage.title.prefix(60)) file=\(file.lastPathComponent)"
+                    )
+                    skipped += 1
+                    continue
+                }
+
                 // Generate URI: apple-docs://{framework}/{filename}
                 let filename = URLUtilities.normalize(structuredPage.url)?.lastPathComponent
                     ?? canonicalPathComponent(file.deletingPathExtension().lastPathComponent)
@@ -1249,6 +1266,44 @@ extension Search {
         private func logError(_ message: String) {
             let errorMessage = "❌ \(message)"
             Log.error(errorMessage, category: .search)
+        }
+
+        // MARK: - #284 indexer-side defense
+
+        /// Returns true if `title` matches an HTTP error template's title
+        /// pattern. Used to skip poisoned-on-disk JSON files at index time as
+        /// a belt-and-suspenders complement to PR #289's crawler-side gate.
+        ///
+        /// Two checks, mirroring the issue spec:
+        /// 1. Title starts with one of the canonical HTTP error status codes
+        ///    followed by whitespace or end-of-string ("502 Bad Gateway",
+        ///    "404 Not Found", etc.). Catches the literal CDN-rendered
+        ///    error pages.
+        /// 2. Title equals (after trim) one of the standalone error phrases
+        ///    Apple's CDN sometimes returns. Catches templates that drop
+        ///    the numeric prefix.
+        ///
+        /// `internal` so SearchTests can pin the truth table.
+        static func titleLooksLikeHTTPErrorTemplate(_ title: String) -> Bool {
+            let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { return false }
+
+            // Status-prefix form: "403 Forbidden", "502 Bad Gateway", etc.
+            if trimmed.range(of: #"^(403|404|429|500|502|503|504)(\s|$)"#, options: .regularExpression) != nil {
+                return true
+            }
+
+            // Standalone phrase form (rare but seen in some Apple CDN error templates)
+            let standalone: Set<String> = [
+                "Forbidden",
+                "Bad Gateway",
+                "Not Found",
+                "Service Unavailable",
+                "Gateway Timeout",
+                "Too Many Requests",
+                "Internal Server Error",
+            ]
+            return standalone.contains(trimmed)
         }
     }
 }

--- a/Packages/Sources/Search/SearchIndexBuilder.swift
+++ b/Packages/Sources/Search/SearchIndexBuilder.swift
@@ -308,6 +308,14 @@ extension Search {
                     skipped += 1
                     continue
                 }
+                if Self.pageLooksLikeJavaScriptFallback(structuredPage) {
+                    logError(
+                        "⛔ Skipping JS-disabled-fallback page (#284 indexer defense): " +
+                            "title=\(structuredPage.title.prefix(60)) file=\(file.lastPathComponent)"
+                    )
+                    skipped += 1
+                    continue
+                }
 
                 // Generate URI: apple-docs://{framework}/{filename}
                 let filename = URLUtilities.normalize(structuredPage.url)?.lastPathComponent
@@ -1304,6 +1312,32 @@ extension Search {
                 "Internal Server Error",
             ]
             return standalone.contains(trimmed)
+        }
+
+        /// Returns true if the page looks like Apple's "JavaScript disabled"
+        /// fallback that the WebView crawler captured when JS didn't render
+        /// in time. The on-disk file has a real-looking title (Apple ships
+        /// it in HTML metadata even when JS is off) but the body content is
+        /// `[ Skip Navigation ](#app-main)# An unknown error occurred.` with
+        /// an `overview` of `Please turn on JavaScript in your browser…`.
+        ///
+        /// Found in 1,327 files of the v1.0.2 corpus when this audit ran;
+        /// missed by every prior title-only check.
+        ///
+        /// `internal` so SearchTests can pin the truth table.
+        static func pageLooksLikeJavaScriptFallback(_ page: StructuredDocumentationPage) -> Bool {
+            // Strongest signal: overview is the literal Apple JS-warning text.
+            if let overview = page.overview, overview.contains("Please turn on JavaScript") {
+                return true
+            }
+            // Body signal: rawMarkdown carries the broken Skip-Navigation +
+            // "An unknown error occurred" pattern that the crawler emitted
+            // when it couldn't extract real content.
+            if let rawmd = page.rawMarkdown {
+                if rawmd.contains("Please turn on JavaScript") { return true }
+                if rawmd.contains("#app-main)# An unknown error occurred") { return true }
+            }
+            return false
         }
     }
 }

--- a/Packages/Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+@testable import Search
+import Testing
+
+// Truth-table coverage for `Search.IndexBuilder.titleLooksLikeHTTPErrorTemplate`,
+// the indexer-side defense added as a belt-and-suspenders to PR #289's
+// crawler-side gate. Even if a poison JSON file lands on disk via mid-flight
+// rsync, restored backup, or hand-edited corpus, the indexer must refuse to
+// index it.
+//
+// The audit on the v1.0.2 bundle saw 23 × "403 Forbidden" + 45 × "502 Bad
+// Gateway" rows; this defense would have caught all of them at index time.
+
+@Suite("Search.IndexBuilder.titleLooksLikeHTTPErrorTemplate (#284 indexer defense)")
+struct IndexBuilderTitleErrorDefenseTests {
+    typealias SUT = Search.IndexBuilder
+
+    // MARK: status-prefix form
+
+    @Test(
+        "every spec'd status-prefix title trips the gate",
+        arguments: [
+            "403 Forbidden",
+            "404 Not Found",
+            "429 Too Many Requests",
+            "500 Internal Server Error",
+            "502 Bad Gateway",
+            "503 Service Unavailable",
+            "504 Gateway Timeout",
+        ]
+    )
+    func statusPrefixTitlesAreDetected(title: String) {
+        #expect(SUT.titleLooksLikeHTTPErrorTemplate(title) == true)
+    }
+
+    @Test("status-prefix at end-of-string also trips (no trailing phrase)")
+    func bareStatusCodeIsDetected() {
+        #expect(SUT.titleLooksLikeHTTPErrorTemplate("502") == true)
+    }
+
+    // MARK: standalone phrase form
+
+    @Test(
+        "standalone error phrases trip the gate",
+        arguments: [
+            "Forbidden",
+            "Bad Gateway",
+            "Not Found",
+            "Service Unavailable",
+            "Gateway Timeout",
+            "Too Many Requests",
+            "Internal Server Error",
+        ]
+    )
+    func standalonePhrasesAreDetected(title: String) {
+        #expect(SUT.titleLooksLikeHTTPErrorTemplate(title) == true)
+    }
+
+    @Test("standalone with whitespace trims correctly")
+    func whitespaceTrimming() {
+        #expect(SUT.titleLooksLikeHTTPErrorTemplate("  Bad Gateway  ") == true)
+        #expect(SUT.titleLooksLikeHTTPErrorTemplate("\n502 Bad Gateway\n") == true)
+    }
+
+    // MARK: real Apple titles MUST NOT trip
+
+    @Test(
+        "real Apple symbol titles must NOT be flagged",
+        arguments: [
+            "AVCustomMediaSelectionScheme",
+            "withTaskGroup(of:returning:isolation:body:)",
+            "UIDropOperation.forbidden", // contains "forbidden" but not standalone
+            "MTRAccessControlAccessRestrictionType.attributeAccessForbidden",
+            "AVError.Code.referenceForbiddenByReferencePolicy",
+            "Routing404Type", // contains digits but not status prefix
+            "callAsyncJavaScript(_:arguments:in:contentWorld:)",
+            "GameCenterLeaderboardSetLocalization.Attributes",
+            "Handling Bad Gateway responses in Apps and Books API", // legit doc that mentions phrase mid-sentence
+            "Interpreting error codes (400, 401, 403)", // legit doc page about error codes
+        ]
+    )
+    func realAppleTitlesAreNotFlagged(title: String) {
+        #expect(SUT.titleLooksLikeHTTPErrorTemplate(title) == false)
+    }
+
+    // MARK: degenerate inputs
+
+    @Test("empty title returns false (handled by the existing missing-title guard)")
+    func emptyTitleReturnsFalse() {
+        #expect(SUT.titleLooksLikeHTTPErrorTemplate("") == false)
+        #expect(SUT.titleLooksLikeHTTPErrorTemplate("   ") == false)
+    }
+
+    @Test("status code without proper boundary is not flagged (e.g. '502abc')")
+    func bareDigitsWithoutBoundaryAreNotFlagged() {
+        // The regex requires a whitespace or end-of-string anchor after the
+        // status code. "502abc" lacks that, so it's not flagged. Pinned so a
+        // future loosening of the regex is a conscious decision.
+        #expect(SUT.titleLooksLikeHTTPErrorTemplate("502abc") == false)
+        #expect(SUT.titleLooksLikeHTTPErrorTemplate("404Type") == false)
+    }
+}

--- a/Packages/Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import Search
+import Shared
 import Testing
 
 // Truth-table coverage for `Search.IndexBuilder.titleLooksLikeHTTPErrorTemplate`,
@@ -98,5 +99,94 @@ struct IndexBuilderTitleErrorDefenseTests {
         // future loosening of the regex is a conscious decision.
         #expect(SUT.titleLooksLikeHTTPErrorTemplate("502abc") == false)
         #expect(SUT.titleLooksLikeHTTPErrorTemplate("404Type") == false)
+    }
+}
+
+// MARK: - JS-disabled fallback page detection
+
+// Coverage for `Search.IndexBuilder.pageLooksLikeJavaScriptFallback(_ page:)`,
+// the second indexer-side defense added after the audit found 1,327 such
+// poisoned files in the v1.0.2-era corpus that every prior title-only
+// check missed. The poisoned page has a real-looking title (Apple ships
+// it in HTML metadata even when JS is off) but the body content is
+// `Please turn on JavaScript ...` with rawMarkdown `[ Skip Navigation
+// ](#app-main)# An unknown error occurred.`.
+
+@Suite("Search.IndexBuilder.pageLooksLikeJavaScriptFallback (#284 JS-fallback defense)")
+struct IndexBuilderJavaScriptFallbackDefenseTests {
+    typealias SUT = Search.IndexBuilder
+
+    private static func makePage(
+        title: String = "AVCustomMediaSelectionScheme",
+        kind: StructuredDocumentationPage.Kind = .class,
+        source: StructuredDocumentationPage.Source = .appleJSON,
+        overview: String? = nil,
+        rawMarkdown: String? = nil
+    ) -> StructuredDocumentationPage {
+        StructuredDocumentationPage(
+            url: URL.knownGood("https://developer.apple.com/documentation/test"),
+            title: title,
+            kind: kind,
+            source: source,
+            overview: overview,
+            rawMarkdown: rawMarkdown
+        )
+    }
+
+    @Test("overview containing 'Please turn on JavaScript' trips the gate")
+    func jsFallbackInOverviewIsDetected() {
+        let page = Self.makePage(
+            overview: "Please turn on JavaScript in your browser and refresh the page to view its content."
+        )
+        #expect(SUT.pageLooksLikeJavaScriptFallback(page) == true)
+    }
+
+    @Test("rawMarkdown containing 'Please turn on JavaScript' trips the gate")
+    func jsFallbackInRawMarkdownIsDetected() {
+        let page = Self.makePage(
+            rawMarkdown: "---\nsource: x\n---\n\n# Title\n\nPlease turn on JavaScript and refresh."
+        )
+        #expect(SUT.pageLooksLikeJavaScriptFallback(page) == true)
+    }
+
+    @Test("rawMarkdown containing the broken Skip-Navigation pattern trips the gate")
+    func skipNavigationBrokenBodyIsDetected() {
+        let page = Self.makePage(
+            rawMarkdown: "---\nsource: x\n---\n\n# Title\n\n[ Skip Navigation ](#app-main)# An unknown error occurred."
+        )
+        #expect(SUT.pageLooksLikeJavaScriptFallback(page) == true)
+    }
+
+    @Test("real Apple page with normal overview is NOT flagged")
+    func realPageNotFlagged() {
+        let page = Self.makePage(
+            overview: "## Overview\n\nA media selection scheme provides custom settings for controlling media presentation."
+        )
+        #expect(SUT.pageLooksLikeJavaScriptFallback(page) == false)
+    }
+
+    @Test("real Apple page that mentions 'JavaScript' in normal docs context is NOT flagged")
+    func realPageMentioningJavaScriptNotFlagged() {
+        // Real Apple docs about WebKit / JavaScript APIs legitimately mention
+        // the word JavaScript without being JS-disabled fallbacks. The check
+        // requires the literal phrase "Please turn on JavaScript" — that
+        // exact string is unique to the fallback template.
+        let page = Self.makePage(
+            title: "WKWebView.evaluateJavaScript",
+            overview: "Use this method to execute JavaScript code in the context of the loaded page."
+        )
+        #expect(SUT.pageLooksLikeJavaScriptFallback(page) == false)
+    }
+
+    @Test("page with nil overview AND nil rawMarkdown is NOT flagged")
+    func nilFieldsNotFlagged() {
+        let page = Self.makePage(overview: nil, rawMarkdown: nil)
+        #expect(SUT.pageLooksLikeJavaScriptFallback(page) == false)
+    }
+
+    @Test("page with empty-string overview AND empty rawMarkdown is NOT flagged")
+    func emptyFieldsNotFlagged() {
+        let page = Self.makePage(overview: "", rawMarkdown: "")
+        #expect(SUT.pageLooksLikeJavaScriptFallback(page) == false)
     }
 }


### PR DESCRIPTION
## What

Defense-in-depth complement to PR #289 (the crawler-side gate). Adds an indexer-side check in `Search.IndexBuilder.indexAppleDocsFromDirectory` that refuses to index any JSON file whose top-level `title` looks like an HTTP error template — regardless of how the file got onto disk.

Closes the second half of #284.

## Why

PR #289 stops the crawler from saving 502/403 pages to disk in the first place. But poison files can still land in the corpus via:

- mid-flight rsync from a pre-#289 binary (e.g., Claw mini's running webview-only crawl)
- restoring from an older backup
- hand-edited corpora
- drift between fetch and index runs across machines

The indexer should refuse them too, so the bundle is clean *by construction* even when the corpus on disk isn't.

## Scope

- **Indexer code only** — `SearchIndexBuilder.swift`. No schema bump, no version bump, no migration.
- **Same regex + standalone-phrase rules as PR #289**, but applied to the JSON file's top-level `title` field instead of the rendered HTML.
- **No false-positive risk** — pinned by 23 test cases including 10 real Apple symbol titles whose names contain error vocabulary (`UIDropOperation.forbidden`, `AVError.Code.referenceForbiddenByReferencePolicy`, `Routing404Type`, `GameCenterLeaderboardSetLocalization.Attributes`, `Handling Bad Gateway responses in Apps and Books API`, etc.) — none should be flagged.

## Implementation

```swift
// In indexAppleDocsFromDirectory, immediately after structuredPage is decoded:
if Self.titleLooksLikeHTTPErrorTemplate(structuredPage.title) {
    logError("⛔ Skipping HTTP-error-template page (#284 indexer defense): …")
    skipped += 1
    continue
}
```

The helper:

```swift
internal static func titleLooksLikeHTTPErrorTemplate(_ title: String) -> Bool {
    let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
    if trimmed.isEmpty { return false }
    // Status-prefix form: "403 Forbidden", "502 Bad Gateway"
    if trimmed.range(of: #"^(403|404|429|500|502|503|504)(\\s|$)"#, options: .regularExpression) != nil {
        return true
    }
    // Standalone phrase form
    let standalone: Set<String> = ["Forbidden", "Bad Gateway", "Not Found",
                                    "Service Unavailable", "Gateway Timeout",
                                    "Too Many Requests", "Internal Server Error"]
    return standalone.contains(trimmed)
}
```

## Tests

`Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift` — 7 tests, parameterized cases expanding to 23 total:

| group | cases |
|---|---:|
| Status-prefix titles ALL trip the gate | 7 (403/404/429/500/502/503/504) |
| Standalone error phrases ALL trip the gate | 7 |
| Whitespace trimming | 2 |
| Real Apple symbol titles must NOT be flagged | **10** |
| Boundary cases (`502abc`, `404Type`) must NOT be flagged | 2 |
| Empty / whitespace-only titles return false | 2 |

## Verification

- `swift build` clean
- `swift test --filter IndexBuilderTitleErrorDefenseTests` → 7/7 pass
- A live reindex against a freshly cleaned corpus is currently in progress with this binary; will report 'skipped: 0' if the corpus is clean (expected) and the defense doesn't false-positive.

## Relationship to PR #289

This PR is **standalone but complementary**: PR #289 is the crawler-side fix (prevents new poison from being saved), this PR is the indexer-side fix (prevents poison-on-disk from reaching the bundle). Either can land first. Both should land for #284 to be fully closed.