### PR TITLE
refactor(Core): merge CoreHTMLParser back into Core; nest as Core.Parser.HTML / Core.Parser.XML

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -24,7 +24,6 @@ let macOSOnlyProducts: [Product] = [
     .singleTargetLibrary("SharedConfiguration"),
     .singleTargetLibrary("MCPSharedTools"),
     .singleTargetLibrary("CoreProtocols"),
-    .singleTargetLibrary("CoreHTMLParser"),
     .singleTargetLibrary("CoreJSONParser"),
     .singleTargetLibrary("CorePackageIndexing"),
     .singleTargetLibrary("Core"),
@@ -172,12 +171,9 @@ let targets: [Target] = {
         dependencies: ["SharedCore", "SharedConstants", "SharedModels", "Resources"]
     )
 
-    // ---------- CoreHTMLParser (v1.2 refactor 2.2: HTMLToMarkdown + XMLTransformer, the worst single-file god in Core) ----------
-    let coreHTMLParserTarget = Target.target(
-        name: "CoreHTMLParser",
-        dependencies: ["CoreProtocols", "SharedModels", "SharedConstants"],
-        path: "Sources/Core/HTMLParser"
-    )
+    // CoreHTMLParser merged back into Core (HTMLToMarkdown -> Core.Parser.HTML,
+    // XMLTransformer -> Core.Parser.XML). The Sources/Core/HTMLParser/ folder
+    // stays; Core picks up those sources directly. See Core target below.
 
     // ---------- CoreJSONParser (v1.2 refactor 2.3: AppleJSONToMarkdown + MarkdownToStructuredPage + RefResolver + JSON engine) ----------
     let coreJSONParserTarget = Target.target(
@@ -197,7 +193,6 @@ let targets: [Target] = {
         name: "Core",
         dependencies: [
             "CoreProtocols",
-            "CoreHTMLParser",
             "CoreJSONParser",
             "CorePackageIndexing",
             "SharedCore",
@@ -209,13 +204,12 @@ let targets: [Target] = {
             "Resources",
             "ASTIndexer",
         ],
-        exclude: ["HTMLParser", "JSONParser", "PackageIndexing"]
+        exclude: ["JSONParser", "PackageIndexing"]
     )
     let coreTestsTarget = Target.testTarget(
         name: "CoreTests",
         dependencies: [
             "CoreProtocols",
-            "CoreHTMLParser",
             "CoreJSONParser",
             "CorePackageIndexing",
             "Core",
@@ -495,7 +489,6 @@ let targets: [Target] = {
         mcpSharedToolsTarget,
         mcpSharedToolsTestsTarget,
         coreProtocolsTarget,
-        coreHTMLParserTarget,
         coreJSONParserTarget,
         corePackageIndexingTarget,
         resourcesTarget,

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -1,15 +1,14 @@
+import CoreJSONParser
+import CorePackageIndexing
+import CoreProtocols
 import Foundation
 import Logging
 import os
-import SharedCore
 import SharedConfiguration
 import SharedConstants
+import SharedCore
 import SharedModels
 import SharedUtils
-import CoreProtocols
-import CoreHTMLParser
-import CoreJSONParser
-import CorePackageIndexing
 
 // MARK: - Documentation Crawler
 
@@ -321,7 +320,7 @@ extension Core {
                     // JSON API failed, fall back to HTML
                     logInfo("   ⚠️ JSON API unavailable, using HTML fallback")
                     let html = try await loadPage(url: url)
-                    if HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) {
+                    if Core.Parser.HTML.looksLikeHTTPErrorPage(html: html) {
                         logInfo("   ⛔ HTTP error template detected, skipping (#284)")
                         await state.updateStatistics { $0.errors += 1 }
                         await state.updateStatistics { $0.totalPages += 1 }
@@ -329,16 +328,16 @@ extension Core {
                     }
                     (markdown, links, structuredPage) = autoreleasepool {
                         (
-                            HTMLToMarkdown.convert(html, url: url),
+                            Core.Parser.HTML.convert(html, url: url),
                             extractLinks(from: html, baseURL: url),
-                            HTMLToMarkdown.toStructuredPage(html, url: url, depth: depth)
+                            Core.Parser.HTML.toStructuredPage(html, url: url, depth: depth)
                         )
                     }
                 }
             } else {
                 // No JSON endpoint available, use HTML directly
                 let html = try await loadPage(url: url)
-                if HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) {
+                if Core.Parser.HTML.looksLikeHTTPErrorPage(html: html) {
                     logInfo("   ⛔ HTTP error template detected, skipping (#284)")
                     await state.updateStatistics { $0.errors += 1 }
                     await state.updateStatistics { $0.totalPages += 1 }
@@ -346,9 +345,9 @@ extension Core {
                 }
                 (markdown, links, structuredPage) = autoreleasepool {
                     (
-                        HTMLToMarkdown.convert(html, url: url),
+                        Core.Parser.HTML.convert(html, url: url),
                         extractLinks(from: html, baseURL: url),
-                        HTMLToMarkdown.toStructuredPage(html, url: url, depth: depth)
+                        Core.Parser.HTML.toStructuredPage(html, url: url, depth: depth)
                     )
                 }
             }

--- a/Packages/Sources/Core/HTMLParser/HTMLToMarkdown.swift
+++ b/Packages/Sources/Core/HTMLParser/HTMLToMarkdown.swift
@@ -23,646 +23,650 @@ import WebKit
 // File length: 580+ lines | Type body length: 400+ lines
 // Disabling: file_length (400 line limit), type_body_length (250 line limit)
 
-/// Converts HTML documentation to clean Markdown
-public struct HTMLToMarkdown: ContentTransformer, @unchecked Sendable {
-    public typealias RawContent = String
+extension Core.Parser {
+    /// Converts HTML documentation to clean Markdown
+    public struct HTML: ContentTransformer, @unchecked Sendable {
+        public typealias RawContent = String
 
-    public init() {}
+        public init() {}
 
-    // MARK: - ContentTransformer Protocol
+        // MARK: - ContentTransformer Protocol
 
-    /// Transform HTML content to Markdown (protocol conformance)
-    public func transform(_ content: String, url: URL) -> String? {
-        Self.convert(content, url: url)
-    }
+        /// Transform HTML content to Markdown (protocol conformance)
+        public func transform(_ content: String, url: URL) -> String? {
+            Self.convert(content, url: url)
+        }
 
-    /// Extract links from HTML content (protocol conformance)
-    public func extractLinks(from content: String) -> [URL] {
-        Self.extractLinks(from: content)
-    }
+        /// Extract links from HTML content (protocol conformance)
+        public func extractLinks(from content: String) -> [URL] {
+            Self.extractLinks(from: content)
+        }
 
-    // MARK: - Static API (backwards compatible)
+        // MARK: - Static API (backwards compatible)
 
-    /// Extract links from HTML content
-    public static func extractLinks(from html: String) -> [URL] {
-        var links: [URL] = []
-        let pattern = #"<a[^>]+href=["']([^"']+)["'][^>]*>"#
-        if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) {
-            let nsString = html as NSString
-            let matches = regex.matches(in: html, range: NSRange(location: 0, length: nsString.length))
-            for match in matches where match.numberOfRanges >= 2 {
-                let hrefRange = match.range(at: 1)
-                let href = nsString.substring(with: hrefRange)
-                if let url = URL(string: href) {
-                    links.append(url)
+        /// Extract links from HTML content
+        public static func extractLinks(from html: String) -> [URL] {
+            var links: [URL] = []
+            let pattern = #"<a[^>]+href=["']([^"']+)["'][^>]*>"#
+            if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) {
+                let nsString = html as NSString
+                let matches = regex.matches(in: html, range: NSRange(location: 0, length: nsString.length))
+                for match in matches where match.numberOfRanges >= 2 {
+                    let hrefRange = match.range(at: 1)
+                    let href = nsString.substring(with: hrefRange)
+                    if let url = URL(string: href) {
+                        links.append(url)
+                    }
                 }
             }
-        }
-        return links
-    }
-
-    /// Convert HTML string to Markdown
-    public static func convert(_ html: String, url: URL) -> String {
-        var markdown = ""
-
-        // Add front matter with metadata
-        markdown += "---\n"
-        markdown += "source: \(url.absoluteString)\n"
-        markdown += "crawled: \(ISO8601DateFormatter().string(from: Date()))\n"
-        markdown += "---\n\n"
-
-        // Extract title
-        if let title = extractTitle(from: html) {
-            markdown += "# \(title)\n\n"
+            return links
         }
 
-        // Extract main content
-        let content = extractMainContent(from: html)
-        markdown += convertHTMLToMarkdown(content)
+        /// Convert HTML string to Markdown
+        public static func convert(_ html: String, url: URL) -> String {
+            var markdown = ""
 
-        return markdown
-    }
+            // Add front matter with metadata
+            markdown += "---\n"
+            markdown += "source: \(url.absoluteString)\n"
+            markdown += "crawled: \(ISO8601DateFormatter().string(from: Date()))\n"
+            markdown += "---\n\n"
 
-    // MARK: - Extraction
-
-    private static func extractTitle(from html: String) -> String? {
-        // Try to extract title from <h1> or <title> tags
-        if let range = html.range(of: #"<h1[^>]*>(.*?)</h1>"#, options: .regularExpression) {
-            let titleHTML = String(html[range])
-            let title = stripHTML(titleHTML)
-            // Skip if it's a JavaScript warning
-            if !isJavaScriptWarning(title) {
-                return title
+            // Extract title
+            if let title = extractTitle(from: html) {
+                markdown += "# \(title)\n\n"
             }
+
+            // Extract main content
+            let content = extractMainContent(from: html)
+            markdown += convertHTMLToMarkdown(content)
+
+            return markdown
         }
 
-        if let range = html.range(of: #"<title>(.*?)</title>"#, options: .regularExpression) {
-            let titleHTML = String(html[range])
-            let title = stripHTML(titleHTML)
-            // Skip if it's a JavaScript warning
-            if !isJavaScriptWarning(title) {
-                return title
+        // MARK: - Extraction
+
+        private static func extractTitle(from html: String) -> String? {
+            // Try to extract title from <h1> or <title> tags
+            if let range = html.range(of: #"<h1[^>]*>(.*?)</h1>"#, options: .regularExpression) {
+                let titleHTML = String(html[range])
+                let title = stripHTML(titleHTML)
+                // Skip if it's a JavaScript warning
+                if !isJavaScriptWarning(title) {
+                    return title
+                }
             }
+
+            if let range = html.range(of: #"<title>(.*?)</title>"#, options: .regularExpression) {
+                let titleHTML = String(html[range])
+                let title = stripHTML(titleHTML)
+                // Skip if it's a JavaScript warning
+                if !isJavaScriptWarning(title) {
+                    return title
+                }
+            }
+
+            return nil
         }
 
-        return nil
-    }
+        private static func isJavaScriptWarning(_ text: String) -> Bool {
+            let lowercased = text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+            return lowercased.contains("requires javascript") ||
+                lowercased.contains("enable javascript") ||
+                lowercased.contains("javascript is required")
+        }
 
-    private static func isJavaScriptWarning(_ text: String) -> Bool {
-        let lowercased = text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-        return lowercased.contains("requires javascript") ||
-            lowercased.contains("enable javascript") ||
-            lowercased.contains("javascript is required")
-    }
+        // MARK: - Error-page detection (#284)
 
-    // MARK: - Error-page detection (#284)
+        /// Returns true if `html` looks like an HTTP error response template
+        /// (Apple's CDN sometimes serves a styled 403/404/502 page with HTTP
+        /// 200 status, which then gets indexed as if it were documentation).
+        /// Used by the crawler's WebView fallback as a defense-in-depth check
+        /// before saving the page. The JSON API path already filters by
+        /// HTTP status code, so this gate fires only on rendered-HTML inputs.
+        public static func looksLikeHTTPErrorPage(html: String) -> Bool {
+            guard let title = extractTitle(from: html) else {
+                // No title means we'll skip via the existing nil-title gate; let
+                // that path handle it rather than double-counting.
+                return false
+            }
+            return looksLikeHTTPErrorPage(title: title, html: html)
+        }
 
-    /// Returns true if `html` looks like an HTTP error response template
-    /// (Apple's CDN sometimes serves a styled 403/404/502 page with HTTP
-    /// 200 status, which then gets indexed as if it were documentation).
-    /// Used by the crawler's WebView fallback as a defense-in-depth check
-    /// before saving the page. The JSON API path already filters by
-    /// HTTP status code, so this gate fires only on rendered-HTML inputs.
-    public static func looksLikeHTTPErrorPage(html: String) -> Bool {
-        guard let title = extractTitle(from: html) else {
-            // No title means we'll skip via the existing nil-title gate; let
-            // that path handle it rather than double-counting.
+        /// Pure decision over a pre-extracted `title` + the surrounding `html`.
+        /// Split out so unit tests can exercise the rule against synthetic
+        /// inputs without round-tripping through the full HTML title-extractor.
+        static func looksLikeHTTPErrorPage(title: String, html: String) -> Bool {
+            let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // Direct prefix: "403 Forbidden", "502 Bad Gateway", etc.
+            // The space/end-anchor matches the issue spec so a real Apple page
+            // titled "404 Not Found · Apple Developer Documentation" still trips
+            // it, while "Routing404" or "Error404Type" do not.
+            if trimmed.range(of: #"^(403|404|429|500|502|503|504)(\s|$)"#, options: .regularExpression) != nil {
+                return true
+            }
+
+            // Defense-in-depth: a very short rendered body whose title contains
+            // a known error phrase. The issue spec calls for a content-body
+            // word-count (not the converted-markdown word-count, which would
+            // include the front-matter overhead `convert()` always emits).
+            let errorPhrases = ["Forbidden", "Bad Gateway", "Not Found", "Service Unavailable", "Gateway Timeout"]
+            let containsErrorPhrase = errorPhrases.contains { trimmed.contains($0) }
+            if containsErrorPhrase, countBodyWords(in: html) < 10 {
+                return true
+            }
+
             return false
         }
-        return looksLikeHTTPErrorPage(title: title, html: html)
-    }
 
-    /// Pure decision over a pre-extracted `title` + the surrounding `html`.
-    /// Split out so unit tests can exercise the rule against synthetic
-    /// inputs without round-tripping through the full HTML title-extractor.
-    static func looksLikeHTTPErrorPage(title: String, html: String) -> Bool {
-        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Direct prefix: "403 Forbidden", "502 Bad Gateway", etc.
-        // The space/end-anchor matches the issue spec so a real Apple page
-        // titled "404 Not Found · Apple Developer Documentation" still trips
-        // it, while "Routing404" or "Error404Type" do not.
-        if trimmed.range(of: #"^(403|404|429|500|502|503|504)(\s|$)"#, options: .regularExpression) != nil {
-            return true
+        /// Approximate body word-count for the error-page heuristic. Strips
+        /// HTML tags + entities from the `<body>` region (or the whole input
+        /// if no body tag), then counts whitespace-separated tokens. Cheap
+        /// enough to run on every WebView fallback page; the only consumer is
+        /// `looksLikeHTTPErrorPage`.
+        private static func countBodyWords(in html: String) -> Int {
+            let body: String
+            let bodyOptions: NSString.CompareOptions = [.regularExpression, .caseInsensitive]
+            if let range = html.range(of: #"<body[^>]*>(.*?)</body>"#, options: bodyOptions) {
+                body = String(html[range])
+            } else {
+                body = html
+            }
+            let stripped = body
+                .replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+                .replacingOccurrences(of: "&[a-z0-9#]+;", with: " ", options: bodyOptions)
+            return stripped.split(whereSeparator: { $0.isWhitespace }).count
         }
 
-        // Defense-in-depth: a very short rendered body whose title contains
-        // a known error phrase. The issue spec calls for a content-body
-        // word-count (not the converted-markdown word-count, which would
-        // include the front-matter overhead `convert()` always emits).
-        let errorPhrases = ["Forbidden", "Bad Gateway", "Not Found", "Service Unavailable", "Gateway Timeout"]
-        let containsErrorPhrase = errorPhrases.contains { trimmed.contains($0) }
-        if containsErrorPhrase, countBodyWords(in: html) < 10 {
-            return true
+        private static func extractMainContent(from html: String) -> String {
+            // Try to extract main content area - need dotMatchesLineSeparators for multiline content
+            let options: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
+
+            if let regex = try? NSRegularExpression(pattern: #"<main[^>]*>(.*?)</main>"#, options: options),
+               let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+               let range = Range(match.range, in: html) {
+                return String(html[range])
+            }
+
+            if let regex = try? NSRegularExpression(pattern: #"<article[^>]*>(.*?)</article>"#, options: options),
+               let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+               let range = Range(match.range, in: html) {
+                return String(html[range])
+            }
+
+            // Fallback to body content
+            if let regex = try? NSRegularExpression(pattern: #"<body[^>]*>(.*?)</body>"#, options: options),
+               let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+               let range = Range(match.range, in: html) {
+                return String(html[range])
+            }
+
+            return html
         }
 
-        return false
-    }
+        // MARK: - Conversion
 
-    /// Approximate body word-count for the error-page heuristic. Strips
-    /// HTML tags + entities from the `<body>` region (or the whole input
-    /// if no body tag), then counts whitespace-separated tokens. Cheap
-    /// enough to run on every WebView fallback page; the only consumer is
-    /// `looksLikeHTTPErrorPage`.
-    private static func countBodyWords(in html: String) -> Int {
-        let body: String
-        let bodyOptions: NSString.CompareOptions = [.regularExpression, .caseInsensitive]
-        if let range = html.range(of: #"<body[^>]*>(.*?)</body>"#, options: bodyOptions) {
-            body = String(html[range])
-        } else {
-            body = html
-        }
-        let stripped = body
-            .replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
-            .replacingOccurrences(of: "&[a-z0-9#]+;", with: " ", options: bodyOptions)
-        return stripped.split(whereSeparator: { $0.isWhitespace }).count
-    }
+        private static func convertHTMLToMarkdown(_ html: String) -> String {
+            var markdown = html
 
-    private static func extractMainContent(from html: String) -> String {
-        // Try to extract main content area - need dotMatchesLineSeparators for multiline content
-        let options: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
+            // Step 1: Remove unwanted sections BEFORE extracting content
+            markdown = removeUnwantedSections(markdown)
 
-        if let regex = try? NSRegularExpression(pattern: #"<main[^>]*>(.*?)</main>"#, options: options),
-           let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
-           let range = Range(match.range, in: html) {
-            return String(html[range])
-        }
+            // Step 2: Extract and protect code blocks to prevent them from being mangled
+            var codeBlocks: [String: String] = [:]
+            markdown = extractAndProtectCodeBlocks(markdown, into: &codeBlocks)
 
-        if let regex = try? NSRegularExpression(pattern: #"<article[^>]*>(.*?)</article>"#, options: options),
-           let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
-           let range = Range(match.range, in: html) {
-            return String(html[range])
+            // Step 3: Remove UI clutter
+            markdown = removeJavaScriptWarnings(markdown)
+            markdown = removeAccessibilityInstructions(markdown)
+
+            // Step 4: Convert HTML elements to markdown
+            markdown = convertHeaders(markdown)
+            markdown = convertInlineFormatting(markdown)
+            markdown = convertLinks(markdown)
+            markdown = convertLists(markdown)
+            markdown = convertParagraphs(markdown)
+
+            // Step 5: Final cleanup
+            markdown = stripHTML(markdown)
+            markdown = cleanupWhitespace(markdown)
+            markdown = decodeHTMLEntities(markdown)
+
+            // Step 6: Restore protected code blocks
+            markdown = restoreCodeBlocks(markdown, from: codeBlocks)
+
+            return markdown
         }
 
-        // Fallback to body content
-        if let regex = try? NSRegularExpression(pattern: #"<body[^>]*>(.*?)</body>"#, options: options),
-           let match = regex.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
-           let range = Range(match.range, in: html) {
-            return String(html[range])
-        }
+        private static func extractAndProtectCodeBlocks(
+            _ html: String,
+            into storage: inout [String: String]
+        ) -> String {
+            var result = html
+            var blockIndex = 0
+            let regexOptions: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
 
-        return html
-    }
+            // Extract <pre><code> blocks with language
+            let pattern = Shared.Constants.Pattern.htmlCodeBlockWithLanguage
+            if let regex = try? NSRegularExpression(pattern: pattern, options: regexOptions) {
+                let nsString = result as NSString
+                let matches = regex.matches(in: result, range: NSRange(location: 0, length: nsString.length))
 
-    // MARK: - Conversion
+                for match in matches.reversed() where match.numberOfRanges >= 3 {
+                    let languageRange = match.range(at: 1)
+                    let codeRange = match.range(at: 2)
 
-    private static func convertHTMLToMarkdown(_ html: String) -> String {
-        var markdown = html
+                    if languageRange.location != NSNotFound, codeRange.location != NSNotFound {
+                        let language = nsString.substring(with: languageRange).lowercased()
+                        var code = nsString.substring(with: codeRange)
 
-        // Step 1: Remove unwanted sections BEFORE extracting content
-        markdown = removeUnwantedSections(markdown)
+                        // Strip HTML tags and decode entities from code
+                        code = stripHTML(code)
+                        code = decodeHTMLEntities(code)
 
-        // Step 2: Extract and protect code blocks to prevent them from being mangled
-        var codeBlocks: [String: String] = [:]
-        markdown = extractAndProtectCodeBlocks(markdown, into: &codeBlocks)
-
-        // Step 3: Remove UI clutter
-        markdown = removeJavaScriptWarnings(markdown)
-        markdown = removeAccessibilityInstructions(markdown)
-
-        // Step 4: Convert HTML elements to markdown
-        markdown = convertHeaders(markdown)
-        markdown = convertInlineFormatting(markdown)
-        markdown = convertLinks(markdown)
-        markdown = convertLists(markdown)
-        markdown = convertParagraphs(markdown)
-
-        // Step 5: Final cleanup
-        markdown = stripHTML(markdown)
-        markdown = cleanupWhitespace(markdown)
-        markdown = decodeHTMLEntities(markdown)
-
-        // Step 6: Restore protected code blocks
-        markdown = restoreCodeBlocks(markdown, from: codeBlocks)
-
-        return markdown
-    }
-
-    private static func extractAndProtectCodeBlocks(
-        _ html: String,
-        into storage: inout [String: String]
-    ) -> String {
-        var result = html
-        var blockIndex = 0
-        let regexOptions: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
-
-        // Extract <pre><code> blocks with language
-        let pattern = Shared.Constants.Pattern.htmlCodeBlockWithLanguage
-        if let regex = try? NSRegularExpression(pattern: pattern, options: regexOptions) {
-            let nsString = result as NSString
-            let matches = regex.matches(in: result, range: NSRange(location: 0, length: nsString.length))
-
-            for match in matches.reversed() where match.numberOfRanges >= 3 {
-                let languageRange = match.range(at: 1)
-                let codeRange = match.range(at: 2)
-
-                if languageRange.location != NSNotFound, codeRange.location != NSNotFound {
-                    let language = nsString.substring(with: languageRange).lowercased()
-                    var code = nsString.substring(with: codeRange)
-
-                    // Strip HTML tags and decode entities from code
-                    code = stripHTML(code)
-                    code = decodeHTMLEntities(code)
-
-                    let placeholder = "___CODEBLOCK_\(blockIndex)___"
-                    storage[placeholder] = "```\(language)\n\(code)\n```"
-                    result = (result as NSString).replacingCharacters(in: match.range, with: placeholder)
-                    blockIndex += 1
+                        let placeholder = "___CODEBLOCK_\(blockIndex)___"
+                        storage[placeholder] = "```\(language)\n\(code)\n```"
+                        result = (result as NSString).replacingCharacters(in: match.range, with: placeholder)
+                        blockIndex += 1
+                    }
                 }
             }
-        }
 
-        // Fallback: Extract <pre><code> blocks without language
-        let fallbackPattern = #"<pre[^>]*>\s*<code[^>]*>(.*?)</code>\s*</pre>"#
-        if let regex = try? NSRegularExpression(pattern: fallbackPattern, options: regexOptions) {
-            let nsString = result as NSString
-            let matches = regex.matches(in: result, range: NSRange(location: 0, length: nsString.length))
+            // Fallback: Extract <pre><code> blocks without language
+            let fallbackPattern = #"<pre[^>]*>\s*<code[^>]*>(.*?)</code>\s*</pre>"#
+            if let regex = try? NSRegularExpression(pattern: fallbackPattern, options: regexOptions) {
+                let nsString = result as NSString
+                let matches = regex.matches(in: result, range: NSRange(location: 0, length: nsString.length))
 
-            for match in matches.reversed() where match.numberOfRanges >= 2 {
-                let codeRange = match.range(at: 1)
-                if codeRange.location != NSNotFound {
-                    var code = nsString.substring(with: codeRange)
+                for match in matches.reversed() where match.numberOfRanges >= 2 {
+                    let codeRange = match.range(at: 1)
+                    if codeRange.location != NSNotFound {
+                        var code = nsString.substring(with: codeRange)
 
-                    // Strip HTML tags and decode entities from code
-                    code = stripHTML(code)
-                    code = decodeHTMLEntities(code)
+                        // Strip HTML tags and decode entities from code
+                        code = stripHTML(code)
+                        code = decodeHTMLEntities(code)
 
-                    let placeholder = "___CODEBLOCK_\(blockIndex)___"
-                    storage[placeholder] = "```\n\(code)\n```"
-                    result = (result as NSString).replacingCharacters(in: match.range, with: placeholder)
-                    blockIndex += 1
+                        let placeholder = "___CODEBLOCK_\(blockIndex)___"
+                        storage[placeholder] = "```\n\(code)\n```"
+                        result = (result as NSString).replacingCharacters(in: match.range, with: placeholder)
+                        blockIndex += 1
+                    }
                 }
             }
+
+            return result
         }
 
-        return result
-    }
-
-    private static func restoreCodeBlocks(_ markdown: String, from storage: [String: String]) -> String {
-        var result = markdown
-        for (placeholder, code) in storage {
-            result = result.replacingOccurrences(of: placeholder, with: "\n\n\(code)\n\n")
-        }
-        return result
-    }
-
-    private static func convertHeaders(_ markdown: String) -> String {
-        var result = markdown
-        result = result.replacingOccurrences(
-            of: #"<h1[^>]*>(.*?)</h1>"#, with: "# $1\n\n", options: .regularExpression
-        )
-        result = result.replacingOccurrences(
-            of: #"<h2[^>]*>(.*?)</h2>"#, with: "## $1\n\n", options: .regularExpression
-        )
-        result = result.replacingOccurrences(
-            of: #"<h3[^>]*>(.*?)</h3>"#, with: "### $1\n\n", options: .regularExpression
-        )
-        result = result.replacingOccurrences(
-            of: #"<h4[^>]*>(.*?)</h4>"#, with: "#### $1\n\n", options: .regularExpression
-        )
-        result = result.replacingOccurrences(
-            of: #"<h5[^>]*>(.*?)</h5>"#, with: "##### $1\n\n", options: .regularExpression
-        )
-        result = result.replacingOccurrences(
-            of: #"<h6[^>]*>(.*?)</h6>"#, with: "###### $1\n\n", options: .regularExpression
-        )
-        return result
-    }
-
-    private static func convertInlineFormatting(_ markdown: String) -> String {
-        var result = markdown
-        let regexOptions: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
-
-        // Inline code (use dotMatchesLineSeparators to handle multiline code)
-        if let regex = try? NSRegularExpression(pattern: #"<code[^>]*>(.*?)</code>"#, options: regexOptions) {
-            let nsString = result as NSString
-            let range = NSRange(location: 0, length: nsString.length)
-            result = regex.stringByReplacingMatches(in: result, options: [], range: range, withTemplate: "`$1`")
+        private static func restoreCodeBlocks(_ markdown: String, from storage: [String: String]) -> String {
+            var result = markdown
+            for (placeholder, code) in storage {
+                result = result.replacingOccurrences(of: placeholder, with: "\n\n\(code)\n\n")
+            }
+            return result
         }
 
-        // Bold
-        if let regex = try? NSRegularExpression(pattern: #"<(strong|b)[^>]*>(.*?)</\1>"#, options: regexOptions) {
-            let nsString = result as NSString
-            let range = NSRange(location: 0, length: nsString.length)
-            result = regex.stringByReplacingMatches(in: result, options: [], range: range, withTemplate: "**$2**")
+        private static func convertHeaders(_ markdown: String) -> String {
+            var result = markdown
+            result = result.replacingOccurrences(
+                of: #"<h1[^>]*>(.*?)</h1>"#, with: "# $1\n\n", options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<h2[^>]*>(.*?)</h2>"#, with: "## $1\n\n", options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<h3[^>]*>(.*?)</h3>"#, with: "### $1\n\n", options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<h4[^>]*>(.*?)</h4>"#, with: "#### $1\n\n", options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<h5[^>]*>(.*?)</h5>"#, with: "##### $1\n\n", options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"<h6[^>]*>(.*?)</h6>"#, with: "###### $1\n\n", options: .regularExpression
+            )
+            return result
         }
 
-        // Italic
-        if let regex = try? NSRegularExpression(pattern: #"<(em|i)[^>]*>(.*?)</\1>"#, options: regexOptions) {
-            let nsString = result as NSString
-            let range = NSRange(location: 0, length: nsString.length)
-            result = regex.stringByReplacingMatches(in: result, options: [], range: range, withTemplate: "*$2*")
+        private static func convertInlineFormatting(_ markdown: String) -> String {
+            var result = markdown
+            let regexOptions: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
+
+            // Inline code (use dotMatchesLineSeparators to handle multiline code)
+            if let regex = try? NSRegularExpression(pattern: #"<code[^>]*>(.*?)</code>"#, options: regexOptions) {
+                let nsString = result as NSString
+                let range = NSRange(location: 0, length: nsString.length)
+                result = regex.stringByReplacingMatches(in: result, options: [], range: range, withTemplate: "`$1`")
+            }
+
+            // Bold
+            if let regex = try? NSRegularExpression(pattern: #"<(strong|b)[^>]*>(.*?)</\1>"#, options: regexOptions) {
+                let nsString = result as NSString
+                let range = NSRange(location: 0, length: nsString.length)
+                result = regex.stringByReplacingMatches(in: result, options: [], range: range, withTemplate: "**$2**")
+            }
+
+            // Italic
+            if let regex = try? NSRegularExpression(pattern: #"<(em|i)[^>]*>(.*?)</\1>"#, options: regexOptions) {
+                let nsString = result as NSString
+                let range = NSRange(location: 0, length: nsString.length)
+                result = regex.stringByReplacingMatches(in: result, options: [], range: range, withTemplate: "*$2*")
+            }
+
+            return result
         }
 
-        return result
-    }
-
-    private static func convertLinks(_ markdown: String) -> String {
-        markdown.replacingOccurrences(
-            of: #"<a[^>]*href=[\"']([^\"']*)[\"'][^>]*>(.*?)</a>"#,
-            with: "[$2]($1)",
-            options: .regularExpression
-        )
-    }
-
-    private static func convertLists(_ markdown: String) -> String {
-        var result = markdown
-
-        // Convert list items first (need dotMatchesLineSeparators for multiline items)
-        if let regex = try? NSRegularExpression(
-            pattern: #"<li[^>]*>(.*?)</li>"#,
-            options: [.caseInsensitive, .dotMatchesLineSeparators]
-        ) {
-            let nsString = result as NSString
-            result = regex.stringByReplacingMatches(
-                in: result,
-                options: [],
-                range: NSRange(location: 0, length: nsString.length),
-                withTemplate: "\n- $1\n"
+        private static func convertLinks(_ markdown: String) -> String {
+            markdown.replacingOccurrences(
+                of: #"<a[^>]*href=[\"']([^\"']*)[\"'][^>]*>(.*?)</a>"#,
+                with: "[$2]($1)",
+                options: .regularExpression
             )
         }
 
-        // Then remove list containers
-        if let regex = try? NSRegularExpression(
-            pattern: #"<ul[^>]*>(.*?)</ul>"#,
-            options: [.caseInsensitive, .dotMatchesLineSeparators]
-        ) {
-            let nsString = result as NSString
-            result = regex.stringByReplacingMatches(
-                in: result,
-                options: [],
-                range: NSRange(location: 0, length: nsString.length),
-                withTemplate: "$1\n\n"
+        private static func convertLists(_ markdown: String) -> String {
+            var result = markdown
+
+            // Convert list items first (need dotMatchesLineSeparators for multiline items)
+            if let regex = try? NSRegularExpression(
+                pattern: #"<li[^>]*>(.*?)</li>"#,
+                options: [.caseInsensitive, .dotMatchesLineSeparators]
+            ) {
+                let nsString = result as NSString
+                result = regex.stringByReplacingMatches(
+                    in: result,
+                    options: [],
+                    range: NSRange(location: 0, length: nsString.length),
+                    withTemplate: "\n- $1\n"
+                )
+            }
+
+            // Then remove list containers
+            if let regex = try? NSRegularExpression(
+                pattern: #"<ul[^>]*>(.*?)</ul>"#,
+                options: [.caseInsensitive, .dotMatchesLineSeparators]
+            ) {
+                let nsString = result as NSString
+                result = regex.stringByReplacingMatches(
+                    in: result,
+                    options: [],
+                    range: NSRange(location: 0, length: nsString.length),
+                    withTemplate: "$1\n\n"
+                )
+            }
+
+            if let regex = try? NSRegularExpression(
+                pattern: #"<ol[^>]*>(.*?)</ol>"#,
+                options: [.caseInsensitive, .dotMatchesLineSeparators]
+            ) {
+                let nsString = result as NSString
+                result = regex.stringByReplacingMatches(
+                    in: result,
+                    options: [],
+                    range: NSRange(location: 0, length: nsString.length),
+                    withTemplate: "$1\n\n"
+                )
+            }
+
+            return result
+        }
+
+        private static func convertParagraphs(_ markdown: String) -> String {
+            var result = markdown
+            result = result.replacingOccurrences(of: #"<p[^>]*>(.*?)</p>"#, with: "$1\n\n", options: .regularExpression)
+            result = result.replacingOccurrences(of: "<br[^>]*>", with: "\n", options: .regularExpression)
+            return result
+        }
+
+        private static func cleanupWhitespace(_ markdown: String) -> String {
+            var result = markdown
+            result = result.replacingOccurrences(of: #"\n{3,}"#, with: "\n\n", options: .regularExpression)
+            result = result.trimmingCharacters(in: .whitespacesAndNewlines)
+            return result
+        }
+
+        // MARK: - Utilities
+
+        private static func removeUnwantedSections(_ html: String) -> String {
+            var result = html
+
+            // Remove noscript tags and their content
+            result = result.replacingOccurrences(
+                of: #"<noscript[^>]*>.*?</noscript>"#,
+                with: "",
+                options: [.regularExpression, .caseInsensitive]
             )
-        }
 
-        if let regex = try? NSRegularExpression(
-            pattern: #"<ol[^>]*>(.*?)</ol>"#,
-            options: [.caseInsensitive, .dotMatchesLineSeparators]
-        ) {
-            let nsString = result as NSString
-            result = regex.stringByReplacingMatches(
-                in: result,
-                options: [],
-                range: NSRange(location: 0, length: nsString.length),
-                withTemplate: "$1\n\n"
+            // Remove script tags
+            result = result.replacingOccurrences(
+                of: #"<script[^>]*>.*?</script>"#,
+                with: "",
+                options: [.regularExpression, .caseInsensitive]
             )
-        }
 
-        return result
-    }
-
-    private static func convertParagraphs(_ markdown: String) -> String {
-        var result = markdown
-        result = result.replacingOccurrences(of: #"<p[^>]*>(.*?)</p>"#, with: "$1\n\n", options: .regularExpression)
-        result = result.replacingOccurrences(of: "<br[^>]*>", with: "\n", options: .regularExpression)
-        return result
-    }
-
-    private static func cleanupWhitespace(_ markdown: String) -> String {
-        var result = markdown
-        result = result.replacingOccurrences(of: #"\n{3,}"#, with: "\n\n", options: .regularExpression)
-        result = result.trimmingCharacters(in: .whitespacesAndNewlines)
-        return result
-    }
-
-    // MARK: - Utilities
-
-    private static func removeUnwantedSections(_ html: String) -> String {
-        var result = html
-
-        // Remove noscript tags and their content
-        result = result.replacingOccurrences(
-            of: #"<noscript[^>]*>.*?</noscript>"#,
-            with: "",
-            options: [.regularExpression, .caseInsensitive]
-        )
-
-        // Remove script tags
-        result = result.replacingOccurrences(
-            of: #"<script[^>]*>.*?</script>"#,
-            with: "",
-            options: [.regularExpression, .caseInsensitive]
-        )
-
-        // Remove style tags
-        result = result.replacingOccurrences(
-            of: #"<style[^>]*>.*?</style>"#,
-            with: "",
-            options: [.regularExpression, .caseInsensitive]
-        )
-
-        // Remove navigation elements
-        result = result.replacingOccurrences(
-            of: #"<nav[^>]*>.*?</nav>"#,
-            with: "",
-            options: [.regularExpression, .caseInsensitive]
-        )
-
-        // Remove header/footer elements (often contain navigation)
-        result = result.replacingOccurrences(
-            of: #"<header[^>]*>.*?</header>"#,
-            with: "",
-            options: [.regularExpression, .caseInsensitive]
-        )
-        result = result.replacingOccurrences(
-            of: #"<footer[^>]*>.*?</footer>"#,
-            with: "",
-            options: [.regularExpression, .caseInsensitive]
-        )
-
-        // Remove SVG elements (icons, graphics) - use dotMatchesLineSeparators for multiline SVG
-        if let regex = try? NSRegularExpression(
-            pattern: #"<svg[^>]*>.*?</svg>"#,
-            options: [.caseInsensitive, .dotMatchesLineSeparators]
-        ) {
-            let nsString = result as NSString
-            result = regex.stringByReplacingMatches(
-                in: result,
-                options: [],
-                range: NSRange(location: 0, length: nsString.length),
-                withTemplate: ""
+            // Remove style tags
+            result = result.replacingOccurrences(
+                of: #"<style[^>]*>.*?</style>"#,
+                with: "",
+                options: [.regularExpression, .caseInsensitive]
             )
-        }
 
-        return result
-    }
-
-    private static func removeJavaScriptWarnings(_ html: String) -> String {
-        var result = html
-
-        // Common JavaScript warning patterns - remove from anywhere in text
-        let warnings = [
-            "This page requires JavaScript.",
-            "This page requires JavaScript",
-            "Please turn on JavaScript",
-            "Please enable JavaScript",
-            "JavaScript is required",
-            "Enable JavaScript to view",
-        ]
-
-        for warning in warnings {
-            result = result.replacingOccurrences(of: warning, with: "", options: .caseInsensitive)
-        }
-
-        // Remove common heading patterns for JavaScript warnings (with any number of #)
-        result = result.replacingOccurrences(
-            of: #"#{1,6}\s*This page requires JavaScript\.?\s*\n+"#,
-            with: "",
-            options: .regularExpression
-        )
-
-        // Also remove if it appears as plain text at start of line
-        if let regex = try? NSRegularExpression(
-            pattern: #"^\s*This page requires JavaScript\.?\s*\n+"#,
-            options: [.anchorsMatchLines]
-        ) {
-            let nsString = result as NSString
-            result = regex.stringByReplacingMatches(
-                in: result,
-                options: [],
-                range: NSRange(location: 0, length: nsString.length),
-                withTemplate: ""
+            // Remove navigation elements
+            result = result.replacingOccurrences(
+                of: #"<nav[^>]*>.*?</nav>"#,
+                with: "",
+                options: [.regularExpression, .caseInsensitive]
             )
-        }
 
-        return result
-    }
-
-    private static func removeAccessibilityInstructions(_ markdown: String) -> String {
-        var result = markdown
-        result = removeNavigationInstructions(result)
-        result = removeSymbolIndicators(result)
-        result = removeSkipNavigation(result)
-        result = removeArtifacts(result)
-        result = cleanupStrayCharacters(result)
-        return result
-    }
-
-    private static func removeNavigationInstructions(_ markdown: String) -> String {
-        var result = markdown
-        result = result.replacingOccurrences(
-            of: #"To navigate the symbols, press Up Arrow, Down Arrow, Left Arrow or Right Arrow\s*"#,
-            with: "",
-            options: .regularExpression
-        )
-        result = result.replacingOccurrences(
-            of: #"\d+ items were found\. Tab back to navigate through them\.\s*"#,
-            with: "",
-            options: .regularExpression
-        )
-        result = result.replacingOccurrences(
-            of: #"/\s*Navigator is ready -\s*"#,
-            with: "",
-            options: .regularExpression
-        )
-        return result
-    }
-
-    private static func removeSymbolIndicators(_ markdown: String) -> String {
-        var result = markdown
-        result = result.replacingOccurrences(
-            of: #"\s*[A-Za-z0-9#]*\d+ of \d+ symbols inside [^\n\[\]]+\s*"#,
-            with: " ",
-            options: .regularExpression
-        )
-        result = result.replacingOccurrences(
-            of: #"containing \d+ symbols"#,
-            with: "",
-            options: .regularExpression
-        )
-        return result
-    }
-
-    private static func removeSkipNavigation(_ markdown: String) -> String {
-        var result = markdown
-        result = result.replacingOccurrences(
-            of: #"\[\s*Skip Navigation\s*\]\s*\(#[^)]*\)"#,
-            with: "",
-            options: .regularExpression
-        )
-        result = result.replacingOccurrences(
-            of: #"\[\s*Skip Navigation\s*\]"#,
-            with: "",
-            options: .regularExpression
-        )
-        return result
-    }
-
-    private static func removeArtifacts(_ markdown: String) -> String {
-        var result = markdown
-        result = result.replacingOccurrences(of: #"\[object Object\]"#, with: "", options: .regularExpression)
-        result = result.replacingOccurrences(of: #"\s*data-v-[a-z0-9]+="[^"]*""#, with: "", options: .regularExpression)
-        result = result.replacingOccurrences(of: #"  +"#, with: " ", options: .regularExpression)
-        result = result.replacingOccurrences(of: #"\n\n\n+"#, with: "\n\n", options: .regularExpression)
-        return result
-    }
-
-    private static func cleanupStrayCharacters(_ markdown: String) -> String {
-        var result = markdown
-        if let regex = try? NSRegularExpression(
-            pattern: #"^\s*">+\s*"#,
-            options: [.anchorsMatchLines]
-        ) {
-            let nsString = result as NSString
-            result = regex.stringByReplacingMatches(
-                in: result,
-                options: [],
-                range: NSRange(location: 0, length: nsString.length),
-                withTemplate: ""
+            // Remove header/footer elements (often contain navigation)
+            result = result.replacingOccurrences(
+                of: #"<header[^>]*>.*?</header>"#,
+                with: "",
+                options: [.regularExpression, .caseInsensitive]
             )
-        }
-        result = result.replacingOccurrences(
-            of: #"\n\s*">+\s*\n"#,
-            with: "\n",
-            options: .regularExpression
-        )
-        return result
-    }
+            result = result.replacingOccurrences(
+                of: #"<footer[^>]*>.*?</footer>"#,
+                with: "",
+                options: [.regularExpression, .caseInsensitive]
+            )
 
-    private static func stripHTML(_ html: String) -> String {
-        html.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
-    }
+            // Remove SVG elements (icons, graphics) - use dotMatchesLineSeparators for multiline SVG
+            if let regex = try? NSRegularExpression(
+                pattern: #"<svg[^>]*>.*?</svg>"#,
+                options: [.caseInsensitive, .dotMatchesLineSeparators]
+            ) {
+                let nsString = result as NSString
+                result = regex.stringByReplacingMatches(
+                    in: result,
+                    options: [],
+                    range: NSRange(location: 0, length: nsString.length),
+                    withTemplate: ""
+                )
+            }
 
-    private static func decodeHTMLEntities(_ text: String) -> String {
-        var result = text
-
-        // Common HTML entities
-        let entities: [String: String] = [
-            "&amp;": "&",
-            "&lt;": "<",
-            "&gt;": ">",
-            "&quot;": "\"",
-            "&apos;": "'",
-            "&nbsp;": " ",
-            "&#39;": "'",
-            "&#x27;": "'",
-        ]
-
-        for (entity, replacement) in entities {
-            result = result.replacingOccurrences(of: entity, with: replacement)
+            return result
         }
 
-        // Numeric entities (&#123;) - simple regex replacement
-        if let regex = try? NSRegularExpression(pattern: #"&#(\d+);"#, options: []) {
-            let nsString = result as NSString
-            let matches = regex.matches(in: result, range: NSRange(location: 0, length: nsString.length))
+        private static func removeJavaScriptWarnings(_ html: String) -> String {
+            var result = html
 
-            for match in matches.reversed() where match.numberOfRanges >= 2 {
-                let numberRange = match.range(at: 1)
-                let numberStr = nsString.substring(with: numberRange)
+            // Common JavaScript warning patterns - remove from anywhere in text
+            let warnings = [
+                "This page requires JavaScript.",
+                "This page requires JavaScript",
+                "Please turn on JavaScript",
+                "Please enable JavaScript",
+                "JavaScript is required",
+                "Enable JavaScript to view",
+            ]
 
-                if let number = Int(numberStr),
-                   let scalar = Unicode.Scalar(number) {
-                    let replacement = String(Character(scalar))
-                    result = (result as NSString).replacingCharacters(in: match.range, with: replacement)
+            for warning in warnings {
+                result = result.replacingOccurrences(of: warning, with: "", options: .caseInsensitive)
+            }
+
+            // Remove common heading patterns for JavaScript warnings (with any number of #)
+            result = result.replacingOccurrences(
+                of: #"#{1,6}\s*This page requires JavaScript\.?\s*\n+"#,
+                with: "",
+                options: .regularExpression
+            )
+
+            // Also remove if it appears as plain text at start of line
+            if let regex = try? NSRegularExpression(
+                pattern: #"^\s*This page requires JavaScript\.?\s*\n+"#,
+                options: [.anchorsMatchLines]
+            ) {
+                let nsString = result as NSString
+                result = regex.stringByReplacingMatches(
+                    in: result,
+                    options: [],
+                    range: NSRange(location: 0, length: nsString.length),
+                    withTemplate: ""
+                )
+            }
+
+            return result
+        }
+
+        private static func removeAccessibilityInstructions(_ markdown: String) -> String {
+            var result = markdown
+            result = removeNavigationInstructions(result)
+            result = removeSymbolIndicators(result)
+            result = removeSkipNavigation(result)
+            result = removeArtifacts(result)
+            result = cleanupStrayCharacters(result)
+            return result
+        }
+
+        private static func removeNavigationInstructions(_ markdown: String) -> String {
+            var result = markdown
+            result = result.replacingOccurrences(
+                of: #"To navigate the symbols, press Up Arrow, Down Arrow, Left Arrow or Right Arrow\s*"#,
+                with: "",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"\d+ items were found\. Tab back to navigate through them\.\s*"#,
+                with: "",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"/\s*Navigator is ready -\s*"#,
+                with: "",
+                options: .regularExpression
+            )
+            return result
+        }
+
+        private static func removeSymbolIndicators(_ markdown: String) -> String {
+            var result = markdown
+            result = result.replacingOccurrences(
+                of: #"\s*[A-Za-z0-9#]*\d+ of \d+ symbols inside [^\n\[\]]+\s*"#,
+                with: " ",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"containing \d+ symbols"#,
+                with: "",
+                options: .regularExpression
+            )
+            return result
+        }
+
+        private static func removeSkipNavigation(_ markdown: String) -> String {
+            var result = markdown
+            result = result.replacingOccurrences(
+                of: #"\[\s*Skip Navigation\s*\]\s*\(#[^)]*\)"#,
+                with: "",
+                options: .regularExpression
+            )
+            result = result.replacingOccurrences(
+                of: #"\[\s*Skip Navigation\s*\]"#,
+                with: "",
+                options: .regularExpression
+            )
+            return result
+        }
+
+        private static func removeArtifacts(_ markdown: String) -> String {
+            var result = markdown
+            result = result.replacingOccurrences(of: #"\[object Object\]"#, with: "", options: .regularExpression)
+            result = result.replacingOccurrences(of: #"\s*data-v-[a-z0-9]+="[^"]*""#, with: "", options: .regularExpression)
+            result = result.replacingOccurrences(of: #"  +"#, with: " ", options: .regularExpression)
+            result = result.replacingOccurrences(of: #"\n\n\n+"#, with: "\n\n", options: .regularExpression)
+            return result
+        }
+
+        private static func cleanupStrayCharacters(_ markdown: String) -> String {
+            var result = markdown
+            if let regex = try? NSRegularExpression(
+                pattern: #"^\s*">+\s*"#,
+                options: [.anchorsMatchLines]
+            ) {
+                let nsString = result as NSString
+                result = regex.stringByReplacingMatches(
+                    in: result,
+                    options: [],
+                    range: NSRange(location: 0, length: nsString.length),
+                    withTemplate: ""
+                )
+            }
+            result = result.replacingOccurrences(
+                of: #"\n\s*">+\s*\n"#,
+                with: "\n",
+                options: .regularExpression
+            )
+            return result
+        }
+
+        private static func stripHTML(_ html: String) -> String {
+            html.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+        }
+
+        private static func decodeHTMLEntities(_ text: String) -> String {
+            var result = text
+
+            // Common HTML entities
+            let entities: [String: String] = [
+                "&amp;": "&",
+                "&lt;": "<",
+                "&gt;": ">",
+                "&quot;": "\"",
+                "&apos;": "'",
+                "&nbsp;": " ",
+                "&#39;": "'",
+                "&#x27;": "'",
+            ]
+
+            for (entity, replacement) in entities {
+                result = result.replacingOccurrences(of: entity, with: replacement)
+            }
+
+            // Numeric entities (&#123;) - simple regex replacement
+            if let regex = try? NSRegularExpression(pattern: #"&#(\d+);"#, options: []) {
+                let nsString = result as NSString
+                let matches = regex.matches(in: result, range: NSRange(location: 0, length: nsString.length))
+
+                for match in matches.reversed() where match.numberOfRanges >= 2 {
+                    let numberRange = match.range(at: 1)
+                    let numberStr = nsString.substring(with: numberRange)
+
+                    if let number = Int(numberStr),
+                       let scalar = Unicode.Scalar(number) {
+                        let replacement = String(Character(scalar))
+                        result = (result as NSString).replacingCharacters(in: match.range, with: replacement)
+                    }
                 }
             }
-        }
 
-        return result
+            return result
+        }
     }
 }
+
+// closes extension Core.Parser
 
 // MARK: - String Extension for Regex Replacements
 
@@ -703,7 +707,7 @@ extension String {
 
 // MARK: - HTML to StructuredDocumentationPage Converter
 
-extension HTMLToMarkdown {
+extension Core.Parser.HTML {
     /// Convert HTML to a StructuredDocumentationPage (best-effort extraction)
     /// Note: This is less structured than JSON API output since HTML doesn't
     /// have explicit semantic structure

--- a/Packages/Sources/Core/HTMLParser/Parser.swift
+++ b/Packages/Sources/Core/HTMLParser/Parser.swift
@@ -1,0 +1,13 @@
+import CoreProtocols
+
+// MARK: - Parser Namespace
+
+extension Core {
+    /// Namespace for content parsers (HTML, XML) that convert raw documentation
+    /// payloads to Markdown for downstream indexing.
+    public enum Parser {
+        // Namespace root - parsers are defined as nested types in extensions:
+        //   Core.Parser.HTML (HTMLToMarkdown)
+        //   Core.Parser.XML  (XMLTransformer)
+    }
+}

--- a/Packages/Sources/Core/HTMLParser/XMLTransformer.swift
+++ b/Packages/Sources/Core/HTMLParser/XMLTransformer.swift
@@ -3,43 +3,47 @@ import Foundation
 
 // MARK: - XML Transformer
 
-/// Transforms XML content (like sitemaps or RSS feeds) into structured data
-/// Useful for parsing web crawled pages that return XML format
-public struct XMLTransformer: ContentTransformer, @unchecked Sendable {
-    public typealias RawContent = Data
+extension Core.Parser {
+    /// Transforms XML content (like sitemaps or RSS feeds) into structured data
+    /// Useful for parsing web crawled pages that return XML format
+    public struct XML: ContentTransformer, @unchecked Sendable {
+        public typealias RawContent = Data
 
-    public init() {}
+        public init() {}
 
-    // MARK: - ContentTransformer Protocol
+        // MARK: - ContentTransformer Protocol
 
-    /// Transform XML content to Markdown (protocol conformance)
-    public func transform(_ content: Data, url: URL) -> String? {
-        Self.convert(content, url: url)
-    }
-
-    /// Extract links from XML content (protocol conformance)
-    public func extractLinks(from content: Data) -> [URL] {
-        Self.extractLinks(from: content)
-    }
-
-    // MARK: - Static API (consistent with other transformers)
-
-    /// Convert XML data to Markdown
-    public static func convert(_ data: Data, url: URL) -> String? {
-        guard let parser = XMLToMarkdownParser(data: data, sourceURL: url) else {
-            return nil
+        /// Transform XML content to Markdown (protocol conformance)
+        public func transform(_ content: Data, url: URL) -> String? {
+            Self.convert(content, url: url)
         }
-        return parser.parse()
-    }
 
-    /// Extract links from XML content
-    public static func extractLinks(from data: Data) -> [URL] {
-        guard let parser = XMLLinkExtractor(data: data) else {
-            return []
+        /// Extract links from XML content (protocol conformance)
+        public func extractLinks(from content: Data) -> [URL] {
+            Self.extractLinks(from: content)
         }
-        return parser.extractLinks()
+
+        // MARK: - Static API (consistent with other transformers)
+
+        /// Convert XML data to Markdown
+        public static func convert(_ data: Data, url: URL) -> String? {
+            guard let parser = XMLToMarkdownParser(data: data, sourceURL: url) else {
+                return nil
+            }
+            return parser.parse()
+        }
+
+        /// Extract links from XML content
+        public static func extractLinks(from data: Data) -> [URL] {
+            guard let parser = XMLLinkExtractor(data: data) else {
+                return []
+            }
+            return parser.extractLinks()
+        }
     }
 }
+
+// closes extension Core.Parser
 
 // MARK: - XML to Markdown Parser
 

--- a/Packages/Sources/Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift
+++ b/Packages/Sources/Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift
@@ -1,16 +1,15 @@
 import Foundation
 import SharedCore
 #if canImport(WebKit)
-import WebKit
-import SharedConstants
 import CoreProtocols
-import CoreHTMLParser
+import SharedConstants
+import WebKit
 #endif
 
 // MARK: - WKWeb Crawler Engine
 
 /// Complete crawler engine using WKWebView for JavaScript-rendered pages
-/// Uses WKWebCrawler.ContentFetcher for fetching and HTMLToMarkdown for transformation
+/// Uses WKWebCrawler.ContentFetcher for fetching and Core.Parser.HTML for transformation
 extension WKWebCrawler {
     #if canImport(WebKit)
     @MainActor
@@ -33,8 +32,8 @@ extension WKWebCrawler {
             let html = result.content
             let finalURL = result.url
 
-            // Transform to markdown using HTMLToMarkdown
-            let markdown = HTMLToMarkdown.convert(html, url: finalURL)
+            // Transform to markdown using Core.Parser.HTML
+            let markdown = Core.Parser.HTML.convert(html, url: finalURL)
 
             // Extract links from HTML
             let links = extractLinks(from: html, baseURL: finalURL)

--- a/Packages/Sources/Resources/Embedded/SwiftPackagesCatalogEmbedded.swift
+++ b/Packages/Sources/Resources/Embedded/SwiftPackagesCatalogEmbedded.swift
@@ -5749,7 +5749,7 @@ public enum SwiftPackagesCatalogEmbedded {
         "https://github.com/jaywcjlove/Colorful",
         "https://github.com/jaywcjlove/FileType",
         "https://github.com/jaywcjlove/HTMLMinifier",
-        "https://github.com/jaywcjlove/HTMLToMarkdown",
+        "https://github.com/jaywcjlove/Core.Parser.HTML",
         "https://github.com/jaywcjlove/OUIData",
         "https://github.com/jaywcjlove/Prettier",
         "https://github.com/jaywcjlove/SFSymbolsPicker",

--- a/Packages/Tests/CoreTests/CupertinoCoreTests.swift
+++ b/Packages/Tests/CoreTests/CupertinoCoreTests.swift
@@ -1,20 +1,19 @@
 import AppKit
 @testable import Core
+@testable import CorePackageIndexing
+import CoreProtocols
 import Foundation
 @testable import Search
+import SharedConfiguration
+import SharedConstants
 @testable import SharedCore
+import SharedModels
 import Testing
 import TestSupport
-import SharedConstants
-import SharedConfiguration
-import SharedModels
-import CoreProtocols
-@testable import CoreHTMLParser
-@testable import CorePackageIndexing
 
 @Test func hTMLToMarkdown() throws {
     let html = "<h1>Title</h1><p>Content</p>"
-    let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+    let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
     #expect(markdown.contains("# Title"))
 }
 

--- a/Packages/Tests/CoreTests/HTMLToMarkdownErrorPageDetectionTests.swift
+++ b/Packages/Tests/CoreTests/HTMLToMarkdownErrorPageDetectionTests.swift
@@ -1,30 +1,29 @@
 @testable import Core
+import CoreProtocols
 import Foundation
 import Testing
-import CoreProtocols
-@testable import CoreHTMLParser
 
-// Coverage for the `HTMLToMarkdown.looksLikeHTTPErrorPage(...)` helper
+// Coverage for the `Core.Parser.HTML.looksLikeHTTPErrorPage(...)` helper
 // added in #284. The helper gates the crawler's WebView fallback path
 // from persisting Apple's CDN-served error templates as if they were
 // documentation pages. The shipped v1.0.2 search.db carries 68 such
 // poison rows (23 × 403 + 45 × 502) that this helper would have caught
 // at crawl time.
 
-@Suite("HTMLToMarkdown.looksLikeHTTPErrorPage (#284)")
+@Suite("Core.Parser.HTML.looksLikeHTTPErrorPage (#284)")
 struct HTMLToMarkdownErrorPageDetectionTests {
     // MARK: HTTP-status-prefix titles
 
     @Test("'403 Forbidden' title trips the gate")
     func detectsForbidden() {
         let html = "<html><head><title>403 Forbidden</title></head><body><p>Forbidden.</p></body></html>"
-        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == true)
+        #expect(Core.Parser.HTML.looksLikeHTTPErrorPage(html: html) == true)
     }
 
     @Test("'502 Bad Gateway' title trips the gate")
     func detectsBadGateway() {
         let html = "<html><head><title>502 Bad Gateway</title></head><body><p>Server error.</p></body></html>"
-        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == true)
+        #expect(Core.Parser.HTML.looksLikeHTTPErrorPage(html: html) == true)
     }
 
     @Test(
@@ -41,7 +40,7 @@ struct HTMLToMarkdownErrorPageDetectionTests {
     )
     func detectsAllStatusPrefixes(title: String) {
         let html = "<html><head><title>\(title)</title></head><body><p>err</p></body></html>"
-        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == true)
+        #expect(Core.Parser.HTML.looksLikeHTTPErrorPage(html: html) == true)
     }
 
     // MARK: Real Apple titles that LOOK error-adjacent must NOT trip
@@ -63,7 +62,7 @@ struct HTMLToMarkdownErrorPageDetectionTests {
         wants to communicate that constraint visually.</p>
         </body></html>
         """
-        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == false)
+        #expect(Core.Parser.HTML.looksLikeHTTPErrorPage(html: html) == false)
     }
 
     @Test("Real Apple symbol page named 'Routing404Type' is not flagged")
@@ -75,7 +74,7 @@ struct HTMLToMarkdownErrorPageDetectionTests {
         observed in the request. Used by the routing layer to differentiate
         legitimate not-found cases from misconfigured routes.</p></body></html>
         """
-        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == false)
+        #expect(Core.Parser.HTML.looksLikeHTTPErrorPage(html: html) == false)
     }
 
     // MARK: word-count defense-in-depth
@@ -83,7 +82,7 @@ struct HTMLToMarkdownErrorPageDetectionTests {
     @Test("Short body + 'Service Unavailable' phrase trips the defense-in-depth gate")
     func shortBodyServiceUnavailableTrips() {
         let html = "<html><head><title>Service Unavailable</title></head><body><p>Try again later.</p></body></html>"
-        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == true)
+        #expect(Core.Parser.HTML.looksLikeHTTPErrorPage(html: html) == true)
     }
 
     @Test("Long body containing 'Bad Gateway' phrase in title is NOT flagged once it has real content")
@@ -93,7 +92,7 @@ struct HTMLToMarkdownErrorPageDetectionTests {
         // incorrectly skipping it.
         let body = String(repeating: "word ", count: 50) // 50 whitespace-separated tokens
         let html = "<html><head><title>Handling Bad Gateway Responses</title></head><body><p>\(body)</p></body></html>"
-        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == false)
+        #expect(Core.Parser.HTML.looksLikeHTTPErrorPage(html: html) == false)
     }
 
     // MARK: degenerate inputs
@@ -101,11 +100,11 @@ struct HTMLToMarkdownErrorPageDetectionTests {
     @Test("Title-less HTML returns false (the existing nil-title gate handles it)")
     func noTitleReturnsFalse() {
         let html = "<html><body><p>Just a body, no head, no title.</p></body></html>"
-        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) == false)
+        #expect(Core.Parser.HTML.looksLikeHTTPErrorPage(html: html) == false)
     }
 
     @Test("Empty HTML returns false")
     func emptyHTMLReturnsFalse() {
-        #expect(HTMLToMarkdown.looksLikeHTTPErrorPage(html: "") == false)
+        #expect(Core.Parser.HTML.looksLikeHTTPErrorPage(html: "") == false)
     }
 }

--- a/Packages/Tests/CoreTests/HTMLToMarkdownTests.swift
+++ b/Packages/Tests/CoreTests/HTMLToMarkdownTests.swift
@@ -1,13 +1,12 @@
 // swiftlint:disable type_body_length
 @testable import Core
+import CoreProtocols
 import Foundation
 import Testing
-import CoreProtocols
-@testable import CoreHTMLParser
 
 // MARK: - HTML to Markdown Converter Tests
 
-// Comprehensive tests for HTMLToMarkdown conversion
+// Comprehensive tests for Core.Parser.HTML conversion
 // Tests code blocks, tables, links, formatting, and edge cases
 
 @Suite("HTML to Markdown Converter")
@@ -17,7 +16,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts simple HTML to Markdown")
     func convertsSimpleHTML() throws {
         let html = "<h1>Title</h1><p>Content</p>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("# Title"))
         #expect(markdown.contains("Content"))
@@ -27,7 +26,7 @@ struct HTMLToMarkdownTests {
     func addsFrontMatter() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/swift/array"))
         let html = "<h1>Array</h1>"
-        let markdown = HTMLToMarkdown.convert(html, url: url)
+        let markdown = Core.Parser.HTML.convert(html, url: url)
 
         #expect(markdown.contains("---"))
         #expect(markdown.contains("source: \(url.absoluteString)"))
@@ -39,7 +38,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts H1 headers")
     func convertsH1Headers() throws {
         let html = "<h1>Main Title</h1>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("# Main Title"))
     }
@@ -47,7 +46,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts H2 headers")
     func convertsH2Headers() throws {
         let html = "<h2>Subtitle</h2>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("## Subtitle"))
     }
@@ -55,7 +54,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts H3 headers")
     func convertsH3Headers() throws {
         let html = "<h3>Section</h3>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("### Section"))
     }
@@ -67,7 +66,7 @@ struct HTMLToMarkdownTests {
         <h2>Subtitle</h2>
         <h3>Section</h3>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("# Title"))
         #expect(markdown.contains("## Subtitle"))
@@ -77,7 +76,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts H4 headers")
     func convertsH4Headers() throws {
         let html = "<h4>Subsection</h4>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("#### Subsection"))
     }
@@ -85,7 +84,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts H5 headers")
     func convertsH5Headers() throws {
         let html = "<h5>Minor Section</h5>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("##### Minor Section"))
     }
@@ -93,7 +92,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts H6 headers")
     func convertsH6Headers() throws {
         let html = "<h6>Smallest Header</h6>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("###### Smallest Header"))
     }
@@ -108,7 +107,7 @@ struct HTMLToMarkdownTests {
         <h5>H5</h5>
         <h6>H6</h6>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("# H1"))
         #expect(markdown.contains("## H2"))
@@ -129,7 +128,7 @@ struct HTMLToMarkdownTests {
         }
         </code></pre>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("```swift"))
         #expect(markdown.contains("func hello()"))
@@ -143,7 +142,7 @@ struct HTMLToMarkdownTests {
         let x = 42
         </code></pre>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("```"))
         #expect(markdown.contains("let x = 42"))
@@ -156,7 +155,7 @@ struct HTMLToMarkdownTests {
         <p>Text between</p>
         <pre><code class="language-swift">let b = 2</code></pre>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("let a = 1"))
         #expect(markdown.contains("let b = 2"))
@@ -174,7 +173,7 @@ struct HTMLToMarkdownTests {
         }
         </code></pre>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("func nested()"))
         #expect(markdown.contains("print(\"indented\")"))
@@ -185,7 +184,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts simple links")
     func convertsSimpleLinks() throws {
         let html = "<a href='https://example.com'>Link Text</a>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("[Link Text]"))
         #expect(markdown.contains("(https://example.com)"))
@@ -194,7 +193,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts relative links")
     func convertsRelativeLinks() throws {
         let html = "<a href='/documentation/swift'>Swift</a>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("[Swift]"))
         #expect(markdown.contains("/documentation/swift"))
@@ -203,7 +202,7 @@ struct HTMLToMarkdownTests {
     @Test("Handles links with nested formatting")
     func handlesLinksWithFormatting() throws {
         let html = "<a href='https://example.com'><strong>Bold Link</strong></a>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("["))
         #expect(markdown.contains("Bold Link"))
@@ -215,7 +214,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts bold text")
     func convertsBoldText() throws {
         let html = "<strong>Bold Text</strong>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("**Bold Text**") || markdown.contains("Bold Text"))
     }
@@ -223,7 +222,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts italic text")
     func convertsItalicText() throws {
         let html = "<em>Italic Text</em>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("*Italic Text*") || markdown.contains("Italic Text"))
     }
@@ -231,7 +230,7 @@ struct HTMLToMarkdownTests {
     @Test("Converts inline code")
     func convertsInlineCode() throws {
         let html = "<code>inline code</code>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("`inline code`") || markdown.contains("inline code"))
     }
@@ -252,7 +251,7 @@ struct HTMLToMarkdownTests {
             </tr>
         </table>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Header 1"))
         #expect(markdown.contains("Header 2"))
@@ -278,7 +277,7 @@ struct HTMLToMarkdownTests {
             </tbody>
         </table>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Name"))
         #expect(markdown.contains("Description"))
@@ -291,7 +290,7 @@ struct HTMLToMarkdownTests {
     @Test("Handles blockquotes")
     func handlesBlockquotes() throws {
         let html = "<blockquote>This is a quote</blockquote>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("This is a quote"))
     }
@@ -306,7 +305,7 @@ struct HTMLToMarkdownTests {
             </blockquote>
         </blockquote>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("First level quote"))
         #expect(markdown.contains("Nested quote"))
@@ -323,7 +322,7 @@ struct HTMLToMarkdownTests {
             <li>Item 3</li>
         </ul>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Item 1"))
         #expect(markdown.contains("Item 2"))
@@ -339,7 +338,7 @@ struct HTMLToMarkdownTests {
             <li>Third</li>
         </ol>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("First"))
         #expect(markdown.contains("Second"))
@@ -354,7 +353,7 @@ struct HTMLToMarkdownTests {
         <p>First paragraph.</p>
         <p>Second paragraph.</p>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("First paragraph"))
         #expect(markdown.contains("Second paragraph"))
@@ -365,7 +364,7 @@ struct HTMLToMarkdownTests {
     @Test("Decodes HTML entities")
     func decodesHTMLEntities() throws {
         let html = "<p>&lt;html&gt; &amp; &quot;quotes&quot;</p>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("<html>") || markdown.contains("&lt;"))
         #expect(markdown.contains("&") || markdown.contains("&amp;"))
@@ -374,7 +373,7 @@ struct HTMLToMarkdownTests {
     @Test("Decodes numeric entities")
     func decodesNumericEntities() throws {
         let html = "<p>&#60;tag&#62;</p>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("tag"))
     }
@@ -382,7 +381,7 @@ struct HTMLToMarkdownTests {
     @Test("Decodes apostrophe entities")
     func decodesApostropheEntities() throws {
         let html = "<p>It&#39;s working &apos; also &#x27; works</p>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("It's working"))
         #expect(markdown.contains("'"))
@@ -391,7 +390,7 @@ struct HTMLToMarkdownTests {
     @Test("Decodes nbsp entities")
     func decodesNbspEntities() throws {
         let html = "<p>Word&nbsp;break&nbsp;here</p>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Word"))
         #expect(markdown.contains("break"))
@@ -401,7 +400,7 @@ struct HTMLToMarkdownTests {
     @Test("Decodes mixed entity types")
     func decodesMixedEntityTypes() throws {
         let html = "<p>&lt;tag&gt; &#60;numeric&#62; &amp; &quot;quotes&quot; &#39;apostrophe&#39;</p>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("<") || markdown.contains("&lt;"))
         #expect(markdown.contains(">") || markdown.contains("&gt;"))
@@ -418,7 +417,7 @@ struct HTMLToMarkdownTests {
         let y = &#60;Type&#62;()
         </code></pre>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("```swift"))
         #expect(markdown.contains("let x"))
@@ -428,7 +427,7 @@ struct HTMLToMarkdownTests {
     @Test("Handles multiple consecutive entities")
     func handlesMultipleConsecutiveEntities() throws {
         let html = "<p>&lt;&lt;&lt;test&gt;&gt;&gt;</p>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("test"))
     }
@@ -444,7 +443,7 @@ struct HTMLToMarkdownTests {
             </ul>
         </div>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Text with"))
         #expect(markdown.contains("item"))
@@ -469,7 +468,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(!markdown.contains("Home"))
         #expect(!markdown.contains("About"))
@@ -492,7 +491,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(!markdown.contains("Site Logo"))
         #expect(!markdown.contains("Navigation"))
@@ -514,7 +513,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Main content"))
         #expect(!markdown.contains("Copyright"))
@@ -534,7 +533,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Title"))
         #expect(markdown.contains("Text content"))
@@ -557,7 +556,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Before SVG"))
         #expect(markdown.contains("After SVG"))
@@ -580,7 +579,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Content"))
         #expect(!markdown.contains("console.log"))
@@ -602,7 +601,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Text"))
         #expect(!markdown.contains("color: red"))
@@ -623,7 +622,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Real content"))
         #expect(!markdown.contains("Please enable JavaScript"))
@@ -644,7 +643,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Documentation"))
         #expect(markdown.contains("Content here"))
@@ -666,7 +665,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("MyClass"))
         #expect(markdown.contains("Documentation"))
@@ -686,7 +685,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Content"))
         #expect(!markdown.contains("Skip Navigation"))
@@ -701,7 +700,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Text before"))
         #expect(markdown.contains("text after"))
@@ -717,7 +716,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Content"))
         #expect(!markdown.contains("data-v-"))
@@ -734,7 +733,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Normal text"))
         #expect(markdown.contains("More text"))
@@ -753,7 +752,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Documentation"))
         #expect(!markdown.contains("Navigator is ready"))
@@ -771,7 +770,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Search Results"))
         #expect(!markdown.contains("items were found"))
@@ -783,7 +782,7 @@ struct HTMLToMarkdownTests {
     @Test("Handles empty HTML")
     func handlesEmptyHTML() throws {
         let html = ""
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("---")) // At least has front matter
     }
@@ -791,7 +790,7 @@ struct HTMLToMarkdownTests {
     @Test("Handles HTML with only whitespace")
     func handlesWhitespaceHTML() throws {
         let html = "   \n\n   "
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("---"))
     }
@@ -802,7 +801,7 @@ struct HTMLToMarkdownTests {
         <h1>This page requires JavaScript</h1>
         <p>Real content</p>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Real content"))
         // JavaScript warning should be filtered out as title
@@ -811,7 +810,7 @@ struct HTMLToMarkdownTests {
     @Test("Extracts title from h1")
     func extractsTitleFromH1() throws {
         let html = "<h1>Page Title</h1><p>Content</p>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("# Page Title"))
     }
@@ -819,7 +818,7 @@ struct HTMLToMarkdownTests {
     @Test("Extracts title from title tag")
     func extractsTitleFromTitleTag() throws {
         let html = "<title>Page Title</title><body><p>Content</p></body>"
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Page Title"))
     }
@@ -837,7 +836,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Main Content"))
     }
@@ -854,7 +853,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("Article Content"))
     }
@@ -880,7 +879,7 @@ struct HTMLToMarkdownTests {
         </body>
         </html>
         """
-        let markdown = try HTMLToMarkdown.convert(html, url: #require(URL(string: "https://example.com")))
+        let markdown = try Core.Parser.HTML.convert(html, url: #require(URL(string: "https://example.com")))
 
         #expect(markdown.contains("# Title"))
         #expect(markdown.contains("## Code Example"))


### PR DESCRIPTION
Folds the CoreHTMLParser target back into Core so the parser types can sit under the Core namespace and read as `Core.Parser.HTML` / `Core.Parser.XML` instead of two free-standing types in a sibling module. The `Sources/Core/HTMLParser/` folder stays in place; Core just picks those sources up directly now that the exclude is gone.

## Renames

- `HTMLToMarkdown` -> `Core.Parser.HTML`
- `XMLTransformer` -> `Core.Parser.XML`

## Package.swift

- Core target: drop `CoreHTMLParser` dependency + the `HTMLParser` exclude.
- Products list: remove `singleTargetLibrary(\"CoreHTMLParser\")`.
- `cupertinoTargets`: drop the `coreHTMLParserTarget` entry and the standalone target definition.
- CoreTests target: drop `CoreHTMLParser` dependency.

## Source changes

- New `Sources/Core/HTMLParser/Parser.swift` declares `extension Core { public enum Parser {} }`.
- `HTMLToMarkdown.swift` wraps the public struct in `extension Core.Parser { ... }` and renames the type to `HTML`. The downstream `extension HTMLToMarkdown` block is rewritten as `extension Core.Parser.HTML`. The file-scope `extension String` helper stays at file scope.
- `XMLTransformer.swift` wraps `XMLTransformer` as `extension Core.Parser { public struct XML ... }`. The file-private `XMLToMarkdownParser` / `XMLLinkExtractor` helper classes stay at file scope.
- All `import CoreHTMLParser` lines removed (production + tests).
- All call sites swapped to `Core.Parser.HTML` / `Core.Parser.XML`.

## Verification

- \`xcrun swift build\` clean.
- \`xcrun swift test\` 1300/1300 passing.

Part of #183 namespace pass; closes the open question from the last AskUserQuestion answer (\"Merge CoreHTMLParser back into Core so Core.Parser.HTML works\").