### PR TITLE
refactor(Search): nest types under struct namespace

### DIFF
--- a/Packages/Sources/Search/ComposableResult.swift
+++ b/Packages/Sources/Search/ComposableResult.swift
@@ -20,7 +20,8 @@ import Foundation
 // MARK: - Source Identity
 
 /// Identifies which documentation source produced a result
-public enum SearchSource: String, Codable, Sendable, CaseIterable {
+extension Search {
+public enum Source: String, Codable, Sendable, CaseIterable {
     case appleDocs = "apple-docs"
     case samples
     case hig
@@ -58,12 +59,13 @@ public enum SearchSource: String, Codable, Sendable, CaseIterable {
         }
     }
 }
+}
 
 // MARK: - Result Atom (Single Item)
 
 /// Protocol for any single search result item
 public protocol ResultAtom: Sendable, Identifiable {
-    var source: SearchSource { get }
+    var source: Search.Source { get }
     var title: String { get }
     var summary: String { get }
     var uri: String { get }
@@ -73,23 +75,23 @@ public protocol ResultAtom: Sendable, Identifiable {
 /// Documentation result atom (Apple Docs, HIG, Archive, Swift Evolution, etc.)
 public struct DocAtom: ResultAtom, Codable, Sendable {
     public let id: UUID
-    public let source: SearchSource
+    public let source: Search.Source
     public let title: String
     public let summary: String
     public let uri: String
     public let score: Double
     public let framework: String?
-    public let availability: [SearchPlatformAvailability]?
+    public let availability: [Search.PlatformAvailability]?
 
     public init(
         id: UUID = UUID(),
-        source: SearchSource,
+        source: Search.Source,
         title: String,
         summary: String,
         uri: String,
         score: Double,
         framework: String? = nil,
-        availability: [SearchPlatformAvailability]? = nil
+        availability: [Search.PlatformAvailability]? = nil
     ) {
         self.id = id
         self.source = source
@@ -102,7 +104,7 @@ public struct DocAtom: ResultAtom, Codable, Sendable {
     }
 
     /// Convert from existing Search.Result
-    public init(from result: Search.Result, source: SearchSource) {
+    public init(from result: Search.Result, source: Search.Source) {
         id = result.id
         self.source = source
         title = result.title
@@ -132,7 +134,7 @@ public struct DocAtom: ResultAtom, Codable, Sendable {
 /// Sample code result atom
 public struct SampleAtom: ResultAtom, Codable, Sendable {
     public let id: UUID
-    public let source: SearchSource
+    public let source: Search.Source
     public let title: String
     public let summary: String
     public let uri: String
@@ -166,7 +168,7 @@ public struct SampleAtom: ResultAtom, Codable, Sendable {
 /// Swift package result atom
 public struct PackageAtom: ResultAtom, Codable, Sendable {
     public let id: UUID
-    public let source: SearchSource
+    public let source: Search.Source
     public let title: String
     public let summary: String
     public let uri: String
@@ -204,11 +206,11 @@ public struct PackageAtom: ResultAtom, Codable, Sendable {
 
 /// A section containing results from a single source
 public struct ResultSection<Atom: ResultAtom>: Sendable {
-    public let source: SearchSource
+    public let source: Search.Source
     public let atoms: [Atom]
     public let totalAvailable: Int // Total in source (may exceed atoms.count due to limits)
 
-    public init(source: SearchSource, atoms: [Atom], totalAvailable: Int? = nil) {
+    public init(source: Search.Source, atoms: [Atom], totalAvailable: Int? = nil) {
         self.source = source
         self.atoms = atoms
         self.totalAvailable = totalAvailable ?? atoms.count
@@ -231,12 +233,12 @@ public struct ResultSection<Atom: ResultAtom>: Sendable {
 
 /// A hint about additional results in other sources
 public struct SourceHint: Codable, Sendable {
-    public let source: SearchSource
+    public let source: Search.Source
     public let count: Int
     public let topTitles: [String] // Preview of what's available
     public let howToAccess: String // e.g., "Use source: samples"
 
-    public init(source: SearchSource, count: Int, topTitles: [String], howToAccess: String) {
+    public init(source: Search.Source, count: Int, topTitles: [String], howToAccess: String) {
         self.source = source
         self.count = count
         self.topTitles = topTitles
@@ -245,7 +247,8 @@ public struct SourceHint: Codable, Sendable {
 }
 
 /// A contextual tip for the user/AI
-public struct SearchTip: Codable, Sendable, Identifiable {
+extension Search {
+public struct Tip: Codable, Sendable, Identifiable {
     public let id: UUID
     public let category: TipCategory
     public let message: String
@@ -270,6 +273,7 @@ public struct SearchTip: Codable, Sendable, Identifiable {
         self.message = message
         self.actionHint = actionHint
     }
+}
 }
 
 /// Quick link to a relevant resource
@@ -312,7 +316,7 @@ public struct ComposedSearchResult: Sendable {
     public let hints: [SourceHint]
 
     /// Contextual tips
-    public let tips: [SearchTip]
+    public let tips: [Search.Tip]
 
     /// Quick links
     public let quickLinks: [QuickLink]
@@ -330,7 +334,7 @@ public struct ComposedSearchResult: Sendable {
         swiftBookSection: ResultSection<DocAtom>? = nil,
         packageSection: ResultSection<PackageAtom>? = nil,
         hints: [SourceHint] = [],
-        tips: [SearchTip] = [],
+        tips: [Search.Tip] = [],
         quickLinks: [QuickLink] = []
     ) {
         self.query = query
@@ -364,8 +368,8 @@ public struct ComposedSearchResult: Sendable {
     }
 
     /// All non-empty sections for iteration
-    public var allSections: [SearchSource] {
-        var sources: [SearchSource] = []
+    public var allSections: [Search.Source] {
+        var sources: [Search.Source] = []
         if let section = primarySection, !section.isEmpty { sources.append(section.source) }
         if let section = sampleSection, !section.isEmpty { sources.append(section.source) }
         if let section = higSection, !section.isEmpty { sources.append(section.source) }
@@ -393,7 +397,7 @@ public final class ComposedResultBuilder: @unchecked Sendable {
     private var swiftBookSection: ResultSection<DocAtom>?
     private var packageSection: ResultSection<PackageAtom>?
     private var hints: [SourceHint] = []
-    private var tips: [SearchTip] = []
+    private var tips: [Search.Tip] = []
     private var quickLinks: [QuickLink] = []
 
     public init() {}
@@ -465,7 +469,7 @@ public final class ComposedResultBuilder: @unchecked Sendable {
     }
 
     @discardableResult
-    public func addTip(_ tip: SearchTip) -> Self {
+    public func addTip(_ tip: Search.Tip) -> Self {
         tips.append(tip)
         return self
     }
@@ -512,7 +516,7 @@ public enum QueryIntent: String, Codable, Sendable {
 
     /// Sources boosted for this intent (in priority order)
     /// Now data-driven via SourceRegistry instead of hardcoded
-    public var boostedSources: [SearchSource] {
+    public var boostedSources: [Search.Source] {
         // Use registry-based lookup (data-driven)
         registryBoostedSources
     }
@@ -734,9 +738,9 @@ public struct SourceProperties: Codable, Sendable {
 @available(*, deprecated, message: "Use SourceRegistry.properties(for:) instead")
 public enum SourcePropertiesRegistry {
     /// @deprecated Use `SourceRegistry.properties(for:)` instead
-    public static var properties: [SearchSource: SourceProperties] {
-        var result: [SearchSource: SourceProperties] = [:]
-        for source in SearchSource.allCases {
+    public static var properties: [Search.Source: SourceProperties] {
+        var result: [Search.Source: SourceProperties] = [:]
+        for source in Search.Source.allCases {
             if let props = SourceRegistry.properties(for: source.rawValue) {
                 result[source] = props
             }
@@ -745,7 +749,7 @@ public enum SourcePropertiesRegistry {
     }
 
     /// @deprecated Use `SourceRegistry.properties(for:)` instead
-    public static func properties(for source: SearchSource) -> SourceProperties {
+    public static func properties(for source: Search.Source) -> SourceProperties {
         SourceRegistry.properties(for: source.rawValue) ?? SourceProperties(
             authority: 0.5, freshness: 0.5, comprehensiveness: 0.5, codeExamples: 0.5,
             hasAvailability: 0.5, designFocus: 0.5, languageFocus: 0.5, searchQuality: 0.5
@@ -761,7 +765,7 @@ public struct UnifiedSearchSummary: Codable, Sendable {
     public let totalResults: Int
     public let sourceSummaries: [SourceSummary]
     public let hints: [SourceHint]
-    public let tips: [SearchTip]
+    public let tips: [Search.Tip]
     public let detectedIntent: QueryIntent
 
     public init(
@@ -769,7 +773,7 @@ public struct UnifiedSearchSummary: Codable, Sendable {
         totalResults: Int,
         sourceSummaries: [SourceSummary],
         hints: [SourceHint] = [],
-        tips: [SearchTip] = [],
+        tips: [Search.Tip] = [],
         detectedIntent: QueryIntent = .apiReference
     ) {
         self.query = query
@@ -782,12 +786,12 @@ public struct UnifiedSearchSummary: Codable, Sendable {
 
     /// Short summary for one source in unified results
     public struct SourceSummary: Codable, Sendable {
-        public let source: SearchSource
+        public let source: Search.Source
         public let count: Int
         public let topResult: TopResultPreview?
         public let hasMore: Bool
 
-        public init(source: SearchSource, count: Int, topResult: TopResultPreview?, hasMore: Bool) {
+        public init(source: Search.Source, count: Int, topResult: TopResultPreview?, hasMore: Bool) {
             self.source = source
             self.count = count
             self.topResult = topResult
@@ -812,60 +816,62 @@ public struct UnifiedSearchSummary: Codable, Sendable {
 // MARK: - Tip Factory (Common Tips)
 
 /// Factory for creating common search tips
-public enum SearchTipFactory {
-    public static func noResultsTip(query: String) -> SearchTip {
-        SearchTip(
+extension Search {
+public enum TipFactory {
+    public static func noResultsTip(query: String) -> Search.Tip {
+        Search.Tip(
             category: .refinement,
             message: "No results for '\(query)'. Try broader terms or check spelling.",
             actionHint: "Remove specific version numbers or use related framework names"
         )
     }
 
-    public static func tryOtherSourceTip(current: SearchSource, suggested: SearchSource) -> SearchTip {
-        SearchTip(
+    public static func tryOtherSourceTip(current: Search.Source, suggested: Search.Source) -> Search.Tip {
+        Search.Tip(
             category: .source,
             message: "Also check \(suggested.displayName) for \(suggested == .hig ? "design guidance" : "more context")",
             actionHint: "Use source: \(suggested.rawValue)"
         )
     }
 
-    public static func availabilityTip(platform: String, minVersion: String) -> SearchTip {
-        SearchTip(
+    public static func availabilityTip(platform: String, minVersion: String) -> Search.Tip {
+        Search.Tip(
             category: .availability,
             message: "This API requires \(platform) \(minVersion)+",
             actionHint: "Check availability before using in production"
         )
     }
 
-    public static func deprecationTip(replacement: String?) -> SearchTip {
-        SearchTip(
+    public static func deprecationTip(replacement: String?) -> Search.Tip {
+        Search.Tip(
             category: .bestPractice,
             message: "This API is deprecated." + (replacement.map { " Use \($0) instead." } ?? ""),
             actionHint: replacement.map { "Search for \($0)" }
         )
     }
 
-    public static func swiftEvolutionTip(proposalID: String) -> SearchTip {
-        SearchTip(
+    public static func swiftEvolutionTip(proposalID: String) -> Search.Tip {
+        Search.Tip(
             category: .related,
             message: "See Swift Evolution proposal \(proposalID) for background",
             actionHint: "Use source: swift-evolution for full proposal"
         )
     }
 
-    public static func sampleCodeAvailableTip(count: Int) -> SearchTip {
-        SearchTip(
+    public static func sampleCodeAvailableTip(count: Int) -> Search.Tip {
+        Search.Tip(
             category: .source,
             message: "\(count) sample project\(count == 1 ? "" : "s") available with working code",
             actionHint: "Use source: samples to explore"
         )
     }
 
-    public static func designGuidelineTip() -> SearchTip {
-        SearchTip(
+    public static func designGuidelineTip() -> Search.Tip {
+        Search.Tip(
             category: .source,
             message: "Check Human Interface Guidelines for design best practices",
             actionHint: "Use source: hig"
         )
     }
+}
 }

--- a/Packages/Sources/Search/PackageIndex.swift
+++ b/Packages/Sources/Search/PackageIndex.swift
@@ -599,7 +599,7 @@ extension Search {
         }
     }
 
-    public enum PackageIndexError: Error, LocalizedError {
+    public enum PackageIndexError: Swift.Error, LocalizedError {
         case databaseNotInitialized
         case sqliteError(String)
 

--- a/Packages/Sources/Search/PackageIndexer.swift
+++ b/Packages/Sources/Search/PackageIndexer.swift
@@ -21,7 +21,7 @@ extension Search {
             public var durationSeconds: TimeInterval = 0
         }
 
-        public enum IndexerError: Error, LocalizedError {
+        public enum IndexerError: Swift.Error, LocalizedError {
             case noPackagesFound(URL)
             case manifestMissing(URL)
             case manifestMalformed(URL, String)

--- a/Packages/Sources/Search/PackageQuery.swift
+++ b/Packages/Sources/Search/PackageQuery.swift
@@ -701,7 +701,7 @@ extension Search {
         }
     }
 
-    public enum PackageQueryError: Error, LocalizedError {
+    public enum PackageQueryError: Swift.Error, LocalizedError {
         case openFailed(String)
         case databaseNotOpen
         case sqliteError(String)

--- a/Packages/Sources/Search/SearchIndex+CodeExamples.swift
+++ b/Packages/Sources/Search/SearchIndex+CodeExamples.swift
@@ -14,7 +14,7 @@ extension Search.Index {
         limit: Int = 20
     ) async throws -> [(docUri: String, code: String, language: String)] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = """
@@ -29,7 +29,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Code search prepare failed")
+            throw Search.Error.searchFailed("Code search prepare failed")
         }
 
         sqlite3_bind_text(statement, 1, (query as NSString).utf8String, -1, nil)
@@ -50,7 +50,7 @@ extension Search.Index {
     /// Get code examples count
     public func codeExamplesCount() async throws -> Int {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = "SELECT COUNT(*) FROM doc_code_examples;"
@@ -73,11 +73,11 @@ extension Search.Index {
         sampleCodeDirectory: URL? = nil
     ) async throws -> [Search.SampleCodeResult] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
-            throw SearchError.invalidQuery("Query cannot be empty")
+            throw Search.Error.invalidQuery("Query cannot be empty")
         }
 
         var sql = """
@@ -105,7 +105,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.searchFailed("Sample code search prepare failed: \(errorMessage)")
+            throw Search.Error.searchFailed("Sample code search prepare failed: \(errorMessage)")
         }
 
         // Bind parameters

--- a/Packages/Sources/Search/SearchIndex+ContentAndPackages.swift
+++ b/Packages/Sources/Search/SearchIndex+ContentAndPackages.swift
@@ -16,11 +16,11 @@ extension Search.Index {
         limit: Int = Shared.Constants.Limit.defaultSearchLimit
     ) async throws -> [Search.PackageResult] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
-            throw SearchError.invalidQuery("Query cannot be empty")
+            throw Search.Error.invalidQuery("Query cannot be empty")
         }
 
         let sql = """
@@ -44,7 +44,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.searchFailed("Package search failed: \(errorMessage)")
+            throw Search.Error.searchFailed("Package search failed: \(errorMessage)")
         }
 
         // Replace spaces with % wildcards for flexible matching (e.g., "swift argument parser" -> "swift%argument%parser")
@@ -109,7 +109,7 @@ extension Search.Index {
     /// - Returns: Document content in requested format, or nil if not found
     public func getDocumentContent(uri: String, format: DocumentFormat = .json) async throws -> String? {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Get json_data from metadata table
@@ -125,7 +125,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.searchFailed("Get content failed: \(errorMessage)")
+            throw Search.Error.searchFailed("Get content failed: \(errorMessage)")
         }
 
         sqlite3_bind_text(statement, 1, (uri as NSString).utf8String, -1, nil)
@@ -216,7 +216,7 @@ extension Search.Index {
     /// Clear all documents from the index
     public func clearIndex() async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = """
@@ -229,7 +229,7 @@ extension Search.Index {
 
         guard sqlite3_exec(database, sql, nil, nil, &errorPointer) == SQLITE_OK else {
             let errorMessage = errorPointer.map { String(cString: $0) } ?? "Unknown error"
-            throw SearchError.sqliteError("Failed to clear index: \(errorMessage)")
+            throw Search.Error.sqliteError("Failed to clear index: \(errorMessage)")
         }
     }
 

--- a/Packages/Sources/Search/SearchIndex+CountsAndAliases.swift
+++ b/Packages/Sources/Search/SearchIndex+CountsAndAliases.swift
@@ -5,7 +5,7 @@ import SQLite3
 extension Search.Index {
     public func symbolCount() async throws -> Int {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = "SELECT COUNT(*) FROM doc_symbols;"
@@ -27,7 +27,7 @@ extension Search.Index {
     /// List all frameworks with document counts
     public func listFrameworks() async throws -> [String: Int] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = """
@@ -42,7 +42,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.searchFailed("List frameworks failed: \(errorMessage)")
+            throw Search.Error.searchFailed("List frameworks failed: \(errorMessage)")
         }
 
         var frameworks: [String: Int] = [:]
@@ -76,7 +76,7 @@ extension Search.Index {
     ///   - displayName: display name from JSON module field (e.g., "App Intents")
     public func registerFrameworkAlias(identifier: String, displayName: String) async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Derive import name by removing spaces from display name
@@ -110,7 +110,7 @@ extension Search.Index {
     ///   - synonyms: Comma-separated alternate names (e.g., "nfc")
     public func updateFrameworkSynonyms(identifier: String, synonyms: String) async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = "UPDATE framework_aliases SET synonyms = ? WHERE identifier = ?;"
@@ -133,7 +133,7 @@ extension Search.Index {
     /// - Returns: The identifier form (e.g., "appintents"), or nil if not found
     public func resolveFrameworkIdentifier(_ input: String) async throws -> String? {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // First try: exact match on identifier (most common case)
@@ -201,7 +201,7 @@ extension Search.Index {
     /// List all frameworks with full alias info and document counts
     public func listFrameworksWithAliases() async throws -> [FrameworkInfo] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = """
@@ -221,7 +221,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.searchFailed("List frameworks with aliases failed: \(errorMessage)")
+            throw Search.Error.searchFailed("List frameworks with aliases failed: \(errorMessage)")
         }
 
         var frameworks: [FrameworkInfo] = []
@@ -249,7 +249,7 @@ extension Search.Index {
     /// Get total document count
     public func documentCount() async throws -> Int {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = "SELECT COUNT(*) FROM docs_metadata;"
@@ -258,7 +258,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Count failed")
+            throw Search.Error.searchFailed("Count failed")
         }
 
         guard sqlite3_step(statement) == SQLITE_ROW else {
@@ -271,7 +271,7 @@ extension Search.Index {
     /// Get total sample code count
     public func sampleCodeCount() async throws -> Int {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = "SELECT COUNT(*) FROM sample_code_metadata;"
@@ -280,7 +280,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Sample code count failed")
+            throw Search.Error.searchFailed("Sample code count failed")
         }
 
         guard sqlite3_step(statement) == SQLITE_ROW else {
@@ -293,7 +293,7 @@ extension Search.Index {
     /// Get total package count
     public func packageCount() async throws -> Int {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = "SELECT COUNT(*) FROM packages;"
@@ -302,7 +302,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Package count failed")
+            throw Search.Error.searchFailed("Package count failed")
         }
 
         guard sqlite3_step(statement) == SQLITE_ROW else {

--- a/Packages/Sources/Search/SearchIndex+Indexing.swift
+++ b/Packages/Sources/Search/SearchIndex+Indexing.swift
@@ -20,7 +20,7 @@ extension Search.Index {
         lastUpdated: String?
     ) async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = """
@@ -34,7 +34,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.prepareFailed("Package insert: \(errorMessage)")
+            throw Search.Error.prepareFailed("Package insert: \(errorMessage)")
         }
 
         sqlite3_bind_text(statement, 1, (name as NSString).utf8String, -1, nil)
@@ -63,7 +63,7 @@ extension Search.Index {
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.insertFailed("Package insert: \(errorMessage)")
+            throw Search.Error.insertFailed("Package insert: \(errorMessage)")
         }
     }
 
@@ -84,7 +84,7 @@ extension Search.Index {
         minVisionOS: String? = nil
     ) async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Insert into FTS5 table
@@ -98,7 +98,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, ftsSql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.prepareFailed("Sample code FTS insert: \(errorMessage)")
+            throw Search.Error.prepareFailed("Sample code FTS insert: \(errorMessage)")
         }
 
         sqlite3_bind_text(statement, 1, (url as NSString).utf8String, -1, nil)
@@ -108,7 +108,7 @@ extension Search.Index {
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.insertFailed("Sample code FTS insert: \(errorMessage)")
+            throw Search.Error.insertFailed("Sample code FTS insert: \(errorMessage)")
         }
 
         // Insert metadata with availability
@@ -124,7 +124,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, metaSql, -1, &metaStatement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.prepareFailed("Sample code metadata insert: \(errorMessage)")
+            throw Search.Error.prepareFailed("Sample code metadata insert: \(errorMessage)")
         }
 
         sqlite3_bind_text(metaStatement, 1, (url as NSString).utf8String, -1, nil)
@@ -140,7 +140,7 @@ extension Search.Index {
 
         guard sqlite3_step(metaStatement) == SQLITE_DONE else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.insertFailed("Sample code metadata insert: \(errorMessage)")
+            throw Search.Error.insertFailed("Sample code metadata insert: \(errorMessage)")
         }
     }
 
@@ -194,7 +194,7 @@ extension Search.Index {
         codeExamples: [(code: String, language: String)]
     ) async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Delete existing code examples for this doc
@@ -254,7 +254,7 @@ extension Search.Index {
         codeExamples: [(code: String, language: String)]
     ) async throws {
         guard database != nil else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let extractor = ASTIndexer.SwiftSourceExtractor()
@@ -314,7 +314,7 @@ extension Search.Index {
     /// table, so this method picks them up uniformly.
     func recomputeSymbolsBlob(docUri: String) async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Read all symbol names for this doc, dedupe, sort.

--- a/Packages/Sources/Search/SearchIndex+IndexingDocs.swift
+++ b/Packages/Sources/Search/SearchIndex+IndexingDocs.swift
@@ -33,7 +33,7 @@ extension Search.Index {
         availabilitySource: String? = nil
     ) async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Extract summary (first 500 chars, stop at sentence)
@@ -59,7 +59,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, ftsSql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.prepareFailed("FTS insert: \(errorMessage)")
+            throw Search.Error.prepareFailed("FTS insert: \(errorMessage)")
         }
 
         sqlite3_bind_text(statement, 1, (uri as NSString).utf8String, -1, nil)
@@ -72,7 +72,7 @@ extension Search.Index {
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.insertFailed("FTS insert: \(errorMessage)")
+            throw Search.Error.insertFailed("FTS insert: \(errorMessage)")
         }
 
         // Create minimal JSON wrapper if no jsonData provided
@@ -107,7 +107,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, metaSql, -1, &metaStatement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.prepareFailed("Metadata insert: \(errorMessage)")
+            throw Search.Error.prepareFailed("Metadata insert: \(errorMessage)")
         }
 
         sqlite3_bind_text(metaStatement, 1, (uri as NSString).utf8String, -1, nil)
@@ -139,7 +139,7 @@ extension Search.Index {
 
         guard sqlite3_step(metaStatement) == SQLITE_DONE else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.insertFailed("Metadata insert: \(errorMessage)")
+            throw Search.Error.insertFailed("Metadata insert: \(errorMessage)")
         }
     }
 
@@ -150,7 +150,7 @@ extension Search.Index {
     /// - Parameters:
     ///   - item: The source item to index
     ///   - extractSymbols: Whether to extract and index AST symbols (default: true)
-    /// - Throws: SearchError if indexing fails
+    /// - Throws: Search.Error if indexing fails
     public func indexItem(_ item: SourceItem, extractSymbols: Bool = true) async throws {
         // Get the indexer for this source
         guard let indexer = IndexerRegistry.indexer(for: item.source) else {
@@ -180,7 +180,7 @@ extension Search.Index {
 
         // Validate the item
         guard indexer.validate(item) else {
-            throw SearchError.invalidQuery("Item failed validation for source: \(item.source)")
+            throw Search.Error.invalidQuery("Item failed validation for source: \(item.source)")
         }
 
         // Preprocess the item
@@ -360,7 +360,7 @@ extension Search.Index {
         let effectiveLanguage = page.language ?? detectLanguage(from: content)
 
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Insert into FTS5 table (db should be deleted before full re-index).
@@ -376,7 +376,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, ftsSql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.prepareFailed("FTS insert: \(errorMessage)")
+            throw Search.Error.prepareFailed("FTS insert: \(errorMessage)")
         }
 
         sqlite3_bind_text(statement, 1, (uri as NSString).utf8String, -1, nil)
@@ -389,7 +389,7 @@ extension Search.Index {
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.insertFailed("FTS insert: \(errorMessage)")
+            throw Search.Error.insertFailed("FTS insert: \(errorMessage)")
         }
 
         // Extract availability from JSON data, with optional overrides
@@ -423,7 +423,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, metaSql, -1, &metaStatement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.prepareFailed("Metadata insert: \(errorMessage)")
+            throw Search.Error.prepareFailed("Metadata insert: \(errorMessage)")
         }
 
         sqlite3_bind_text(metaStatement, 1, (uri as NSString).utf8String, -1, nil)
@@ -448,7 +448,7 @@ extension Search.Index {
 
         guard sqlite3_step(metaStatement) == SQLITE_DONE else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.insertFailed("Metadata insert: \(errorMessage)")
+            throw Search.Error.insertFailed("Metadata insert: \(errorMessage)")
         }
 
         // Insert structured fields for querying
@@ -460,7 +460,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, structSql, -1, &structStatement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.prepareFailed("Structured insert: \(errorMessage)")
+            throw Search.Error.prepareFailed("Structured insert: \(errorMessage)")
         }
 
         sqlite3_bind_text(structStatement, 1, (uri as NSString).utf8String, -1, nil)
@@ -531,7 +531,7 @@ extension Search.Index {
 
         guard sqlite3_step(structStatement) == SQLITE_DONE else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.insertFailed("Structured insert: \(errorMessage)")
+            throw Search.Error.insertFailed("Structured insert: \(errorMessage)")
         }
 
         // Extract symbols from declaration using SwiftSyntax (#81). Re-running
@@ -566,7 +566,7 @@ extension Search.Index {
         symbols: [ASTIndexer.ExtractedSymbol]
     ) async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = """
@@ -672,7 +672,7 @@ extension Search.Index {
         imports: [ASTIndexer.ExtractedImport]
     ) async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = """

--- a/Packages/Sources/Search/SearchIndex+Migrations.swift
+++ b/Packages/Sources/Search/SearchIndex+Migrations.swift
@@ -20,7 +20,7 @@ extension Search.Index {
 
     func setSchemaVersion() async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Skip the write if the on-disk version already matches. Every
@@ -40,7 +40,7 @@ extension Search.Index {
 
         guard sqlite3_exec(database, sql, nil, nil, &errorPointer) == SQLITE_OK else {
             let errorMessage = errorPointer.map { String(cString: $0) } ?? "Unknown error"
-            throw SearchError.sqliteError("Failed to set schema version: \(errorMessage)")
+            throw Search.Error.sqliteError("Failed to set schema version: \(errorMessage)")
         }
     }
 
@@ -54,7 +54,7 @@ extension Search.Index {
 
         // Future version - incompatible
         if currentVersion > Self.schemaVersion {
-            throw SearchError.sqliteError(
+            throw Search.Error.sqliteError(
                 "Database schema version \(currentVersion) is newer than supported version \(Self.schemaVersion). "
                     + "Please update cupertino or delete the database to recreate it."
             )
@@ -82,7 +82,7 @@ extension Search.Index {
             // Version 4 -> 5: Added language field to docs_fts and docs_metadata
             // BREAKING CHANGE: FTS5 tables cannot have columns added.
             // Database must be deleted and rebuilt with 'cupertino save'.
-            throw SearchError.sqliteError(
+            throw Search.Error.sqliteError(
                 "Database schema version \(currentVersion) requires migration to version 5. " +
                     "This is a breaking change that adds the 'language' field. " +
                     "Please delete the database and run 'cupertino save' to rebuild: " +
@@ -121,7 +121,7 @@ extension Search.Index {
             // bm25 can weight directly on AST-extracted symbol names. FTS5
             // does not support ALTER TABLE ADD COLUMN on virtual tables, so
             // this is a BREAKING change — existing DBs must be rebuilt.
-            throw SearchError.sqliteError(
+            throw Search.Error.sqliteError(
                 "Database schema version \(currentVersion) requires migration to version 12. " +
                     "This is a breaking change that adds AST-derived symbols to the FTS index. " +
                     "Please delete the database and run 'cupertino save' to rebuild: " +
@@ -136,7 +136,7 @@ extension Search.Index {
             // `URLUtilities.filename(_:)` makes new crawls produce canonical
             // URIs. The v1.0.2 bundle ships pre-built at v13, so `cupertino
             // setup` is the production upgrade path.
-            throw SearchError.sqliteError(
+            throw Search.Error.sqliteError(
                 "Database schema version \(currentVersion) requires migration to version 13. " +
                     "This is a breaking change that drops case-axis duplicate URIs (#283). " +
                     "Please delete the database and run 'cupertino setup' to download the " +
@@ -148,7 +148,7 @@ extension Search.Index {
 
     func migrateToVersion11() async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let statements = [
@@ -168,7 +168,7 @@ extension Search.Index {
 
     func migrateToVersion10() async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = "ALTER TABLE framework_aliases ADD COLUMN synonyms TEXT;"
@@ -182,7 +182,7 @@ extension Search.Index {
 
     func migrateToVersion7() async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Add availability columns to sample_code_metadata
@@ -207,7 +207,7 @@ extension Search.Index {
 
     func migrateToVersion6() async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Add availability columns - these can be added with ALTER TABLE
@@ -249,7 +249,7 @@ extension Search.Index {
 
     func migrateToVersion4() async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Add source column to docs_metadata (this can be done with ALTER)
@@ -266,7 +266,7 @@ extension Search.Index {
 
     func migrateToVersion3() async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Add json_data column if it doesn't exist

--- a/Packages/Sources/Search/SearchIndex+Schema.swift
+++ b/Packages/Sources/Search/SearchIndex+Schema.swift
@@ -10,7 +10,7 @@ import SQLite3
 extension Search.Index {
     func createTables() async throws {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // FTS5 virtual table for full-text search
@@ -231,7 +231,7 @@ extension Search.Index {
 
         guard sqlite3_exec(database, sql, nil, nil, &errorPointer) == SQLITE_OK else {
             let errorMessage = errorPointer.map { String(cString: $0) } ?? "Unknown error"
-            throw SearchError.sqliteError("Failed to create tables: \(errorMessage)")
+            throw Search.Error.sqliteError("Failed to create tables: \(errorMessage)")
         }
     }
 

--- a/Packages/Sources/Search/SearchIndex+Search.swift
+++ b/Packages/Sources/Search/SearchIndex+Search.swift
@@ -32,11 +32,11 @@ extension Search.Index {
         minVisionOS: String? = nil
     ) async throws -> [Search.Result] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
-            throw SearchError.invalidQuery("Query cannot be empty")
+            throw Search.Error.invalidQuery("Query cannot be empty")
         }
 
         // Detect query intent for source boosting (#81)
@@ -164,7 +164,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.searchFailed("Prepare failed: \(errorMessage)")
+            throw Search.Error.searchFailed("Prepare failed: \(errorMessage)")
         }
 
         // Bind parameters (use sanitized query for FTS5)
@@ -224,9 +224,9 @@ extension Search.Index {
             let minVisionOSPtr = sqlite3_column_text(statement, 13)
 
             // Build availability array from columns
-            var availabilityItems: [SearchPlatformAvailability] = []
+            var availabilityItems: [Search.PlatformAvailability] = []
             if let ptr = miniOSPtr {
-                availabilityItems.append(SearchPlatformAvailability(
+                availabilityItems.append(Search.PlatformAvailability(
                     name: "iOS",
                     introducedAt: String(cString: ptr),
                     deprecated: false,
@@ -235,7 +235,7 @@ extension Search.Index {
                 ))
             }
             if let ptr = minMacOSPtr {
-                availabilityItems.append(SearchPlatformAvailability(
+                availabilityItems.append(Search.PlatformAvailability(
                     name: "macOS",
                     introducedAt: String(cString: ptr),
                     deprecated: false,
@@ -244,7 +244,7 @@ extension Search.Index {
                 ))
             }
             if let ptr = minTvOSPtr {
-                availabilityItems.append(SearchPlatformAvailability(
+                availabilityItems.append(Search.PlatformAvailability(
                     name: "tvOS",
                     introducedAt: String(cString: ptr),
                     deprecated: false,
@@ -253,7 +253,7 @@ extension Search.Index {
                 ))
             }
             if let ptr = minWatchOSPtr {
-                availabilityItems.append(SearchPlatformAvailability(
+                availabilityItems.append(Search.PlatformAvailability(
                     name: "watchOS",
                     introducedAt: String(cString: ptr),
                     deprecated: false,
@@ -262,7 +262,7 @@ extension Search.Index {
                 ))
             }
             if let ptr = minVisionOSPtr {
-                availabilityItems.append(SearchPlatformAvailability(
+                availabilityItems.append(Search.PlatformAvailability(
                     name: "visionOS",
                     introducedAt: String(cString: ptr),
                     deprecated: false,
@@ -270,7 +270,7 @@ extension Search.Index {
                     beta: false
                 ))
             }
-            let availability: [SearchPlatformAvailability]? = availabilityItems.isEmpty ? nil : availabilityItems
+            let availability: [Search.PlatformAvailability]? = availabilityItems.isEmpty ? nil : availabilityItems
             let rawKind = String(cString: kindPtr)
 
             // Infer kind when unknown using multiple signals
@@ -369,8 +369,8 @@ extension Search.Index {
                     return 2.5 // Strong penalty - release notes pollute general searches
                 }
 
-                // Convert source string to SearchSource for intent matching
-                let searchSource = SearchSource(rawValue: source)
+                // Convert source string to Search.Source for intent matching
+                let searchSource = Search.Source(rawValue: source)
 
                 // Check if this source is boosted for the detected intent
                 let isIntentBoosted = searchSource.map { queryIntent.boostedSources.contains($0) } ?? false
@@ -934,21 +934,21 @@ extension Search.Index {
                 let filePath = sqlite3_column_text(statement, 5).map { String(cString: $0) } ?? ""
                 let wordCount = Int(sqlite3_column_int(statement, 6))
 
-                var availabilityArray: [SearchPlatformAvailability] = []
+                var availabilityArray: [Search.PlatformAvailability] = []
                 if let ios = sqlite3_column_text(statement, 7).map({ String(cString: $0) }) {
-                    availabilityArray.append(SearchPlatformAvailability(name: "iOS", introducedAt: ios))
+                    availabilityArray.append(Search.PlatformAvailability(name: "iOS", introducedAt: ios))
                 }
                 if let macos = sqlite3_column_text(statement, 8).map({ String(cString: $0) }) {
-                    availabilityArray.append(SearchPlatformAvailability(name: "macOS", introducedAt: macos))
+                    availabilityArray.append(Search.PlatformAvailability(name: "macOS", introducedAt: macos))
                 }
                 if let tvos = sqlite3_column_text(statement, 9).map({ String(cString: $0) }) {
-                    availabilityArray.append(SearchPlatformAvailability(name: "tvOS", introducedAt: tvos))
+                    availabilityArray.append(Search.PlatformAvailability(name: "tvOS", introducedAt: tvos))
                 }
                 if let watchos = sqlite3_column_text(statement, 10).map({ String(cString: $0) }) {
-                    availabilityArray.append(SearchPlatformAvailability(name: "watchOS", introducedAt: watchos))
+                    availabilityArray.append(Search.PlatformAvailability(name: "watchOS", introducedAt: watchos))
                 }
                 if let visionos = sqlite3_column_text(statement, 11).map({ String(cString: $0) }) {
-                    availabilityArray.append(SearchPlatformAvailability(name: "visionOS", introducedAt: visionos))
+                    availabilityArray.append(Search.PlatformAvailability(name: "visionOS", introducedAt: visionos))
                 }
 
                 hits.append(Search.Result(
@@ -1024,21 +1024,21 @@ extension Search.Index {
         let wordCount = Int(sqlite3_column_int(statement, 6))
 
         // Build availability array from platform versions
-        var availabilityArray: [SearchPlatformAvailability] = []
+        var availabilityArray: [Search.PlatformAvailability] = []
         if let ios = sqlite3_column_text(statement, 7).map({ String(cString: $0) }) {
-            availabilityArray.append(SearchPlatformAvailability(name: "iOS", introducedAt: ios))
+            availabilityArray.append(Search.PlatformAvailability(name: "iOS", introducedAt: ios))
         }
         if let macos = sqlite3_column_text(statement, 8).map({ String(cString: $0) }) {
-            availabilityArray.append(SearchPlatformAvailability(name: "macOS", introducedAt: macos))
+            availabilityArray.append(Search.PlatformAvailability(name: "macOS", introducedAt: macos))
         }
         if let tvos = sqlite3_column_text(statement, 9).map({ String(cString: $0) }) {
-            availabilityArray.append(SearchPlatformAvailability(name: "tvOS", introducedAt: tvos))
+            availabilityArray.append(Search.PlatformAvailability(name: "tvOS", introducedAt: tvos))
         }
         if let watchos = sqlite3_column_text(statement, 10).map({ String(cString: $0) }) {
-            availabilityArray.append(SearchPlatformAvailability(name: "watchOS", introducedAt: watchos))
+            availabilityArray.append(Search.PlatformAvailability(name: "watchOS", introducedAt: watchos))
         }
         if let visionos = sqlite3_column_text(statement, 11).map({ String(cString: $0) }) {
-            availabilityArray.append(SearchPlatformAvailability(name: "visionOS", introducedAt: visionos))
+            availabilityArray.append(Search.PlatformAvailability(name: "visionOS", introducedAt: visionos))
         }
 
         // Return with best possible rank (most negative)

--- a/Packages/Sources/Search/SearchIndex+SearchByAttribute.swift
+++ b/Packages/Sources/Search/SearchIndex+SearchByAttribute.swift
@@ -7,7 +7,7 @@ extension Search.Index {
     /// Get full JSON data for a document
     public func getDocumentJSON(uri: String) async throws -> String? {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = "SELECT json_data FROM docs_metadata WHERE uri = ?;"
@@ -38,7 +38,7 @@ extension Search.Index {
         limit: Int = 50
     ) async throws -> [Search.Result] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         var sql = """
@@ -59,7 +59,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Kind search prepare failed")
+            throw Search.Error.searchFailed("Kind search prepare failed")
         }
 
         sqlite3_bind_text(statement, 1, (kind as NSString).utf8String, -1, nil)
@@ -104,7 +104,7 @@ extension Search.Index {
         limit: Int = 50
     ) async throws -> [Search.Result] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = """
@@ -120,7 +120,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Conforms search prepare failed")
+            throw Search.Error.searchFailed("Conforms search prepare failed")
         }
 
         sqlite3_bind_text(statement, 1, ("%\(protocolName)%" as NSString).utf8String, -1, nil)
@@ -160,7 +160,7 @@ extension Search.Index {
         limit: Int = 50
     ) async throws -> [Search.Result] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         var sql = """
@@ -181,7 +181,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Module search prepare failed")
+            throw Search.Error.searchFailed("Module search prepare failed")
         }
 
         sqlite3_bind_text(statement, 1, (module as NSString).utf8String, -1, nil)
@@ -226,7 +226,7 @@ extension Search.Index {
         limit: Int = 50
     ) async throws -> [Search.Result] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = """
@@ -242,7 +242,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Inherited search prepare failed")
+            throw Search.Error.searchFailed("Inherited search prepare failed")
         }
 
         sqlite3_bind_text(statement, 1, ("%\(typeName)%" as NSString).utf8String, -1, nil)
@@ -281,7 +281,7 @@ extension Search.Index {
         limit: Int = 50
     ) async throws -> [Search.Result] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let sql = """
@@ -297,7 +297,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Conforming types search prepare failed")
+            throw Search.Error.searchFailed("Conforming types search prepare failed")
         }
 
         sqlite3_bind_text(statement, 1, ("%\(protocolName)%" as NSString).utf8String, -1, nil)
@@ -337,7 +337,7 @@ extension Search.Index {
         limit: Int = 50
     ) async throws -> [Search.Result] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         var sql = """
@@ -358,7 +358,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Declaration search prepare failed")
+            throw Search.Error.searchFailed("Declaration search prepare failed")
         }
 
         sqlite3_bind_text(statement, 1, ("%\(pattern)%" as NSString).utf8String, -1, nil)
@@ -404,7 +404,7 @@ extension Search.Index {
         limit: Int = 50
     ) async throws -> [Search.Result] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         var sql = """
@@ -425,7 +425,7 @@ extension Search.Index {
         defer { sqlite3_finalize(statement) }
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw SearchError.searchFailed("Platform search prepare failed")
+            throw Search.Error.searchFailed("Platform search prepare failed")
         }
 
         sqlite3_bind_text(statement, 1, ("%\(platform)%" as NSString).utf8String, -1, nil)

--- a/Packages/Sources/Search/SearchIndex+SemanticSearch.swift
+++ b/Packages/Sources/Search/SearchIndex+SemanticSearch.swift
@@ -17,7 +17,7 @@ extension Search.Index {
         limit: Int = Shared.Constants.Limit.defaultSearchLimit
     ) async throws -> [SymbolSearchResult] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         var conditions: [String] = []
@@ -69,7 +69,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.searchFailed("Symbol search failed: \(errorMessage)")
+            throw Search.Error.searchFailed("Symbol search failed: \(errorMessage)")
         }
 
         var paramIndex: Int32 = 1
@@ -123,7 +123,7 @@ extension Search.Index {
         limit: Int = Shared.Constants.Limit.defaultSearchLimit
     ) async throws -> [SymbolSearchResult] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         // Normalize wrapper name (add @ if not present)
@@ -165,7 +165,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.searchFailed("Property wrapper search failed: \(errorMessage)")
+            throw Search.Error.searchFailed("Property wrapper search failed: \(errorMessage)")
         }
 
         var paramIndex: Int32 = 1
@@ -217,7 +217,7 @@ extension Search.Index {
         limit: Int = Shared.Constants.Limit.defaultSearchLimit
     ) async throws -> [SymbolSearchResult] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         var conditions: [String] = []
@@ -278,7 +278,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.searchFailed("Concurrency pattern search failed: \(errorMessage)")
+            throw Search.Error.searchFailed("Concurrency pattern search failed: \(errorMessage)")
         }
 
         var paramIndex: Int32 = 1
@@ -330,7 +330,7 @@ extension Search.Index {
         limit: Int = Shared.Constants.Limit.defaultSearchLimit
     ) async throws -> [SymbolSearchResult] {
         guard let database else {
-            throw SearchError.databaseNotInitialized
+            throw Search.Error.databaseNotInitialized
         }
 
         let conformancePattern = "%\(protocolName)%"
@@ -370,7 +370,7 @@ extension Search.Index {
 
         guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
             let errorMessage = String(cString: sqlite3_errmsg(database))
-            throw SearchError.searchFailed("Conformance search failed: \(errorMessage)")
+            throw Search.Error.searchFailed("Conformance search failed: \(errorMessage)")
         }
 
         var paramIndex: Int32 = 1

--- a/Packages/Sources/Search/SearchIndex.swift
+++ b/Packages/Sources/Search/SearchIndex.swift
@@ -84,7 +84,7 @@ extension Search {
             guard sqlite3_open(dbPath.path, &dbPointer) == SQLITE_OK else {
                 let errorMessage = String(cString: sqlite3_errmsg(dbPointer))
                 sqlite3_close(dbPointer)
-                throw SearchError.sqliteError("Failed to open database: \(errorMessage)")
+                throw Search.Error.sqliteError("Failed to open database: \(errorMessage)")
             }
 
             // Auto-retry on SQLITE_BUSY for up to 5 seconds so concurrent

--- a/Packages/Sources/Search/SearchResult.swift
+++ b/Packages/Sources/Search/SearchResult.swift
@@ -33,7 +33,8 @@ public struct FrameworkAvailability: Sendable {
 // MARK: - Platform Availability (Search Module)
 
 /// Lightweight platform availability for search results
-public struct SearchPlatformAvailability: Codable, Sendable, Hashable {
+extension Search {
+public struct PlatformAvailability: Codable, Sendable, Hashable {
     public let name: String
     public let introducedAt: String?
     public let deprecated: Bool
@@ -53,6 +54,7 @@ public struct SearchPlatformAvailability: Codable, Sendable, Hashable {
         self.unavailable = unavailable
         self.beta = beta
     }
+}
 }
 
 // MARK: - Matched Symbol
@@ -94,7 +96,7 @@ extension Search {
         public let filePath: String
         public let wordCount: Int
         public let rank: Double // BM25 score (negative, closer to 0 = better match)
-        public let availability: [SearchPlatformAvailability]?
+        public let availability: [Search.PlatformAvailability]?
         public let matchedSymbols: [MatchedSymbol]? // AST-extracted symbols that matched query (#81)
 
         public init(
@@ -107,7 +109,7 @@ extension Search {
             filePath: String,
             wordCount: Int,
             rank: Double,
-            availability: [SearchPlatformAvailability]? = nil,
+            availability: [Search.PlatformAvailability]? = nil,
             matchedSymbols: [MatchedSymbol]? = nil
         ) {
             self.id = id
@@ -234,7 +236,7 @@ extension Search {
             filePath = try container.decode(String.self, forKey: .filePath)
             wordCount = try container.decode(Int.self, forKey: .wordCount)
             rank = try container.decode(Double.self, forKey: .rank)
-            availability = try container.decodeIfPresent([SearchPlatformAvailability].self, forKey: .availability)
+            availability = try container.decodeIfPresent([Search.PlatformAvailability].self, forKey: .availability)
             matchedSymbols = try container.decodeIfPresent([MatchedSymbol].self, forKey: .matchedSymbols)
             // summaryTruncated and availabilityString are computed, ignore during decode
         }
@@ -334,7 +336,8 @@ extension Search {
 
 // MARK: - Search Errors
 
-public enum SearchError: Error, LocalizedError {
+extension Search {
+public enum Error: Swift.Error, LocalizedError {
     case databaseNotInitialized
     case sqliteError(String)
     case prepareFailed(String)
@@ -358,4 +361,5 @@ public enum SearchError: Error, LocalizedError {
             return "Invalid search query: \(msg)"
         }
     }
+}
 }

--- a/Packages/Sources/Search/SourceDefinition.swift
+++ b/Packages/Sources/Search/SourceDefinition.swift
@@ -315,10 +315,10 @@ public enum SourceRegistry {
     }
 }
 
-// MARK: - SearchSource Extension
+// MARK: - Search.Source Extension
 
-/// Extend SearchSource to use SourceRegistry
-public extension SearchSource {
+/// Extend Search.Source to use SourceRegistry
+public extension Search.Source {
     /// Get the SourceDefinition for this source
     var definition: SourceDefinition? {
         SourceRegistry.definition(for: rawValue)
@@ -345,7 +345,7 @@ public extension QueryIntent {
     }
 
     /// Get boosted SearchSources from registry
-    var registryBoostedSources: [SearchSource] {
-        boostedSourceIDs.compactMap { SearchSource(rawValue: $0) }
+    var registryBoostedSources: [Search.Source] {
+        boostedSourceIDs.compactMap { Search.Source(rawValue: $0) }
     }
 }

--- a/Packages/Tests/SearchTests/CupertinoSearchTests.swift
+++ b/Packages/Tests/SearchTests/CupertinoSearchTests.swift
@@ -285,7 +285,7 @@ struct CupertinoSearchTests {
         defer { try? cleanup() }
 
         // Empty query should throw invalidQuery error
-        await #expect(throws: SearchError.self) {
+        await #expect(throws: Search.Error.self) {
             try await index.search(query: "", framework: nil, limit: 10)
         }
 
@@ -298,7 +298,7 @@ struct CupertinoSearchTests {
         defer { try? cleanup() }
 
         // Whitespace query should throw invalidQuery error
-        await #expect(throws: SearchError.self) {
+        await #expect(throws: Search.Error.self) {
             try await index.search(query: "   ", framework: nil, limit: 10)
         }
 


### PR DESCRIPTION
## What

Continues the namespace sweep started in #345. This PR covers the **Search** module.

| Before | After |
|---|---|
| `SearchSource` | `Search.Source` |
| `SearchTip` | `Search.Tip` |
| `SearchTipFactory` | `Search.TipFactory` |
| `SearchPlatformAvailability` | `Search.PlatformAvailability` |
| `SearchError` | `Search.Error` |

## Pattern

Same as #345 (Availability / RemoteSync / WKWebCrawler):
1. Wrap top-level `public XxxX` declaration in `extension Search { public Xxx X { ... } }` via Python brace-matching script.
2. Word-boundary `re.sub` sweep across all .swift files for the bare type names.

## Disambiguation

Other Swift.Error conformances inside the Search module (`IndexerError`, `PackageIndexError`, `PackageQueryError`) now read `: Swift.Error, LocalizedError` to avoid the bare `Error` shadowing collision with the new `Search.Error`.

## Verification

| Step | Result |
|---|---|
| `xcrun swift build` (clean) | green |
| `xcrun swift package clean && xcrun swift test` | **1300 / 1300**, 0 failures |
| `swift run cupertino --help` | green |

## Coming next on this branch (rolling)

- MCP (the big one, deep `MCP.Core.Protocol.Tool` etc., per the rules clarified in #345)
- Resources (`ArchiveGuidesCatalogEmbedded → Resources.Embedded.ArchiveGuidesCatalog`)
- HTMLToMarkdown → ? (need rules clarification: type is in `CoreHTMLParser` module, you wrote `Core.Parser.HTML` — cross-module namespace doesn't natively work; do you want a typealias in Core, or rename to just `HTML` inside CoreHTMLParser?)

I'll keep pushing commits to this branch as I go.
