### PR TITLE
refactor: nest types under struct namespaces (Availability ✓, more coming)

### DIFF
--- a/Packages/Sources/Availability/AvailabilityError.swift
+++ b/Packages/Sources/Availability/AvailabilityError.swift
@@ -2,50 +2,52 @@ import Foundation
 
 // MARK: - Availability Errors
 
-/// Errors that can occur during availability fetching
-public enum AvailabilityError: Error, LocalizedError, Sendable {
-    /// Network request failed
-    case networkError(Error)
+extension Availability {
+    /// Errors that can occur during availability fetching
+    public enum Error: Swift.Error, LocalizedError, Sendable {
+        /// Network request failed
+        case networkError(Swift.Error)
 
-    /// Request timed out
-    case timeout
+        /// Request timed out
+        case timeout
 
-    /// API returned 404 (symbol not found)
-    case notFound(String)
+        /// API returned 404 (symbol not found)
+        case notFound(String)
 
-    /// Invalid response from API
-    case invalidResponse
+        /// Invalid response from API
+        case invalidResponse
 
-    /// Rate limited by API
-    case rateLimited
+        /// Rate limited by API
+        case rateLimited
 
-    /// No documentation directory found
-    case noDocumentationFound
+        /// No documentation directory found
+        case noDocumentationFound
 
-    /// Failed to parse JSON
-    case jsonParseError(Error)
+        /// Failed to parse JSON
+        case jsonParseError(Swift.Error)
 
-    /// Failed to write updated file
-    case writeError(Error)
+        /// Failed to write updated file
+        case writeError(Swift.Error)
 
-    public var errorDescription: String? {
-        switch self {
-        case .networkError(let error):
-            return "Network error: \(error.localizedDescription)"
-        case .timeout:
-            return "Request timed out"
-        case .notFound(let symbol):
-            return "Symbol not found: \(symbol)"
-        case .invalidResponse:
-            return "Invalid response from Apple API"
-        case .rateLimited:
-            return "Rate limited by Apple API"
-        case .noDocumentationFound:
-            return "No documentation directory found"
-        case .jsonParseError(let error):
-            return "JSON parse error: \(error.localizedDescription)"
-        case .writeError(let error):
-            return "Failed to write file: \(error.localizedDescription)"
+        public var errorDescription: String? {
+            switch self {
+            case .networkError(let error):
+                return "Network error: \(error.localizedDescription)"
+            case .timeout:
+                return "Request timed out"
+            case .notFound(let symbol):
+                return "Symbol not found: \(symbol)"
+            case .invalidResponse:
+                return "Invalid response from Apple API"
+            case .rateLimited:
+                return "Rate limited by Apple API"
+            case .noDocumentationFound:
+                return "No documentation directory found"
+            case .jsonParseError(let error):
+                return "JSON parse error: \(error.localizedDescription)"
+            case .writeError(let error):
+                return "Failed to write file: \(error.localizedDescription)"
+            }
         }
     }
 }

--- a/Packages/Sources/Availability/AvailabilityFetcher.swift
+++ b/Packages/Sources/Availability/AvailabilityFetcher.swift
@@ -7,12 +7,13 @@ import FoundationNetworking
 // MARK: - Availability Fetcher
 
 // swiftlint:disable type_body_length
-// Justification: AvailabilityFetcher is a self-contained actor that handles availability data fetching.
+// Justification: Availability.Fetcher is a self-contained actor that handles availability data fetching.
 // It manages API calls, caching, fallback strategies, and statistics tracking as a cohesive unit.
 // Splitting would fragment the actor's state management and reduce thread-safety guarantees.
 
 /// Fetches platform availability data from Apple's API and updates existing documentation JSONs
-public actor AvailabilityFetcher {
+extension Availability {
+    public actor Fetcher {
     // MARK: - Configuration
 
     /// Configuration for the availability fetcher
@@ -59,10 +60,10 @@ public actor AvailabilityFetcher {
     private let urlSession: URLSession
 
     /// Cache of framework-level availability for inheritance
-    private var frameworkAvailabilityCache: [String: [PlatformAvailability]] = [:]
+    private var frameworkAvailabilityCache: [String: [Availability.Platform]] = [:]
 
     /// Cache of all document availability (populated in pass 1, used in pass 2 for articles)
-    private var documentAvailabilityCache: [String: [PlatformAvailability]] = [:]
+    private var documentAvailabilityCache: [String: [Availability.Platform]] = [:]
 
     // MARK: - Initialization
 
@@ -85,14 +86,14 @@ public actor AvailabilityFetcher {
 
     /// Fetch availability data and update all documentation JSONs
     public func fetch(
-        onProgress: (@Sendable (AvailabilityProgress) -> Void)? = nil
-    ) async throws -> AvailabilityStatistics {
-        var stats = AvailabilityStatistics(startTime: Date())
+        onProgress: (@Sendable (Availability.Progress) -> Void)? = nil
+    ) async throws -> Availability.Statistics {
+        var stats = Availability.Statistics(startTime: Date())
 
         // Discover all frameworks
         let frameworks = try discoverFrameworks()
         guard !frameworks.isEmpty else {
-            throw AvailabilityError.noDocumentationFound
+            throw Availability.Error.noDocumentationFound
         }
 
         // Collect all JSON files
@@ -149,8 +150,8 @@ public actor AvailabilityFetcher {
 
     private func processFiles(
         _ files: [(framework: String, file: URL)],
-        stats: inout AvailabilityStatistics,
-        onProgress: (@Sendable (AvailabilityProgress) -> Void)?
+        stats: inout Availability.Statistics,
+        onProgress: (@Sendable (Availability.Progress) -> Void)?
     ) async throws {
         // Phase 1: Cache framework root availability
         await cacheFrameworkAvailability(from: files)
@@ -260,7 +261,7 @@ public actor AvailabilityFetcher {
 
     private func updateStats(
         result: ProcessResult,
-        stats: inout AvailabilityStatistics,
+        stats: inout Availability.Statistics,
         successful: inout Int,
         failed: inout Int,
         filesWithNoAvailability: inout [String]
@@ -297,10 +298,10 @@ public actor AvailabilityFetcher {
         total: Int,
         successful: Int,
         failed: Int,
-        onProgress: (@Sendable (AvailabilityProgress) -> Void)?
+        onProgress: (@Sendable (Availability.Progress) -> Void)?
     ) {
         if let onProgress {
-            let progress = AvailabilityProgress(
+            let progress = Availability.Progress(
                 currentDocument: result.filename,
                 completed: completed,
                 total: total,
@@ -325,9 +326,9 @@ public actor AvailabilityFetcher {
             if let data = try? Data(contentsOf: file),
                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let availabilityArray = json["availability"] as? [[String: Any]] {
-                let platforms = availabilityArray.compactMap { dict -> PlatformAvailability? in
+                let platforms = availabilityArray.compactMap { dict -> Availability.Platform? in
                     guard let name = dict["name"] as? String else { return nil }
-                    return PlatformAvailability(
+                    return Availability.Platform(
                         name: name,
                         introducedAt: dict["introducedAt"] as? String,
                         deprecated: dict["deprecated"] as? Bool ?? false,
@@ -383,7 +384,7 @@ public actor AvailabilityFetcher {
 
         // Fallback 1: If API failed or returned empty, try parsing @available from local content
         if availability?.isEmpty ?? true {
-            availability = AvailabilityInfo.extractFromJSONContent(data)
+            availability = Availability.Info.extractFromJSONContent(data)
         }
 
         // Fallback 2: For articles, derive from referenced APIs
@@ -397,7 +398,7 @@ public actor AvailabilityFetcher {
         // Fallback 3: If still no availability, try inheriting from framework
         if availability?.isEmpty ?? true,
            let frameworkPlatforms = frameworkAvailabilityCache[framework] {
-            availability = AvailabilityInfo(platforms: frameworkPlatforms)
+            availability = Availability.Info(platforms: frameworkPlatforms)
             inherited = true
         }
 
@@ -456,12 +457,12 @@ public actor AvailabilityFetcher {
     }
 
     /// Cache document availability for reference lookups
-    private func cacheDocumentAvailability(key: String, platforms: [PlatformAvailability]) {
+    private func cacheDocumentAvailability(key: String, platforms: [Availability.Platform]) {
         documentAvailabilityCache[key] = platforms
     }
 
     /// Derive availability from doc:// references in article content
-    private func deriveAvailabilityFromReferences(json: [String: Any]) -> AvailabilityInfo? {
+    private func deriveAvailabilityFromReferences(json: [String: Any]) -> Availability.Info? {
         guard let rawMarkdown = json["rawMarkdown"] as? String else { return nil }
 
         // Extract doc:// references from markdown
@@ -475,7 +476,7 @@ public actor AvailabilityFetcher {
         let range = NSRange(rawMarkdown.startIndex..., in: rawMarkdown)
         let matches = regex.matches(in: rawMarkdown, options: [], range: range)
 
-        var allPlatforms: [[PlatformAvailability]] = []
+        var allPlatforms: [[Availability.Platform]] = []
 
         for match in matches {
             guard let pathRange = Range(match.range(at: 1), in: rawMarkdown) else { continue }
@@ -498,8 +499,8 @@ public actor AvailabilityFetcher {
     /// Compute the most restrictive availability from multiple sources
     /// Uses the highest minimum version for each platform
     private func computeMostRestrictiveAvailability(
-        from sources: [[PlatformAvailability]]
-    ) -> AvailabilityInfo? {
+        from sources: [[Availability.Platform]]
+    ) -> Availability.Info? {
         var platformVersions: [String: (version: String, deprecated: Bool, beta: Bool)] = [:]
 
         for platforms in sources {
@@ -524,7 +525,7 @@ public actor AvailabilityFetcher {
         guard !platformVersions.isEmpty else { return nil }
 
         let platforms = platformVersions.map { name, info in
-            PlatformAvailability(
+            Availability.Platform(
                 name: name,
                 introducedAt: info.version,
                 deprecated: info.deprecated,
@@ -534,7 +535,7 @@ public actor AvailabilityFetcher {
             )
         }
 
-        return AvailabilityInfo(platforms: platforms)
+        return Availability.Info(platforms: platforms)
     }
 
     /// Compare version strings - returns true if lhs > rhs
@@ -572,7 +573,7 @@ public actor AvailabilityFetcher {
         return URL(string: "\(configuration.apiBaseURL)/\(apiPath).json")!
     }
 
-    private func fetchAvailability(from url: URL) async -> AvailabilityInfo? {
+    private func fetchAvailability(from url: URL) async -> Availability.Info? {
         do {
             let (data, response) = try await urlSession.data(from: url)
 
@@ -591,8 +592,8 @@ public actor AvailabilityFetcher {
                 return nil
             }
 
-            let availability = platforms.map { $0.toPlatformAvailability() }
-            return AvailabilityInfo(platforms: availability)
+            let availability = platforms.map { $0.toPlatform() }
+            return Availability.Info(platforms: availability)
         } catch {
             // Network error or JSON parse error - return nil to mark as failed
             return nil
@@ -616,4 +617,5 @@ private struct ProcessResult: Sendable {
     let status: Status
     let filename: String
     let framework: String
+}
 }

--- a/Packages/Sources/Availability/AvailabilityProgress.swift
+++ b/Packages/Sources/Availability/AvailabilityProgress.swift
@@ -2,45 +2,47 @@ import Foundation
 
 // MARK: - Availability Fetch Progress
 
-/// Progress information for availability fetching
-public struct AvailabilityProgress: Sendable {
-    /// Current document being processed
-    public let currentDocument: String
+extension Availability {
+    /// Progress information for availability fetching
+    public struct Progress: Sendable {
+        /// Current document being processed
+        public let currentDocument: String
 
-    /// Number of documents processed
-    public let completed: Int
+        /// Number of documents processed
+        public let completed: Int
 
-    /// Total documents to process
-    public let total: Int
+        /// Total documents to process
+        public let total: Int
 
-    /// Number of successful fetches
-    public let successful: Int
+        /// Number of successful fetches
+        public let successful: Int
 
-    /// Number of failed fetches
-    public let failed: Int
+        /// Number of failed fetches
+        public let failed: Int
 
-    /// Current framework being processed
-    public let currentFramework: String
+        /// Current framework being processed
+        public let currentFramework: String
 
-    public init(
-        currentDocument: String,
-        completed: Int,
-        total: Int,
-        successful: Int,
-        failed: Int,
-        currentFramework: String
-    ) {
-        self.currentDocument = currentDocument
-        self.completed = completed
-        self.total = total
-        self.successful = successful
-        self.failed = failed
-        self.currentFramework = currentFramework
-    }
+        public init(
+            currentDocument: String,
+            completed: Int,
+            total: Int,
+            successful: Int,
+            failed: Int,
+            currentFramework: String
+        ) {
+            self.currentDocument = currentDocument
+            self.completed = completed
+            self.total = total
+            self.successful = successful
+            self.failed = failed
+            self.currentFramework = currentFramework
+        }
 
-    /// Progress percentage (0-100)
-    public var percentage: Double {
-        guard total > 0 else { return 0 }
-        return (Double(completed) / Double(total)) * 100.0
+        /// Progress percentage (0-100)
+        public var percentage: Double {
+            guard total > 0 else { return 0 }
+            return (Double(completed) / Double(total)) * 100.0
+        }
     }
 }

--- a/Packages/Sources/Availability/AvailabilityStatistics.swift
+++ b/Packages/Sources/Availability/AvailabilityStatistics.swift
@@ -2,8 +2,9 @@ import Foundation
 
 // MARK: - Availability Fetch Statistics
 
-/// Statistics for availability fetch operation
-public struct AvailabilityStatistics: Sendable {
+extension Availability {
+    /// Statistics for availability fetch operation
+    public struct Statistics: Sendable {
     /// Total documents scanned
     public var totalDocuments: Int = 0
 
@@ -82,4 +83,5 @@ public struct AvailabilityStatistics: Sendable {
         guard attempted > 0 else { return 0 }
         return (Double(successfulFetches) / Double(attempted)) * 100.0
     }
+}
 }

--- a/Packages/Sources/Availability/PlatformAvailability.swift
+++ b/Packages/Sources/Availability/PlatformAvailability.swift
@@ -2,41 +2,43 @@ import Foundation
 
 // MARK: - Platform Availability
 
-/// Represents platform availability information for an API symbol
-/// Matches Apple's /tutorials/data/documentation API response format
-public struct PlatformAvailability: Codable, Sendable, Hashable {
-    /// Platform name (iOS, macOS, watchOS, etc.)
-    public let name: String
+extension Availability {
+    /// Represents platform availability information for an API symbol
+    /// Matches Apple's /tutorials/data/documentation API response format
+    public struct Platform: Codable, Sendable, Hashable {
+        /// Platform name (iOS, macOS, watchOS, etc.)
+        public let name: String
 
-    /// Version when this API was introduced (e.g., "13.0", "10.15")
-    public let introducedAt: String?
+        /// Version when this API was introduced (e.g., "13.0", "10.15")
+        public let introducedAt: String?
 
-    /// Whether this API is deprecated
-    public let deprecated: Bool
+        /// Whether this API is deprecated
+        public let deprecated: Bool
 
-    /// Version when this API was deprecated (if applicable)
-    public let deprecatedAt: String?
+        /// Version when this API was deprecated (if applicable)
+        public let deprecatedAt: String?
 
-    /// Whether this API is unavailable on this platform
-    public let unavailable: Bool
+        /// Whether this API is unavailable on this platform
+        public let unavailable: Bool
 
-    /// Whether this API is in beta
-    public let beta: Bool
+        /// Whether this API is in beta
+        public let beta: Bool
 
-    public init(
-        name: String,
-        introducedAt: String? = nil,
-        deprecated: Bool = false,
-        deprecatedAt: String? = nil,
-        unavailable: Bool = false,
-        beta: Bool = false
-    ) {
-        self.name = name
-        self.introducedAt = introducedAt
-        self.deprecated = deprecated
-        self.deprecatedAt = deprecatedAt
-        self.unavailable = unavailable
-        self.beta = beta
+        public init(
+            name: String,
+            introducedAt: String? = nil,
+            deprecated: Bool = false,
+            deprecatedAt: String? = nil,
+            unavailable: Bool = false,
+            beta: Bool = false
+        ) {
+            self.name = name
+            self.introducedAt = introducedAt
+            self.deprecated = deprecated
+            self.deprecatedAt = deprecatedAt
+            self.unavailable = unavailable
+            self.beta = beta
+        }
     }
 }
 
@@ -59,8 +61,8 @@ extension Availability {
             let unavailable: Bool?
             let beta: Bool?
 
-            func toPlatformAvailability() -> PlatformAvailability {
-                PlatformAvailability(
+            func toPlatform() -> Availability.Platform {
+                Availability.Platform(
                     name: name,
                     introducedAt: introducedAt,
                     deprecated: deprecated ?? false,
@@ -75,54 +77,56 @@ extension Availability {
 
 // MARK: - Availability Info
 
-/// Complete availability information for a documentation page
-public struct AvailabilityInfo: Codable, Sendable, Hashable {
-    /// Platform availability array
-    public let platforms: [PlatformAvailability]
+extension Availability {
+    /// Complete availability information for a documentation page
+    public struct Info: Codable, Sendable, Hashable {
+        /// Platform availability array
+        public let platforms: [Availability.Platform]
 
-    /// When the availability was fetched
-    public let fetchedAt: Date
+        /// When the availability was fetched
+        public let fetchedAt: Date
 
-    public init(platforms: [PlatformAvailability], fetchedAt: Date = Date()) {
-        self.platforms = platforms
-        self.fetchedAt = fetchedAt
-    }
+        public init(platforms: [Availability.Platform], fetchedAt: Date = Date()) {
+            self.platforms = platforms
+            self.fetchedAt = fetchedAt
+        }
 
-    /// Empty availability (no data available)
-    public static let empty = AvailabilityInfo(platforms: [])
+        /// Empty availability (no data available)
+        public static let empty = Availability.Info(platforms: [])
 
-    /// Check if availability data exists
-    public var isEmpty: Bool {
-        platforms.isEmpty
-    }
+        /// Check if availability data exists
+        public var isEmpty: Bool {
+            platforms.isEmpty
+        }
 
-    /// Minimum iOS version required (nil if not available on iOS)
-    public var minimumiOS: String? {
-        platforms.first { $0.name == "iOS" && !$0.unavailable }?.introducedAt
-    }
+        /// Minimum iOS version required (nil if not available on iOS)
+        public var minimumiOS: String? {
+            platforms.first { $0.name == "iOS" && !$0.unavailable }?.introducedAt
+        }
 
-    /// Minimum macOS version required (nil if not available on macOS)
-    public var minimumMacOS: String? {
-        platforms.first { $0.name == "macOS" && !$0.unavailable }?.introducedAt
-    }
+        /// Minimum macOS version required (nil if not available on macOS)
+        public var minimumMacOS: String? {
+            platforms.first { $0.name == "macOS" && !$0.unavailable }?.introducedAt
+        }
 
-    /// Check if deprecated on any platform
-    public var isDeprecated: Bool {
-        platforms.contains { $0.deprecated }
-    }
+        /// Check if deprecated on any platform
+        public var isDeprecated: Bool {
+            platforms.contains { $0.deprecated }
+        }
 
-    /// Check if in beta on any platform
-    public var isBeta: Bool {
-        platforms.contains { $0.beta }
+        /// Check if in beta on any platform
+        public var isBeta: Bool {
+            platforms.contains { $0.beta }
+        }
     }
 }
 
 // MARK: - @available Annotation Parser
 
-extension AvailabilityInfo {
+extension Availability.Info {
     /// Parse availability from @available annotations in Swift code
     /// Example: @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-    public static func parseFromAnnotation(_ content: String) -> AvailabilityInfo? {
+    public static func parseFromAnnotation(_ content: String) -> Availability.Info? {
         // Match @available(iOS 13.0, macOS 10.15, *) pattern
         let pattern = #"@available\s*\(\s*([^)]+)\s*\)"#
 
@@ -138,7 +142,7 @@ extension AvailabilityInfo {
         }
 
         let annotationContent = String(content[range])
-        var platforms: [PlatformAvailability] = []
+        var platforms: [Availability.Platform] = []
 
         // Split by comma and parse each platform
         let parts = annotationContent.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
@@ -162,7 +166,7 @@ extension AvailabilityInfo {
                 let isDeprecated = part.lowercased().contains("deprecated")
                 let isUnavailable = part.lowercased().contains("unavailable")
 
-                platforms.append(PlatformAvailability(
+                platforms.append(Availability.Platform(
                     name: platformName,
                     introducedAt: version,
                     deprecated: isDeprecated,
@@ -173,7 +177,7 @@ extension AvailabilityInfo {
             }
         }
 
-        return platforms.isEmpty ? nil : AvailabilityInfo(platforms: platforms)
+        return platforms.isEmpty ? nil : Availability.Info(platforms: platforms)
     }
 
     /// Normalize platform names to match Apple's API format
@@ -191,7 +195,7 @@ extension AvailabilityInfo {
     }
 
     /// Try to extract availability from JSON content (rawMarkdown, codeExamples, declaration)
-    public static func extractFromJSONContent(_ jsonData: Data) -> AvailabilityInfo? {
+    public static func extractFromJSONContent(_ jsonData: Data) -> Availability.Info? {
         // Try to parse as dictionary
         guard let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
             return nil

--- a/Packages/Sources/CLI/Commands/FetchCommand.swift
+++ b/Packages/Sources/CLI/Commands/FetchCommand.swift
@@ -985,18 +985,18 @@ struct FetchCommand: AsyncParsableCommand {
         Logging.ConsoleLogger.info("   Source: \(docsDir.path)")
         Logging.ConsoleLogger.info("   API: developer.apple.com/tutorials/data/documentation\n")
 
-        let configuration: AvailabilityFetcher.Configuration
+        let configuration: Availability.Fetcher.Configuration
         if fast {
             configuration = .fast
         } else {
-            configuration = AvailabilityFetcher.Configuration(
+            configuration = Availability.Fetcher.Configuration(
                 concurrency: 50,
                 timeout: 1.0,
                 skipExisting: !force
             )
         }
 
-        let fetcher = AvailabilityFetcher(
+        let fetcher = Availability.Fetcher(
             docsDirectory: docsDir,
             configuration: configuration
         )

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -28,7 +28,7 @@ extension Core {
         private let output: Shared.OutputConfiguration
         private let state: CrawlerState
 
-        private var webPageFetcher: WKWebCrawler.WKWebContentFetcher!
+        private var webPageFetcher: WKWebCrawler.ContentFetcher!
         private var visited = Set<String>()
         private var queue: [(url: URL, depth: Int)] = []
         // Tracks URLs currently in `queue` so the same URL discovered from
@@ -51,8 +51,8 @@ extension Core {
             stats = CrawlStatistics()
             super.init()
 
-            // Initialize WKWebContentFetcher from WKWebCrawler namespace
-            webPageFetcher = WKWebCrawler.WKWebContentFetcher()
+            // Initialize WKWebCrawler.ContentFetcher from WKWebCrawler namespace
+            webPageFetcher = WKWebCrawler.ContentFetcher()
 
             // Temporary debug logging for #25
             let logPath = self.configuration.outputDirectory
@@ -503,7 +503,7 @@ extension Core {
         }
 
         private func loadPage(url: URL) async throws -> String {
-            // Delegate to WKWebCrawler's WKWebContentFetcher
+            // Delegate to WKWebCrawler's WKWebCrawler.ContentFetcher
             try await webPageFetcher.fetch(url: url).content
         }
 
@@ -623,18 +623,18 @@ extension Core {
         }
 
         private func getMemoryUsageMB() -> Double {
-            // Delegate to WKWebCrawler's WKWebContentFetcher
+            // Delegate to WKWebCrawler's WKWebCrawler.ContentFetcher
             webPageFetcher.getMemoryUsageMB()
         }
 
         private func recycleWebView() async {
             let memBefore = getMemoryUsageMB()
-            // Delegate to WKWebCrawler's WKWebContentFetcher
+            // Delegate to WKWebCrawler's WKWebCrawler.ContentFetcher
             webPageFetcher.recycle()
             let memAfter = getMemoryUsageMB()
             let before = String(format: "%.1f", memBefore)
             let after = String(format: "%.1f", memAfter)
-            logInfo("♻️ Recycled WKWebContentFetcher: \(before)MB → \(after)MB")
+            logInfo("♻️ Recycled WKWebCrawler.ContentFetcher: \(before)MB → \(after)MB")
         }
 
         /// Auto-generate priority package list if this was a Swift.org crawl

--- a/Packages/Sources/Core/HIGCrawler.swift
+++ b/Packages/Sources/Core/HIGCrawler.swift
@@ -26,7 +26,7 @@ extension Core {
         private let maxPages: Int
 
         #if canImport(WebKit)
-        private var fetcher: WKWebCrawler.WKWebContentFetcher?
+        private var fetcher: WKWebCrawler.ContentFetcher?
         #endif
 
         public init(
@@ -59,7 +59,7 @@ extension Core {
 
             #if canImport(WebKit)
             // Initialize content fetcher with HIG-specific wait time
-            fetcher = WKWebCrawler.WKWebContentFetcher(
+            fetcher = WKWebCrawler.ContentFetcher(
                 pageLoadTimeout: Shared.Constants.Timeout.pageLoad,
                 javascriptWaitTime: Shared.Constants.Timeout.higJavascriptWait
             )

--- a/Packages/Sources/Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift
+++ b/Packages/Sources/Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift
@@ -10,18 +10,18 @@ import CoreHTMLParser
 // MARK: - WKWeb Crawler Engine
 
 /// Complete crawler engine using WKWebView for JavaScript-rendered pages
-/// Uses WKWebContentFetcher for fetching and HTMLToMarkdown for transformation
+/// Uses WKWebCrawler.ContentFetcher for fetching and HTMLToMarkdown for transformation
 extension WKWebCrawler {
     #if canImport(WebKit)
     @MainActor
-    public final class WKWebCrawlerEngine: @preconcurrency CrawlerEngine {
-        private let fetcher: WKWebContentFetcher
+    public final class Engine: @preconcurrency CrawlerEngine {
+        private let fetcher: WKWebCrawler.ContentFetcher
 
         public init(
             pageLoadTimeout: Duration = Shared.Constants.Timeout.pageLoad,
             javascriptWaitTime: Duration = Shared.Constants.Timeout.javascriptWait
         ) {
-            fetcher = WKWebContentFetcher(
+            fetcher = WKWebCrawler.ContentFetcher(
                 pageLoadTimeout: pageLoadTimeout,
                 javascriptWaitTime: javascriptWaitTime
             )

--- a/Packages/Sources/Core/WKWebCrawler/Fetchers/WKWebContentFetcher.swift
+++ b/Packages/Sources/Core/WKWebCrawler/Fetchers/WKWebContentFetcher.swift
@@ -13,7 +13,7 @@ import CoreProtocols
 extension WKWebCrawler {
     #if canImport(WebKit)
     @MainActor
-    public final class WKWebContentFetcher: NSObject, @preconcurrency ContentFetcher {
+    public final class ContentFetcher: NSObject, @preconcurrency CoreProtocols.ContentFetcher {
         public typealias RawContent = String
 
         // `webView` is an IUO on purpose: `recycle()` (below) is called
@@ -132,7 +132,7 @@ extension WKWebCrawler {
 // MARK: - WKNavigationDelegate
 
 #if canImport(WebKit)
-extension WKWebCrawler.WKWebContentFetcher: WKNavigationDelegate {
+extension WKWebCrawler.ContentFetcher: WKNavigationDelegate {
     public nonisolated func webView(
         _ webView: WKWebView,
         didFailProvisionalNavigation navigation: WKNavigation!,

--- a/Packages/Sources/RemoteSync/AnimatedProgress.swift
+++ b/Packages/Sources/RemoteSync/AnimatedProgress.swift
@@ -22,7 +22,7 @@ public struct AnimatedProgress: Sendable {
     // MARK: - Rendering
 
     /// Render progress to string (for terminal output)
-    public func render(_ progress: RemoteSyncProgress) -> String {
+    public func render(_ progress: RemoteSync.Progress) -> String {
         // Phase and framework progress
         let phaseIcon = useEmoji ? phaseEmoji(progress.phase) : "-"
         let frameworkBar = renderBar(
@@ -50,7 +50,7 @@ public struct AnimatedProgress: Sendable {
     }
 
     /// Render a single-line status update
-    public func renderCompact(_ progress: RemoteSyncProgress) -> String {
+    public func renderCompact(_ progress: RemoteSync.Progress) -> String {
         let bar = renderBar(current: progress.frameworkIndex, total: progress.frameworksTotal)
         let framework = progress.framework ?? "..."
         let fileInfo = progress.filesTotal > 0 ? " (\(progress.fileIndex)/\(progress.filesTotal))" : ""
@@ -128,7 +128,7 @@ public final class ProgressReporter: @unchecked Sendable {
     }
 
     /// Update progress display (single line, overwrites previous)
-    public func update(_ progress: RemoteSyncProgress) {
+    public func update(_ progress: RemoteSync.Progress) {
         lock.lock()
         defer { lock.unlock() }
 

--- a/Packages/Sources/RemoteSync/RemoteIndexState.swift
+++ b/Packages/Sources/RemoteSync/RemoteIndexState.swift
@@ -208,8 +208,9 @@ public struct RemoteIndexState: Codable, Sendable, Equatable {
 
 // MARK: - Progress Callback
 
+extension RemoteSync {
 /// Progress information for callbacks
-public struct RemoteSyncProgress: Sendable {
+public struct Progress: Sendable {
     public let phase: RemoteIndexState.Phase
     public let framework: String?
     public let frameworkIndex: Int
@@ -245,4 +246,5 @@ public struct RemoteSyncProgress: Sendable {
         let totalEstimated = elapsed / overallProgress
         return totalEstimated - elapsed
     }
+}
 }

--- a/Packages/Sources/RemoteSync/RemoteIndexer.swift
+++ b/Packages/Sources/RemoteSync/RemoteIndexer.swift
@@ -8,7 +8,7 @@ import SharedConstants
 /// Reduces function parameter count while maintaining type safety.
 struct IndexingContext: @unchecked Sendable {
     let indexDocument: RemoteIndexer.DocumentIndexer
-    let onProgress: @Sendable (RemoteSyncProgress) -> Void
+    let onProgress: @Sendable (RemoteSync.Progress) -> Void
     let onDocument: (@Sendable (RemoteIndexer.IndexResult) -> Void)?
 }
 
@@ -103,7 +103,7 @@ public actor RemoteIndexer {
     ///   - onDocument: Called for each document processed
     public func run(
         indexDocument: @escaping DocumentIndexer,
-        onProgress: @escaping @Sendable (RemoteSyncProgress) -> Void,
+        onProgress: @escaping @Sendable (RemoteSync.Progress) -> Void,
         onDocument: (@Sendable (IndexResult) -> Void)? = nil
     ) async throws {
         // Determine which phases to run
@@ -139,7 +139,7 @@ public actor RemoteIndexer {
     private func runPhase(
         _ phase: RemoteIndexState.Phase,
         indexDocument: @escaping DocumentIndexer,
-        onProgress: @escaping @Sendable (RemoteSyncProgress) -> Void,
+        onProgress: @escaping @Sendable (RemoteSync.Progress) -> Void,
         onDocument: (@Sendable (IndexResult) -> Void)?
     ) async throws {
         let path = phasePath(phase)
@@ -314,8 +314,8 @@ public actor RemoteIndexer {
             .capitalized
     }
 
-    private func reportProgress(_ onProgress: @Sendable (RemoteSyncProgress) -> Void) {
-        let progress = RemoteSyncProgress(
+    private func reportProgress(_ onProgress: @Sendable (RemoteSync.Progress) -> Void) {
+        let progress = RemoteSync.Progress(
             phase: state.phase,
             framework: state.currentFramework,
             frameworkIndex: state.frameworksCompleted.count + (state.currentFramework != nil ? 1 : 0),

--- a/Packages/Tests/AvailabilityTests/AvailabilityTests.swift
+++ b/Packages/Tests/AvailabilityTests/AvailabilityTests.swift
@@ -4,11 +4,11 @@ import Testing
 
 // MARK: - Platform Availability Tests
 
-@Suite("PlatformAvailability Tests")
+@Suite("Availability.Platform Tests")
 struct PlatformAvailabilityTests {
     @Test("Initialize with all parameters")
     func fullInitialization() {
-        let availability = PlatformAvailability(
+        let availability = Availability.Platform(
             name: "iOS",
             introducedAt: "13.0",
             deprecated: true,
@@ -27,7 +27,7 @@ struct PlatformAvailabilityTests {
 
     @Test("Initialize with minimal parameters")
     func minimalInitialization() {
-        let availability = PlatformAvailability(name: "macOS")
+        let availability = Availability.Platform(name: "macOS")
 
         #expect(availability.name == "macOS")
         #expect(availability.introducedAt == nil)
@@ -39,9 +39,9 @@ struct PlatformAvailabilityTests {
 
     @Test("Hashable conformance")
     func hashable() {
-        let iosAvailability = PlatformAvailability(name: "iOS", introducedAt: "13.0")
-        let iosAvailabilityCopy = PlatformAvailability(name: "iOS", introducedAt: "13.0")
-        let macOSAvailability = PlatformAvailability(name: "macOS", introducedAt: "10.15")
+        let iosAvailability = Availability.Platform(name: "iOS", introducedAt: "13.0")
+        let iosAvailabilityCopy = Availability.Platform(name: "iOS", introducedAt: "13.0")
+        let macOSAvailability = Availability.Platform(name: "macOS", introducedAt: "10.15")
 
         #expect(iosAvailability == iosAvailabilityCopy)
         #expect(iosAvailability != macOSAvailability)
@@ -50,7 +50,7 @@ struct PlatformAvailabilityTests {
 
     @Test("Codable round-trip")
     func codable() throws {
-        let original = PlatformAvailability(
+        let original = Availability.Platform(
             name: "iOS",
             introducedAt: "15.0",
             deprecated: false,
@@ -63,7 +63,7 @@ struct PlatformAvailabilityTests {
         let data = try encoder.encode(original)
 
         let decoder = JSONDecoder()
-        let decoded = try decoder.decode(PlatformAvailability.self, from: data)
+        let decoded = try decoder.decode(Availability.Platform.self, from: data)
 
         #expect(decoded == original)
     }
@@ -71,11 +71,11 @@ struct PlatformAvailabilityTests {
 
 // MARK: - Availability Info Tests
 
-@Suite("AvailabilityInfo Tests")
+@Suite("Availability.Info Tests")
 struct AvailabilityInfoTests {
     @Test("Empty availability")
     func testEmpty() {
-        let empty = AvailabilityInfo.empty
+        let empty = Availability.Info.empty
 
         #expect(empty.isEmpty == true)
         #expect(empty.platforms.isEmpty == true)
@@ -88,10 +88,10 @@ struct AvailabilityInfoTests {
     @Test("Non-empty availability")
     func nonEmpty() {
         let platforms = [
-            PlatformAvailability(name: "iOS", introducedAt: "13.0"),
-            PlatformAvailability(name: "macOS", introducedAt: "10.15"),
+            Availability.Platform(name: "iOS", introducedAt: "13.0"),
+            Availability.Platform(name: "macOS", introducedAt: "10.15"),
         ]
-        let info = AvailabilityInfo(platforms: platforms)
+        let info = Availability.Info(platforms: platforms)
 
         #expect(info.isEmpty == false)
         #expect(info.platforms.count == 2)
@@ -100,10 +100,10 @@ struct AvailabilityInfoTests {
     @Test("Minimum iOS version")
     func testMinimumiOS() {
         let platforms = [
-            PlatformAvailability(name: "iOS", introducedAt: "14.0"),
-            PlatformAvailability(name: "macOS", introducedAt: "11.0"),
+            Availability.Platform(name: "iOS", introducedAt: "14.0"),
+            Availability.Platform(name: "macOS", introducedAt: "11.0"),
         ]
-        let info = AvailabilityInfo(platforms: platforms)
+        let info = Availability.Info(platforms: platforms)
 
         #expect(info.minimumiOS == "14.0")
     }
@@ -111,10 +111,10 @@ struct AvailabilityInfoTests {
     @Test("Minimum macOS version")
     func testMinimumMacOS() {
         let platforms = [
-            PlatformAvailability(name: "iOS", introducedAt: "15.0"),
-            PlatformAvailability(name: "macOS", introducedAt: "12.0"),
+            Availability.Platform(name: "iOS", introducedAt: "15.0"),
+            Availability.Platform(name: "macOS", introducedAt: "12.0"),
         ]
-        let info = AvailabilityInfo(platforms: platforms)
+        let info = Availability.Info(platforms: platforms)
 
         #expect(info.minimumMacOS == "12.0")
     }
@@ -122,10 +122,10 @@ struct AvailabilityInfoTests {
     @Test("iOS unavailable returns nil")
     func unavailableiOS() {
         let platforms = [
-            PlatformAvailability(name: "iOS", introducedAt: "13.0", unavailable: true),
-            PlatformAvailability(name: "macOS", introducedAt: "10.15"),
+            Availability.Platform(name: "iOS", introducedAt: "13.0", unavailable: true),
+            Availability.Platform(name: "macOS", introducedAt: "10.15"),
         ]
-        let info = AvailabilityInfo(platforms: platforms)
+        let info = Availability.Info(platforms: platforms)
 
         #expect(info.minimumiOS == nil)
         #expect(info.minimumMacOS == "10.15")
@@ -134,10 +134,10 @@ struct AvailabilityInfoTests {
     @Test("Deprecation check - deprecated")
     func isDeprecatedTrue() {
         let platforms = [
-            PlatformAvailability(name: "iOS", introducedAt: "10.0", deprecated: true),
-            PlatformAvailability(name: "macOS", introducedAt: "10.12"),
+            Availability.Platform(name: "iOS", introducedAt: "10.0", deprecated: true),
+            Availability.Platform(name: "macOS", introducedAt: "10.12"),
         ]
-        let info = AvailabilityInfo(platforms: platforms)
+        let info = Availability.Info(platforms: platforms)
 
         #expect(info.isDeprecated == true)
     }
@@ -145,10 +145,10 @@ struct AvailabilityInfoTests {
     @Test("Deprecation check - not deprecated")
     func isDeprecatedFalse() {
         let platforms = [
-            PlatformAvailability(name: "iOS", introducedAt: "15.0"),
-            PlatformAvailability(name: "macOS", introducedAt: "12.0"),
+            Availability.Platform(name: "iOS", introducedAt: "15.0"),
+            Availability.Platform(name: "macOS", introducedAt: "12.0"),
         ]
-        let info = AvailabilityInfo(platforms: platforms)
+        let info = Availability.Info(platforms: platforms)
 
         #expect(info.isDeprecated == false)
     }
@@ -156,9 +156,9 @@ struct AvailabilityInfoTests {
     @Test("Beta check - in beta")
     func isBetaTrue() {
         let platforms = [
-            PlatformAvailability(name: "visionOS", introducedAt: "1.0", beta: true),
+            Availability.Platform(name: "visionOS", introducedAt: "1.0", beta: true),
         ]
-        let info = AvailabilityInfo(platforms: platforms)
+        let info = Availability.Info(platforms: platforms)
 
         #expect(info.isBeta == true)
     }
@@ -166,9 +166,9 @@ struct AvailabilityInfoTests {
     @Test("Beta check - not in beta")
     func isBetaFalse() {
         let platforms = [
-            PlatformAvailability(name: "iOS", introducedAt: "17.0"),
+            Availability.Platform(name: "iOS", introducedAt: "17.0"),
         ]
-        let info = AvailabilityInfo(platforms: platforms)
+        let info = Availability.Info(platforms: platforms)
 
         #expect(info.isBeta == false)
     }
@@ -176,16 +176,16 @@ struct AvailabilityInfoTests {
     @Test("Codable round-trip")
     func testCodable() throws {
         let platforms = [
-            PlatformAvailability(name: "iOS", introducedAt: "16.0"),
-            PlatformAvailability(name: "watchOS", introducedAt: "9.0"),
+            Availability.Platform(name: "iOS", introducedAt: "16.0"),
+            Availability.Platform(name: "watchOS", introducedAt: "9.0"),
         ]
-        let original = AvailabilityInfo(platforms: platforms)
+        let original = Availability.Info(platforms: platforms)
 
         let encoder = JSONEncoder()
         let data = try encoder.encode(original)
 
         let decoder = JSONDecoder()
-        let decoded = try decoder.decode(AvailabilityInfo.self, from: data)
+        let decoded = try decoder.decode(Availability.Info.self, from: data)
 
         #expect(decoded.platforms.count == original.platforms.count)
         #expect(decoded.minimumiOS == original.minimumiOS)
@@ -194,11 +194,11 @@ struct AvailabilityInfoTests {
 
 // MARK: - Availability Statistics Tests
 
-@Suite("AvailabilityStatistics Tests")
+@Suite("Availability.Statistics Tests")
 struct AvailabilityStatisticsTests {
     @Test("Default initialization")
     func defaultInit() {
-        let stats = AvailabilityStatistics()
+        let stats = Availability.Statistics()
 
         #expect(stats.totalDocuments == 0)
         #expect(stats.updatedDocuments == 0)
@@ -216,7 +216,7 @@ struct AvailabilityStatisticsTests {
         let start = Date()
         let end = start.addingTimeInterval(120)
 
-        let stats = AvailabilityStatistics(
+        let stats = Availability.Statistics(
             startTime: start,
             endTime: end
         )
@@ -226,21 +226,21 @@ struct AvailabilityStatisticsTests {
 
     @Test("Duration nil when no end time")
     func durationNilNoEnd() {
-        let stats = AvailabilityStatistics(startTime: Date())
+        let stats = Availability.Statistics(startTime: Date())
 
         #expect(stats.duration == nil)
     }
 
     @Test("Duration nil when no start time")
     func durationNilNoStart() {
-        let stats = AvailabilityStatistics(endTime: Date())
+        let stats = Availability.Statistics(endTime: Date())
 
         #expect(stats.duration == nil)
     }
 
     @Test("Success rate calculation - all successful")
     func successRateAllSuccess() {
-        var stats = AvailabilityStatistics()
+        var stats = Availability.Statistics()
         stats.successfulFetches = 100
         stats.failedFetches = 0
 
@@ -249,7 +249,7 @@ struct AvailabilityStatisticsTests {
 
     @Test("Success rate calculation - mixed")
     func successRateMixed() {
-        var stats = AvailabilityStatistics()
+        var stats = Availability.Statistics()
         stats.successfulFetches = 75
         stats.failedFetches = 25
 
@@ -258,7 +258,7 @@ struct AvailabilityStatisticsTests {
 
     @Test("Success rate calculation - all failed")
     func successRateAllFailed() {
-        var stats = AvailabilityStatistics()
+        var stats = Availability.Statistics()
         stats.successfulFetches = 0
         stats.failedFetches = 50
 
@@ -267,7 +267,7 @@ struct AvailabilityStatisticsTests {
 
     @Test("Success rate calculation - no attempts")
     func successRateNoAttempts() {
-        let stats = AvailabilityStatistics()
+        let stats = Availability.Statistics()
 
         #expect(stats.successRate == 0.0)
     }
@@ -275,11 +275,11 @@ struct AvailabilityStatisticsTests {
 
 // MARK: - Availability Progress Tests
 
-@Suite("AvailabilityProgress Tests")
+@Suite("Availability.Progress Tests")
 struct AvailabilityProgressTests {
     @Test("Progress percentage calculation")
     func testPercentage() {
-        let progress = AvailabilityProgress(
+        let progress = Availability.Progress(
             currentDocument: "test.json",
             completed: 50,
             total: 100,
@@ -293,7 +293,7 @@ struct AvailabilityProgressTests {
 
     @Test("Progress percentage - zero total")
     func percentageZeroTotal() {
-        let progress = AvailabilityProgress(
+        let progress = Availability.Progress(
             currentDocument: "test.json",
             completed: 0,
             total: 0,
@@ -307,7 +307,7 @@ struct AvailabilityProgressTests {
 
     @Test("Progress percentage - 100%")
     func percentageFull() {
-        let progress = AvailabilityProgress(
+        let progress = Availability.Progress(
             currentDocument: "last.json",
             completed: 200,
             total: 200,
@@ -321,7 +321,7 @@ struct AvailabilityProgressTests {
 
     @Test("Progress stores all values")
     func allValues() {
-        let progress = AvailabilityProgress(
+        let progress = Availability.Progress(
             currentDocument: "view.json",
             completed: 10,
             total: 50,
@@ -341,13 +341,13 @@ struct AvailabilityProgressTests {
 
 // MARK: - Availability Error Tests
 
-@Suite("AvailabilityError Tests")
+@Suite("Availability.Error Tests")
 struct AvailabilityErrorTests {
     @Test("Network error description")
     func testNetworkError() {
         let userInfo = [NSLocalizedDescriptionKey: "Connection failed"]
         let underlyingError = NSError(domain: "test", code: -1, userInfo: userInfo)
-        let error = AvailabilityError.networkError(underlyingError)
+        let error = Availability.Error.networkError(underlyingError)
 
         #expect(error.errorDescription?.contains("Network error") == true)
         #expect(error.errorDescription?.contains("Connection failed") == true)
@@ -355,14 +355,14 @@ struct AvailabilityErrorTests {
 
     @Test("Timeout error description")
     func timeoutError() {
-        let error = AvailabilityError.timeout
+        let error = Availability.Error.timeout
 
         #expect(error.errorDescription == "Request timed out")
     }
 
     @Test("Not found error description")
     func notFoundError() {
-        let error = AvailabilityError.notFound("SwiftUI/View")
+        let error = Availability.Error.notFound("SwiftUI/View")
 
         #expect(error.errorDescription?.contains("not found") == true)
         #expect(error.errorDescription?.contains("SwiftUI/View") == true)
@@ -370,21 +370,21 @@ struct AvailabilityErrorTests {
 
     @Test("Invalid response error description")
     func invalidResponseError() {
-        let error = AvailabilityError.invalidResponse
+        let error = Availability.Error.invalidResponse
 
         #expect(error.errorDescription == "Invalid response from Apple API")
     }
 
     @Test("Rate limited error description")
     func rateLimitedError() {
-        let error = AvailabilityError.rateLimited
+        let error = Availability.Error.rateLimited
 
         #expect(error.errorDescription == "Rate limited by Apple API")
     }
 
     @Test("No documentation found error description")
     func noDocumentationFoundError() {
-        let error = AvailabilityError.noDocumentationFound
+        let error = Availability.Error.noDocumentationFound
 
         #expect(error.errorDescription == "No documentation directory found")
     }
@@ -392,7 +392,7 @@ struct AvailabilityErrorTests {
     @Test("JSON parse error description")
     func jSONParseError() {
         let underlyingError = NSError(domain: "JSON", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"])
-        let error = AvailabilityError.jsonParseError(underlyingError)
+        let error = Availability.Error.jsonParseError(underlyingError)
 
         #expect(error.errorDescription?.contains("JSON parse error") == true)
     }
@@ -401,7 +401,7 @@ struct AvailabilityErrorTests {
     func testWriteError() {
         let userInfo = [NSLocalizedDescriptionKey: "Permission denied"]
         let underlyingError = NSError(domain: "File", code: 2, userInfo: userInfo)
-        let error = AvailabilityError.writeError(underlyingError)
+        let error = Availability.Error.writeError(underlyingError)
 
         #expect(error.errorDescription?.contains("Failed to write file") == true)
     }
@@ -409,11 +409,11 @@ struct AvailabilityErrorTests {
 
 // MARK: - Availability Fetcher Configuration Tests
 
-@Suite("AvailabilityFetcher.Configuration Tests")
+@Suite("Availability.Fetcher.Configuration Tests")
 struct AvailabilityFetcherConfigurationTests {
     @Test("Default configuration values")
     func defaultConfig() {
-        let config = AvailabilityFetcher.Configuration.default
+        let config = Availability.Fetcher.Configuration.default
 
         #expect(config.concurrency == 50)
         #expect(config.timeout == 1.0)
@@ -423,7 +423,7 @@ struct AvailabilityFetcherConfigurationTests {
 
     @Test("Fast configuration values")
     func fastConfig() {
-        let config = AvailabilityFetcher.Configuration.fast
+        let config = Availability.Fetcher.Configuration.fast
 
         #expect(config.concurrency == 100)
         #expect(config.timeout == 0.5)
@@ -432,7 +432,7 @@ struct AvailabilityFetcherConfigurationTests {
 
     @Test("Custom configuration")
     func customConfig() {
-        let config = AvailabilityFetcher.Configuration(
+        let config = Availability.Fetcher.Configuration(
             concurrency: 25,
             timeout: 2.0,
             skipExisting: true,
@@ -448,12 +448,12 @@ struct AvailabilityFetcherConfigurationTests {
 
 // MARK: - @available Annotation Parser Tests
 
-@Suite("AvailabilityInfo Annotation Parser Tests")
+@Suite("Availability.Info Annotation Parser Tests")
 struct AvailabilityAnnotationParserTests {
     @Test("Parse simple @available annotation")
     func parseSimpleAnnotation() {
         let code = "@available(iOS 13.0, macOS 10.15, *)"
-        let result = AvailabilityInfo.parseFromAnnotation(code)
+        let result = Availability.Info.parseFromAnnotation(code)
 
         #expect(result != nil)
         #expect(result?.platforms.count == 2)
@@ -464,7 +464,7 @@ struct AvailabilityAnnotationParserTests {
     @Test("Parse multiple platforms")
     func parseMultiplePlatforms() {
         let code = "@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)"
-        let result = AvailabilityInfo.parseFromAnnotation(code)
+        let result = Availability.Info.parseFromAnnotation(code)
 
         #expect(result != nil)
         #expect(result?.platforms.count == 5)
@@ -475,7 +475,7 @@ struct AvailabilityAnnotationParserTests {
     @Test("Parse annotation with extra whitespace")
     func parseWithWhitespace() {
         let code = "@available(  iOS 16.0 ,  macOS 13.0  , * )"
-        let result = AvailabilityInfo.parseFromAnnotation(code)
+        let result = Availability.Info.parseFromAnnotation(code)
 
         #expect(result != nil)
         #expect(result?.minimumiOS == "16.0")
@@ -494,7 +494,7 @@ struct AvailabilityAnnotationParserTests {
             }
         }
         """
-        let result = AvailabilityInfo.parseFromAnnotation(code)
+        let result = Availability.Info.parseFromAnnotation(code)
 
         #expect(result != nil)
         #expect(result?.minimumiOS == "17.0")
@@ -504,7 +504,7 @@ struct AvailabilityAnnotationParserTests {
     @Test("No annotation returns nil")
     func noAnnotation() {
         let code = "struct MyView: View { }"
-        let result = AvailabilityInfo.parseFromAnnotation(code)
+        let result = Availability.Info.parseFromAnnotation(code)
 
         #expect(result == nil)
     }
@@ -512,7 +512,7 @@ struct AvailabilityAnnotationParserTests {
     @Test("Platform name normalization")
     func platformNormalization() {
         let code = "@available(ios 15.0, MACOS 12.0, watchos 8.0, *)"
-        let result = AvailabilityInfo.parseFromAnnotation(code)
+        let result = Availability.Info.parseFromAnnotation(code)
 
         #expect(result != nil)
         // Check normalized names
@@ -535,7 +535,7 @@ struct AvailabilityAnnotationParserTests {
             """,
         ]
         let data = try JSONSerialization.data(withJSONObject: json)
-        let result = AvailabilityInfo.extractFromJSONContent(data)
+        let result = Availability.Info.extractFromJSONContent(data)
 
         #expect(result != nil)
         #expect(result?.minimumiOS == "16.0")
@@ -551,7 +551,7 @@ struct AvailabilityAnnotationParserTests {
             ],
         ]
         let data = try JSONSerialization.data(withJSONObject: json)
-        let result = AvailabilityInfo.extractFromJSONContent(data)
+        let result = Availability.Info.extractFromJSONContent(data)
 
         #expect(result != nil)
         #expect(result?.minimumiOS == "15.0")
@@ -566,7 +566,7 @@ struct AvailabilityAnnotationParserTests {
             ],
         ]
         let data = try JSONSerialization.data(withJSONObject: json)
-        let result = AvailabilityInfo.extractFromJSONContent(data)
+        let result = Availability.Info.extractFromJSONContent(data)
 
         #expect(result != nil)
         #expect(result?.minimumiOS == "17.0")

--- a/Packages/Tests/RemoteSyncTests/RemoteSyncTests.swift
+++ b/Packages/Tests/RemoteSyncTests/RemoteSyncTests.swift
@@ -137,14 +137,14 @@ struct RemoteIndexStateTests {
     }
 }
 
-// MARK: - RemoteSyncProgress Tests
+// MARK: - RemoteSync.Progress Tests
 
-@Suite("RemoteSyncProgress Tests")
+@Suite("RemoteSync.Progress Tests")
 struct RemoteSyncProgressTests {
     @Test("Progress ETA calculation")
     func progressETA() throws {
         // 50% done in 60 seconds = ~60 seconds remaining
-        let progress = RemoteSyncProgress(
+        let progress = RemoteSync.Progress(
             phase: .docs,
             framework: "swiftui",
             frameworkIndex: 124,
@@ -163,7 +163,7 @@ struct RemoteSyncProgressTests {
 
     @Test("Progress ETA nil for early progress")
     func progressETAEarly() {
-        let progress = RemoteSyncProgress(
+        let progress = RemoteSync.Progress(
             phase: .docs,
             framework: nil,
             frameworkIndex: 0,
@@ -185,7 +185,7 @@ struct AnimatedProgressTests {
     @Test("Progress bar rendering")
     func progressBarRendering() {
         let display = AnimatedProgress(barWidth: 10, useEmoji: false)
-        let progress = RemoteSyncProgress(
+        let progress = RemoteSync.Progress(
             phase: .docs,
             framework: "swiftui",
             frameworkIndex: 5,
@@ -207,7 +207,7 @@ struct AnimatedProgressTests {
     @Test("Compact rendering")
     func compactRendering() {
         let display = AnimatedProgress(barWidth: 10, useEmoji: false)
-        let progress = RemoteSyncProgress(
+        let progress = RemoteSync.Progress(
             phase: .docs,
             framework: "foundation",
             frameworkIndex: 3,


### PR DESCRIPTION
## What

Comprehensive struct-namespace refactor: nest types under their module's namespace, strip the redundant module-prefix from type names ("no repeating"), deep folder-mirror nesting where folders are subdirectories.

This PR is **incremental** — committed module-by-module on the same branch so you can review the pattern and steer mid-sweep.

## Module 1: Availability ✓ (this commit)

| Before | After |
|---|---|
| `AvailabilityError` | `Availability.Error` |
| `AvailabilityFetcher` | `Availability.Fetcher` |
| `AvailabilityProgress` | `Availability.Progress` |
| `AvailabilityStatistics` | `Availability.Statistics` |
| `PlatformAvailability` | `Availability.Platform` |
| `AvailabilityInfo` | `Availability.Info` |
| `PlatformInfo.toPlatformAvailability()` | `.toPlatform()` |

7 files changed, 275 / 263 lines, global rename via word-boundary regex sweep.

Verification:
- `xcrun swift build`: green
- `xcrun swift test`: **1300 / 1300**, 0 failures

## Coming next (will add commits to this branch as I go)

Alphabetical sweep continues. Modules to audit:

- CLI, Cleanup, Core (HTMLToMarkdown → Core.Parser.HTML, WKWebCrawlerEngine → WKWebCrawler.Engine, WKWebContentFetcher → WKWebCrawler.ContentFetcher)
- CoreProtocols (likely already namespaced)
- Diagnostics, Distribution, Indexer, Ingest, Logging
- MCP (the big one — deep `MCP.Core.Protocol.Tool` etc.)
- MockAIAgent, ReleaseTool, RemoteSync
- Resources (`ArchiveGuidesCatalogEmbedded → Resources.Embedded.ArchiveGuidesCatalog`)
- SampleIndex, Search, SearchToolProvider, Services
- Shared (already mostly namespaced)
- TUI, TestSupport

Rule on what gets renamed: any public type whose name carries a redundant module-or-folder prefix. Types without such prefixes (e.g., `Logger`, `Tool`, `Resource`) stay as-is.

## Out of scope

- Pre-existing lint warnings (function_body_length, blanket_disable_command) carried forward from the source files.
- Internal types and protocols that don't have a redundant prefix.
