### PR TITLE
refactor(CorePackageIndexing): extract package resolver / fetcher / archive / annotator from Core (#304)

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -26,6 +26,7 @@ let macOSOnlyProducts: [Product] = [
     .singleTargetLibrary("CoreProtocols"),
     .singleTargetLibrary("CoreHTMLParser"),
     .singleTargetLibrary("CoreJSONParser"),
+    .singleTargetLibrary("CorePackageIndexing"),
     .singleTargetLibrary("Core"),
     .singleTargetLibrary("Cleanup"),
     .singleTargetLibrary("Search"),
@@ -185,12 +186,20 @@ let targets: [Target] = {
         path: "Sources/Core/JSONParser"
     )
 
+    // ---------- CorePackageIndexing (v1.2 refactor 2.4: Resolver + Fetcher + Archive Extractor + Annotator + FileKind + ManifestCache + Store + DocDownloader) ----------
+    let corePackageIndexingTarget = Target.target(
+        name: "CorePackageIndexing",
+        dependencies: ["CoreProtocols", "SharedCore", "SharedModels", "SharedConstants", "SharedUtils", "Logging", "ASTIndexer"],
+        path: "Sources/Core/PackageIndexing"
+    )
+
     let coreTarget = Target.target(
         name: "Core",
         dependencies: [
             "CoreProtocols",
             "CoreHTMLParser",
             "CoreJSONParser",
+            "CorePackageIndexing",
             "SharedCore",
             "SharedConfiguration",
             "SharedConstants",
@@ -200,11 +209,22 @@ let targets: [Target] = {
             "Resources",
             "ASTIndexer",
         ],
-        exclude: ["HTMLParser", "JSONParser"]
+        exclude: ["HTMLParser", "JSONParser", "PackageIndexing"]
     )
     let coreTestsTarget = Target.testTarget(
         name: "CoreTests",
-        dependencies: ["CoreProtocols", "CoreHTMLParser", "CoreJSONParser", "Core", "Search", "SharedCore", "SharedConstants", "SharedModels", "TestSupport"],
+        dependencies: [
+            "CoreProtocols",
+            "CoreHTMLParser",
+            "CoreJSONParser",
+            "CorePackageIndexing",
+            "Core",
+            "Search",
+            "SharedCore",
+            "SharedConstants",
+            "SharedModels",
+            "TestSupport",
+        ],
         resources: [.copy("Resources/AppleJSON")]
     )
 
@@ -219,11 +239,11 @@ let targets: [Target] = {
 
     let searchTarget = Target.target(
         name: "Search",
-        dependencies: ["SharedCore", "SharedConstants", "SharedModels", "Logging", "CoreProtocols", "CoreJSONParser", "Core", "ASTIndexer"]
+        dependencies: ["SharedCore", "SharedConstants", "SharedModels", "Logging", "CoreProtocols", "CoreJSONParser", "CorePackageIndexing", "Core", "ASTIndexer"]
     )
     let searchTestsTarget = Target.testTarget(
         name: "SearchTests",
-        dependencies: ["Search", "SharedCore", "SharedConstants", "SharedModels", "SharedUtils", "TestSupport"]
+        dependencies: ["Search", "SharedCore", "SharedConstants", "SharedModels", "SharedUtils", "TestSupport", "CorePackageIndexing"]
     )
 
     let sampleIndexTarget = Target.target(
@@ -356,7 +376,7 @@ let targets: [Target] = {
             "SharedConstants",
             "SharedModels",
             "SharedUtils",
-            "CoreProtocols", "CoreJSONParser", "Core",
+            "CoreProtocols", "CoreJSONParser", "CorePackageIndexing", "Core",
             "Cleanup",
             "Search",
             "SampleIndex",
@@ -382,7 +402,7 @@ let targets: [Target] = {
             "SharedCore",
             "SharedConstants",
             "SharedUtils",
-            "CoreProtocols", "Core",
+            "CoreProtocols", "CorePackageIndexing", "Core",
             "Search",
             "Resources",
             "Logging",
@@ -435,7 +455,7 @@ let targets: [Target] = {
 
     let fetchTestsTarget = Target.testTarget(
         name: "FetchTests",
-        dependencies: ["CLI", "CoreProtocols", "Core", "Ingest", "SharedCore", "TestSupport"],
+        dependencies: ["CLI", "CoreProtocols", "CorePackageIndexing", "Core", "Ingest", "SharedCore", "TestSupport"],
         path: "Tests/CLICommandTests/FetchTests"
     )
 
@@ -477,6 +497,7 @@ let targets: [Target] = {
         coreProtocolsTarget,
         coreHTMLParserTarget,
         coreJSONParserTarget,
+        corePackageIndexingTarget,
         resourcesTarget,
         resourcesTestsTarget,
         coreTarget,

--- a/Packages/Sources/CLI/Commands/DoctorCommand.swift
+++ b/Packages/Sources/CLI/Commands/DoctorCommand.swift
@@ -13,6 +13,7 @@ import SharedCore
 import SharedConstants
 import SharedUtils
 import CoreProtocols
+import CorePackageIndexing
 
 // MARK: - Doctor Command
 

--- a/Packages/Sources/CLI/Commands/FetchCommand.swift
+++ b/Packages/Sources/CLI/Commands/FetchCommand.swift
@@ -11,6 +11,7 @@ import SharedConstants
 import SharedModels
 import SharedUtils
 import CoreProtocols
+import CorePackageIndexing
 
 /// Lets ArgumentParser parse `--discovery-mode <mode>` directly into the
 /// shared enum. The conformance lives here (not in Shared) so the Shared

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -9,6 +9,7 @@ import SharedUtils
 import CoreProtocols
 import CoreHTMLParser
 import CoreJSONParser
+import CorePackageIndexing
 
 // MARK: - Documentation Crawler
 

--- a/Packages/Sources/Core/PackageIndexing/ManifestCache.swift
+++ b/Packages/Sources/Core/PackageIndexing/ManifestCache.swift
@@ -1,6 +1,6 @@
+import CoreProtocols
 import Foundation
 import SharedCore
-import CoreProtocols
 
 extension Core {
     /// Disk cache for fetched `Package.swift` / `Package.resolved` files, keyed by

--- a/Packages/Sources/Core/PackageIndexing/PackageArchiveExtractor.swift
+++ b/Packages/Sources/Core/PackageIndexing/PackageArchiveExtractor.swift
@@ -1,7 +1,7 @@
-import Foundation
-import SharedCore
-import SharedConstants
 import CoreProtocols
+import Foundation
+import SharedConstants
+import SharedCore
 
 extension Core {
     /// Fetches a repo's source tarball from `codeload.github.com/<owner>/<repo>/tar.gz/<ref>`

--- a/Packages/Sources/Core/PackageIndexing/PackageAvailabilityAnnotator.swift
+++ b/Packages/Sources/Core/PackageIndexing/PackageAvailabilityAnnotator.swift
@@ -1,7 +1,7 @@
 import ASTIndexer
+import CoreProtocols
 import Foundation
 import SharedCore
-import CoreProtocols
 
 extension Core {
     /// Walks a downloaded package on disk and writes an `availability.json`

--- a/Packages/Sources/Core/PackageIndexing/PackageDependencyResolver.swift
+++ b/Packages/Sources/Core/PackageIndexing/PackageDependencyResolver.swift
@@ -1,12 +1,13 @@
+import CoreProtocols
+
 // swiftlint:disable identifier_name
 // swiftlint:disable function_body_length type_body_length
 import Foundation
 import Logging
-import SharedCore
 import SharedConstants
+import SharedCore
 import SharedModels
 import SharedUtils
-import CoreProtocols
 
 extension Core {
     /// Walks each seed repo's dependency graph via raw.githubusercontent.com and returns
@@ -215,12 +216,12 @@ extension Core {
 
         // MARK: - Manifest fetch
 
-        struct FetchSuccess: Sendable {
+        struct FetchSuccess {
             let dependencyURLs: [String]
             let registryIdentifierCount: Int
         }
 
-        enum FetchResult: Sendable {
+        enum FetchResult {
             case success(FetchSuccess)
             case missing
             case malformed

--- a/Packages/Sources/Core/PackageIndexing/PackageDocumentationDownloader.swift
+++ b/Packages/Sources/Core/PackageIndexing/PackageDocumentationDownloader.swift
@@ -1,8 +1,8 @@
+import CoreProtocols
 import Foundation
 import Logging
 import SharedCore
 import SharedModels
-import CoreProtocols
 
 // MARK: - Package Documentation Downloader
 

--- a/Packages/Sources/Core/PackageIndexing/PackageFetcher.swift
+++ b/Packages/Sources/Core/PackageIndexing/PackageFetcher.swift
@@ -1,9 +1,9 @@
+import CoreProtocols
 import Foundation
 import Logging
-import SharedCore
 import SharedConstants
+import SharedCore
 import SharedUtils
-import CoreProtocols
 
 // MARK: - Package Fetcher
 

--- a/Packages/Sources/Core/PackageIndexing/PackageFileKind.swift
+++ b/Packages/Sources/Core/PackageIndexing/PackageFileKind.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreProtocols
+import Foundation
 
 extension Core {
     /// Categorisation for every indexed file inside a Swift package. Drives the

--- a/Packages/Sources/Core/PackageIndexing/PriorityPackageGenerator.swift
+++ b/Packages/Sources/Core/PackageIndexing/PriorityPackageGenerator.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Logging
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // swiftlint:disable function_body_length
 // Justification: The generate() function orchestrates the complete package analysis workflow:
@@ -214,7 +214,7 @@ public struct PriorityPackageList: Codable, Sendable {
     let sources: [String]
     let updatePolicy: String
     let priorityLevels: PriorityLevels
-    let stats: PackageStats
+    public let stats: PackageStats
     let notes: [String]
 
     enum CodingKeys: String, CodingKey {
@@ -255,11 +255,11 @@ public struct PriorityPackageInfo: Codable, Hashable, Sendable {
 }
 
 public struct PackageStats: Codable, Sendable {
-    let totalApplePackagesInSwiftorg: Int
-    let totalSwiftlangPackagesInSwiftorg: Int
-    let totalEcosystemPackagesInSwiftorg: Int
-    let totalUniqueReposFound: Int
-    let sourceFilesScanned: Int
+    public let totalApplePackagesInSwiftorg: Int
+    public let totalSwiftlangPackagesInSwiftorg: Int
+    public let totalEcosystemPackagesInSwiftorg: Int
+    public let totalUniqueReposFound: Int
+    public let sourceFilesScanned: Int
 
     enum CodingKeys: String, CodingKey {
         case totalApplePackagesInSwiftorg = "total_apple_packages_in_swiftorg"

--- a/Packages/Sources/Core/PackageIndexing/PriorityPackagesCatalog.swift
+++ b/Packages/Sources/Core/PackageIndexing/PriorityPackagesCatalog.swift
@@ -4,8 +4,8 @@
 
 import Foundation
 import Resources
-import SharedCore
 import SharedConstants
+import SharedCore
 
 /// Represents a priority package entry
 public struct PriorityPackage: Codable, Sendable {

--- a/Packages/Sources/Core/PackageIndexing/ResolvedPackagesStore.swift
+++ b/Packages/Sources/Core/PackageIndexing/ResolvedPackagesStore.swift
@@ -1,7 +1,7 @@
+import CoreProtocols
 import Foundation
 import SharedCore
 import SharedModels
-import CoreProtocols
 
 extension Core {
     /// One entry in the resolved closure. Seeds list themselves as their own parent;

--- a/Packages/Sources/Search/PackageIndex.swift
+++ b/Packages/Sources/Search/PackageIndex.swift
@@ -4,6 +4,7 @@ import SharedCore
 import SQLite3
 import SharedConstants
 import CoreProtocols
+import CorePackageIndexing
 
 // MARK: - Package Index (separate DB)
 

--- a/Packages/Sources/Search/PackageIndexer.swift
+++ b/Packages/Sources/Search/PackageIndexer.swift
@@ -4,6 +4,7 @@ import SharedCore
 import SharedConstants
 import SharedModels
 import CoreProtocols
+import CorePackageIndexing
 
 extension Search {
     /// Reads downloaded-and-extracted package trees from

--- a/Packages/Sources/TUI/Helpers/PackageActions.swift
+++ b/Packages/Sources/TUI/Helpers/PackageActions.swift
@@ -1,9 +1,10 @@
 import Core
+import CorePackageIndexing
+import CoreProtocols
 import Foundation
 import Resources
-import SharedCore
 import SharedConstants
-import CoreProtocols
+import SharedCore
 
 /// Open a package's GitHub page in the default browser
 @MainActor

--- a/Packages/Sources/TUI/PackageCurator.swift
+++ b/Packages/Sources/TUI/PackageCurator.swift
@@ -4,6 +4,7 @@ import Resources
 import SharedCore
 import SharedConstants
 import CoreProtocols
+import CorePackageIndexing
 
 // swiftlint:disable type_body_length function_body_length
 // Justification: PackageCuratorApp is a self-contained CLI tool for curating Swift packages.

--- a/Packages/Tests/CLICommandTests/FetchTests/FetchTests.swift
+++ b/Packages/Tests/CLICommandTests/FetchTests/FetchTests.swift
@@ -7,6 +7,7 @@ import Foundation
 import Testing
 import TestSupport
 import CoreProtocols
+@testable import CorePackageIndexing
 
 // MARK: - Fetch Command Tests
 

--- a/Packages/Tests/CoreTests/CupertinoCoreTests.swift
+++ b/Packages/Tests/CoreTests/CupertinoCoreTests.swift
@@ -10,6 +10,7 @@ import SharedConfiguration
 import SharedModels
 import CoreProtocols
 @testable import CoreHTMLParser
+@testable import CorePackageIndexing
 
 @Test func hTMLToMarkdown() throws {
     let html = "<h1>Title</h1><p>Content</p>"

--- a/Packages/Tests/CoreTests/PackageDependencyResolverTests.swift
+++ b/Packages/Tests/CoreTests/PackageDependencyResolverTests.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Testing
 import CoreProtocols
+@testable import CorePackageIndexing
 
 // MARK: - GitHub URL parsing
 

--- a/Packages/Tests/CoreTests/PackageDocumentationDownloaderTests.swift
+++ b/Packages/Tests/CoreTests/PackageDocumentationDownloaderTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import SharedCore
 import Testing
 import CoreProtocols
+@testable import CorePackageIndexing
 
 // MARK: - Package Documentation Downloader Tests
 

--- a/Packages/Tests/CoreTests/PackageFetcherTests.swift
+++ b/Packages/Tests/CoreTests/PackageFetcherTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import SharedCore
 import Testing
 import CoreProtocols
+@testable import CorePackageIndexing
 
 // MARK: - Package Fetcher Tests
 

--- a/Packages/Tests/CoreTests/PriorityPackageGeneratorTests.swift
+++ b/Packages/Tests/CoreTests/PriorityPackageGeneratorTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import SharedCore
 import Testing
 import CoreProtocols
+@testable import CorePackageIndexing
 
 // MARK: - Priority Package Generator Tests
 

--- a/Packages/Tests/CoreTests/ResolverPipelineTests.swift
+++ b/Packages/Tests/CoreTests/ResolverPipelineTests.swift
@@ -6,6 +6,7 @@ import Testing
 import SharedConstants
 import SharedModels
 @testable import CoreProtocols
+@testable import CorePackageIndexing
 
 // MARK: - Checksum stability
 

--- a/Packages/Tests/SearchTests/PackageIndexTests.swift
+++ b/Packages/Tests/SearchTests/PackageIndexTests.swift
@@ -6,6 +6,7 @@ import SharedCore
 import SQLite3
 import Testing
 import CoreProtocols
+@testable import CorePackageIndexing
 
 // MARK: - PackageIndexTests
 


### PR DESCRIPTION
Closes #304. Refactor plan task 2.4.

## What

Lifts the Swift-package indexing pipeline out of `Core` into a new `CorePackageIndexing` target under `Sources/Core/PackageIndexing/`.

## Files moved (`git mv`, 10 files)

Plan 2.4 list:
- `PackageDependencyResolver.swift`, `PackageFetcher.swift`, `PackageArchiveExtractor.swift`, `PackageAvailabilityAnnotator.swift`, `PackageDocumentationDownloader.swift`, `ResolvedPackagesStore.swift`, `PackageFileKind.swift`, `ManifestCache.swift`

Pulled forward from plan 2.5 (CoreSampleCode):
- `PriorityPackageGenerator.swift`, `PriorityPackagesCatalog.swift`

**Why the pull-forward:** `PackageFetcher.swift` references `PriorityPackageList` and `PriorityPackageGenerator` at runtime. Keeping the priority files in CoreSampleCode while moving PackageFetcher to CorePackageIndexing would have created a CorePackageIndexing → CoreSampleCode cycle (since CoreSampleCode in turn depends on package types). Plan 2.5 loses two entries and stays sample-code-only.

## Public API tightening

`PriorityPackageList.stats` and `PackageStats.*` fields bumped from `internal` to `public`. `Crawler.swift` accesses `priorityList.stats.totalUniqueReposFound` across the new module boundary; `internal` stops working post-extraction.

## Package.swift

- New `CorePackageIndexing` target, deps `["CoreProtocols", "SharedCore", "SharedModels", "SharedConstants", "SharedUtils", "Logging", "ASTIndexer"]`, `path: "Sources/Core/PackageIndexing"`.
- New `CorePackageIndexing` product.
- `Core` target deps gain `CorePackageIndexing`; `Core` `exclude` gains `"PackageIndexing"` (alongside `"HTMLParser"`, `"JSONParser"`).
- `CLI`, `Search`, `TUI`, `CoreTests`, `SearchTests`, `FetchTests` deps gain `CorePackageIndexing`.

## Import sweep (~16 source + test files)

- Production: `ASTIndexer/AvailabilityParsers.swift`'s spurious `CorePackageIndexing` import (a comment-only reference to `Core.PackageAvailabilityAnnotator`) was reverted; ASTIndexer keeps its zero-Core deps.
- Tests: `PackageFetcherTests`, `PackageDependencyResolverTests`, `PackageDocumentationDownloaderTests`, `PriorityPackageGeneratorTests`, `ResolverPipelineTests`, `CupertinoCoreTests`, `PackageIndexTests`, `FetchTests` pick up `@testable import CorePackageIndexing`.

## Verification

| Step | Result |
|---|---|
| `xcrun swift build` (clean) | green |
| `xcrun swift package clean && xcrun swift test` | **1293 / 1293**, 0 failures |
| `xcrun swift run cupertino --help` | green |
| `swiftformat` | 12 / 12 reformatted (committed) |
| `swiftlint` on `Core/PackageIndexing/` | 11 pre-existing warnings (function_body_length on long fetcher pipelines, blanket type_body_length / function_body_length disables, large_tuple); all carried forward, not introduced |

## Out of scope

- Pre-existing lint warnings in `PriorityPackageGenerator` / `PackageFetcher`. Phase 4.
- Type renaming (`PackageStats` → `CorePackageIndexing.PackageStats`, etc.). Queued for the namespacing pass after Phase 2 wraps.
