### PR TITLE
fix(tests): rewrite ResolverPipelineTests' 'try try #require' so Xcode 26 toolchain compiles it

### DIFF
--- a/Packages/Tests/CoreTests/ResolverPipelineTests.swift
+++ b/Packages/Tests/CoreTests/ResolverPipelineTests.swift
@@ -159,7 +159,8 @@ func exclusionListMalformed() throws {
     try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: tempDir) }
     let fileURL = tempDir.appendingPathComponent(Shared.Constants.FileName.excludedPackages)
-    try try #require("not a json array".data(using: .utf8)?.write(to: fileURL))
+    let badPayload = try #require("not a json array".data(using: .utf8))
+    try badPayload.write(to: fileURL)
     #expect(Core.ExclusionList.load(from: tempDir).isEmpty)
 }
 


### PR DESCRIPTION
The line

    try try #require(\"not a json array\".data(using: .utf8)?.write(to: fileURL))

rolled both the throwing \`write(to:)\` and the Optional-unwrapping into one \`try try\` chain. The Xcode 26 Swift Testing macro expansion (\`Testing.__checkFunctionCall(...)\`) emits a closure body that calls the unwrapped expression itself, which means the throw needs to be marked **inside** the closure body, not at the outer expression position. The current macro flags this as:

    macro expansion #require:2:3: error: call can throw, but it is not marked with 'try' and the error is not handled

and the whole CoreTests target fails to compile, taking down every test in CoreTests with it (\"fatalError\" link step).

Fix: split the unwrap from the write.

    let badPayload = try #require(\"not a json array\".data(using: .utf8))
    try badPayload.write(to: fileURL)

Behaviour is identical: unwrap the optional from \`.data(using:)\`, then perform the throwing \`write(to:)\`. The test continues to exercise \`Core.ExclusionList.load(from:)\` against a non-JSON-array payload.

## Verification

\`xcrun swift test\` — 1300/1300 passing.