### PR TITLE
refactor(CoreHTMLParser): extract HTMLToMarkdown + XMLTransformer from Core (#302)

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -24,6 +24,7 @@ let macOSOnlyProducts: [Product] = [
     .singleTargetLibrary("SharedConfiguration"),
     .singleTargetLibrary("MCPSharedTools"),
     .singleTargetLibrary("CoreProtocols"),
+    .singleTargetLibrary("CoreHTMLParser"),
     .singleTargetLibrary("Core"),
     .singleTargetLibrary("Cleanup"),
     .singleTargetLibrary("Search"),
@@ -128,7 +129,7 @@ let targets: [Target] = {
     )
     let sharedCoreTestsTarget = Target.testTarget(
         name: "SharedCoreTests",
-        dependencies: ["SharedCore", "SharedConstants", "SharedUtils", "SharedModels", "TestSupport"],
+        dependencies: ["SharedCore", "SharedConstants", "SharedUtils", "SharedModels", "CoreProtocols", "TestSupport"],
         path: "Tests/Shared/CoreTests"
     )
 
@@ -169,13 +170,32 @@ let targets: [Target] = {
         dependencies: ["SharedCore", "SharedConstants", "SharedModels", "Resources"]
     )
 
+    // ---------- CoreHTMLParser (v1.2 refactor 2.2: HTMLToMarkdown + XMLTransformer, the worst single-file god in Core) ----------
+    let coreHTMLParserTarget = Target.target(
+        name: "CoreHTMLParser",
+        dependencies: ["CoreProtocols", "SharedModels", "SharedConstants"],
+        path: "Sources/Core/HTMLParser"
+    )
+
     let coreTarget = Target.target(
         name: "Core",
-        dependencies: ["CoreProtocols", "SharedCore", "SharedConfiguration", "SharedConstants", "SharedModels", "SharedUtils", "Logging", "Resources", "ASTIndexer"]
+        dependencies: [
+            "CoreProtocols",
+            "CoreHTMLParser",
+            "SharedCore",
+            "SharedConfiguration",
+            "SharedConstants",
+            "SharedModels",
+            "SharedUtils",
+            "Logging",
+            "Resources",
+            "ASTIndexer",
+        ],
+        exclude: ["HTMLParser"]
     )
     let coreTestsTarget = Target.testTarget(
         name: "CoreTests",
-        dependencies: ["CoreProtocols", "Core", "Search", "SharedCore", "SharedConstants", "SharedModels", "TestSupport"],
+        dependencies: ["CoreProtocols", "CoreHTMLParser", "Core", "Search", "SharedCore", "SharedConstants", "SharedModels", "TestSupport"],
         resources: [.copy("Resources/AppleJSON")]
     )
 
@@ -446,6 +466,7 @@ let targets: [Target] = {
         mcpSharedToolsTarget,
         mcpSharedToolsTestsTarget,
         coreProtocolsTarget,
+        coreHTMLParserTarget,
         resourcesTarget,
         resourcesTestsTarget,
         coreTarget,

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -7,6 +7,7 @@ import SharedConstants
 import SharedModels
 import SharedUtils
 import CoreProtocols
+import CoreHTMLParser
 
 // MARK: - Documentation Crawler
 

--- a/Packages/Sources/Core/HTMLParser/HTMLToMarkdown.swift
+++ b/Packages/Sources/Core/HTMLParser/HTMLToMarkdown.swift
@@ -1,10 +1,10 @@
 import Foundation
 import SharedCore
 #if canImport(WebKit)
-import WebKit
+import CoreProtocols
 import SharedConstants
 import SharedModels
-import CoreProtocols
+import WebKit
 #endif
 
 // MARK: - HTML to Markdown Converter

--- a/Packages/Sources/Core/HTMLParser/XMLTransformer.swift
+++ b/Packages/Sources/Core/HTMLParser/XMLTransformer.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreProtocols
+import Foundation
 
 // MARK: - XML Transformer
 

--- a/Packages/Sources/Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift
+++ b/Packages/Sources/Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift
@@ -4,6 +4,7 @@ import SharedCore
 import WebKit
 import SharedConstants
 import CoreProtocols
+import CoreHTMLParser
 #endif
 
 // MARK: - WKWeb Crawler Engine

--- a/Packages/Tests/CoreTests/CupertinoCoreTests.swift
+++ b/Packages/Tests/CoreTests/CupertinoCoreTests.swift
@@ -9,6 +9,7 @@ import SharedConstants
 import SharedConfiguration
 import SharedModels
 import CoreProtocols
+@testable import CoreHTMLParser
 
 @Test func hTMLToMarkdown() throws {
     let html = "<h1>Title</h1><p>Content</p>"

--- a/Packages/Tests/CoreTests/HTMLToMarkdownErrorPageDetectionTests.swift
+++ b/Packages/Tests/CoreTests/HTMLToMarkdownErrorPageDetectionTests.swift
@@ -2,6 +2,7 @@
 import Foundation
 import Testing
 import CoreProtocols
+@testable import CoreHTMLParser
 
 // Coverage for the `HTMLToMarkdown.looksLikeHTTPErrorPage(...)` helper
 // added in #284. The helper gates the crawler's WebView fallback path

--- a/Packages/Tests/CoreTests/HTMLToMarkdownTests.swift
+++ b/Packages/Tests/CoreTests/HTMLToMarkdownTests.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Testing
 import CoreProtocols
+@testable import CoreHTMLParser
 
 // MARK: - HTML to Markdown Converter Tests
 


### PR DESCRIPTION
Closes #302. Refactor plan task 2.2.

## What

Extracts the worst single-file god in Core (`HTMLToMarkdown`, 1070 LOC) plus `XMLTransformer` (232 LOC) into a new `CoreHTMLParser` target. First Phase-2 PR using the **nested-under-`Core/`** layout pattern: target sources live at `Sources/Core/HTMLParser/`, mirroring the `Shared/Configuration`, `Shared/Core`, `MCP/Core`, `MCP/Support` nesting from #340.

## Files moved (`git mv`)

- `Core/Transformers/HTMLToMarkdown.swift` → `Core/HTMLParser/`
- `Core/Transformers/XMLTransformer.swift` → `Core/HTMLParser/`

`Core/Transformers/` retains `AppleJSONToMarkdown` and `MarkdownToStructuredPage`; those go to `CoreJSONParser` in 2.3.

## Package.swift

- New `CoreHTMLParser` target, deps `["CoreProtocols", "SharedModels", "SharedConstants"]`, `path: "Sources/Core/HTMLParser"`.
- New `CoreHTMLParser` product.
- `Core` target deps gain `"CoreHTMLParser"`.
- `Core` target adds `exclude: ["HTMLParser"]` so SwiftPM does not also compile the new subfolder into the Core module.
- `SharedCoreTests` deps gain `"CoreProtocols"` (catching a `SwiftPackageEntry` reference inside `ModelsTests` that was previously resolved transitively but now needs explicit declaration).
- `CoreTests` deps gain `"CoreHTMLParser"`.

## Import sweep (5 files)

- `Core/Crawler.swift`: `import CoreHTMLParser` (uses `HTMLToMarkdown.convert`, `XMLTransformer.toMarkdown`)
- `Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift`: same
- `Tests/CoreTests/HTMLToMarkdownTests.swift`, `HTMLToMarkdownErrorPageDetectionTests.swift`, `CupertinoCoreTests.swift`: `@testable import CoreHTMLParser`

Public API unchanged.

## Verification

| Step | Result |
|---|---|
| `xcrun swift build` (clean) | green |
| `xcrun swift package clean && xcrun swift test` | **1293 / 1293**, 0 failures |
| `xcrun swift run cupertino --help` | green |
| `swiftformat` | 3 / 3 reformatted (committed) |
| `swiftlint` on `Core/HTMLParser/` | 3 pre-existing warnings (blanket type-body-length disable + two function-body-length on long parser methods); carried forward, not introduced |

## Out of scope

- Lint warnings inside the moved files. Phase 4.
- `HTMLToMarkdown` internal complexity. Future targeted refactor.
