### PR TITLE
docs(refactor): move plan to docs/plans/<date>-<slug>.md (writing-plans Rule 5)

### DIFF
--- a/docs/plans/2026-05-12-v1-1-package-split.md
+++ b/docs/plans/2026-05-12-v1-1-package-split.md
@@ -597,7 +597,7 @@ refactor(<package>): <summary> (#<issue> / refactor-plan §<task-number>)
 ## Context
 
 Closes #<issue>.
-Refactor plan: docs/REFACTOR_PLAN.md §<task-number>
+Refactor plan: docs/plans/2026-05-12-v1-1-package-split.md §<task-number>
 
 ## Changes
 


### PR DESCRIPTION
## Context

Per `universal/writing-plans.md` Rule 5, refactor plans default to `docs/plans/YYYY-MM-DD-<feature-slug>.md` and the rule only allows the project `CLAUDE.md` to override the location. The project `CLAUDE.md` does not override, so `docs/REFACTOR_PLAN.md` (landed in #294) was a deviation, not an authorized override.

This PR moves the plan to the canonical path: `docs/plans/2026-05-12-v1-1-package-split.md`.

## Changes

- `git mv docs/REFACTOR_PLAN.md docs/plans/2026-05-12-v1-1-package-split.md`
- One in-doc self-reference at line 600 (PR template section) updated to the new path

## Follow-up after merge (not in this PR)

- Update issue bodies #295 through #329 (path reference inside each body)
- Update the v1.1 scope comment on #183 (URL to the plan)

## Verification

Document-only move; no code changes, no build implications. `swiftformat` / `swiftlint` / `swift build` / `swift test` are not affected.
