### PR TITLE
fix(search): #285 normalize underscore→dash in sub-page URI segments (rebase of #286)

### DIFF
--- a/Packages/Sources/Shared/Models/URLUtilities.swift
+++ b/Packages/Sources/Shared/Models/URLUtilities.swift
@@ -5,23 +5,46 @@ import SharedConstants
 
 /// Utilities for URL manipulation
 public enum URLUtilities {
-    /// Normalize a URL: strip fragment and query, lowercase the path.
-    /// Apple's docs server is case-insensitive on the path
-    /// (`/documentation/Cinematic/CNAssetInfo-2ata2` and the all-lowercase
-    /// form return the same content), so dedup logic must treat them as one
-    /// page (#200). Dash-vs-underscore framework variants
-    /// (`professional-video-applications` ↔ `professional_video_applications`)
-    /// are NOT collapsed here because at least one Apple framework
-    /// (`installer_js`) legitimately uses underscore in its path; that axis
-    /// is handled at the search-index save layer instead.
+    /// Returns a normalized copy of `url` with fragment and query stripped,
+    /// path lowercased, and underscores replaced with dashes in sub-page
+    /// segments within `/documentation/` paths.
+    ///
+    /// Applies underscore-to-dash replacement only to path segments at depth
+    /// ≥ 3 (sub-page level). Framework slugs at depth 2 are preserved because
+    /// at least two Apple frameworks (`installer_js`,
+    /// `professional_video_applications`) use underscores canonically and
+    /// their dash forms return 404. This resolves the 31 duplicate URI
+    /// clusters in search.db (#285).
+    ///
+    /// - Parameter url: The URL to normalize.
+    /// - Returns: The normalized URL, or `nil` if `url` cannot be decomposed
+    ///   into URL components.
     public static func normalize(_ url: URL) -> URL? {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         components?.fragment = nil
         components?.query = nil
         if let path = components?.path {
-            components?.path = path.lowercased()
+            components?.path = normalizeDocPath(path.lowercased())
         }
         return components?.url
+    }
+
+    // Replace underscores with dashes in sub-page path segments only.
+    // Framework slugs at depth 2 after /documentation/ use underscores
+    // canonically (installer_js, professional_video_applications) and must
+    // be left untouched.
+    private static func normalizeDocPath(_ path: String) -> String {
+        let parts = path.components(separatedBy: "/")
+        guard let docIdx = parts.firstIndex(of: "documentation"),
+              docIdx + 2 < parts.count else { return path }
+
+        let normalizeFromIdx = docIdx + 2
+        return parts
+            .enumerated()
+            .map { index, part in
+                index >= normalizeFromIdx ? String(part.map { $0 == "_" ? "-" : $0 }) : part
+            }
+            .joined(separator: "/")
     }
 
     /// Extract framework name from documentation URL (Apple or Swift.org)

--- a/Packages/Tests/CoreTests/CrawlerTests.swift
+++ b/Packages/Tests/CoreTests/CrawlerTests.swift
@@ -104,6 +104,69 @@ struct CrawlerTests {
         #expect(try !#require(normalized?.absoluteString.contains("installer-js")))
     }
 
+    @Test("URLUtilities normalize converts underscore sub-page slug to dash")
+    func urlNormalizeConvertsUnderscoreSubpageToDash() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/corelocation/getting_heading_and_course_information")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/corelocation/getting-heading-and-course-information")
+    }
+
+    @Test("URLUtilities normalize preserves framework slug at depth 2 and normalizes sub-page underscore")
+    func urlNormalizePreservesFrameworkSlugNormalizesSubpage() throws {
+        // driverkit/driverkit_constants is one of the 31 duplicate-cluster pairs from #285.
+        // The framework slug "driverkit" at depth 2 must be left untouched;
+        // only "driverkit_constants" at depth 3 is collapsed to dashes.
+        let url = URL(string: "https://developer.apple.com/documentation/driverkit/driverkit_constants")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/driverkit/driverkit-constants")
+    }
+
+    @Test("URLUtilities normalize converts underscores at multiple sub-page depths")
+    func urlNormalizeConvertsUnderscoresAtMultipleDepths() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/swiftui/some_class/some_method")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/swiftui/some-class/some-method")
+    }
+
+    @Test("URLUtilities normalize does not touch non-documentation URL underscores")
+    func urlNormalizeDoesNotTouchNonDocsPaths() throws {
+        let url = URL(string: "https://developer.apple.com/videos/play/wwdc2023/10_video")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/videos/play/wwdc2023/10_video")
+    }
+
+    @Test("URLUtilities normalize strips fragment and query and collapses sub-page underscore")
+    func urlNormalizeStripsFragmentQueryAndNormalizesUnderscore() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/swiftui/some_method?foo=1#bar")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/swiftui/some-method")
+        #expect(normalized?.query == nil)
+        #expect(normalized?.fragment == nil)
+    }
+
+    @Test("URLUtilities normalize lowercases before collapsing underscore to dash")
+    func urlNormalizeLowercasesBeforeCollapsingUnderscore() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/SwiftUI/Some_Method")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/swiftui/some-method")
+    }
+
+    @Test("URLUtilities normalize does not crash on /documentation with no framework slug")
+    func urlNormalizeHandlesDocumentationOnlyPath() throws {
+        // Regression: normalizeDocPath used to trap with "Range requires lowerBound <= upperBound"
+        // when documentation was found but had fewer than 2 following path segments.
+        let url = URL(string: "https://developer.apple.com/documentation")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation")
+    }
+
     // MARK: - Framework Extraction Tests
 
     @Test("URLUtilities extracts framework from Apple docs URL")


### PR DESCRIPTION
Closes #285. Rebases the contributor work from #286 (by @Vignesh-Thangamariappan) onto develop's post-refactor file layout.

## Why a new PR

#286 targets `main` and patches `Packages/Sources/Shared/Models.swift`, which no longer exists on `develop` after refactor tasks 1.2 + 1.5 + the #340 reorg (URLUtilities now lives at `Packages/Sources/Shared/Models/URLUtilities.swift`). Cherry-picking the three commits hits a modify/delete conflict because the old path is gone.

This PR re-applies the same fix to the new path and adds the same 7 regression tests.

## The fix

`URLUtilities.normalize()` now replaces `_` with `-` in path segments at depth ≥ 3 within `/documentation/` paths, while preserving framework slugs at depth 2. The two frameworks the original code worried about (`installer_js`, `professional_video_applications`) keep their underscores because they sit at depth 2.

Closes the 31 dash/underscore duplicate URI clusters #285 identified in the v1.0.2 reindex audit.

## Tests added (`Tests/CoreTests/CrawlerTests.swift`)

| Case | Verifies |
|---|---|
| `urlNormalizeConvertsUnderscoreSubpageToDash` | underscore at depth 3 → dash |
| `urlNormalizePreservesFrameworkSlugNormalizesSubpage` | `driverkit/driverkit_constants` regression case from the #285 audit |
| `urlNormalizeConvertsUnderscoresAtMultipleDepths` | depths 3 and 4 both normalize |
| `urlNormalizeDoesNotTouchNonDocsPaths` | `/videos/play/...` untouched |
| `urlNormalizeStripsFragmentQueryAndNormalizesUnderscore` | fragment/query stripping + underscore collapse |
| `urlNormalizeLowercasesBeforeCollapsingUnderscore` | lowercase + underscore order |
| `urlNormalizeHandlesDocumentationOnlyPath` | `/documentation` alone does not trap |

The pre-existing `installer_js/license` test (line 95) still passes; framework slugs at depth 2 are preserved.

## Verification

| Step | Result |
|---|---|
| `xcrun swift build` (clean) | green |
| `xcrun swift test --filter CrawlerTests` | **68 / 68** including 7 new |
| Full-suite baseline (1293) | unchanged |

## Credit

`Co-authored-by: Vignesh-Thangamariappan <vignesh.thangamariappan@gmail.com>` in the commit. #286 will be closed pointing at this PR once it lands.

## After merge

- Close #286 with a comment linking here.
- Re-index the bundle (separate process; not in this PR). Closes the 31 duplicate-cluster cleanup item from the v1.0.3 docs.
