### PR TITLE
chore(workspace): drop stale FileRef to root AGENTS.md

### DIFF
--- a/Main.xcworkspace/contents.xcworkspacedata
+++ b/Main.xcworkspace/contents.xcworkspacedata
@@ -5,9 +5,6 @@
       location = "group:README.md">
    </FileRef>
    <FileRef
-      location = "group:AGENTS.md">
-   </FileRef>
-   <FileRef
       location = "group:install.sh">
    </FileRef>
    <FileRef


### PR DESCRIPTION
The workspace navigator showed `AGENTS.md` in red because `Main.xcworkspace/contents.xcworkspacedata` had a `<FileRef location="group:AGENTS.md">` entry pointing at a workspace-root file that does not exist in this repo (the canonical rules file lives in `mihaela-agents/Rules/AGENTS.md` and is reached from the project's `CLAUDE.md` via `@`-import). Xcode auto-emitted the cleanup on workspace open; this PR commits it.

## Diff

```
-   <FileRef
-      location = "group:AGENTS.md">
-   </FileRef>
```

Three-line deletion in `Main.xcworkspace/contents.xcworkspacedata`. Nothing else touched.

## Verification

Workspace-only. No source changes, no build implications.
