### PR TITLE
refactor(Shared): nest Constants / Utils / Models types under hierarchical sub-namespaces; rewrite callers

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -108,7 +108,7 @@ let targets: [Target] = {
         path: "Sources/Shared/Constants"
     )
 
-    // ---------- SharedUtils (v1.1 refactor 1.4: extracts JSONCoding, PathResolver, Formatting, FTSQuery, SchemaVersion) ----------
+    // ---------- SharedUtils (v1.1 refactor 1.4: extracts Shared.Utils.JSONCoding, Shared.Utils.PathResolver, Formatting, FTSQuery, SchemaVersion) ----------
     let sharedUtilsTarget = Target.target(
         name: "SharedUtils",
         dependencies: ["SharedConstants"],

--- a/Packages/Sources/Availability/AvailabilityFetcher.swift
+++ b/Packages/Sources/Availability/AvailabilityFetcher.swift
@@ -14,608 +14,608 @@ import FoundationNetworking
 /// Fetches platform availability data from Apple's API and updates existing documentation JSONs
 extension Availability {
     public actor Fetcher {
-    // MARK: - Configuration
+        // MARK: - Configuration
 
-    /// Configuration for the availability fetcher
-    public struct Configuration: Sendable {
-        /// Maximum concurrent requests
-        public let concurrency: Int
+        /// Configuration for the availability fetcher
+        public struct Configuration: Sendable {
+            /// Maximum concurrent requests
+            public let concurrency: Int
 
-        /// Request timeout in seconds
-        public let timeout: TimeInterval
+            /// Request timeout in seconds
+            public let timeout: TimeInterval
 
-        /// Whether to skip documents that already have availability
-        public let skipExisting: Bool
+            /// Whether to skip documents that already have availability
+            public let skipExisting: Bool
 
-        /// Base URL for Apple's tutorials/data API
-        public let apiBaseURL: String
+            /// Base URL for Apple's tutorials/data API
+            public let apiBaseURL: String
+
+            public init(
+                concurrency: Int = 50,
+                timeout: TimeInterval = 1.0,
+                skipExisting: Bool = false,
+                apiBaseURL: String = "https://developer.apple.com/tutorials/data/documentation"
+            ) {
+                self.concurrency = concurrency
+                self.timeout = timeout
+                self.skipExisting = skipExisting
+                self.apiBaseURL = apiBaseURL
+            }
+
+            /// Default configuration
+            public static let `default` = Configuration()
+
+            /// Fast configuration for quick updates
+            public static let fast = Configuration(
+                concurrency: 100,
+                timeout: 0.5,
+                skipExisting: true
+            )
+        }
+
+        // MARK: - Properties
+
+        private let docsDirectory: URL
+        private let configuration: Configuration
+        private let urlSession: URLSession
+
+        /// Cache of framework-level availability for inheritance
+        private var frameworkAvailabilityCache: [String: [Availability.Platform]] = [:]
+
+        /// Cache of all document availability (populated in pass 1, used in pass 2 for articles)
+        private var documentAvailabilityCache: [String: [Availability.Platform]] = [:]
+
+        // MARK: - Initialization
 
         public init(
-            concurrency: Int = 50,
-            timeout: TimeInterval = 1.0,
-            skipExisting: Bool = false,
-            apiBaseURL: String = "https://developer.apple.com/tutorials/data/documentation"
+            docsDirectory: URL,
+            configuration: Configuration = .default
         ) {
-            self.concurrency = concurrency
-            self.timeout = timeout
-            self.skipExisting = skipExisting
-            self.apiBaseURL = apiBaseURL
+            self.docsDirectory = docsDirectory
+            self.configuration = configuration
+
+            // Configure URLSession with timeout
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = configuration.timeout
+            config.timeoutIntervalForResource = configuration.timeout * 2
+            config.httpMaximumConnectionsPerHost = configuration.concurrency
+            urlSession = URLSession(configuration: config)
         }
 
-        /// Default configuration
-        public static let `default` = Configuration()
+        // MARK: - Public API
 
-        /// Fast configuration for quick updates
-        public static let fast = Configuration(
-            concurrency: 100,
-            timeout: 0.5,
-            skipExisting: true
-        )
-    }
+        /// Fetch availability data and update all documentation JSONs
+        public func fetch(
+            onProgress: (@Sendable (Availability.Progress) -> Void)? = nil
+        ) async throws -> Availability.Statistics {
+            var stats = Availability.Statistics(startTime: Date())
 
-    // MARK: - Properties
+            // Discover all frameworks
+            let frameworks = try discoverFrameworks()
+            guard !frameworks.isEmpty else {
+                throw Availability.Error.noDocumentationFound
+            }
 
-    private let docsDirectory: URL
-    private let configuration: Configuration
-    private let urlSession: URLSession
+            // Collect all JSON files
+            let allFiles = try collectJSONFiles(from: frameworks)
+            stats.totalDocuments = allFiles.count
+            stats.frameworksProcessed = frameworks.count
 
-    /// Cache of framework-level availability for inheritance
-    private var frameworkAvailabilityCache: [String: [Availability.Platform]] = [:]
+            // Process files with concurrency
+            try await processFiles(
+                allFiles,
+                stats: &stats,
+                onProgress: onProgress
+            )
 
-    /// Cache of all document availability (populated in pass 1, used in pass 2 for articles)
-    private var documentAvailabilityCache: [String: [Availability.Platform]] = [:]
-
-    // MARK: - Initialization
-
-    public init(
-        docsDirectory: URL,
-        configuration: Configuration = .default
-    ) {
-        self.docsDirectory = docsDirectory
-        self.configuration = configuration
-
-        // Configure URLSession with timeout
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = configuration.timeout
-        config.timeoutIntervalForResource = configuration.timeout * 2
-        config.httpMaximumConnectionsPerHost = configuration.concurrency
-        urlSession = URLSession(configuration: config)
-    }
-
-    // MARK: - Public API
-
-    /// Fetch availability data and update all documentation JSONs
-    public func fetch(
-        onProgress: (@Sendable (Availability.Progress) -> Void)? = nil
-    ) async throws -> Availability.Statistics {
-        var stats = Availability.Statistics(startTime: Date())
-
-        // Discover all frameworks
-        let frameworks = try discoverFrameworks()
-        guard !frameworks.isEmpty else {
-            throw Availability.Error.noDocumentationFound
+            stats.endTime = Date()
+            return stats
         }
 
-        // Collect all JSON files
-        let allFiles = try collectJSONFiles(from: frameworks)
-        stats.totalDocuments = allFiles.count
-        stats.frameworksProcessed = frameworks.count
+        // MARK: - Private Methods - Discovery
 
-        // Process files with concurrency
-        try await processFiles(
-            allFiles,
-            stats: &stats,
-            onProgress: onProgress
-        )
-
-        stats.endTime = Date()
-        return stats
-    }
-
-    // MARK: - Private Methods - Discovery
-
-    private func discoverFrameworks() throws -> [String] {
-        let contents = try FileManager.default.contentsOfDirectory(
-            at: docsDirectory,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        )
-
-        return contents.compactMap { url -> String? in
-            let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory
-            return isDirectory == true ? url.lastPathComponent : nil
-        }.sorted()
-    }
-
-    private func collectJSONFiles(from frameworks: [String]) throws -> [(framework: String, file: URL)] {
-        var files: [(String, URL)] = []
-
-        for framework in frameworks {
-            let frameworkDir = docsDirectory.appendingPathComponent(framework)
+        private func discoverFrameworks() throws -> [String] {
             let contents = try FileManager.default.contentsOfDirectory(
-                at: frameworkDir,
-                includingPropertiesForKeys: nil,
+                at: docsDirectory,
+                includingPropertiesForKeys: [.isDirectoryKey],
                 options: [.skipsHiddenFiles]
             )
 
-            for file in contents where file.pathExtension == "json" {
-                files.append((framework, file))
-            }
+            return contents.compactMap { url -> String? in
+                let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory
+                return isDirectory == true ? url.lastPathComponent : nil
+            }.sorted()
         }
 
-        return files
-    }
+        private func collectJSONFiles(from frameworks: [String]) throws -> [(framework: String, file: URL)] {
+            var files: [(String, URL)] = []
 
-    // MARK: - Private Methods - Processing
+            for framework in frameworks {
+                let frameworkDir = docsDirectory.appendingPathComponent(framework)
+                let contents = try FileManager.default.contentsOfDirectory(
+                    at: frameworkDir,
+                    includingPropertiesForKeys: nil,
+                    options: [.skipsHiddenFiles]
+                )
 
-    private func processFiles(
-        _ files: [(framework: String, file: URL)],
-        stats: inout Availability.Statistics,
-        onProgress: (@Sendable (Availability.Progress) -> Void)?
-    ) async throws {
-        // Phase 1: Cache framework root availability
-        await cacheFrameworkAvailability(from: files)
+                for file in contents where file.pathExtension == "json" {
+                    files.append((framework, file))
+                }
+            }
 
-        // Phase 2: First pass - process API docs (non-articles) and cache their availability
-        // This populates documentAvailabilityCache for article reference lookups
-        let (apiDocs, articles) = separateAPIDocsAndArticles(files)
+            return files
+        }
 
-        let batchSize = configuration.concurrency
-        var completed = 0
-        var successful = 0
-        var failed = 0
-        var filesWithNoAvailability: [String] = []
+        // MARK: - Private Methods - Processing
 
-        // Process API docs first
-        for batch in stride(from: 0, to: apiDocs.count, by: batchSize) {
-            let endIndex = min(batch + batchSize, apiDocs.count)
-            let batchFiles = Array(apiDocs[batch..<endIndex])
+        private func processFiles(
+            _ files: [(framework: String, file: URL)],
+            stats: inout Availability.Statistics,
+            onProgress: (@Sendable (Availability.Progress) -> Void)?
+        ) async throws {
+            // Phase 1: Cache framework root availability
+            await cacheFrameworkAvailability(from: files)
 
-            await withTaskGroup(of: ProcessResult.self) { group in
-                for (framework, file) in batchFiles {
-                    group.addTask {
-                        await self.processFile(file, framework: framework, isArticle: false)
+            // Phase 2: First pass - process API docs (non-articles) and cache their availability
+            // This populates documentAvailabilityCache for article reference lookups
+            let (apiDocs, articles) = separateAPIDocsAndArticles(files)
+
+            let batchSize = configuration.concurrency
+            var completed = 0
+            var successful = 0
+            var failed = 0
+            var filesWithNoAvailability: [String] = []
+
+            // Process API docs first
+            for batch in stride(from: 0, to: apiDocs.count, by: batchSize) {
+                let endIndex = min(batch + batchSize, apiDocs.count)
+                let batchFiles = Array(apiDocs[batch..<endIndex])
+
+                await withTaskGroup(of: ProcessResult.self) { group in
+                    for (framework, file) in batchFiles {
+                        group.addTask {
+                            await self.processFile(file, framework: framework, isArticle: false)
+                        }
                     }
-                }
 
-                for await result in group {
-                    completed += 1
-                    updateStats(
-                        result: result,
-                        stats: &stats,
-                        successful: &successful,
-                        failed: &failed,
-                        filesWithNoAvailability: &filesWithNoAvailability
-                    )
+                    for await result in group {
+                        completed += 1
+                        updateStats(
+                            result: result,
+                            stats: &stats,
+                            successful: &successful,
+                            failed: &failed,
+                            filesWithNoAvailability: &filesWithNoAvailability
+                        )
 
-                    reportProgress(
-                        result: result,
-                        completed: completed,
-                        total: files.count,
-                        successful: successful,
-                        failed: failed,
-                        onProgress: onProgress
-                    )
-                }
-            }
-        }
-
-        // Phase 3: Second pass - process articles with reference lookup
-        for batch in stride(from: 0, to: articles.count, by: batchSize) {
-            let endIndex = min(batch + batchSize, articles.count)
-            let batchFiles = Array(articles[batch..<endIndex])
-
-            await withTaskGroup(of: ProcessResult.self) { group in
-                for (framework, file) in batchFiles {
-                    group.addTask {
-                        await self.processFile(file, framework: framework, isArticle: true)
-                    }
-                }
-
-                for await result in group {
-                    completed += 1
-                    updateStats(
-                        result: result,
-                        stats: &stats,
-                        successful: &successful,
-                        failed: &failed,
-                        filesWithNoAvailability: &filesWithNoAvailability
-                    )
-
-                    reportProgress(
-                        result: result,
-                        completed: completed,
-                        total: files.count,
-                        successful: successful,
-                        failed: failed,
-                        onProgress: onProgress
-                    )
-                }
-            }
-        }
-
-        // Store files with no availability for logging (limit to first 100)
-        stats.filesWithNoAvailability = Array(filesWithNoAvailability.prefix(100))
-    }
-
-    /// Separate files into API docs and articles based on document kind
-    private func separateAPIDocsAndArticles(
-        _ files: [(framework: String, file: URL)]
-    ) -> (apiDocs: [(framework: String, file: URL)], articles: [(framework: String, file: URL)]) {
-        var apiDocs: [(String, URL)] = []
-        var articles: [(String, URL)] = []
-
-        for (framework, file) in files {
-            if let data = try? Data(contentsOf: file),
-               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let kind = json["kind"] as? String,
-               kind == "article" {
-                articles.append((framework, file))
-            } else {
-                apiDocs.append((framework, file))
-            }
-        }
-
-        return (apiDocs, articles)
-    }
-
-    private func updateStats(
-        result: ProcessResult,
-        stats: inout Availability.Statistics,
-        successful: inout Int,
-        failed: inout Int,
-        filesWithNoAvailability: inout [String]
-    ) {
-        switch result.status {
-        case .updated:
-            stats.updatedDocuments += 1
-            stats.successfulFetches += 1
-            successful += 1
-        case .inherited:
-            stats.inheritedFromParent += 1
-            stats.updatedDocuments += 1
-            successful += 1
-        case .derivedFromReferences:
-            stats.derivedFromReferences += 1
-            stats.updatedDocuments += 1
-            successful += 1
-        case .markedEmpty:
-            stats.markedEmpty += 1
-            filesWithNoAvailability.append("\(result.framework)/\(result.filename)")
-        case .skipped:
-            stats.skippedDocuments += 1
-        case .failed:
-            stats.failedFetches += 1
-            failed += 1
-        case .notApplicable:
-            stats.skippedDocuments += 1
-        }
-    }
-
-    private func reportProgress(
-        result: ProcessResult,
-        completed: Int,
-        total: Int,
-        successful: Int,
-        failed: Int,
-        onProgress: (@Sendable (Availability.Progress) -> Void)?
-    ) {
-        if let onProgress {
-            let progress = Availability.Progress(
-                currentDocument: result.filename,
-                completed: completed,
-                total: total,
-                successful: successful,
-                failed: failed,
-                currentFramework: result.framework
-            )
-            onProgress(progress)
-        }
-    }
-
-    /// Cache framework-level availability by processing root documentation files
-    private func cacheFrameworkAvailability(from files: [(framework: String, file: URL)]) async {
-        // Find framework root files (e.g., documentation_swiftui.json)
-        let frameworkRoots = files.filter { framework, file in
-            let filename = file.deletingPathExtension().lastPathComponent
-            return filename == "documentation_\(framework)"
-        }
-
-        // Process framework roots to cache their availability
-        for (framework, file) in frameworkRoots {
-            if let data = try? Data(contentsOf: file),
-               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let availabilityArray = json["availability"] as? [[String: Any]] {
-                let platforms = availabilityArray.compactMap { dict -> Availability.Platform? in
-                    guard let name = dict["name"] as? String else { return nil }
-                    return Availability.Platform(
-                        name: name,
-                        introducedAt: dict["introducedAt"] as? String,
-                        deprecated: dict["deprecated"] as? Bool ?? false,
-                        deprecatedAt: dict["deprecatedAt"] as? String,
-                        unavailable: dict["unavailable"] as? Bool ?? false,
-                        beta: dict["beta"] as? Bool ?? false
-                    )
-                }
-                if !platforms.isEmpty {
-                    frameworkAvailabilityCache[framework] = platforms
-                }
-            }
-        }
-    }
-
-    private func processFile(
-        _ fileURL: URL,
-        framework: String,
-        isArticle: Bool
-    ) async -> ProcessResult {
-        let filename = fileURL.lastPathComponent
-
-        // Load existing JSON
-        guard let data = try? Data(contentsOf: fileURL),
-              var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            return ProcessResult(status: .failed, filename: filename, framework: framework)
-        }
-
-        // Check if already has availability (if skipExisting is enabled)
-        if configuration.skipExisting,
-           let existingAvailability = json["availability"] as? [[String: Any]],
-           !existingAvailability.isEmpty {
-            return ProcessResult(status: .skipped, filename: filename, framework: framework)
-        }
-
-        // Extract URL to build API path
-        guard let urlString = json["url"] as? String,
-              let docURL = URL(string: urlString)
-        else {
-            return ProcessResult(status: .notApplicable, filename: filename, framework: framework)
-        }
-
-        // Build API URL from doc URL
-        // https://developer.apple.com/documentation/SwiftUI/View
-        // -> https://developer.apple.com/tutorials/data/documentation/swiftui/view.json
-        let apiURL = buildAPIURL(from: docURL)
-
-        // Fetch availability from API
-        var availability = await fetchAvailability(from: apiURL)
-        var inherited = false
-        var derivedFromRefs = false
-
-        // Fallback 1: If API failed or returned empty, try parsing @available from local content
-        if availability?.isEmpty ?? true {
-            availability = Availability.Info.extractFromJSONContent(data)
-        }
-
-        // Fallback 2: For articles, derive from referenced APIs
-        if isArticle, availability?.isEmpty ?? true {
-            if let derived = deriveAvailabilityFromReferences(json: json) {
-                availability = derived
-                derivedFromRefs = true
-            }
-        }
-
-        // Fallback 3: If still no availability, try inheriting from framework
-        if availability?.isEmpty ?? true,
-           let frameworkPlatforms = frameworkAvailabilityCache[framework] {
-            availability = Availability.Info(platforms: frameworkPlatforms)
-            inherited = true
-        }
-
-        // Determine the final status and what to write
-        let finalStatus: ProcessResult.Status
-        let platformsToWrite: [[String: Any]]
-
-        if let availability, !availability.isEmpty {
-            // We have availability data
-            platformsToWrite = availability.platforms.map { platform in
-                var dict: [String: Any] = [
-                    "name": platform.name,
-                    "deprecated": platform.deprecated,
-                    "unavailable": platform.unavailable,
-                    "beta": platform.beta,
-                ]
-                if let introduced = platform.introducedAt {
-                    dict["introducedAt"] = introduced
-                }
-                if let deprecatedAt = platform.deprecatedAt {
-                    dict["deprecatedAt"] = deprecatedAt
-                }
-                return dict
-            }
-            if derivedFromRefs {
-                finalStatus = .derivedFromReferences
-            } else if inherited {
-                finalStatus = .inherited
-            } else {
-                finalStatus = .updated
-            }
-
-            // Cache availability for this document (for article reference lookups)
-            let cacheKey = docURL.path.lowercased()
-            cacheDocumentAvailability(key: cacheKey, platforms: availability.platforms)
-        } else {
-            // Fallback 4: Mark with empty availability to indicate we checked
-            platformsToWrite = []
-            finalStatus = .markedEmpty
-        }
-
-        // Update JSON with availability (even if empty)
-        json["availability"] = platformsToWrite
-
-        // Write updated JSON
-        do {
-            let updatedData = try JSONSerialization.data(
-                withJSONObject: json,
-                options: [.prettyPrinted, .sortedKeys]
-            )
-            try updatedData.write(to: fileURL)
-            return ProcessResult(status: finalStatus, filename: filename, framework: framework)
-        } catch {
-            return ProcessResult(status: .failed, filename: filename, framework: framework)
-        }
-    }
-
-    /// Cache document availability for reference lookups
-    private func cacheDocumentAvailability(key: String, platforms: [Availability.Platform]) {
-        documentAvailabilityCache[key] = platforms
-    }
-
-    /// Derive availability from doc:// references in article content
-    private func deriveAvailabilityFromReferences(json: [String: Any]) -> Availability.Info? {
-        guard let rawMarkdown = json["rawMarkdown"] as? String else { return nil }
-
-        // Extract doc:// references from markdown
-        // Pattern: [doc://com.apple.storekit/documentation/StoreKit/Transaction]
-        // or: [doc://com.apple.documentation/documentation/Foundation/URL]
-        let docRefPattern = #"doc://[^/]+/documentation/([^\]]+)"#
-        guard let regex = try? NSRegularExpression(pattern: docRefPattern, options: []) else {
-            return nil
-        }
-
-        let range = NSRange(rawMarkdown.startIndex..., in: rawMarkdown)
-        let matches = regex.matches(in: rawMarkdown, options: [], range: range)
-
-        var allPlatforms: [[Availability.Platform]] = []
-
-        for match in matches {
-            guard let pathRange = Range(match.range(at: 1), in: rawMarkdown) else { continue }
-            let refPath = String(rawMarkdown[pathRange]).lowercased()
-
-            // Build the full path for cache lookup
-            let cacheKey = "/documentation/\(refPath)"
-
-            if let platforms = documentAvailabilityCache[cacheKey], !platforms.isEmpty {
-                allPlatforms.append(platforms)
-            }
-        }
-
-        guard !allPlatforms.isEmpty else { return nil }
-
-        // Compute most restrictive availability (highest minimum version per platform)
-        return computeMostRestrictiveAvailability(from: allPlatforms)
-    }
-
-    /// Compute the most restrictive availability from multiple sources
-    /// Uses the highest minimum version for each platform
-    private func computeMostRestrictiveAvailability(
-        from sources: [[Availability.Platform]]
-    ) -> Availability.Info? {
-        var platformVersions: [String: (version: String, deprecated: Bool, beta: Bool)] = [:]
-
-        for platforms in sources {
-            for platform in platforms where !platform.unavailable {
-                guard let version = platform.introducedAt else { continue }
-
-                if let existing = platformVersions[platform.name] {
-                    // Keep the higher (more restrictive) version
-                    if Self.isVersion(version, greaterThan: existing.version) {
-                        platformVersions[platform.name] = (
-                            version,
-                            platform.deprecated || existing.deprecated,
-                            platform.beta || existing.beta
+                        reportProgress(
+                            result: result,
+                            completed: completed,
+                            total: files.count,
+                            successful: successful,
+                            failed: failed,
+                            onProgress: onProgress
                         )
                     }
+                }
+            }
+
+            // Phase 3: Second pass - process articles with reference lookup
+            for batch in stride(from: 0, to: articles.count, by: batchSize) {
+                let endIndex = min(batch + batchSize, articles.count)
+                let batchFiles = Array(articles[batch..<endIndex])
+
+                await withTaskGroup(of: ProcessResult.self) { group in
+                    for (framework, file) in batchFiles {
+                        group.addTask {
+                            await self.processFile(file, framework: framework, isArticle: true)
+                        }
+                    }
+
+                    for await result in group {
+                        completed += 1
+                        updateStats(
+                            result: result,
+                            stats: &stats,
+                            successful: &successful,
+                            failed: &failed,
+                            filesWithNoAvailability: &filesWithNoAvailability
+                        )
+
+                        reportProgress(
+                            result: result,
+                            completed: completed,
+                            total: files.count,
+                            successful: successful,
+                            failed: failed,
+                            onProgress: onProgress
+                        )
+                    }
+                }
+            }
+
+            // Store files with no availability for logging (limit to first 100)
+            stats.filesWithNoAvailability = Array(filesWithNoAvailability.prefix(100))
+        }
+
+        /// Separate files into API docs and articles based on document kind
+        private func separateAPIDocsAndArticles(
+            _ files: [(framework: String, file: URL)]
+        ) -> (apiDocs: [(framework: String, file: URL)], articles: [(framework: String, file: URL)]) {
+            var apiDocs: [(String, URL)] = []
+            var articles: [(String, URL)] = []
+
+            for (framework, file) in files {
+                if let data = try? Data(contentsOf: file),
+                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let kind = json["kind"] as? String,
+                   kind == "article" {
+                    articles.append((framework, file))
                 } else {
-                    platformVersions[platform.name] = (version, platform.deprecated, platform.beta)
+                    apiDocs.append((framework, file))
+                }
+            }
+
+            return (apiDocs, articles)
+        }
+
+        private func updateStats(
+            result: ProcessResult,
+            stats: inout Availability.Statistics,
+            successful: inout Int,
+            failed: inout Int,
+            filesWithNoAvailability: inout [String]
+        ) {
+            switch result.status {
+            case .updated:
+                stats.updatedDocuments += 1
+                stats.successfulFetches += 1
+                successful += 1
+            case .inherited:
+                stats.inheritedFromParent += 1
+                stats.updatedDocuments += 1
+                successful += 1
+            case .derivedFromReferences:
+                stats.derivedFromReferences += 1
+                stats.updatedDocuments += 1
+                successful += 1
+            case .markedEmpty:
+                stats.markedEmpty += 1
+                filesWithNoAvailability.append("\(result.framework)/\(result.filename)")
+            case .skipped:
+                stats.skippedDocuments += 1
+            case .failed:
+                stats.failedFetches += 1
+                failed += 1
+            case .notApplicable:
+                stats.skippedDocuments += 1
+            }
+        }
+
+        private func reportProgress(
+            result: ProcessResult,
+            completed: Int,
+            total: Int,
+            successful: Int,
+            failed: Int,
+            onProgress: (@Sendable (Availability.Progress) -> Void)?
+        ) {
+            if let onProgress {
+                let progress = Availability.Progress(
+                    currentDocument: result.filename,
+                    completed: completed,
+                    total: total,
+                    successful: successful,
+                    failed: failed,
+                    currentFramework: result.framework
+                )
+                onProgress(progress)
+            }
+        }
+
+        /// Cache framework-level availability by processing root documentation files
+        private func cacheFrameworkAvailability(from files: [(framework: String, file: URL)]) async {
+            // Find framework root files (e.g., documentation_swiftui.json)
+            let frameworkRoots = files.filter { framework, file in
+                let filename = file.deletingPathExtension().lastPathComponent
+                return filename == "documentation_\(framework)"
+            }
+
+            // Process framework roots to cache their availability
+            for (framework, file) in frameworkRoots {
+                if let data = try? Data(contentsOf: file),
+                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let availabilityArray = json["availability"] as? [[String: Any]] {
+                    let platforms = availabilityArray.compactMap { dict -> Availability.Platform? in
+                        guard let name = dict["name"] as? String else { return nil }
+                        return Availability.Platform(
+                            name: name,
+                            introducedAt: dict["introducedAt"] as? String,
+                            deprecated: dict["deprecated"] as? Bool ?? false,
+                            deprecatedAt: dict["deprecatedAt"] as? String,
+                            unavailable: dict["unavailable"] as? Bool ?? false,
+                            beta: dict["beta"] as? Bool ?? false
+                        )
+                    }
+                    if !platforms.isEmpty {
+                        frameworkAvailabilityCache[framework] = platforms
+                    }
                 }
             }
         }
 
-        guard !platformVersions.isEmpty else { return nil }
+        private func processFile(
+            _ fileURL: URL,
+            framework: String,
+            isArticle: Bool
+        ) async -> ProcessResult {
+            let filename = fileURL.lastPathComponent
 
-        let platforms = platformVersions.map { name, info in
-            Availability.Platform(
-                name: name,
-                introducedAt: info.version,
-                deprecated: info.deprecated,
-                deprecatedAt: nil,
-                unavailable: false,
-                beta: info.beta
-            )
+            // Load existing JSON
+            guard let data = try? Data(contentsOf: fileURL),
+                  var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else {
+                return ProcessResult(status: .failed, filename: filename, framework: framework)
+            }
+
+            // Check if already has availability (if skipExisting is enabled)
+            if configuration.skipExisting,
+               let existingAvailability = json["availability"] as? [[String: Any]],
+               !existingAvailability.isEmpty {
+                return ProcessResult(status: .skipped, filename: filename, framework: framework)
+            }
+
+            // Extract URL to build API path
+            guard let urlString = json["url"] as? String,
+                  let docURL = URL(string: urlString)
+            else {
+                return ProcessResult(status: .notApplicable, filename: filename, framework: framework)
+            }
+
+            // Build API URL from doc URL
+            // https://developer.apple.com/documentation/SwiftUI/View
+            // -> https://developer.apple.com/tutorials/data/documentation/swiftui/view.json
+            let apiURL = buildAPIURL(from: docURL)
+
+            // Fetch availability from API
+            var availability = await fetchAvailability(from: apiURL)
+            var inherited = false
+            var derivedFromRefs = false
+
+            // Fallback 1: If API failed or returned empty, try parsing @available from local content
+            if availability?.isEmpty ?? true {
+                availability = Availability.Info.extractFromJSONContent(data)
+            }
+
+            // Fallback 2: For articles, derive from referenced APIs
+            if isArticle, availability?.isEmpty ?? true {
+                if let derived = deriveAvailabilityFromReferences(json: json) {
+                    availability = derived
+                    derivedFromRefs = true
+                }
+            }
+
+            // Fallback 3: If still no availability, try inheriting from framework
+            if availability?.isEmpty ?? true,
+               let frameworkPlatforms = frameworkAvailabilityCache[framework] {
+                availability = Availability.Info(platforms: frameworkPlatforms)
+                inherited = true
+            }
+
+            // Determine the final status and what to write
+            let finalStatus: ProcessResult.Status
+            let platformsToWrite: [[String: Any]]
+
+            if let availability, !availability.isEmpty {
+                // We have availability data
+                platformsToWrite = availability.platforms.map { platform in
+                    var dict: [String: Any] = [
+                        "name": platform.name,
+                        "deprecated": platform.deprecated,
+                        "unavailable": platform.unavailable,
+                        "beta": platform.beta,
+                    ]
+                    if let introduced = platform.introducedAt {
+                        dict["introducedAt"] = introduced
+                    }
+                    if let deprecatedAt = platform.deprecatedAt {
+                        dict["deprecatedAt"] = deprecatedAt
+                    }
+                    return dict
+                }
+                if derivedFromRefs {
+                    finalStatus = .derivedFromReferences
+                } else if inherited {
+                    finalStatus = .inherited
+                } else {
+                    finalStatus = .updated
+                }
+
+                // Cache availability for this document (for article reference lookups)
+                let cacheKey = docURL.path.lowercased()
+                cacheDocumentAvailability(key: cacheKey, platforms: availability.platforms)
+            } else {
+                // Fallback 4: Mark with empty availability to indicate we checked
+                platformsToWrite = []
+                finalStatus = .markedEmpty
+            }
+
+            // Update JSON with availability (even if empty)
+            json["availability"] = platformsToWrite
+
+            // Write updated JSON
+            do {
+                let updatedData = try JSONSerialization.data(
+                    withJSONObject: json,
+                    options: [.prettyPrinted, .sortedKeys]
+                )
+                try updatedData.write(to: fileURL)
+                return ProcessResult(status: finalStatus, filename: filename, framework: framework)
+            } catch {
+                return ProcessResult(status: .failed, filename: filename, framework: framework)
+            }
         }
 
-        return Availability.Info(platforms: platforms)
-    }
-
-    /// Compare version strings - returns true if lhs > rhs
-    private static func isVersion(_ lhs: String, greaterThan rhs: String) -> Bool {
-        let lhsComponents = lhs.split(separator: ".").compactMap { Int($0) }
-        let rhsComponents = rhs.split(separator: ".").compactMap { Int($0) }
-
-        for idx in 0..<max(lhsComponents.count, rhsComponents.count) {
-            let lhsValue = idx < lhsComponents.count ? lhsComponents[idx] : 0
-            let rhsValue = idx < rhsComponents.count ? rhsComponents[idx] : 0
-
-            if lhsValue > rhsValue { return true }
-            if lhsValue < rhsValue { return false }
-        }
-        return false // Equal versions
-    }
-
-    private func buildAPIURL(from docURL: URL) -> URL {
-        // Extract path after /documentation/
-        let path = docURL.path.lowercased()
-        let apiPath: String
-
-        if path.hasPrefix("/documentation/") {
-            apiPath = String(path.dropFirst("/documentation/".count))
-        } else {
-            apiPath = path
+        /// Cache document availability for reference lookups
+        private func cacheDocumentAvailability(key: String, platforms: [Availability.Platform]) {
+            documentAvailabilityCache[key] = platforms
         }
 
-        // Availability target deliberately has no `Shared` dependency, so the
-        // `URL.knownGood` helper used elsewhere in the codebase isn't
-        // available here. The single site, with a known-good base + sanitized
-        // path, gets a localized swiftlint exemption rather than dragging a
-        // whole package dependency in just for one URL constructor.
-        // swiftlint:disable:next force_unwrapping
-        return URL(string: "\(configuration.apiBaseURL)/\(apiPath).json")!
-    }
+        /// Derive availability from doc:// references in article content
+        private func deriveAvailabilityFromReferences(json: [String: Any]) -> Availability.Info? {
+            guard let rawMarkdown = json["rawMarkdown"] as? String else { return nil }
 
-    private func fetchAvailability(from url: URL) async -> Availability.Info? {
-        do {
-            let (data, response) = try await urlSession.data(from: url)
-
-            guard let httpResponse = response as? HTTPURLResponse else {
+            // Extract doc:// references from markdown
+            // Pattern: [doc://com.apple.storekit/documentation/StoreKit/Transaction]
+            // or: [doc://com.apple.documentation/documentation/Foundation/URL]
+            let docRefPattern = #"doc://[^/]+/documentation/([^\]]+)"#
+            guard let regex = try? NSRegularExpression(pattern: docRefPattern, options: []) else {
                 return nil
             }
 
-            guard httpResponse.statusCode == 200 else {
-                return nil
+            let range = NSRange(rawMarkdown.startIndex..., in: rawMarkdown)
+            let matches = regex.matches(in: rawMarkdown, options: [], range: range)
+
+            var allPlatforms: [[Availability.Platform]] = []
+
+            for match in matches {
+                guard let pathRange = Range(match.range(at: 1), in: rawMarkdown) else { continue }
+                let refPath = String(rawMarkdown[pathRange]).lowercased()
+
+                // Build the full path for cache lookup
+                let cacheKey = "/documentation/\(refPath)"
+
+                if let platforms = documentAvailabilityCache[cacheKey], !platforms.isEmpty {
+                    allPlatforms.append(platforms)
+                }
             }
 
-            let decoder = JSONDecoder()
-            let apiResponse = try decoder.decode(Availability.APIResponse.self, from: data)
+            guard !allPlatforms.isEmpty else { return nil }
 
-            guard let platforms = apiResponse.metadata?.platforms else {
-                return nil
+            // Compute most restrictive availability (highest minimum version per platform)
+            return computeMostRestrictiveAvailability(from: allPlatforms)
+        }
+
+        /// Compute the most restrictive availability from multiple sources
+        /// Uses the highest minimum version for each platform
+        private func computeMostRestrictiveAvailability(
+            from sources: [[Availability.Platform]]
+        ) -> Availability.Info? {
+            var platformVersions: [String: (version: String, deprecated: Bool, beta: Bool)] = [:]
+
+            for platforms in sources {
+                for platform in platforms where !platform.unavailable {
+                    guard let version = platform.introducedAt else { continue }
+
+                    if let existing = platformVersions[platform.name] {
+                        // Keep the higher (more restrictive) version
+                        if Self.isVersion(version, greaterThan: existing.version) {
+                            platformVersions[platform.name] = (
+                                version,
+                                platform.deprecated || existing.deprecated,
+                                platform.beta || existing.beta
+                            )
+                        }
+                    } else {
+                        platformVersions[platform.name] = (version, platform.deprecated, platform.beta)
+                    }
+                }
             }
 
-            let availability = platforms.map { $0.toPlatform() }
-            return Availability.Info(platforms: availability)
-        } catch {
-            // Network error or JSON parse error - return nil to mark as failed
-            return nil
+            guard !platformVersions.isEmpty else { return nil }
+
+            let platforms = platformVersions.map { name, info in
+                Availability.Platform(
+                    name: name,
+                    introducedAt: info.version,
+                    deprecated: info.deprecated,
+                    deprecatedAt: nil,
+                    unavailable: false,
+                    beta: info.beta
+                )
+            }
+
+            return Availability.Info(platforms: platforms)
+        }
+
+        /// Compare version strings - returns true if lhs > rhs
+        private static func isVersion(_ lhs: String, greaterThan rhs: String) -> Bool {
+            let lhsComponents = lhs.split(separator: ".").compactMap { Int($0) }
+            let rhsComponents = rhs.split(separator: ".").compactMap { Int($0) }
+
+            for idx in 0..<max(lhsComponents.count, rhsComponents.count) {
+                let lhsValue = idx < lhsComponents.count ? lhsComponents[idx] : 0
+                let rhsValue = idx < rhsComponents.count ? rhsComponents[idx] : 0
+
+                if lhsValue > rhsValue { return true }
+                if lhsValue < rhsValue { return false }
+            }
+            return false // Equal versions
+        }
+
+        private func buildAPIURL(from docURL: URL) -> URL {
+            // Extract path after /documentation/
+            let path = docURL.path.lowercased()
+            let apiPath: String
+
+            if path.hasPrefix("/documentation/") {
+                apiPath = String(path.dropFirst("/documentation/".count))
+            } else {
+                apiPath = path
+            }
+
+            // Availability target deliberately has no `Shared` dependency, so the
+            // `URL.knownGood` helper used elsewhere in the codebase isn't
+            // available here. The single site, with a known-good base + sanitized
+            // path, gets a localized swiftlint exemption rather than dragging a
+            // whole package dependency in just for one URL constructor.
+            // swiftlint:disable:next force_unwrapping
+            return URL(string: "\(configuration.apiBaseURL)/\(apiPath).json")!
+        }
+
+        private func fetchAvailability(from url: URL) async -> Availability.Info? {
+            do {
+                let (data, response) = try await urlSession.data(from: url)
+
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    return nil
+                }
+
+                guard httpResponse.statusCode == 200 else {
+                    return nil
+                }
+
+                let decoder = JSONDecoder()
+                let apiResponse = try decoder.decode(Availability.APIResponse.self, from: data)
+
+                guard let platforms = apiResponse.metadata?.platforms else {
+                    return nil
+                }
+
+                let availability = platforms.map { $0.toPlatform() }
+                return Availability.Info(platforms: availability)
+            } catch {
+                // Network error or JSON parse error - return nil to mark as failed
+                return nil
+            }
         }
     }
-}
 
-// MARK: - Process Result
+    // MARK: - Process Result
 
-private struct ProcessResult: Sendable {
-    enum Status: Sendable {
-        case updated // Availability fetched from API or parsed from @available
-        case inherited // Inherited from parent/framework
-        case derivedFromReferences // Derived from doc:// references (articles)
-        case markedEmpty // Checked but no availability found, marked with empty array
-        case skipped // Already has availability (when skipExisting is true)
-        case failed // JSON parsing or write error
-        case notApplicable // No URL to fetch from
+    private struct ProcessResult {
+        enum Status {
+            case updated // Availability fetched from API or parsed from @available
+            case inherited // Inherited from parent/framework
+            case derivedFromReferences // Derived from doc:// references (articles)
+            case markedEmpty // Checked but no availability found, marked with empty array
+            case skipped // Already has availability (when skipExisting is true)
+            case failed // JSON parsing or write error
+            case notApplicable // No URL to fetch from
+        }
+
+        let status: Status
+        let filename: String
+        let framework: String
     }
-
-    let status: Status
-    let filename: String
-    let framework: String
-}
 }

--- a/Packages/Sources/Availability/AvailabilityStatistics.swift
+++ b/Packages/Sources/Availability/AvailabilityStatistics.swift
@@ -5,83 +5,83 @@ import Foundation
 extension Availability {
     /// Statistics for availability fetch operation
     public struct Statistics: Sendable {
-    /// Total documents scanned
-    public var totalDocuments: Int = 0
+        /// Total documents scanned
+        public var totalDocuments: Int = 0
 
-    /// Documents that had availability updated
-    public var updatedDocuments: Int = 0
+        /// Documents that had availability updated
+        public var updatedDocuments: Int = 0
 
-    /// Documents where availability fetch was successful
-    public var successfulFetches: Int = 0
+        /// Documents where availability fetch was successful
+        public var successfulFetches: Int = 0
 
-    /// Documents where availability fetch failed (timeouts, 404s, etc.)
-    public var failedFetches: Int = 0
+        /// Documents where availability fetch failed (timeouts, 404s, etc.)
+        public var failedFetches: Int = 0
 
-    /// Documents skipped (already have availability or not applicable)
-    public var skippedDocuments: Int = 0
+        /// Documents skipped (already have availability or not applicable)
+        public var skippedDocuments: Int = 0
 
-    /// Documents that inherited availability from parent/framework
-    public var inheritedFromParent: Int = 0
+        /// Documents that inherited availability from parent/framework
+        public var inheritedFromParent: Int = 0
 
-    /// Articles that derived availability from referenced APIs
-    public var derivedFromReferences: Int = 0
+        /// Articles that derived availability from referenced APIs
+        public var derivedFromReferences: Int = 0
 
-    /// Documents marked with empty availability (checked but none found)
-    public var markedEmpty: Int = 0
+        /// Documents marked with empty availability (checked but none found)
+        public var markedEmpty: Int = 0
 
-    /// Number of frameworks processed
-    public var frameworksProcessed: Int = 0
+        /// Number of frameworks processed
+        public var frameworksProcessed: Int = 0
 
-    /// Files that had no availability after all fallbacks (for logging)
-    public var filesWithNoAvailability: [String] = []
+        /// Files that had no availability after all fallbacks (for logging)
+        public var filesWithNoAvailability: [String] = []
 
-    /// Start time of the operation
-    public var startTime: Date?
+        /// Start time of the operation
+        public var startTime: Date?
 
-    /// End time of the operation
-    public var endTime: Date?
+        /// End time of the operation
+        public var endTime: Date?
 
-    public init(
-        totalDocuments: Int = 0,
-        updatedDocuments: Int = 0,
-        successfulFetches: Int = 0,
-        failedFetches: Int = 0,
-        skippedDocuments: Int = 0,
-        inheritedFromParent: Int = 0,
-        derivedFromReferences: Int = 0,
-        markedEmpty: Int = 0,
-        frameworksProcessed: Int = 0,
-        filesWithNoAvailability: [String] = [],
-        startTime: Date? = nil,
-        endTime: Date? = nil
-    ) {
-        self.totalDocuments = totalDocuments
-        self.updatedDocuments = updatedDocuments
-        self.successfulFetches = successfulFetches
-        self.failedFetches = failedFetches
-        self.skippedDocuments = skippedDocuments
-        self.inheritedFromParent = inheritedFromParent
-        self.derivedFromReferences = derivedFromReferences
-        self.markedEmpty = markedEmpty
-        self.frameworksProcessed = frameworksProcessed
-        self.filesWithNoAvailability = filesWithNoAvailability
-        self.startTime = startTime
-        self.endTime = endTime
-    }
-
-    /// Duration of the operation in seconds
-    public var duration: TimeInterval? {
-        guard let start = startTime, let end = endTime else {
-            return nil
+        public init(
+            totalDocuments: Int = 0,
+            updatedDocuments: Int = 0,
+            successfulFetches: Int = 0,
+            failedFetches: Int = 0,
+            skippedDocuments: Int = 0,
+            inheritedFromParent: Int = 0,
+            derivedFromReferences: Int = 0,
+            markedEmpty: Int = 0,
+            frameworksProcessed: Int = 0,
+            filesWithNoAvailability: [String] = [],
+            startTime: Date? = nil,
+            endTime: Date? = nil
+        ) {
+            self.totalDocuments = totalDocuments
+            self.updatedDocuments = updatedDocuments
+            self.successfulFetches = successfulFetches
+            self.failedFetches = failedFetches
+            self.skippedDocuments = skippedDocuments
+            self.inheritedFromParent = inheritedFromParent
+            self.derivedFromReferences = derivedFromReferences
+            self.markedEmpty = markedEmpty
+            self.frameworksProcessed = frameworksProcessed
+            self.filesWithNoAvailability = filesWithNoAvailability
+            self.startTime = startTime
+            self.endTime = endTime
         }
-        return end.timeIntervalSince(start)
-    }
 
-    /// Success rate as percentage
-    public var successRate: Double {
-        let attempted = successfulFetches + failedFetches
-        guard attempted > 0 else { return 0 }
-        return (Double(successfulFetches) / Double(attempted)) * 100.0
+        /// Duration of the operation in seconds
+        public var duration: TimeInterval? {
+            guard let start = startTime, let end = endTime else {
+                return nil
+            }
+            return end.timeIntervalSince(start)
+        }
+
+        /// Success rate as percentage
+        public var successRate: Double {
+            let attempted = successfulFetches + failedFetches
+            guard attempted > 0 else { return 0 }
+            return (Double(successfulFetches) / Double(attempted)) * 100.0
+        }
     }
-}
 }

--- a/Packages/Sources/Availability/PlatformAvailability.swift
+++ b/Packages/Sources/Availability/PlatformAvailability.swift
@@ -46,14 +46,14 @@ extension Availability {
 
 extension Availability {
     /// Response from Apple's /tutorials/data/documentation API
-    struct APIResponse: Codable, Sendable {
+    struct APIResponse: Codable {
         let metadata: Metadata?
 
-        struct Metadata: Codable, Sendable {
+        struct Metadata: Codable {
             let platforms: [PlatformInfo]?
         }
 
-        struct PlatformInfo: Codable, Sendable {
+        struct PlatformInfo: Codable {
             let name: String
             let introducedAt: String?
             let deprecated: Bool?

--- a/Packages/Sources/CLI/Commands/CleanupCommand.swift
+++ b/Packages/Sources/CLI/Commands/CleanupCommand.swift
@@ -86,7 +86,7 @@ struct CleanupCommand: AsyncParsableCommand {
 
         let stats = try await cleaner.cleanup { progress in
             let percent = String(format: "%.1f", progress.percentage)
-            let saved = Shared.Formatting.formatBytes(progress.originalSize - progress.cleanedSize)
+            let saved = Shared.Utils.Formatting.formatBytes(progress.originalSize - progress.cleanedSize)
             Logging.Log.output("   [\(percent)%] \(progress.currentFile) (saved \(saved))")
         }
 
@@ -104,11 +104,11 @@ struct CleanupCommand: AsyncParsableCommand {
         Logging.Log.output("   Errors: \(stats.errors)")
         Logging.Log.output("   Items to remove: \(stats.totalItemsRemoved)")
         Logging.Log.output("")
-        Logging.Log.output("   Original size: \(Shared.Formatting.formatBytes(stats.originalTotalSize))")
+        Logging.Log.output("   Original size: \(Shared.Utils.Formatting.formatBytes(stats.originalTotalSize))")
         if !dryRun {
-            Logging.Log.output("   Cleaned size: \(Shared.Formatting.formatBytes(stats.cleanedTotalSize))")
+            Logging.Log.output("   Cleaned size: \(Shared.Utils.Formatting.formatBytes(stats.cleanedTotalSize))")
             Logging.Log.output(
-                "   Space saved: \(Shared.Formatting.formatBytes(stats.spaceSaved)) " +
+                "   Space saved: \(Shared.Utils.Formatting.formatBytes(stats.spaceSaved)) " +
                     "(\(String(format: "%.1f", stats.spaceSavedPercentage))%)"
             )
         }

--- a/Packages/Sources/CLI/Commands/DoctorCommand.swift
+++ b/Packages/Sources/CLI/Commands/DoctorCommand.swift
@@ -208,7 +208,7 @@ struct DoctorCommand: AsyncParsableCommand {
 
         let fileSize = (try? FileManager.default.attributesOfItem(atPath: searchDBURL.path)[.size] as? UInt64) ?? 0
         Logging.Log.output("   ✓ Database: \(searchDBURL.path)")
-        Logging.Log.output("   ✓ Size: \(Shared.Formatting.formatBytes(Int64(fileSize)))")
+        Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
 
         if !reportSchemaVersion(at: searchDBURL) {
             return false
@@ -295,7 +295,7 @@ struct DoctorCommand: AsyncParsableCommand {
 
         let fileSize = (try? FileManager.default.attributesOfItem(atPath: samplesDBURL.path)[.size] as? UInt64) ?? 0
         Logging.Log.output("   ✓ Database: \(samplesDBURL.path)")
-        Logging.Log.output("   ✓ Size: \(Shared.Formatting.formatBytes(Int64(fileSize)))")
+        Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
 
         let projectCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM projects;")
         let fileCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM files;")
@@ -327,7 +327,7 @@ struct DoctorCommand: AsyncParsableCommand {
 
         let fileSize = (try? FileManager.default.attributesOfItem(atPath: packagesDBURL.path)[.size] as? UInt64) ?? 0
         Logging.Log.output("   ✓ Database: \(packagesDBURL.path)")
-        Logging.Log.output("   ✓ Size: \(Shared.Formatting.formatBytes(Int64(fileSize)))")
+        Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
 
         let packageCount = Diagnostics.Probes.rowCount(at: packagesDBURL, sql: "SELECT COUNT(*) FROM packages;")
         let fileCount = Diagnostics.Probes.rowCount(at: packagesDBURL, sql: "SELECT COUNT(*) FROM package_files;")

--- a/Packages/Sources/CLI/Commands/FetchCommand.swift
+++ b/Packages/Sources/CLI/Commands/FetchCommand.swift
@@ -452,7 +452,7 @@ struct FetchCommand: AsyncParsableCommand {
         logCrawlCompletion(stats)
     }
 
-    private func logCrawlCompletion(_ stats: CrawlStatistics) {
+    private func logCrawlCompletion(_ stats: Shared.Models.CrawlStatistics) {
         Logging.ConsoleLogger.output("")
         Logging.ConsoleLogger.info("✅ Crawl completed!")
         Logging.ConsoleLogger.info("   Total: \(stats.totalPages) pages")
@@ -634,7 +634,7 @@ struct FetchCommand: AsyncParsableCommand {
         }
 
         // Convert to PackageReference format
-        let seedRefs = priorityPackages.compactMap { pkg -> PackageReference? in
+        let seedRefs = priorityPackages.compactMap { pkg -> Shared.Models.PackageReference? in
             // Extract owner from URL if not provided
             let owner: String
             if let explicitOwner = pkg.owner, !explicitOwner.isEmpty {
@@ -654,7 +654,7 @@ struct FetchCommand: AsyncParsableCommand {
             let isApple = owner == Shared.Constants.GitHubOrg.apple
                 || owner == Shared.Constants.GitHubOrg.swiftlang
                 || owner == Shared.Constants.GitHubOrg.swiftServer
-            return PackageReference(
+            return Shared.Models.PackageReference(
                 owner: owner,
                 repo: pkg.repo,
                 url: pkg.url,
@@ -744,7 +744,7 @@ struct FetchCommand: AsyncParsableCommand {
 
         let extractor = Core.PackageArchiveExtractor()
         let startedAt = Date()
-        var stats = PackageDownloadStatistics(
+        var stats = Shared.Models.PackageDownloadStatistics(
             totalPackages: resolvedPackages.count,
             startTime: startedAt
         )

--- a/Packages/Sources/CLI/Commands/ReadSampleCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadSampleCommand.swift
@@ -77,7 +77,7 @@ struct ReadSampleCommand: AsyncParsableCommand {
         Logging.Log.output("Project ID: \(project.id)")
         Logging.Log.output("Frameworks: \(project.frameworks.joined(separator: ", "))")
         Logging.Log.output("Files: \(project.fileCount)")
-        Logging.Log.output("Size: \(Shared.Formatting.formatBytes(project.totalSize))")
+        Logging.Log.output("Size: \(Shared.Utils.Formatting.formatBytes(project.totalSize))")
 
         if !project.webURL.isEmpty {
             Logging.Log.output("Apple Developer: \(project.webURL)")
@@ -161,7 +161,7 @@ struct ReadSampleCommand: AsyncParsableCommand {
         Logging.Log.output("## Metadata\n")
         Logging.Log.output("- **Frameworks:** \(project.frameworks.joined(separator: ", "))")
         Logging.Log.output("- **Files:** \(project.fileCount)")
-        Logging.Log.output("- **Size:** \(Shared.Formatting.formatBytes(project.totalSize))")
+        Logging.Log.output("- **Size:** \(Shared.Utils.Formatting.formatBytes(project.totalSize))")
 
         if !project.webURL.isEmpty {
             Logging.Log.output("- **Apple Developer:** \(project.webURL)")

--- a/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
@@ -76,7 +76,7 @@ struct ReadSampleFileCommand: AsyncParsableCommand {
     private func outputText(_ file: SampleIndex.File) {
         Logging.Log.output("// File: \(file.path)")
         Logging.Log.output("// Project: \(file.projectId)")
-        Logging.Log.output("// Size: \(Shared.Formatting.formatBytes(file.size))")
+        Logging.Log.output("// Size: \(Shared.Utils.Formatting.formatBytes(file.size))")
         Logging.Log.output("")
         Logging.Log.output(file.content)
     }

--- a/Packages/Sources/CLI/Commands/SaveCommand.swift
+++ b/Packages/Sources/CLI/Commands/SaveCommand.swift
@@ -273,7 +273,7 @@ extension SaveCommand {
         Logging.ConsoleLogger.info("   Total documents: \(docCount)")
         Logging.ConsoleLogger.info("   Frameworks: \(frameworks.count)")
         Logging.ConsoleLogger.info("   Indexed: \(stats.successCount) | Errors: \(stats.errorCount)")
-        Logging.ConsoleLogger.info("   Time: \(Shared.Formatting.formatDuration(elapsed))")
+        Logging.ConsoleLogger.info("   Time: \(Shared.Utils.Formatting.formatDuration(elapsed))")
         Logging.ConsoleLogger.info("   Database: \(searchDBURL.path)")
         Logging.ConsoleLogger.info("   Size: \(Self.formatFileSize(searchDBURL))")
         Logging.ConsoleLogger.info(

--- a/Packages/Sources/CLI/Commands/SetupCommand.swift
+++ b/Packages/Sources/CLI/Commands/SetupCommand.swift
@@ -83,7 +83,7 @@ private final class SetupRenderer: @unchecked Sendable {
 
         case .downloadComplete(let label, let bytes):
             printRaw("\n")
-            let size = Shared.Formatting.formatBytes(bytes)
+            let size = Shared.Utils.Formatting.formatBytes(bytes)
             Logging.ConsoleLogger.info("   ✓ \(label) (\(size))")
 
         case .extractStart(let label):
@@ -123,7 +123,7 @@ private final class SetupRenderer: @unchecked Sendable {
         spinnerIndex += 1
         lock.unlock()
 
-        let written = Shared.Formatting.formatBytes(progress.bytesWritten)
+        let written = Shared.Utils.Formatting.formatBytes(progress.bytesWritten)
 
         if let total = progress.totalBytes, total > 0 {
             let frac = Double(progress.bytesWritten) / Double(total)
@@ -131,7 +131,7 @@ private final class SetupRenderer: @unchecked Sendable {
             let empty = barWidth - filled
             let bar = String(repeating: "█", count: filled) + String(repeating: "░", count: empty)
             let percent = String(format: "%3.0f%%", frac * 100)
-            let totalStr = Shared.Formatting.formatBytes(total)
+            let totalStr = Shared.Utils.Formatting.formatBytes(total)
             printRaw("\(clearLine)   \(frame) [\(bar)] \(percent) (\(written)/\(totalStr))")
         } else {
             printRaw("\(clearLine)   \(frame) Downloading... \(written)")

--- a/Packages/Sources/CLI/SupportingTypes.swift
+++ b/Packages/Sources/CLI/SupportingTypes.swift
@@ -62,7 +62,7 @@ extension Cupertino {
         }
 
         /// Per-type default output dir. Routes through `Shared.Constants.default*`
-        /// getters so the path resolves via `Shared.BinaryConfig` (#211) like
+        /// getters so the path resolves via `Shared.Constants.BinaryConfig` (#211) like
         /// every other default does. The earlier manual construction
         /// (`homeDir + baseDirectoryName + Directory.<x>`) bypassed BinaryConfig
         /// and silently wrote to `~/.cupertino/<x>` even when a binary-co-located

--- a/Packages/Sources/Cleanup/SampleCodeCleaner.swift
+++ b/Packages/Sources/Cleanup/SampleCodeCleaner.swift
@@ -39,8 +39,8 @@ public actor SampleCodeCleaner {
 
     /// Clean all ZIP archives in the sample code directory
     public func cleanup(
-        onProgress: (@Sendable (CleanupProgress) -> Void)? = nil
-    ) async throws -> CleanupStatistics {
+        onProgress: (@Sendable (Shared.Models.CleanupProgress) -> Void)? = nil
+    ) async throws -> Shared.Models.CleanupStatistics {
         let startTime = Date()
 
         // Find all ZIP files
@@ -48,7 +48,7 @@ public actor SampleCodeCleaner {
 
         guard !zipFiles.isEmpty else {
             Logging.Log.info("No ZIP files found in \(sampleCodeDirectory.path)", category: .samples)
-            return CleanupStatistics(
+            return Shared.Models.CleanupStatistics(
                 totalArchives: 0,
                 cleanedArchives: 0,
                 skippedArchives: 0,
@@ -88,7 +88,7 @@ public actor SampleCodeCleaner {
                 }
             }
 
-            onProgress?(CleanupProgress(
+            onProgress?(Shared.Models.CleanupProgress(
                 current: index + 1,
                 total: zipFiles.count,
                 currentFile: zipFile.lastPathComponent,
@@ -97,7 +97,7 @@ public actor SampleCodeCleaner {
             ))
         }
 
-        return CleanupStatistics(
+        return Shared.Models.CleanupStatistics(
             totalArchives: zipFiles.count,
             cleanedArchives: cleanedArchives,
             skippedArchives: skippedArchives,
@@ -124,7 +124,7 @@ public actor SampleCodeCleaner {
     }
 
     /// Clean a single archive
-    private func cleanArchive(at zipURL: URL) async -> CleanupResult {
+    private func cleanArchive(at zipURL: URL) async -> Shared.Models.CleanupResult {
         let filename = zipURL.lastPathComponent
 
         // Get original size
@@ -133,7 +133,7 @@ public actor SampleCodeCleaner {
             let attributes = try FileManager.default.attributesOfItem(atPath: zipURL.path)
             originalSize = (attributes[.size] as? Int64) ?? 0
         } catch {
-            return CleanupResult(
+            return Shared.Models.CleanupResult(
                 filename: filename,
                 originalSize: 0,
                 cleanedSize: 0,
@@ -146,7 +146,7 @@ public actor SampleCodeCleaner {
         // Dry run - just report what would be cleaned
         if dryRun {
             let itemsToRemove = await countItemsToRemove(in: zipURL)
-            return CleanupResult(
+            return Shared.Models.CleanupResult(
                 filename: filename,
                 originalSize: originalSize,
                 cleanedSize: originalSize,
@@ -173,7 +173,7 @@ public actor SampleCodeCleaner {
             // Extract ZIP
             let extractResult = try await extractZip(zipURL, to: tempDir)
             guard extractResult else {
-                return CleanupResult(
+                return Shared.Models.CleanupResult(
                     filename: filename,
                     originalSize: originalSize,
                     cleanedSize: originalSize,
@@ -188,7 +188,7 @@ public actor SampleCodeCleaner {
 
             // Skip recompression if nothing was removed
             if itemsRemoved == 0 {
-                return CleanupResult(
+                return Shared.Models.CleanupResult(
                     filename: filename,
                     originalSize: originalSize,
                     cleanedSize: originalSize,
@@ -213,7 +213,7 @@ public actor SampleCodeCleaner {
 
             let compressResult = try await compressDirectory(tempDir, to: cleanedZipURL)
             guard compressResult else {
-                return CleanupResult(
+                return Shared.Models.CleanupResult(
                     filename: filename,
                     originalSize: originalSize,
                     cleanedSize: originalSize,
@@ -227,7 +227,7 @@ public actor SampleCodeCleaner {
             let newAttributes = try FileManager.default.attributesOfItem(atPath: cleanedZipURL.path)
             let cleanedSize = (newAttributes[.size] as? Int64) ?? 0
 
-            return CleanupResult(
+            return Shared.Models.CleanupResult(
                 filename: filename,
                 originalSize: originalSize,
                 cleanedSize: cleanedSize,
@@ -236,7 +236,7 @@ public actor SampleCodeCleaner {
             )
 
         } catch {
-            return CleanupResult(
+            return Shared.Models.CleanupResult(
                 filename: filename,
                 originalSize: originalSize,
                 cleanedSize: originalSize,

--- a/Packages/Sources/Core/AppleArchiveCrawler.swift
+++ b/Packages/Sources/Core/AppleArchiveCrawler.swift
@@ -82,7 +82,7 @@ extension Core {
 
                     // Save book.json for reference
                     let bookJSONPath = guideDir.appendingPathComponent("book.json")
-                    let bookData = try JSONCoding.encode(bookJSON)
+                    let bookData = try Shared.Utils.JSONCoding.encode(bookJSON)
                     try bookData.write(to: bookJSONPath)
 
                     // Crawl each page

--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -37,7 +37,7 @@ extension Core {
         // on resume so the existing CrawlSessionState schema doesn't need a
         // migration. (#206)
         private var enqueued = Set<String>()
-        private var stats: CrawlStatistics
+        private var stats: Shared.Models.CrawlStatistics
 
         private var onProgress: (@Sendable (CrawlProgress) -> Void)?
         private var logFileHandle: FileHandle?
@@ -47,7 +47,7 @@ extension Core {
             changeDetection = configuration.changeDetection
             output = configuration.output
             state = CrawlerState(configuration: configuration.changeDetection)
-            stats = CrawlStatistics()
+            stats = Shared.Models.CrawlStatistics()
             super.init()
 
             // Initialize WKWebCrawler.ContentFetcher from WKWebCrawler namespace
@@ -64,7 +64,7 @@ extension Core {
         // MARK: - Public API
 
         /// Start crawling from the configured start URL
-        public func crawl(onProgress: (@Sendable (CrawlProgress) -> Void)? = nil) async throws -> CrawlStatistics {
+        public func crawl(onProgress: (@Sendable (CrawlProgress) -> Void)? = nil) async throws -> Shared.Models.CrawlStatistics {
             self.onProgress = onProgress
 
             // Check for resumable session (must match current start URL)
@@ -81,7 +81,7 @@ extension Core {
                 visited = savedSession.visited
                 queue = savedSession.queue.compactMap { queued in
                     guard let url = URL(string: queued.url),
-                          let normalized = URLUtilities.normalize(url) else { return nil }
+                          let normalized = Shared.Models.URLUtilities.normalize(url) else { return nil }
                     return (url: normalized, depth: queued.depth)
                 }
                 // Rebuild the enqueued-URL set from the restored queue so the
@@ -104,7 +104,7 @@ extension Core {
                 // Initialize stats for new crawl
                 let startTime = Date()
                 await state.updateStatistics { stats in
-                    stats = CrawlStatistics(startTime: startTime)
+                    stats = Shared.Models.CrawlStatistics(startTime: startTime)
                 }
 
                 // Initialize queue — seed from technologies.json for Apple docs root
@@ -117,17 +117,17 @@ extension Core {
                         logInfo("📋 Fetching technology index for complete framework coverage...")
                         let frameworkURLs = try await TechnologiesIndexFetcher.fetchFrameworkURLs()
                         queue = frameworkURLs.compactMap { url in
-                            URLUtilities.normalize(url).map { (url: $0, depth: 0) }
+                            Shared.Models.URLUtilities.normalize(url).map { (url: $0, depth: 0) }
                         }
                         logInfo("   ✅ Seeded queue with \(frameworkURLs.count) framework root URLs")
                     } catch {
                         logInfo("   ⚠️ Failed to fetch technology index: \(error.localizedDescription)")
                         logInfo("   ⚠️ Falling back to start URL only")
-                        let startURL = URLUtilities.normalize(configuration.startURL) ?? configuration.startURL
+                        let startURL = Shared.Models.URLUtilities.normalize(configuration.startURL) ?? configuration.startURL
                         queue = [(url: startURL, depth: 0)]
                     }
                 } else {
-                    let startURL = URLUtilities.normalize(configuration.startURL) ?? configuration.startURL
+                    let startURL = Shared.Models.URLUtilities.normalize(configuration.startURL) ?? configuration.startURL
                     queue = [(url: startURL, depth: 0)]
                 }
 
@@ -154,7 +154,7 @@ extension Core {
                 // raw URL string since enqueue keys on `link.absoluteString`.
                 enqueued.remove(url.absoluteString)
 
-                guard let normalizedURL = URLUtilities.normalize(url),
+                guard let normalizedURL = Shared.Models.URLUtilities.normalize(url),
                       !visited.contains(normalizedURL.absoluteString)
                 else {
                     continue
@@ -251,7 +251,7 @@ extension Core {
         }
 
         private func crawlPage(url: URL, depth: Int) async throws {
-            let framework = URLUtilities.extractFramework(from: url)
+            let framework = Shared.Models.URLUtilities.extractFramework(from: url)
 
             // Get framework page count for display
             let fwStats = await state.getFrameworkStats(framework: framework)
@@ -262,7 +262,7 @@ extension Core {
             logInfo("📄 \(progress) depth=\(depth) \(urlString)")
 
             // Try JSON API first (better data quality), fall back to HTML if unavailable
-            var structuredPage: StructuredDocumentationPage?
+            var structuredPage: Shared.Models.StructuredDocumentationPage?
             var markdown: String
             var links: [URL]
             // storageURL is the post-redirect canonical URL used for all on-disk paths.
@@ -353,18 +353,18 @@ extension Core {
             }
 
             // Compute content hash from structured page or markdown
-            let contentHash = structuredPage?.contentHash ?? HashUtilities.sha256(of: markdown)
+            let contentHash = structuredPage?.contentHash ?? Shared.Models.HashUtilities.sha256(of: markdown)
 
             // Derive output path from the canonical post-redirect URL so the on-disk
             // structure always reflects the final URL, not the stale request URL.
-            let storageFramework = URLUtilities.extractFramework(from: storageURL)
+            let storageFramework = Shared.Models.URLUtilities.extractFramework(from: storageURL)
             let frameworkDir = configuration.outputDirectory.appendingPathComponent(storageFramework)
             try FileManager.default.createDirectory(
                 at: frameworkDir,
                 withIntermediateDirectories: true
             )
 
-            let filename = URLUtilities.filename(from: storageURL)
+            let filename = Shared.Models.URLUtilities.filename(from: storageURL)
 
             // JSON file path (primary output format)
             let jsonFilePath = frameworkDir.appendingPathComponent(
@@ -456,7 +456,7 @@ extension Core {
         /// Load page via Apple's JSON API - avoids WKWebView memory issues
         /// Returns structured page data for JSON output, links for crawling, and the post-redirect canonical URL
         private func loadPageViaJSON(url: URL, depth: Int) async throws -> (
-            structuredPage: StructuredDocumentationPage?,
+            structuredPage: Shared.Models.StructuredDocumentationPage?,
             markdown: String,
             links: [URL],
             canonicalURL: URL
@@ -537,7 +537,7 @@ extension Core {
             }
 
             // Check if already visited
-            guard let normalized = URLUtilities.normalize(url) else {
+            guard let normalized = Shared.Models.URLUtilities.normalize(url) else {
                 return false
             }
 
@@ -547,7 +547,7 @@ extension Core {
             }
 
             return !queue.contains { queuedURL, _ in
-                URLUtilities.normalize(queuedURL)?.absoluteString == normalizedString
+                Shared.Models.URLUtilities.normalize(queuedURL)?.absoluteString == normalizedString
             }
         }
 
@@ -579,8 +579,8 @@ extension Core {
                 "   New: \(stats.newPages) | Updated: \(stats.updatedPages) | Skipped: \(stats.skippedPages)",
                 "   Errors: \(stats.errors)",
                 "   Speed: \(String(format: "%.2f", pagesPerSecond)) pages/sec",
-                "   Elapsed: \(Shared.Formatting.formatDurationVerbose(elapsed))",
-                "   ETA: \(Shared.Formatting.formatDurationVerbose(etaSeconds))",
+                "   Elapsed: \(Shared.Utils.Formatting.formatDurationVerbose(elapsed))",
+                "   ETA: \(Shared.Utils.Formatting.formatDurationVerbose(etaSeconds))",
                 "",
             ]
 
@@ -598,7 +598,7 @@ extension Core {
                 "   Updated pages: \(stats.updatedPages)",
                 "   Skipped (unchanged): \(stats.skippedPages)",
                 "   Errors: \(stats.errors)",
-                stats.duration.map { "   Duration: \(Shared.Formatting.formatDurationVerbose($0))" } ?? "",
+                stats.duration.map { "   Duration: \(Shared.Utils.Formatting.formatDurationVerbose($0))" } ?? "",
                 "",
                 "📁 Output: \(configuration.outputDirectory.path)",
             ]
@@ -672,7 +672,7 @@ public struct CrawlProgress: Sendable {
     public let currentURL: URL
     public let visitedCount: Int
     public let totalPages: Int
-    public let stats: CrawlStatistics
+    public let stats: Shared.Models.CrawlStatistics
 
     public var percentage: Double {
         Double(visitedCount) / Double(totalPages) * 100

--- a/Packages/Sources/Core/CrawlerState.swift
+++ b/Packages/Sources/Core/CrawlerState.swift
@@ -10,18 +10,18 @@ import SharedModels
 /// Manages crawler state including metadata and change detection
 public actor CrawlerState {
     private let configuration: Shared.ChangeDetectionConfiguration
-    private var metadata: CrawlMetadata
+    private var metadata: Shared.Models.CrawlMetadata
     private var autoSaveInterval: TimeInterval = Shared.Constants.Interval.autoSave
     private var lastAutoSave: Date = .init()
 
     public init(configuration: Shared.ChangeDetectionConfiguration) {
         self.configuration = configuration
-        metadata = CrawlMetadata()
+        metadata = Shared.Models.CrawlMetadata()
 
         // Load existing metadata if available
         if FileManager.default.fileExists(atPath: configuration.metadataFile.path) {
             do {
-                var loadedMetadata = try CrawlMetadata.load(from: configuration.metadataFile)
+                var loadedMetadata = try Shared.Models.CrawlMetadata.load(from: configuration.metadataFile)
 
                 // Validate metadata by checking if files actually exist
                 if Self.validateMetadata(loadedMetadata, metadataFile: configuration.metadataFile) {
@@ -53,7 +53,7 @@ public actor CrawlerState {
     /// the absolute path stored in `page.filePath` — that string was captured
     /// on the writing host and may point under the wrong home directory after
     /// the metadata has been rsynced between machines.
-    static func validateMetadata(_ metadata: CrawlMetadata, metadataFile: URL) -> Bool {
+    static func validateMetadata(_ metadata: Shared.Models.CrawlMetadata, metadataFile: URL) -> Bool {
         // If metadata claims many pages, verify some actually exist
         guard !metadata.pages.isEmpty else { return true }
 
@@ -95,7 +95,7 @@ public actor CrawlerState {
     /// Uses `framework` + the basename of the saved `filePath`, so the result
     /// only depends on data captured *within* the metadata, never on the
     /// absolute prefix the writing host happened to use.
-    static func expectedFilePath(for page: PageMetadata, under outputDir: URL) -> String {
+    static func expectedFilePath(for page: Shared.Models.PageMetadata, under outputDir: URL) -> String {
         let filename = (page.filePath as NSString).lastPathComponent
         return outputDir
             .appendingPathComponent(page.framework)
@@ -110,7 +110,7 @@ public actor CrawlerState {
     /// where the saved path is still valid (e.g. tests with non-canonical
     /// fixture paths, or runs against custom output directories).
     /// Idempotent.
-    static func rebasePagePaths(in metadata: inout CrawlMetadata, to outputDir: URL) {
+    static func rebasePagePaths(in metadata: inout Shared.Models.CrawlMetadata, to outputDir: URL) {
         for (url, page) in metadata.pages {
             // Saved path still resolves → leave it alone.
             if FileManager.default.fileExists(atPath: page.filePath) {
@@ -118,7 +118,7 @@ public actor CrawlerState {
             }
             let expected = Self.expectedFilePath(for: page, under: outputDir)
             if expected != page.filePath {
-                metadata.pages[url] = PageMetadata(
+                metadata.pages[url] = Shared.Models.PageMetadata(
                     url: page.url,
                     framework: page.framework,
                     filePath: expected,
@@ -173,7 +173,7 @@ public actor CrawlerState {
         depth: Int,
         isNew: Bool = true
     ) {
-        let pageMetadata = PageMetadata(
+        let pageMetadata = Shared.Models.PageMetadata(
             url: url,
             framework: framework,
             filePath: filePath,
@@ -196,7 +196,7 @@ public actor CrawlerState {
             fwStats.crawlStatus = .inProgress
             metadata.frameworks[fwKey] = fwStats
         } else {
-            metadata.frameworks[fwKey] = FrameworkStats(
+            metadata.frameworks[fwKey] = Shared.Models.FrameworkStats(
                 name: framework,
                 pageCount: 1,
                 newPages: isNew ? 1 : 0,
@@ -214,7 +214,7 @@ public actor CrawlerState {
             fwStats.errors += 1
             metadata.frameworks[fwKey] = fwStats
         } else {
-            metadata.frameworks[fwKey] = FrameworkStats(
+            metadata.frameworks[fwKey] = Shared.Models.FrameworkStats(
                 name: framework,
                 errors: 1,
                 crawlStatus: .inProgress
@@ -233,17 +233,17 @@ public actor CrawlerState {
     }
 
     /// Get stats for a specific framework
-    public func getFrameworkStats(framework: String) -> FrameworkStats? {
+    public func getFrameworkStats(framework: String) -> Shared.Models.FrameworkStats? {
         metadata.frameworks[framework.lowercased()]
     }
 
     /// Get all framework stats
-    public func getAllFrameworkStats() -> [String: FrameworkStats] {
+    public func getAllFrameworkStats() -> [String: Shared.Models.FrameworkStats] {
         metadata.frameworks
     }
 
     /// Finalize crawl and save metadata
-    public func finalizeCrawl(stats: CrawlStatistics) throws {
+    public func finalizeCrawl(stats: Shared.Models.CrawlStatistics) throws {
         metadata.lastCrawl = Date()
         metadata.stats = stats
 
@@ -260,12 +260,12 @@ public actor CrawlerState {
     // MARK: - Statistics
 
     /// Get current crawl statistics
-    public func getStatistics() -> CrawlStatistics {
+    public func getStatistics() -> Shared.Models.CrawlStatistics {
         metadata.stats
     }
 
     /// Update statistics
-    public func updateStatistics(_ update: @Sendable (inout CrawlStatistics) -> Void) {
+    public func updateStatistics(_ update: @Sendable (inout Shared.Models.CrawlStatistics) -> Void) {
         update(&metadata.stats)
     }
 
@@ -288,9 +288,9 @@ public actor CrawlerState {
         startURL: URL,
         outputDirectory: URL
     ) throws {
-        let queuedURLs = queue.map { QueuedURL(url: $0.url.absoluteString, depth: $0.depth) }
+        let queuedURLs = queue.map { Shared.Models.QueuedURL(url: $0.url.absoluteString, depth: $0.depth) }
 
-        metadata.crawlState = CrawlSessionState(
+        metadata.crawlState = Shared.Models.CrawlSessionState(
             visited: visited,
             queue: queuedURLs,
             startURL: startURL.absoluteString,
@@ -320,7 +320,7 @@ public actor CrawlerState {
     }
 
     /// Get saved session state for resuming
-    public func getSavedSession() -> CrawlSessionState? {
+    public func getSavedSession() -> Shared.Models.CrawlSessionState? {
         metadata.crawlState
     }
 

--- a/Packages/Sources/Core/HTMLParser/HTMLToMarkdown.swift
+++ b/Packages/Sources/Core/HTMLParser/HTMLToMarkdown.swift
@@ -714,9 +714,9 @@ extension Core.Parser.HTML {
     public static func toStructuredPage(
         _ html: String,
         url: URL,
-        source: StructuredDocumentationPage.Source = .appleWebKit,
+        source: Shared.Models.StructuredDocumentationPage.Source = .appleWebKit,
         depth: Int? = nil
-    ) -> StructuredDocumentationPage? {
+    ) -> Shared.Models.StructuredDocumentationPage? {
         // Extract title
         guard let title = extractTitle(from: html) else {
             return nil
@@ -749,8 +749,8 @@ extension Core.Parser.HTML {
         // Hash canonical structured fields, not raw `html` — page bytes carry
         // volatile cache/build metadata that doesn't reach our parsed output,
         // so `sha256(of: html)` was non-deterministic across runs (#199).
-        let page = StructuredDocumentationPage(
-            id: StructuredDocumentationPage.deterministicID(for: url),
+        let page = Shared.Models.StructuredDocumentationPage(
+            id: Shared.Models.StructuredDocumentationPage.deterministicID(for: url),
             url: url,
             title: title,
             kind: kind,
@@ -772,8 +772,8 @@ extension Core.Parser.HTML {
 
     private static func detectSource(
         from url: URL,
-        provided: StructuredDocumentationPage.Source
-    ) -> StructuredDocumentationPage.Source {
+        provided: Shared.Models.StructuredDocumentationPage.Source
+    ) -> Shared.Models.StructuredDocumentationPage.Source {
         guard let host = url.host?.lowercased() else {
             return provided
         }
@@ -792,7 +792,7 @@ extension Core.Parser.HTML {
     private static func detectKind(
         from html: String,
         url: URL
-    ) -> StructuredDocumentationPage.Kind {
+    ) -> Shared.Models.StructuredDocumentationPage.Kind {
         let lowercased = html.lowercased()
 
         // Check URL path for hints
@@ -893,7 +893,7 @@ extension Core.Parser.HTML {
 
     private static func extractDeclarationFromHTML(
         from html: String
-    ) -> StructuredDocumentationPage.Declaration? {
+    ) -> Shared.Models.StructuredDocumentationPage.Declaration? {
         let mainContent = extractMainContent(from: html)
         let regexOptions: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
 
@@ -918,7 +918,7 @@ extension Core.Parser.HTML {
 
                     // Check if this looks like a declaration
                     if looksLikeDeclaration(trimmed) {
-                        return StructuredDocumentationPage.Declaration(
+                        return Shared.Models.StructuredDocumentationPage.Declaration(
                             code: trimmed,
                             language: language.isEmpty ? "swift" : language
                         )
@@ -945,7 +945,7 @@ extension Core.Parser.HTML {
                     let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
 
                     if looksLikeDeclaration(trimmed) {
-                        return StructuredDocumentationPage.Declaration(
+                        return Shared.Models.StructuredDocumentationPage.Declaration(
                             code: trimmed,
                             language: "swift"
                         )
@@ -964,8 +964,8 @@ extension Core.Parser.HTML {
 
     private static func extractCodeExamplesFromHTML(
         from html: String
-    ) -> [StructuredDocumentationPage.CodeExample] {
-        var examples: [StructuredDocumentationPage.CodeExample] = []
+    ) -> [Shared.Models.StructuredDocumentationPage.CodeExample] {
+        var examples: [Shared.Models.StructuredDocumentationPage.CodeExample] = []
         let mainContent = extractMainContent(from: html)
         let regexOptions: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
 
@@ -993,7 +993,7 @@ extension Core.Parser.HTML {
 
                     // Skip if this looks like a declaration (already captured)
                     if !looksLikeDeclaration(trimmed), !trimmed.isEmpty {
-                        examples.append(StructuredDocumentationPage.CodeExample(
+                        examples.append(Shared.Models.StructuredDocumentationPage.CodeExample(
                             code: trimmed,
                             language: language
                         ))
@@ -1040,8 +1040,8 @@ extension Core.Parser.HTML {
 
     private static func extractSectionsFromHTML(
         from html: String
-    ) -> [StructuredDocumentationPage.Section] {
-        var sections: [StructuredDocumentationPage.Section] = []
+    ) -> [Shared.Models.StructuredDocumentationPage.Section] {
+        var sections: [Shared.Models.StructuredDocumentationPage.Section] = []
         let mainContent = extractMainContent(from: html)
 
         // Find all H2 headers
@@ -1064,7 +1064,7 @@ extension Core.Parser.HTML {
                     let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
 
                     if !trimmedTitle.isEmpty {
-                        sections.append(StructuredDocumentationPage.Section(
+                        sections.append(Shared.Models.StructuredDocumentationPage.Section(
                             title: trimmedTitle
                         ))
                     }

--- a/Packages/Sources/Core/JSONParser/AppleJSONToMarkdown.swift
+++ b/Packages/Sources/Core/JSONParser/AppleJSONToMarkdown.swift
@@ -1,5 +1,6 @@
 import CoreProtocols
 import Foundation
+import SharedConstants
 import SharedCore
 import SharedModels
 
@@ -537,7 +538,7 @@ extension AppleJSONToMarkdown {
         _ json: Data,
         url: URL,
         depth: Int? = nil
-    ) -> StructuredDocumentationPage? {
+    ) -> Shared.Models.StructuredDocumentationPage? {
         guard let doc = try? JSONDecoder().decode(AppleDocumentation.self, from: json) else {
             return nil
         }
@@ -563,7 +564,7 @@ extension AppleJSONToMarkdown {
         let codeExamples = extractCodeExamples(from: doc.primaryContentSections)
 
         // Extract sections (topics, see also)
-        var sections: [StructuredDocumentationPage.Section] = []
+        var sections: [Shared.Models.StructuredDocumentationPage.Section] = []
 
         if let topics = doc.topicSections {
             for topic in topics {
@@ -600,7 +601,7 @@ extension AppleJSONToMarkdown {
                     conformingTypes = types
                 default:
                     // Add as a section
-                    sections.append(StructuredDocumentationPage.Section(
+                    sections.append(Shared.Models.StructuredDocumentationPage.Section(
                         title: section.title,
                         items: types.map { .init(name: $0) }
                     ))
@@ -620,8 +621,8 @@ extension AppleJSONToMarkdown {
         // Hash canonical structured fields, not raw `json` — Apple's response
         // includes volatile cache/build metadata that doesn't reach our parsed
         // output, so `sha256(of: json)` is non-deterministic across runs (#199).
-        let page = StructuredDocumentationPage(
-            id: StructuredDocumentationPage.deterministicID(for: url),
+        let page = Shared.Models.StructuredDocumentationPage(
+            id: Shared.Models.StructuredDocumentationPage.deterministicID(for: url),
             url: url,
             title: doc.metadata.title,
             kind: kind,
@@ -650,7 +651,7 @@ extension AppleJSONToMarkdown {
     private static func parseKind(
         from roleHeading: String?,
         role: String?
-    ) -> StructuredDocumentationPage.Kind {
+    ) -> Shared.Models.StructuredDocumentationPage.Kind {
         let heading = roleHeading?.lowercased() ?? ""
         let roleStr = role?.lowercased() ?? ""
 
@@ -679,7 +680,7 @@ extension AppleJSONToMarkdown {
 
     private static func extractDeclaration(
         from sections: [PrimaryContentSection]?
-    ) -> StructuredDocumentationPage.Declaration? {
+    ) -> Shared.Models.StructuredDocumentationPage.Declaration? {
         guard let sections else { return nil }
 
         for section in sections where section.kind == "declarations" {
@@ -687,7 +688,7 @@ extension AppleJSONToMarkdown {
                let first = declarations.first,
                let tokens = first.tokens {
                 let code = tokens.map(\.text).joined()
-                return StructuredDocumentationPage.Declaration(code: code, language: "swift")
+                return Shared.Models.StructuredDocumentationPage.Declaration(code: code, language: "swift")
             }
         }
         return nil
@@ -727,16 +728,16 @@ extension AppleJSONToMarkdown {
 
     private static func extractCodeExamples(
         from sections: [PrimaryContentSection]?
-    ) -> [StructuredDocumentationPage.CodeExample] {
+    ) -> [Shared.Models.StructuredDocumentationPage.CodeExample] {
         guard let sections else { return [] }
 
-        var examples: [StructuredDocumentationPage.CodeExample] = []
+        var examples: [Shared.Models.StructuredDocumentationPage.CodeExample] = []
 
         for section in sections where section.kind == "content" {
             if let content = section.content {
                 for block in content where block.type == "codeListing" {
                     if let code = block.code {
-                        examples.append(StructuredDocumentationPage.CodeExample(
+                        examples.append(Shared.Models.StructuredDocumentationPage.CodeExample(
                             code: code.joined(separator: "\n"),
                             language: block.syntax
                         ))
@@ -764,18 +765,18 @@ extension AppleJSONToMarkdown {
     private static func convertTopicSection(
         _ section: TopicSection,
         references: [String: Reference]?
-    ) -> StructuredDocumentationPage.Section {
-        let items = section.identifiers.compactMap { identifier -> StructuredDocumentationPage.Section.Item? in
+    ) -> Shared.Models.StructuredDocumentationPage.Section {
+        let items = section.identifiers.compactMap { identifier -> Shared.Models.StructuredDocumentationPage.Section.Item? in
             let ref = references?[identifier]
             let name = ref?.title ?? identifier.components(separatedBy: "/").last ?? identifier
             let description = ref?.abstract.map { renderInlineContent($0) }
             let itemURL = documentationURLFromIdentifier(identifier)
-            return StructuredDocumentationPage.Section.Item(
+            return Shared.Models.StructuredDocumentationPage.Section.Item(
                 name: name,
                 description: description,
                 url: itemURL
             )
         }
-        return StructuredDocumentationPage.Section(title: section.title, items: items)
+        return Shared.Models.StructuredDocumentationPage.Section(title: section.title, items: items)
     }
 }

--- a/Packages/Sources/Core/JSONParser/MarkdownToStructuredPage.swift
+++ b/Packages/Sources/Core/JSONParser/MarkdownToStructuredPage.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SharedConstants
 import SharedCore
 import SharedModels
 
@@ -16,7 +17,7 @@ public enum MarkdownToStructuredPage {
     ///   - markdown: The markdown content
     ///   - url: Optional URL (extracted from frontmatter if not provided)
     /// - Returns: A StructuredDocumentationPage if extraction succeeds
-    public static func convert(_ markdown: String, url: URL? = nil) -> StructuredDocumentationPage? {
+    public static func convert(_ markdown: String, url: URL? = nil) -> Shared.Models.StructuredDocumentationPage? {
         // Parse frontmatter
         let (frontmatter, content) = parseFrontmatter(markdown)
 
@@ -75,8 +76,8 @@ public enum MarkdownToStructuredPage {
         // Hash canonical structured fields, not raw `markdown` — the markdown
         // body embeds the `crawled:` timestamp in its frontmatter, so
         // `sha256(of: markdown)` was non-deterministic across runs (#199).
-        let page = StructuredDocumentationPage(
-            id: StructuredDocumentationPage.deterministicID(for: pageURL),
+        let page = Shared.Models.StructuredDocumentationPage(
+            id: Shared.Models.StructuredDocumentationPage.deterministicID(for: pageURL),
             url: pageURL,
             title: title,
             kind: kind,
@@ -147,7 +148,7 @@ public enum MarkdownToStructuredPage {
 
     // MARK: - Kind Extraction
 
-    private static func extractKind(from content: String) -> StructuredDocumentationPage.Kind {
+    private static func extractKind(from content: String) -> Shared.Models.StructuredDocumentationPage.Kind {
         let lines = content.split(separator: "\n", omittingEmptySubsequences: false)
 
         // Look for pattern: "Kind# Title" on a single line
@@ -165,7 +166,7 @@ public enum MarkdownToStructuredPage {
         return .unknown
     }
 
-    private static func parseKind(_ kindString: String) -> StructuredDocumentationPage.Kind {
+    private static func parseKind(_ kindString: String) -> Shared.Models.StructuredDocumentationPage.Kind {
         let kind = kindString.lowercased().trimmingCharacters(in: .whitespaces)
 
         switch kind {
@@ -189,7 +190,7 @@ public enum MarkdownToStructuredPage {
 
     // MARK: - Declaration Extraction
 
-    private static func extractDeclaration(from content: String) -> StructuredDocumentationPage.Declaration? {
+    private static func extractDeclaration(from content: String) -> Shared.Models.StructuredDocumentationPage.Declaration? {
         // Find first fenced code block after title
         let pattern = #"```(?:swift)?\n([\s\S]*?)```"#
 
@@ -212,11 +213,11 @@ public enum MarkdownToStructuredPage {
             code.contains("protocol ") || code.contains("init(") ||
             code.contains("typealias ") || code.hasPrefix("@") ||
             code.hasPrefix("nonisolated") {
-            return StructuredDocumentationPage.Declaration(code: code, language: "swift")
+            return Shared.Models.StructuredDocumentationPage.Declaration(code: code, language: "swift")
         }
 
         // Return first code block anyway as declaration
-        return StructuredDocumentationPage.Declaration(code: code, language: "swift")
+        return Shared.Models.StructuredDocumentationPage.Declaration(code: code, language: "swift")
     }
 
     // MARK: - Abstract Extraction
@@ -346,8 +347,8 @@ public enum MarkdownToStructuredPage {
 
     // MARK: - Code Examples Extraction
 
-    private static func extractCodeExamples(from content: String) -> [StructuredDocumentationPage.CodeExample] {
-        var examples: [StructuredDocumentationPage.CodeExample] = []
+    private static func extractCodeExamples(from content: String) -> [Shared.Models.StructuredDocumentationPage.CodeExample] {
+        var examples: [Shared.Models.StructuredDocumentationPage.CodeExample] = []
 
         // Extract ALL code blocks from the document
         let pattern = #"```(?:swift)?\n([\s\S]*?)```"#
@@ -373,7 +374,7 @@ public enum MarkdownToStructuredPage {
                     }
                 }
 
-                examples.append(StructuredDocumentationPage.CodeExample(
+                examples.append(Shared.Models.StructuredDocumentationPage.CodeExample(
                     code: code,
                     language: "swift"
                 ))
@@ -403,7 +404,7 @@ public enum MarkdownToStructuredPage {
 
     // MARK: - Sections Extraction
 
-    private static func extractSections(from content: String) -> [StructuredDocumentationPage.Section] {
+    private static func extractSections(from content: String) -> [Shared.Models.StructuredDocumentationPage.Section] {
         // Try traditional Topics-based extraction first
         var sections = extractTopicsSections(from: content)
 
@@ -416,8 +417,8 @@ public enum MarkdownToStructuredPage {
     }
 
     /// Extract sections from ## [Topics] / ### [Section] format (WebKit HTML)
-    private static func extractTopicsSections(from content: String) -> [StructuredDocumentationPage.Section] {
-        var sections: [StructuredDocumentationPage.Section] = []
+    private static func extractTopicsSections(from content: String) -> [Shared.Models.StructuredDocumentationPage.Section] {
+        var sections: [Shared.Models.StructuredDocumentationPage.Section] = []
 
         // Find ## [Topics] section
         guard let topicsStart = content.range(of: "## [Topics]") ??
@@ -440,7 +441,7 @@ public enum MarkdownToStructuredPage {
         // Parse ### sections
         let lines = topicsContent.split(separator: "\n", omittingEmptySubsequences: false)
         var currentSection: String?
-        var currentItems: [StructuredDocumentationPage.Section.Item] = []
+        var currentItems: [Shared.Models.StructuredDocumentationPage.Section.Item] = []
         var currentContent: [String] = []
 
         for line in lines {
@@ -449,7 +450,7 @@ public enum MarkdownToStructuredPage {
             if trimmed.hasPrefix("### ") {
                 // Save previous section
                 if let section = currentSection {
-                    sections.append(StructuredDocumentationPage.Section(
+                    sections.append(Shared.Models.StructuredDocumentationPage.Section(
                         title: section,
                         content: currentContent.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines),
                         items: currentItems.isEmpty ? nil : currentItems
@@ -473,7 +474,7 @@ public enum MarkdownToStructuredPage {
 
         // Save last section
         if let section = currentSection {
-            sections.append(StructuredDocumentationPage.Section(
+            sections.append(Shared.Models.StructuredDocumentationPage.Section(
                 title: section,
                 content: currentContent.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines),
                 items: currentItems.isEmpty ? nil : currentItems
@@ -484,12 +485,12 @@ public enum MarkdownToStructuredPage {
     }
 
     /// Extract sections from ## Header / - **item**: format (JSON API markdown)
-    private static func extractH2Sections(from content: String) -> [StructuredDocumentationPage.Section] {
-        var sections: [StructuredDocumentationPage.Section] = []
+    private static func extractH2Sections(from content: String) -> [Shared.Models.StructuredDocumentationPage.Section] {
+        var sections: [Shared.Models.StructuredDocumentationPage.Section] = []
 
         let lines = content.split(separator: "\n", omittingEmptySubsequences: false)
         var currentSection: String?
-        var currentItems: [StructuredDocumentationPage.Section.Item] = []
+        var currentItems: [Shared.Models.StructuredDocumentationPage.Section.Item] = []
         var currentContent: [String] = []
         var inTopicsArea = false
 
@@ -514,7 +515,7 @@ public enum MarkdownToStructuredPage {
             if trimmed.hasPrefix("## ") {
                 // Save previous section if it had items
                 if let section = currentSection, !currentItems.isEmpty {
-                    sections.append(StructuredDocumentationPage.Section(
+                    sections.append(Shared.Models.StructuredDocumentationPage.Section(
                         title: section,
                         content: currentContent.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines),
                         items: currentItems
@@ -553,7 +554,7 @@ public enum MarkdownToStructuredPage {
 
         // Save last section
         if let section = currentSection, !currentItems.isEmpty {
-            sections.append(StructuredDocumentationPage.Section(
+            sections.append(Shared.Models.StructuredDocumentationPage.Section(
                 title: section,
                 content: currentContent.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines),
                 items: currentItems
@@ -564,7 +565,7 @@ public enum MarkdownToStructuredPage {
     }
 
     /// Parse - **name**: Description format
-    private static func parseBoldItem(_ line: String) -> StructuredDocumentationPage.Section.Item? {
+    private static func parseBoldItem(_ line: String) -> Shared.Models.StructuredDocumentationPage.Section.Item? {
         // Pattern: - **name**: Description or - **name**
         let pattern = #"- \*\*([^*]+)\*\*(?::?\s*(.*))?"#
 
@@ -589,7 +590,7 @@ public enum MarkdownToStructuredPage {
             }
         }
 
-        return StructuredDocumentationPage.Section.Item(name: name, description: description)
+        return Shared.Models.StructuredDocumentationPage.Section.Item(name: name, description: description)
     }
 
     private static func extractLinkText(from text: String) -> String {
@@ -603,8 +604,8 @@ public enum MarkdownToStructuredPage {
 
     /// Parse ALL topic items from a line (WebKit puts multiple items on one line)
     /// Format: [`name`](url)Description[`name2`](url2)Description2
-    private static func parseAllTopicItems(_ line: String) -> [StructuredDocumentationPage.Section.Item] {
-        var items: [StructuredDocumentationPage.Section.Item] = []
+    private static func parseAllTopicItems(_ line: String) -> [Shared.Models.StructuredDocumentationPage.Section.Item] {
+        var items: [Shared.Models.StructuredDocumentationPage.Section.Item] = []
 
         // Pattern matches: [`name`](url) followed by description (until next [` or end)
         // The description is everything up to the next [`
@@ -638,13 +639,13 @@ public enum MarkdownToStructuredPage {
                 }
             }
 
-            items.append(StructuredDocumentationPage.Section.Item(name: name, description: description, url: url))
+            items.append(Shared.Models.StructuredDocumentationPage.Section.Item(name: name, description: description, url: url))
         }
 
         return items
     }
 
-    private static func parseTopicItem(_ line: String) -> StructuredDocumentationPage.Section.Item? {
+    private static func parseTopicItem(_ line: String) -> Shared.Models.StructuredDocumentationPage.Section.Item? {
         // Pattern: [`name`](link)Description
         let pattern = #"\[`([^`]+)`\]\(([^)]+)\)(.*)"#
 
@@ -674,7 +675,7 @@ public enum MarkdownToStructuredPage {
             }
         }
 
-        return StructuredDocumentationPage.Section.Item(name: name, description: description, url: url)
+        return Shared.Models.StructuredDocumentationPage.Section.Item(name: name, description: description, url: url)
     }
 
     // MARK: - Platform Extraction

--- a/Packages/Sources/Core/JSONParser/RefResolver.swift
+++ b/Packages/Sources/Core/JSONParser/RefResolver.swift
@@ -162,7 +162,7 @@ public struct RefResolver {
         for fileURL in pageFiles {
             stats.pagesScanned += 1
             guard let data = try? Data(contentsOf: fileURL) else { continue }
-            guard let page = try? decoder.decode(StructuredDocumentationPage.self, from: data) else {
+            guard let page = try? decoder.decode(Shared.Models.StructuredDocumentationPage.self, from: data) else {
                 continue
             }
 
@@ -209,7 +209,7 @@ public struct RefResolver {
 
         for fileURL in pageFiles {
             guard let data = try? Data(contentsOf: fileURL) else { continue }
-            guard let page = try? decoder.decode(StructuredDocumentationPage.self, from: data) else {
+            guard let page = try? decoder.decode(Shared.Models.StructuredDocumentationPage.self, from: data) else {
                 continue
             }
             guard let markdown = page.rawMarkdown, !markdown.isEmpty else { continue }
@@ -375,14 +375,14 @@ private extension NSTextCheckingResult {
 
 // MARK: - StructuredDocumentationPage helper
 
-private extension StructuredDocumentationPage {
+private extension Shared.Models.StructuredDocumentationPage {
     /// Return a copy of the page with `rawMarkdown` replaced. All other
     /// fields preserved including `crawlDepth` and `contentHash` (we
     /// deliberately leave the content hash intact — resolve-refs is a
     /// downstream rewrite, not a recrawl, and we don't want it to look
     /// like the page changed at the source).
-    func with(rawMarkdown newMarkdown: String) -> StructuredDocumentationPage {
-        StructuredDocumentationPage(
+    func with(rawMarkdown newMarkdown: String) -> Shared.Models.StructuredDocumentationPage {
+        Shared.Models.StructuredDocumentationPage(
             id: id,
             url: url,
             title: title,

--- a/Packages/Sources/Core/PackageIndexing/PackageDependencyResolver.swift
+++ b/Packages/Sources/Core/PackageIndexing/PackageDependencyResolver.swift
@@ -65,7 +65,7 @@ extension Core {
         /// `apple/swift-docc` and `swiftlang/swift-docc` collapse into one entry);
         /// exclusions drop matched canonical names before adding them to the frontier.
         public func resolve(
-            seeds: [PackageReference],
+            seeds: [Shared.Models.PackageReference],
             onProgress: (@Sendable (String, Int, Int) -> Void)? = nil
         ) async -> (packages: [ResolvedPackage], stats: Statistics) {
             let startedAt = Date()
@@ -449,7 +449,7 @@ extension Core {
 
         // MARK: - Helpers
 
-        private func classify(owner: String) -> PackagePriority {
+        private func classify(owner: String) -> Shared.Models.PackagePriority {
             if owner == Shared.Constants.GitHubOrg.apple
                 || owner == Shared.Constants.GitHubOrg.swiftlang
                 || owner == Shared.Constants.GitHubOrg.swiftServer {

--- a/Packages/Sources/Core/PackageIndexing/PackageDocumentationDownloader.swift
+++ b/Packages/Sources/Core/PackageIndexing/PackageDocumentationDownloader.swift
@@ -1,6 +1,7 @@
 import CoreProtocols
 import Foundation
 import Logging
+import SharedConstants
 import SharedCore
 import SharedModels
 
@@ -60,12 +61,12 @@ extension Core {
         public func detectDocumentationSite(
             owner: String,
             repo: String
-        ) async -> DocumentationSite? {
+        ) async -> Shared.Models.DocumentationSite? {
             struct KnownSite {
                 let owner: String
                 let repo: String
                 let url: String
-                let type: DocumentationSite.DocumentationType
+                let type: Shared.Models.DocumentationSite.DocumentationType
             }
 
             let knownSites = [
@@ -80,13 +81,13 @@ extension Core {
                 if owner.lowercased() == site.owner.lowercased(),
                    repo.lowercased() == site.repo.lowercased(),
                    let url = URL(string: site.url) {
-                    return DocumentationSite(type: site.type, baseURL: url)
+                    return Shared.Models.DocumentationSite(type: site.type, baseURL: url)
                 }
             }
 
             if let githubPagesURL = URL(string: "https://\(owner).github.io/\(repo)/") {
                 if await urlExists(githubPagesURL) {
-                    return DocumentationSite(type: .githubPages, baseURL: githubPagesURL)
+                    return Shared.Models.DocumentationSite(type: .githubPages, baseURL: githubPagesURL)
                 }
             }
 

--- a/Packages/Sources/Core/PackageIndexing/ResolvedPackagesStore.swift
+++ b/Packages/Sources/Core/PackageIndexing/ResolvedPackagesStore.swift
@@ -1,5 +1,6 @@
 import CoreProtocols
 import Foundation
+import SharedConstants
 import SharedCore
 import SharedModels
 
@@ -11,14 +12,14 @@ extension Core {
         public let owner: String
         public let repo: String
         public let url: String
-        public let priority: PackagePriority
+        public let priority: Shared.Models.PackagePriority
         public let parents: [String]
 
         public init(
             owner: String,
             repo: String,
             url: String,
-            priority: PackagePriority,
+            priority: Shared.Models.PackagePriority,
             parents: [String]
         ) {
             self.owner = owner
@@ -84,7 +85,7 @@ extension Core {
         /// change here must invalidate the cache. Sort for stability so cosmetic
         /// reorderings in the seed file don't trigger a needless re-resolve.
         public static func checksum(
-            seeds: [PackageReference],
+            seeds: [Shared.Models.PackageReference],
             exclusions: Set<String>
         ) -> String {
             let seedEntries = seeds

--- a/Packages/Sources/Core/SwiftEvolutionCrawler.swift
+++ b/Packages/Sources/Core/SwiftEvolutionCrawler.swift
@@ -173,7 +173,7 @@ extension Core {
             }
 
             // Compute hash for change detection
-            _ = HashUtilities.sha256(of: markdown)
+            _ = Shared.Models.HashUtilities.sha256(of: markdown)
 
             // Save to file with proposal ID prefix (e.g., "SE-0001.md" or "ST-0001.md")
             let filename = "\(proposal.id)\(Shared.Constants.FileName.markdownExtension)"

--- a/Packages/Sources/CoreProtocols/ContentTransformer.swift
+++ b/Packages/Sources/CoreProtocols/ContentTransformer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SharedConstants
 import SharedCore
 import SharedModels
 
@@ -30,13 +31,13 @@ public struct TransformResult: Sendable {
     public let markdown: String
     public let links: [URL]
     public let metadata: TransformMetadata?
-    public let structuredPage: StructuredDocumentationPage?
+    public let structuredPage: Shared.Models.StructuredDocumentationPage?
 
     public init(
         markdown: String,
         links: [URL],
         metadata: TransformMetadata? = nil,
-        structuredPage: StructuredDocumentationPage? = nil
+        structuredPage: Shared.Models.StructuredDocumentationPage? = nil
     ) {
         self.markdown = markdown
         self.links = links

--- a/Packages/Sources/Distribution/ArtifactDownloader.swift
+++ b/Packages/Sources/Distribution/ArtifactDownloader.swift
@@ -1,6 +1,6 @@
 import Foundation
-import SharedCore
 import SharedConstants
+import SharedCore
 
 extension Distribution {
     /// Async file downloader with a progress callback. The callback fires

--- a/Packages/Sources/Distribution/InstalledVersion.swift
+++ b/Packages/Sources/Distribution/InstalledVersion.swift
@@ -1,6 +1,6 @@
 import Foundation
-import SharedCore
 import SharedConstants
+import SharedCore
 
 extension Distribution {
     /// Reads / writes / classifies the installed-version stamp under the

--- a/Packages/Sources/Distribution/SetupService.swift
+++ b/Packages/Sources/Distribution/SetupService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Logging
-import SharedCore
 import SharedConstants
+import SharedCore
 
 extension Distribution {
     /// High-level orchestrator for `cupertino setup`. Composes

--- a/Packages/Sources/Indexer/DocsIndexerService.swift
+++ b/Packages/Sources/Indexer/DocsIndexerService.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Logging
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 extension Indexer {
     /// Build `search.db` from on-disk corpus (apple-docs JSON, swift

--- a/Packages/Sources/Indexer/PackagesIndexerService.swift
+++ b/Packages/Sources/Indexer/PackagesIndexerService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 extension Indexer {
     /// Build `packages.db` from extracted package archives at

--- a/Packages/Sources/Indexer/Preflight.swift
+++ b/Packages/Sources/Indexer/Preflight.swift
@@ -1,6 +1,6 @@
 import Foundation
-import SharedCore
 import SharedConstants
+import SharedCore
 import SharedUtils
 
 extension Indexer {

--- a/Packages/Sources/Indexer/SamplesIndexerService.swift
+++ b/Packages/Sources/Indexer/SamplesIndexerService.swift
@@ -1,8 +1,8 @@
 import Core
+import CoreProtocols
 import Foundation
 import SampleIndex
 import SharedCore
-import CoreProtocols
 
 extension Indexer {
     /// Build `samples.db` from extracted sample-code zips at

--- a/Packages/Sources/Ingest/Session.swift
+++ b/Packages/Sources/Ingest/Session.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Logging
-import SharedCore
 import SharedConstants
+import SharedCore
 import SharedModels
 import SharedUtils
 
@@ -24,7 +24,7 @@ extension Ingest {
                 )
                 return
             }
-            var metadata = try CrawlMetadata.load(from: metadataFile)
+            var metadata = try Shared.Models.CrawlMetadata.load(from: metadataFile)
             metadata.crawlState = nil
             try metadata.save(to: metadataFile)
             Logging.ConsoleLogger.info(
@@ -46,7 +46,7 @@ extension Ingest {
                 )
                 return
             }
-            var metadata = try CrawlMetadata.load(from: metadataFile)
+            var metadata = try Shared.Models.CrawlMetadata.load(from: metadataFile)
             guard var crawlState = metadata.crawlState else {
                 Logging.ConsoleLogger.info(
                     "🔁 --retry-errors: no saved crawlState — nothing to retry"
@@ -64,7 +64,7 @@ extension Ingest {
                 return
             }
 
-            let erroredItems = errored.map { QueuedURL(url: $0, depth: maxDepth) }
+            let erroredItems = errored.map { Shared.Models.QueuedURL(url: $0, depth: maxDepth) }
             crawlState.queue = erroredItems + crawlState.queue
             for url in errored {
                 crawlState.visited.remove(url)
@@ -103,7 +103,7 @@ extension Ingest {
                 return
             }
 
-            var metadata = try CrawlMetadata.load(from: metadataFile)
+            var metadata = try Shared.Models.CrawlMetadata.load(from: metadataFile)
             guard var crawlState = metadata.crawlState else {
                 Logging.ConsoleLogger.info(
                     "🩹 --baseline: no saved crawlState — run with auto-resume "
@@ -150,7 +150,7 @@ extension Ingest {
                 return
             }
 
-            let injected = missing.map { QueuedURL(url: $0, depth: maxDepth) }
+            let injected = missing.map { Shared.Models.QueuedURL(url: $0, depth: maxDepth) }
             crawlState.queue = injected + crawlState.queue
             crawlState.lastSaveTime = Date()
             metadata.crawlState = crawlState
@@ -201,19 +201,19 @@ extension Ingest {
                 withIntermediateDirectories: true
             )
 
-            var metadata: CrawlMetadata
+            var metadata: Shared.Models.CrawlMetadata
             if FileManager.default.fileExists(atPath: metadataFile.path) {
-                metadata = try CrawlMetadata.load(from: metadataFile)
+                metadata = try Shared.Models.CrawlMetadata.load(from: metadataFile)
             } else {
-                metadata = CrawlMetadata()
+                metadata = Shared.Models.CrawlMetadata()
             }
 
-            var crawlState = metadata.crawlState ?? CrawlSessionState(
+            var crawlState = metadata.crawlState ?? Shared.Models.CrawlSessionState(
                 startURL: startURL.absoluteString,
                 outputDirectory: outputDirectory.path
             )
 
-            let newItems = validURLs.map { QueuedURL(url: $0, depth: 0) }
+            let newItems = validURLs.map { Shared.Models.QueuedURL(url: $0, depth: 0) }
             crawlState.queue = newItems + crawlState.queue
             crawlState.lastSaveTime = Date()
             metadata.crawlState = crawlState
@@ -234,7 +234,7 @@ extension Ingest {
             let metadataFile = directory.appendingPathComponent(Shared.Constants.FileName.metadata)
             guard FileManager.default.fileExists(atPath: metadataFile.path),
                   let data = try? Data(contentsOf: metadataFile),
-                  let metadata = try? JSONCoding.decode(CrawlMetadata.self, from: data),
+                  let metadata = try? Shared.Utils.JSONCoding.decode(Shared.Models.CrawlMetadata.self, from: data),
                   let session = metadata.crawlState,
                   session.isActive,
                   session.startURL == url.absoluteString

--- a/Packages/Sources/MCP/Support/DocsResourceProvider.swift
+++ b/Packages/Sources/MCP/Support/DocsResourceProvider.swift
@@ -14,7 +14,7 @@ import SharedUtils
 /// Provides crawled documentation as MCP resources
 public actor DocsResourceProvider: MCP.Core.ResourceProvider {
     private let configuration: Shared.Configuration
-    private var metadata: CrawlMetadata?
+    private var metadata: Shared.Models.CrawlMetadata?
     private let evolutionDirectory: URL
     private let archiveDirectory: URL
     private let searchIndex: Search.Index?
@@ -56,7 +56,7 @@ public actor DocsResourceProvider: MCP.Core.ResourceProvider {
                     continue
                 }
                 let uri = "\(Shared.Constants.Search.appleDocsScheme)\(pageMetadata.framework)/"
-                    + "\(URLUtilities.filename(from: parsedURL))"
+                    + "\(Shared.Models.URLUtilities.filename(from: parsedURL))"
                 let resource = MCP.Core.Protocols.Resource(
                     uri: uri,
                     name: extractTitle(from: url),
@@ -146,7 +146,7 @@ public actor DocsResourceProvider: MCP.Core.ResourceProvider {
             if FileManager.default.fileExists(atPath: jsonPath.path) {
                 // Read JSON and extract rawMarkdown
                 let jsonData = try Data(contentsOf: jsonPath)
-                let page = try JSONCoding.decode(StructuredDocumentationPage.self, from: jsonData)
+                let page = try Shared.Utils.JSONCoding.decode(Shared.Models.StructuredDocumentationPage.self, from: jsonData)
                 guard let rawMarkdown = page.rawMarkdown else {
                     throw ToolError.notFound(uri)
                 }
@@ -239,7 +239,7 @@ public actor DocsResourceProvider: MCP.Core.ResourceProvider {
         }
 
         do {
-            metadata = try CrawlMetadata.load(from: metadataURL)
+            metadata = try Shared.Models.CrawlMetadata.load(from: metadataURL)
         } catch {
             Logging.Log.warning("Failed to load metadata: \(error)", category: .mcp)
         }
@@ -251,13 +251,13 @@ public actor DocsResourceProvider: MCP.Core.ResourceProvider {
     /// can exercise `listResources` against a hand-crafted `CrawlMetadata`
     /// (including malformed-URL rows) without bootstrapping a real
     /// crawl + metadata.json fixture on disk.
-    func injectMetadataForTesting(_ metadata: CrawlMetadata) {
+    func injectMetadataForTesting(_ metadata: Shared.Models.CrawlMetadata) {
         self.metadata = metadata
     }
 
     // MARK: - Metadata
 
-    private func getMetadata() async throws -> CrawlMetadata {
+    private func getMetadata() async throws -> Shared.Models.CrawlMetadata {
         if let metadata {
             return metadata
         }

--- a/Packages/Sources/ReleaseTool/DatabaseReleaseCommand.swift
+++ b/Packages/Sources/ReleaseTool/DatabaseReleaseCommand.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
-import SharedCore
 import SharedConstants
+import SharedCore
 import SharedUtils
 
 // MARK: - Database Release Command (search.db + samples.db + packages.db → cupertino-docs)
@@ -80,10 +80,10 @@ struct DatabaseReleaseCommand: AsyncParsableCommand {
         let samplesSize = try ReleasePublishing.fileSize(at: samplesDBURL)
         let packagesSize = try packagesDBPresent ? (ReleasePublishing.fileSize(at: packagesDBURL)) : 0
         Console.info("📊 Database sizes:")
-        Console.substep("search.db:   \(Shared.Formatting.formatBytes(searchSize))")
-        Console.substep("samples.db:  \(Shared.Formatting.formatBytes(samplesSize))")
+        Console.substep("search.db:   \(Shared.Utils.Formatting.formatBytes(searchSize))")
+        Console.substep("samples.db:  \(Shared.Utils.Formatting.formatBytes(samplesSize))")
         if packagesDBPresent {
-            Console.substep("packages.db: \(Shared.Formatting.formatBytes(packagesSize))")
+            Console.substep("packages.db: \(Shared.Utils.Formatting.formatBytes(packagesSize))")
         } else {
             Console.warning("packages.db: missing (continuing because --allow-missing-packages was passed)")
         }
@@ -100,7 +100,7 @@ struct DatabaseReleaseCommand: AsyncParsableCommand {
         try ReleasePublishing.createZip(containing: bundled, at: zipURL)
 
         let zipSize = try ReleasePublishing.fileSize(at: zipURL)
-        Console.substep("✓ Created (\(Shared.Formatting.formatBytes(zipSize)))")
+        Console.substep("✓ Created (\(Shared.Utils.Formatting.formatBytes(zipSize)))")
 
         Console.info("\n🔐 Calculating SHA256...")
         let sha256 = try ReleasePublishing.calculateSHA256(of: zipURL)

--- a/Packages/Sources/ReleaseTool/ReleaseCLI.swift
+++ b/Packages/Sources/ReleaseTool/ReleaseCLI.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Release CLI
 

--- a/Packages/Sources/ReleaseTool/ReleasePublishingHelpers.swift
+++ b/Packages/Sources/ReleaseTool/ReleasePublishingHelpers.swift
@@ -1,6 +1,6 @@
 import Foundation
-import SharedCore
 import SharedConstants
+import SharedCore
 import SharedUtils
 
 // MARK: - Shared publishing helpers
@@ -273,7 +273,7 @@ private final class UploadProgressDelegate: NSObject, URLSessionTaskDelegate, @u
         let expectedSize = totalBytesExpectedToSend > 0 ? totalBytesExpectedToSend : totalSize
 
         guard expectedSize > 0 else {
-            let uploaded = Shared.Formatting.formatBytes(totalBytesSent)
+            let uploaded = Shared.Utils.Formatting.formatBytes(totalBytesSent)
             let output = "\(clearLine)   \(currentSpinner) Uploading... \(uploaded)"
             FileHandle.standardOutput.write(Data(output.utf8))
             fflush(stdout)
@@ -286,8 +286,8 @@ private final class UploadProgressDelegate: NSObject, URLSessionTaskDelegate, @u
 
         let bar = String(repeating: "█", count: filled) + String(repeating: "░", count: empty)
         let percent = String(format: "%3.0f%%", progress * 100)
-        let uploaded = Shared.Formatting.formatBytes(totalBytesSent)
-        let total = Shared.Formatting.formatBytes(expectedSize)
+        let uploaded = Shared.Utils.Formatting.formatBytes(totalBytesSent)
+        let total = Shared.Utils.Formatting.formatBytes(expectedSize)
 
         let output = "\(clearLine)   \(currentSpinner) [\(bar)] \(percent) (\(uploaded)/\(total))"
         FileHandle.standardOutput.write(Data(output.utf8))

--- a/Packages/Sources/RemoteSync/AnimatedProgress.swift
+++ b/Packages/Sources/RemoteSync/AnimatedProgress.swift
@@ -1,7 +1,7 @@
 import Foundation
+import SharedConstants
 import SharedCore
 import SharedUtils
-import SharedConstants
 
 // MARK: - Animated Progress Display
 
@@ -43,7 +43,7 @@ public struct AnimatedProgress: Sendable {
         }
 
         // Time info
-        let elapsedStr = Shared.Formatting.formatDuration(progress.elapsed)
+        let elapsedStr = Shared.Utils.Formatting.formatDuration(progress.elapsed)
         line += " | \(elapsedStr)"
 
         return line

--- a/Packages/Sources/RemoteSync/GitHubFetcher.swift
+++ b/Packages/Sources/RemoteSync/GitHubFetcher.swift
@@ -1,6 +1,6 @@
 import Foundation
-import SharedCore
 import SharedConstants
+import SharedCore
 import SharedUtils
 
 // MARK: - GitHub Fetcher

--- a/Packages/Sources/RemoteSync/RemoteIndexState.swift
+++ b/Packages/Sources/RemoteSync/RemoteIndexState.swift
@@ -209,42 +209,42 @@ public struct RemoteIndexState: Codable, Sendable, Equatable {
 // MARK: - Progress Callback
 
 extension RemoteSync {
-/// Progress information for callbacks
-public struct Progress: Sendable {
-    public let phase: RemoteIndexState.Phase
-    public let framework: String?
-    public let frameworkIndex: Int
-    public let frameworksTotal: Int
-    public let fileIndex: Int
-    public let filesTotal: Int
-    public let elapsed: TimeInterval
-    public let overallProgress: Double
+    /// Progress information for callbacks
+    public struct Progress: Sendable {
+        public let phase: RemoteIndexState.Phase
+        public let framework: String?
+        public let frameworkIndex: Int
+        public let frameworksTotal: Int
+        public let fileIndex: Int
+        public let filesTotal: Int
+        public let elapsed: TimeInterval
+        public let overallProgress: Double
 
-    public init(
-        phase: RemoteIndexState.Phase,
-        framework: String?,
-        frameworkIndex: Int,
-        frameworksTotal: Int,
-        fileIndex: Int,
-        filesTotal: Int,
-        elapsed: TimeInterval,
-        overallProgress: Double
-    ) {
-        self.phase = phase
-        self.framework = framework
-        self.frameworkIndex = frameworkIndex
-        self.frameworksTotal = frameworksTotal
-        self.fileIndex = fileIndex
-        self.filesTotal = filesTotal
-        self.elapsed = elapsed
-        self.overallProgress = overallProgress
-    }
+        public init(
+            phase: RemoteIndexState.Phase,
+            framework: String?,
+            frameworkIndex: Int,
+            frameworksTotal: Int,
+            fileIndex: Int,
+            filesTotal: Int,
+            elapsed: TimeInterval,
+            overallProgress: Double
+        ) {
+            self.phase = phase
+            self.framework = framework
+            self.frameworkIndex = frameworkIndex
+            self.frameworksTotal = frameworksTotal
+            self.fileIndex = fileIndex
+            self.filesTotal = filesTotal
+            self.elapsed = elapsed
+            self.overallProgress = overallProgress
+        }
 
-    /// Estimated time remaining based on current progress
-    public var estimatedTimeRemaining: TimeInterval? {
-        guard overallProgress > 0.01 else { return nil }
-        let totalEstimated = elapsed / overallProgress
-        return totalEstimated - elapsed
+        /// Estimated time remaining based on current progress
+        public var estimatedTimeRemaining: TimeInterval? {
+            guard overallProgress > 0.01 else { return nil }
+            let totalEstimated = elapsed / overallProgress
+            return totalEstimated - elapsed
+        }
     }
-}
 }

--- a/Packages/Sources/RemoteSync/RemoteIndexer.swift
+++ b/Packages/Sources/RemoteSync/RemoteIndexer.swift
@@ -1,6 +1,6 @@
 import Foundation
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Indexing Context
 

--- a/Packages/Sources/SampleIndex/SampleIndex.swift
+++ b/Packages/Sources/SampleIndex/SampleIndex.swift
@@ -1,6 +1,6 @@
 import Foundation
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - SampleIndex Namespace
 

--- a/Packages/Sources/SampleIndex/SampleIndexBuilder.swift
+++ b/Packages/Sources/SampleIndex/SampleIndexBuilder.swift
@@ -1,8 +1,8 @@
 import ASTIndexer
 import Foundation
 import OSLog
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Sample Index Builder
 

--- a/Packages/Sources/SampleIndex/SampleIndexDatabase.swift
+++ b/Packages/Sources/SampleIndex/SampleIndexDatabase.swift
@@ -1,9 +1,9 @@
 import ASTIndexer
 import Foundation
-import SharedCore
-import SQLite3
-import SharedUtils
 import SharedConstants
+import SharedCore
+import SharedUtils
+import SQLite3
 
 // MARK: - Sample Index Database
 
@@ -16,12 +16,12 @@ extension SampleIndex {
         /// Version history:
         /// - 1: Initial schema (projects, files, projects_fts, files_fts)
         /// - 2: Added file_symbols, file_imports tables for SwiftSyntax AST indexing (#81)
-        // Bumped to 3 in #228 phase 2: added per-sample availability
-        // columns to `projects` (`min_ios`, `min_macos`, `min_tvos`,
-        // `min_watchos`, `min_visionos`, `availability_source`) plus
-        // `available_attrs_json` on `files`. No migration — `save
-        // --samples` always wipes the DB and rebuilds, so existing v2
-        // databases get replaced wholesale on the next run.
+        /// Bumped to 3 in #228 phase 2: added per-sample availability
+        /// columns to `projects` (`min_ios`, `min_macos`, `min_tvos`,
+        /// `min_watchos`, `min_visionos`, `availability_source`) plus
+        /// `available_attrs_json` on `files`. No migration — `save
+        /// --samples` always wipes the DB and rebuilds, so existing v2
+        /// databases get replaced wholesale on the next run.
         public static let schemaVersion: Int32 = 3
 
         private var database: OpaquePointer?
@@ -285,7 +285,7 @@ extension SampleIndex {
             sqlite3_bind_int64(statement, 9, Int64(project.totalSize))
             sqlite3_bind_int64(statement, 10, Int64(project.indexedAt.timeIntervalSince1970))
 
-            // #228 phase 2: availability columns 11-16.
+            /// #228 phase 2: availability columns 11-16.
             func bindMin(_ pos: Int32, _ key: String) {
                 if let value = project.deploymentTargets[key] {
                     sqlite3_bind_text(statement, pos, (value as NSString).utf8String, -1, nil)
@@ -583,8 +583,8 @@ extension SampleIndex {
             // Build FTS5 query: tokenize natural language, drop
             // stopwords, OR-join the remainder. Same shape as
             // Search.PackageQuery uses for packages.db (#238 unified
-            // both paths via Shared.FTSQuery).
-            let sanitizedQuery = Shared.FTSQuery.build(question: query)
+            // both paths via Shared.Utils.FTSQuery).
+            let sanitizedQuery = Shared.Utils.FTSQuery.build(question: query)
             guard !sanitizedQuery.isEmpty else { return [] }
 
             var sql = """
@@ -686,8 +686,8 @@ extension SampleIndex {
             // Build FTS5 query: tokenize natural language, drop
             // stopwords, OR-join the remainder. Same shape as
             // Search.PackageQuery uses for packages.db (#238 unified
-            // both paths via Shared.FTSQuery).
-            let sanitizedQuery = Shared.FTSQuery.build(question: query)
+            // both paths via Shared.Utils.FTSQuery).
+            let sanitizedQuery = Shared.Utils.FTSQuery.build(question: query)
             guard !sanitizedQuery.isEmpty else { return [] }
 
             // #233: optional platform filter — JOIN projects table when

--- a/Packages/Sources/Search/PackageIndexer.swift
+++ b/Packages/Sources/Search/PackageIndexer.swift
@@ -145,7 +145,7 @@ extension Search {
                 throw IndexerError.manifestMalformed(manifestURL, String(describing: error))
             }
 
-            let priority: PackagePriority
+            let priority: Shared.Models.PackagePriority
             if manifest.owner == Shared.Constants.GitHubOrg.apple
                 || manifest.owner == Shared.Constants.GitHubOrg.swiftlang
                 || manifest.owner == Shared.Constants.GitHubOrg.swiftServer {

--- a/Packages/Sources/Search/SearchIndex+ContentAndPackages.swift
+++ b/Packages/Sources/Search/SearchIndex+ContentAndPackages.swift
@@ -152,7 +152,7 @@ extension Search.Index {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
 
-            if let page = try? decoder.decode(StructuredDocumentationPage.self, from: jsonData) {
+            if let page = try? decoder.decode(Shared.Models.StructuredDocumentationPage.self, from: jsonData) {
                 // 1. Try rawMarkdown first
                 if let rawMarkdown = page.rawMarkdown, !rawMarkdown.isEmpty {
                     return rawMarkdown

--- a/Packages/Sources/Search/SearchIndex+IndexingDocs.swift
+++ b/Packages/Sources/Search/SearchIndex+IndexingDocs.swift
@@ -260,7 +260,7 @@ extension Search.Index {
     /// Extract optimized FTS content based on document kind
     /// Core types get focused content (title, abstract, overview) without member noise
     /// Members get title + abstract + declaration for quick matching
-    func extractOptimizedContent(from page: StructuredDocumentationPage) -> String {
+    func extractOptimizedContent(from page: Shared.Models.StructuredDocumentationPage) -> String {
         let kind = page.inferredKind
         var parts: [String] = []
 
@@ -328,7 +328,7 @@ extension Search.Index {
         uri: String,
         source: String,
         framework: String,
-        page: StructuredDocumentationPage,
+        page: Shared.Models.StructuredDocumentationPage,
         jsonData: String,
         overrideMinIOS: String? = nil,
         overrideMinMacOS: String? = nil,

--- a/Packages/Sources/Search/SearchIndexBuilder.swift
+++ b/Packages/Sources/Search/SearchIndexBuilder.swift
@@ -18,7 +18,7 @@ import SharedModels
 extension Search {
     public actor IndexBuilder {
         private let searchIndex: Search.Index
-        private let metadata: CrawlMetadata?
+        private let metadata: Shared.Models.CrawlMetadata?
         private let docsDirectory: URL
         private let evolutionDirectory: URL?
         private let swiftOrgDirectory: URL?
@@ -28,7 +28,7 @@ extension Search {
 
         public init(
             searchIndex: Search.Index,
-            metadata: CrawlMetadata?,
+            metadata: Shared.Models.CrawlMetadata?,
             docsDirectory: URL,
             evolutionDirectory: URL? = nil,
             swiftOrgDirectory: URL? = nil,
@@ -146,7 +146,7 @@ extension Search {
         /// branch added in PR #288) without needing to bootstrap the whole
         /// `buildIndex()` orchestration.
         func indexAppleDocsFromMetadata(
-            metadata: CrawlMetadata,
+            metadata: Shared.Models.CrawlMetadata,
             onProgress: (@Sendable (Int, Int) -> Void)?
         ) async throws {
             let total = metadata.pages.count
@@ -187,10 +187,10 @@ extension Search {
                 }
 
                 // Extract title from front matter or first heading
-                let title = extractTitle(from: content) ?? URLUtilities.filename(from: parsedURL)
+                let title = extractTitle(from: content) ?? Shared.Models.URLUtilities.filename(from: parsedURL)
 
                 // Build URI
-                let uri = "apple-docs://\(pageMetadata.framework)/\(URLUtilities.filename(from: parsedURL))"
+                let uri = "apple-docs://\(pageMetadata.framework)/\(Shared.Models.URLUtilities.filename(from: parsedURL))"
 
                 // Index document (Apple docs from /docs folder)
                 do {
@@ -253,7 +253,7 @@ extension Search {
                 let framework = canonicalPathComponent(rawFramework)
 
                 // Always work with StructuredDocumentationPage
-                let structuredPage: StructuredDocumentationPage
+                let structuredPage: Shared.Models.StructuredDocumentationPage
                 let jsonString: String
 
                 if file.pathExtension == "json" {
@@ -263,7 +263,7 @@ extension Search {
                         jsonString = String(data: jsonData, encoding: .utf8) ?? "{}"
                         let decoder = JSONDecoder()
                         decoder.dateDecodingStrategy = .iso8601
-                        structuredPage = try decoder.decode(StructuredDocumentationPage.self, from: jsonData)
+                        structuredPage = try decoder.decode(Shared.Models.StructuredDocumentationPage.self, from: jsonData)
                     } catch {
                         logError("Failed to decode \(file.lastPathComponent): \(error)")
                         skipped += 1
@@ -322,7 +322,7 @@ extension Search {
                 }
 
                 // Generate URI: apple-docs://{framework}/{filename}
-                let filename = URLUtilities.normalize(structuredPage.url)?.lastPathComponent
+                let filename = Shared.Models.URLUtilities.normalize(structuredPage.url)?.lastPathComponent
                     ?? canonicalPathComponent(file.deletingPathExtension().lastPathComponent)
                 let uri = "apple-docs://\(framework)/\(filename)"
 
@@ -452,19 +452,19 @@ extension Search {
         /// `crawledAt`; without this the decode silently fails on every real
         /// Apple-doc JSON file and the dedup primary path becomes dead code.
         /// See `indexStructuredDocument` for the canonical decoder config.
-        func loadStructuredPage(from file: URL) -> StructuredDocumentationPage? {
+        func loadStructuredPage(from file: URL) -> Shared.Models.StructuredDocumentationPage? {
             guard file.pathExtension.lowercased() == "json",
                   let data = try? Data(contentsOf: file) else {
                 return nil
             }
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            return try? decoder.decode(StructuredDocumentationPage.self, from: data)
+            return try? decoder.decode(Shared.Models.StructuredDocumentationPage.self, from: data)
         }
 
         func canonicalDocumentationURL(for file: URL) -> String? {
             if let page = loadStructuredPage(from: file) {
-                return URLUtilities.normalize(page.url)?.absoluteString
+                return Shared.Models.URLUtilities.normalize(page.url)?.absoluteString
             }
 
             guard let rawFramework = extractFrameworkFromPath(file, relativeTo: docsDirectory) else {
@@ -609,7 +609,7 @@ extension Search {
 
             let attributes = try? FileManager.default.attributesOfItem(atPath: file.path)
             let modDate = attributes?[.modificationDate] as? Date ?? Date()
-            let contentHash = HashUtilities.sha256(of: content)
+            let contentHash = Shared.Models.HashUtilities.sha256(of: content)
 
             // Extract Swift version from status and map to iOS/macOS
             let status = extractProposalStatus(from: content)
@@ -775,7 +775,7 @@ extension Search {
                     ?? Shared.Constants.SourcePrefix.swiftOrg
 
                 // Handle JSON and MD files (same pattern as Apple docs)
-                let structuredPage: StructuredDocumentationPage
+                let structuredPage: Shared.Models.StructuredDocumentationPage
                 let jsonString: String
 
                 if file.pathExtension == "json" {
@@ -785,7 +785,7 @@ extension Search {
                         jsonString = String(data: jsonData, encoding: .utf8) ?? "{}"
                         let decoder = JSONDecoder()
                         decoder.dateDecodingStrategy = .iso8601
-                        structuredPage = try decoder.decode(StructuredDocumentationPage.self, from: jsonData)
+                        structuredPage = try decoder.decode(Shared.Models.StructuredDocumentationPage.self, from: jsonData)
                     } catch {
                         logError("Failed to decode \(file.lastPathComponent): \(error)")
                         skipped += 1
@@ -928,7 +928,7 @@ extension Search {
                 let uri = "apple-archive://\(guideID)/\(filename)"
 
                 // Calculate content hash
-                let contentHash = HashUtilities.sha256(of: content)
+                let contentHash = Shared.Models.HashUtilities.sha256(of: content)
 
                 // Use file modification date
                 let attributes = try? FileManager.default.attributesOfItem(atPath: file.path)
@@ -1017,7 +1017,7 @@ extension Search {
                 let uri = "hig://\(category)/\(filename)"
 
                 // Calculate content hash
-                let contentHash = HashUtilities.sha256(of: content)
+                let contentHash = Shared.Models.HashUtilities.sha256(of: content)
 
                 // Use file modification date
                 let attributes = try? FileManager.default.attributesOfItem(atPath: file.path)
@@ -1329,7 +1329,7 @@ extension Search {
         /// missed by every prior title-only check.
         ///
         /// `internal` so SearchTests can pin the truth table.
-        static func pageLooksLikeJavaScriptFallback(_ page: StructuredDocumentationPage) -> Bool {
+        static func pageLooksLikeJavaScriptFallback(_ page: Shared.Models.StructuredDocumentationPage) -> Bool {
             // Strongest signal: overview is the literal Apple JS-warning text.
             if let overview = page.overview, overview.contains("Please turn on JavaScript") {
                 return true

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -700,7 +700,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         markdown += "## Metadata\n\n"
         markdown += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
         markdown += "- **Files:** \(project.fileCount)\n"
-        markdown += "- **Size:** \(Shared.Formatting.formatBytes(project.totalSize))\n"
+        markdown += "- **Size:** \(Shared.Utils.Formatting.formatBytes(project.totalSize))\n"
         if !project.webURL.isEmpty {
             markdown += "- **Apple Developer:** \(project.webURL)\n"
         }
@@ -747,7 +747,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         var markdown = "# \(file.filename)\n\n"
         markdown += "**Project:** `\(file.projectId)`\n"
         markdown += "**Path:** `\(file.path)`\n"
-        markdown += "**Size:** \(Shared.Formatting.formatBytes(file.size))\n\n"
+        markdown += "**Size:** \(Shared.Utils.Formatting.formatBytes(file.size))\n\n"
 
         let language = languageForExtension(file.fileExtension)
 

--- a/Packages/Sources/Services/Formatters/FooterFormatter.swift
+++ b/Packages/Sources/Services/Formatters/FooterFormatter.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SampleIndex
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Footer Types
 

--- a/Packages/Sources/Services/Formatters/HIGFormatters.swift
+++ b/Packages/Sources/Services/Formatters/HIGFormatters.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - HIG Text Formatter
 

--- a/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SampleIndex
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Markdown Search Result Formatter
 

--- a/Packages/Sources/Services/Formatters/SampleMarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleMarkdownFormatter.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SampleIndex
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Sample Search Markdown Formatter
 

--- a/Packages/Sources/Services/Formatters/SampleTextFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleTextFormatter.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SampleIndex
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Sample Search Text Formatter
 

--- a/Packages/Sources/Services/Formatters/TeaserResults.swift
+++ b/Packages/Sources/Services/Formatters/TeaserResults.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SampleIndex
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Teaser Results
 

--- a/Packages/Sources/Services/Formatters/TextFormatter.swift
+++ b/Packages/Sources/Services/Formatters/TextFormatter.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Text Search Result Formatter
 

--- a/Packages/Sources/Services/Formatters/UnifiedSearchFormatters.swift
+++ b/Packages/Sources/Services/Formatters/UnifiedSearchFormatters.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SampleIndex
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Text Formatter for Unified Search
 

--- a/Packages/Sources/Services/ReadCommands/DocsSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/DocsSearchService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Documentation Search Service
 

--- a/Packages/Sources/Services/ReadCommands/HIGSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/HIGSearchService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - HIG Search Query
 

--- a/Packages/Sources/Services/ReadCommands/ReadService.swift
+++ b/Packages/Sources/Services/ReadCommands/ReadService.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SampleIndex
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Unified read service
 

--- a/Packages/Sources/Services/ReadCommands/SampleSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/SampleSearchService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SampleIndex
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Sample Search Query
 

--- a/Packages/Sources/Services/ReadCommands/TeaserService.swift
+++ b/Packages/Sources/Services/ReadCommands/TeaserService.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SampleIndex
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 import SharedUtils
 
 // MARK: - Teaser Service
@@ -21,13 +21,13 @@ public actor TeaserService {
 
     /// Initialize with database paths (creates connections)
     public init(searchDbPath: URL?, sampleDbPath: URL?) async throws {
-        if let searchDbPath, PathResolver.exists(searchDbPath) {
+        if let searchDbPath, Shared.Utils.PathResolver.exists(searchDbPath) {
             searchIndex = try await Search.Index(dbPath: searchDbPath)
         } else {
             searchIndex = nil
         }
 
-        if let sampleDbPath, PathResolver.exists(sampleDbPath) {
+        if let sampleDbPath, Shared.Utils.PathResolver.exists(sampleDbPath) {
             sampleDatabase = try await SampleIndex.Database(dbPath: sampleDbPath)
         } else {
             sampleDatabase = nil
@@ -163,12 +163,12 @@ extension ServiceContainer {
         sampleDbPath: URL? = nil,
         operation: (TeaserService) async throws -> T
     ) async throws -> T {
-        let resolvedSearchPath = PathResolver.searchDatabase(searchDbPath)
+        let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
         let resolvedSamplePath = sampleDbPath ?? SampleIndex.defaultDatabasePath
 
         let service = try await TeaserService(
-            searchDbPath: PathResolver.exists(resolvedSearchPath) ? resolvedSearchPath : nil,
-            sampleDbPath: PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil
+            searchDbPath: Shared.Utils.PathResolver.exists(resolvedSearchPath) ? resolvedSearchPath : nil,
+            sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil
         )
 
         return try await operation(service)

--- a/Packages/Sources/Services/ReadCommands/UnifiedSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/UnifiedSearchService.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SampleIndex
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 import SharedUtils
 
 // MARK: - Unified Search Service
@@ -21,13 +21,13 @@ public actor UnifiedSearchService {
 
     /// Initialize with database paths (creates connections)
     public init(searchDbPath: URL?, sampleDbPath: URL?) async throws {
-        if let searchDbPath, PathResolver.exists(searchDbPath) {
+        if let searchDbPath, Shared.Utils.PathResolver.exists(searchDbPath) {
             searchIndex = try await Search.Index(dbPath: searchDbPath)
         } else {
             searchIndex = nil
         }
 
-        if let sampleDbPath, PathResolver.exists(sampleDbPath) {
+        if let sampleDbPath, Shared.Utils.PathResolver.exists(sampleDbPath) {
             sampleDatabase = try await SampleIndex.Database(dbPath: sampleDbPath)
         } else {
             sampleDatabase = nil
@@ -174,12 +174,12 @@ extension ServiceContainer {
         sampleDbPath: URL? = nil,
         operation: (UnifiedSearchService) async throws -> T
     ) async throws -> T {
-        let resolvedSearchPath = PathResolver.searchDatabase(searchDbPath)
+        let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
         let resolvedSamplePath = sampleDbPath ?? SampleIndex.defaultDatabasePath
 
         let service = try await UnifiedSearchService(
-            searchDbPath: PathResolver.exists(resolvedSearchPath) ? resolvedSearchPath : nil,
-            sampleDbPath: PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil
+            searchDbPath: Shared.Utils.PathResolver.exists(resolvedSearchPath) ? resolvedSearchPath : nil,
+            sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil
         )
 
         return try await operation(service)

--- a/Packages/Sources/Services/SampleCandidateFetcher.swift
+++ b/Packages/Sources/Services/SampleCandidateFetcher.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SampleIndex
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Sample candidate fetcher (#230)
 

--- a/Packages/Sources/Services/SearchService.swift
+++ b/Packages/Sources/Services/SearchService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 
 // MARK: - Search Service Protocol
 

--- a/Packages/Sources/Services/ServiceContainer.swift
+++ b/Packages/Sources/Services/ServiceContainer.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SampleIndex
 import Search
-import SharedCore
 import SharedConstants
+import SharedCore
 import SharedUtils
 
 // MARK: - Service Container
@@ -93,9 +93,9 @@ public actor ServiceContainer {
         dbPath: String? = nil,
         operation: (DocsSearchService) async throws -> T
     ) async throws -> T {
-        let resolvedPath = PathResolver.searchDatabase(dbPath)
+        let resolvedPath = Shared.Utils.PathResolver.searchDatabase(dbPath)
 
-        guard PathResolver.exists(resolvedPath) else {
+        guard Shared.Utils.PathResolver.exists(resolvedPath) else {
             throw ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
         }
 
@@ -114,9 +114,9 @@ public actor ServiceContainer {
         dbPath: String? = nil,
         operation: (HIGSearchService) async throws -> T
     ) async throws -> T {
-        let resolvedPath = PathResolver.searchDatabase(dbPath)
+        let resolvedPath = Shared.Utils.PathResolver.searchDatabase(dbPath)
 
-        guard PathResolver.exists(resolvedPath) else {
+        guard Shared.Utils.PathResolver.exists(resolvedPath) else {
             throw ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
         }
 
@@ -136,7 +136,7 @@ public actor ServiceContainer {
         dbPath: URL,
         operation: (SampleSearchService) async throws -> T
     ) async throws -> T {
-        guard PathResolver.exists(dbPath) else {
+        guard Shared.Utils.PathResolver.exists(dbPath) else {
             throw ToolError.noData("Sample database not found at \(dbPath.path). Run 'cupertino save --samples' to build the index.")
         }
 

--- a/Packages/Sources/Shared/Constants/BinaryConfig.swift
+++ b/Packages/Sources/Shared/Constants/BinaryConfig.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension Shared {
+extension Shared.Constants {
     /// Optional configuration loaded from a JSON file sitting next to the cupertino
     /// executable. Lets multiple binaries (e.g. brew install vs dev build) point at
     /// different data directories without env vars or per-command flags.

--- a/Packages/Sources/Shared/Constants/Constants.swift
+++ b/Packages/Sources/Shared/Constants/Constants.swift
@@ -10,1366 +10,1364 @@ import SharedConstants
 // Organized with clear MARK sections for easy navigation.
 
 /// Global constants for Cupertino application
-extension Shared {
-    public enum Constants {
-        // MARK: - Directory Names
+extension Shared.Constants {
+    // MARK: - Directory Names
 
-        /// Base directory name for Cupertino data
-        public static let baseDirectoryName = ".cupertino"
+    /// Base directory name for Cupertino data
+    public static let baseDirectoryName = ".cupertino"
 
-        /// Subdirectory names
-        public enum Directory {
-            public static let docs = "docs"
-            public static let swiftEvolution = "swift-evolution"
-            public static let swiftOrg = "swift-org"
-            public static let swiftBook = "swift-book"
-            public static let packages = "packages"
-            public static let sampleCode = "sample-code"
-            public static let archive = "archive"
-            public static let hig = "hig"
+    /// Subdirectory names
+    public enum Directory {
+        public static let docs = "docs"
+        public static let swiftEvolution = "swift-evolution"
+        public static let swiftOrg = "swift-org"
+        public static let swiftBook = "swift-book"
+        public static let packages = "packages"
+        public static let sampleCode = "sample-code"
+        public static let archive = "archive"
+        public static let hig = "hig"
+    }
+
+    // MARK: - File Names
+
+    public enum FileName {
+        // MARK: Configuration Files
+
+        /// Main metadata file for crawler state
+        public static let metadata = "metadata.json"
+
+        /// Configuration file
+        public static let config = "config.json"
+
+        /// TUI configuration file
+        public static let tuiConfig = "tui-config.json"
+
+        /// Application log file
+        public static let logFile = "cupertino.log"
+
+        /// Search database file
+        public static let searchDatabase = "search.db"
+
+        /// Samples database file
+        public static let samplesDatabase = "samples.db"
+
+        /// Package source + docs FTS index (separate from search.db; hidden feature)
+        public static let packagesIndexDatabase = "packages.db"
+
+        /// Stores the `databaseVersion` that was active when `setup` last succeeded.
+        /// Read on subsequent setup invocations to distinguish stale DBs from current ones (#168).
+        public static let setupVersionFile = ".setup-version"
+
+        // MARK: Package Data Files
+
+        /// Swift packages with GitHub stars data
+        public static let packagesWithStars = "swift-packages-with-stars.json"
+
+        /// Priority packages list (bundled)
+        public static let priorityPackages = "priority-packages.json"
+
+        /// User-selected packages file
+        public static let selectedPackages = "selected-packages.json"
+
+        /// User-maintained exclusion list (flat array of "owner/repo" strings)
+        public static let excludedPackages = "excluded-packages.json"
+
+        /// Machine-written transitive closure of seeds+exclusions (cache)
+        public static let resolvedPackages = "resolved-packages.json"
+
+        /// Per-repo GitHub canonical-name cache (owner/repo → redirect target)
+        public static let canonicalOwnersCache = "canonical-owners.json"
+
+        /// Package fetch checkpoint file
+        public static let checkpoint = "checkpoint.json"
+
+        /// Authentication cookies file
+        public static let authCookies = ".auth-cookies.json"
+
+        // MARK: File Extensions
+
+        /// Markdown file extension
+        public static let markdownExtension = ".md"
+
+        /// JSON file extension
+        public static let jsonExtension = ".json"
+    }
+
+    // MARK: - Default Paths
+
+    /// Default base directory path: ~/.cupertino, unless overridden by a
+    /// `cupertino.config.json` sitting next to the running executable
+    /// (see `Shared.Constants.BinaryConfig`, #211).
+    public static var defaultBaseDirectory: URL {
+        if let override = Shared.Constants.BinaryConfig.shared.resolvedBaseDirectory {
+            return override
         }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(baseDirectoryName)
+    }
+
+    /// Default docs directory: ~/.cupertino/docs
+    public static var defaultDocsDirectory: URL {
+        defaultBaseDirectory.appendingPathComponent(Directory.docs)
+    }
+
+    /// Default Swift Evolution directory: ~/.cupertino/swift-evolution
+    public static var defaultSwiftEvolutionDirectory: URL {
+        defaultBaseDirectory.appendingPathComponent(Directory.swiftEvolution)
+    }
+
+    /// Default Swift.org directory: ~/.cupertino/swift-org
+    public static var defaultSwiftOrgDirectory: URL {
+        defaultBaseDirectory.appendingPathComponent(Directory.swiftOrg)
+    }
+
+    /// Default Swift Book directory: ~/.cupertino/swift-book
+    public static var defaultSwiftBookDirectory: URL {
+        defaultBaseDirectory.appendingPathComponent(Directory.swiftBook)
+    }
+
+    /// Default packages directory: ~/.cupertino/packages
+    public static var defaultPackagesDirectory: URL {
+        defaultBaseDirectory.appendingPathComponent(Directory.packages)
+    }
+
+    /// Default sample code directory: ~/.cupertino/sample-code
+    public static var defaultSampleCodeDirectory: URL {
+        defaultBaseDirectory.appendingPathComponent(Directory.sampleCode)
+    }
+
+    /// Default archive directory: ~/.cupertino/archive
+    public static var defaultArchiveDirectory: URL {
+        defaultBaseDirectory.appendingPathComponent(Directory.archive)
+    }
+
+    /// Default HIG directory: ~/.cupertino/hig
+    public static var defaultHIGDirectory: URL {
+        defaultBaseDirectory.appendingPathComponent(Directory.hig)
+    }
+
+    /// Default metadata file: ~/.cupertino/metadata.json
+    public static var defaultMetadataFile: URL {
+        defaultBaseDirectory.appendingPathComponent(FileName.metadata)
+    }
 
-        // MARK: - File Names
+    /// Default config file: ~/.cupertino/config.json
+    public static var defaultConfigFile: URL {
+        defaultBaseDirectory.appendingPathComponent(FileName.config)
+    }
+
+    /// Default search database: ~/.cupertino/search.db
+    public static var defaultSearchDatabase: URL {
+        defaultBaseDirectory.appendingPathComponent(FileName.searchDatabase)
+    }
 
-        public enum FileName {
-            // MARK: Configuration Files
+    /// Default package-index database: ~/.cupertino/packages.db
+    public static var defaultPackagesDatabase: URL {
+        defaultBaseDirectory.appendingPathComponent(FileName.packagesIndexDatabase)
+    }
 
-            /// Main metadata file for crawler state
-            public static let metadata = "metadata.json"
+    // MARK: - Application Info
 
-            /// Configuration file
-            public static let config = "config.json"
+    public enum App {
+        /// Application name
+        public static let name = "Cupertino"
 
-            /// TUI configuration file
-            public static let tuiConfig = "tui-config.json"
+        /// Command name
+        public static let commandName = "cupertino"
 
-            /// Application log file
-            public static let logFile = "cupertino.log"
+        /// MCP server name
+        public static let mcpServerName = "cupertino"
 
-            /// Search database file
-            public static let searchDatabase = "search.db"
+        /// User agent for HTTP requests
+        public static let userAgent = "CupertinoCrawler/1.0"
 
-            /// Samples database file
-            public static let samplesDatabase = "samples.db"
+        /// Current version
+        public static let version = "1.0.2"
 
-            /// Package source + docs FTS index (separate from search.db; hidden feature)
-            public static let packagesIndexDatabase = "packages.db"
+        /// Database version - separate from CLI version, only bump when schema/content changes.
+        /// Controls the cupertino-docs release tag that `cupertino setup` downloads from.
+        /// v1.0.2 bumps from v1.0.0 to ship a re-indexed bundle: the v1.0.0 search.db
+        /// carried 61,257 case-axis duplicate clusters covering 122,522 rows (#283), and
+        /// the prior v1.0.1 "verified clean" claim used the wrong query column. The new
+        /// v1.0.2 bundle was built with the post-#283 `URLUtilities.filename(_:)` against
+        /// the full 404,729-page corpus (Studio v1.0.0 base + Claw fresh overlay) and
+        /// verified: 277,640 documents, `GROUP BY LOWER(url) HAVING COUNT > 1` returns
+        /// zero, schema `user_version` stamped 13.
+        public static let databaseVersion = "1.0.2"
 
-            /// Stores the `databaseVersion` that was active when `setup` last succeeded.
-            /// Read on subsequent setup invocations to distinguish stale DBs from current ones (#168).
-            public static let setupVersionFile = ".setup-version"
+        /// Base URL for cupertino-docs release downloads. As of v1.0.0 the
+        /// single `cupertino-databases-vX.zip` artifact bundles search.db,
+        /// samples.db, and packages.db — earlier versions split packages.db
+        /// into a separate `mihaelamj/cupertino-packages` companion repo
+        /// which is now deprecated.
+        public static let docsReleaseBaseURL = "https://github.com/mihaelamj/cupertino-docs/releases/download"
 
-            // MARK: Package Data Files
+        /// Approximate database zip file size for progress display when Content-Length is unknown.
+        /// v1.0.0 bundle is ~833 MB (search.db + samples.db + packages.db, DEFLATE-compressed).
+        public static let approximateZipSize: Int64 = 850 * 1024 * 1024
+    }
 
-            /// Swift packages with GitHub stars data
-            public static let packagesWithStars = "swift-packages-with-stars.json"
+    // MARK: - Display Names
 
-            /// Priority packages list (bundled)
-            public static let priorityPackages = "priority-packages.json"
+    public enum DisplayName {
+        /// Swift.org display name (for log messages and UI)
+        public static let swiftOrg = "Swift.org"
 
-            /// User-selected packages file
-            public static let selectedPackages = "selected-packages.json"
+        /// Apple display name
+        public static let apple = "Apple"
 
-            /// User-maintained exclusion list (flat array of "owner/repo" strings)
-            public static let excludedPackages = "excluded-packages.json"
+        // MARK: Documentation Type Display Names
 
-            /// Machine-written transitive closure of seeds+exclusions (cache)
-            public static let resolvedPackages = "resolved-packages.json"
+        /// Apple Documentation display name
+        public static let appleDocs = "Apple Documentation"
 
-            /// Per-repo GitHub canonical-name cache (owner/repo → redirect target)
-            public static let canonicalOwnersCache = "canonical-owners.json"
+        /// Swift.org Documentation display name
+        public static let swiftOrgDocs = "Swift.org Documentation"
 
-            /// Package fetch checkpoint file
-            public static let checkpoint = "checkpoint.json"
+        /// Swift Evolution Proposals display name
+        public static let swiftEvolution = "Swift Evolution Proposals"
 
-            /// Authentication cookies file
-            public static let authCookies = ".auth-cookies.json"
+        /// Swift Package Documentation display name
+        public static let swiftPackages = "Swift Package Documentation"
 
-            // MARK: File Extensions
+        /// All Documentation display name
+        public static let allDocs = "All Documentation"
 
-            /// Markdown file extension
-            public static let markdownExtension = ".md"
+        // MARK: Fetch Type Display Names
 
-            /// JSON file extension
-            public static let jsonExtension = ".json"
-        }
+        /// Swift Package Metadata display name
+        public static let packageMetadata = "Swift Package Metadata"
 
-        // MARK: - Default Paths
+        /// Apple Sample Code display name
+        public static let sampleCode = "Apple Sample Code"
 
-        /// Default base directory path: ~/.cupertino, unless overridden by a
-        /// `cupertino.config.json` sitting next to the running executable
-        /// (see `Shared.BinaryConfig`, #211).
-        public static var defaultBaseDirectory: URL {
-            if let override = Shared.BinaryConfig.shared.resolvedBaseDirectory {
-                return override
-            }
-            return FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(baseDirectoryName)
-        }
+        /// Apple Archive Documentation display name
+        public static let archive = "Apple Archive Documentation"
 
-        /// Default docs directory: ~/.cupertino/docs
-        public static var defaultDocsDirectory: URL {
-            defaultBaseDirectory.appendingPathComponent(Directory.docs)
-        }
+        /// Human Interface Guidelines display name
+        public static let humanInterfaceGuidelines = "Human Interface Guidelines"
+    }
 
-        /// Default Swift Evolution directory: ~/.cupertino/swift-evolution
-        public static var defaultSwiftEvolutionDirectory: URL {
-            defaultBaseDirectory.appendingPathComponent(Directory.swiftEvolution)
-        }
+    // MARK: - GitHub Organizations
 
-        /// Default Swift.org directory: ~/.cupertino/swift-org
-        public static var defaultSwiftOrgDirectory: URL {
-            defaultBaseDirectory.appendingPathComponent(Directory.swiftOrg)
-        }
+    public enum GitHubOrg {
+        /// Apple organization name (lowercase for comparisons)
+        public static let apple = "apple"
 
-        /// Default Swift Book directory: ~/.cupertino/swift-book
-        public static var defaultSwiftBookDirectory: URL {
-            defaultBaseDirectory.appendingPathComponent(Directory.swiftBook)
-        }
+        /// Apple organization display name
+        public static let appleDisplay = "Apple"
 
-        /// Default packages directory: ~/.cupertino/packages
-        public static var defaultPackagesDirectory: URL {
-            defaultBaseDirectory.appendingPathComponent(Directory.packages)
-        }
-
-        /// Default sample code directory: ~/.cupertino/sample-code
-        public static var defaultSampleCodeDirectory: URL {
-            defaultBaseDirectory.appendingPathComponent(Directory.sampleCode)
-        }
+        /// SwiftLang organization name (lowercase for comparisons)
+        public static let swiftlang = "swiftlang"
 
-        /// Default archive directory: ~/.cupertino/archive
-        public static var defaultArchiveDirectory: URL {
-            defaultBaseDirectory.appendingPathComponent(Directory.archive)
-        }
-
-        /// Default HIG directory: ~/.cupertino/hig
-        public static var defaultHIGDirectory: URL {
-            defaultBaseDirectory.appendingPathComponent(Directory.hig)
-        }
+        /// SwiftLang organization display name
+        public static let swiftlangDisplay = "SwiftLang"
 
-        /// Default metadata file: ~/.cupertino/metadata.json
-        public static var defaultMetadataFile: URL {
-            defaultBaseDirectory.appendingPathComponent(FileName.metadata)
-        }
-
-        /// Default config file: ~/.cupertino/config.json
-        public static var defaultConfigFile: URL {
-            defaultBaseDirectory.appendingPathComponent(FileName.config)
-        }
-
-        /// Default search database: ~/.cupertino/search.db
-        public static var defaultSearchDatabase: URL {
-            defaultBaseDirectory.appendingPathComponent(FileName.searchDatabase)
-        }
-
-        /// Default package-index database: ~/.cupertino/packages.db
-        public static var defaultPackagesDatabase: URL {
-            defaultBaseDirectory.appendingPathComponent(FileName.packagesIndexDatabase)
-        }
-
-        // MARK: - Application Info
-
-        public enum App {
-            /// Application name
-            public static let name = "Cupertino"
-
-            /// Command name
-            public static let commandName = "cupertino"
-
-            /// MCP server name
-            public static let mcpServerName = "cupertino"
-
-            /// User agent for HTTP requests
-            public static let userAgent = "CupertinoCrawler/1.0"
-
-            /// Current version
-            public static let version = "1.0.2"
-
-            /// Database version - separate from CLI version, only bump when schema/content changes.
-            /// Controls the cupertino-docs release tag that `cupertino setup` downloads from.
-            /// v1.0.2 bumps from v1.0.0 to ship a re-indexed bundle: the v1.0.0 search.db
-            /// carried 61,257 case-axis duplicate clusters covering 122,522 rows (#283), and
-            /// the prior v1.0.1 "verified clean" claim used the wrong query column. The new
-            /// v1.0.2 bundle was built with the post-#283 `URLUtilities.filename(_:)` against
-            /// the full 404,729-page corpus (Studio v1.0.0 base + Claw fresh overlay) and
-            /// verified: 277,640 documents, `GROUP BY LOWER(url) HAVING COUNT > 1` returns
-            /// zero, schema `user_version` stamped 13.
-            public static let databaseVersion = "1.0.2"
-
-            /// Base URL for cupertino-docs release downloads. As of v1.0.0 the
-            /// single `cupertino-databases-vX.zip` artifact bundles search.db,
-            /// samples.db, and packages.db — earlier versions split packages.db
-            /// into a separate `mihaelamj/cupertino-packages` companion repo
-            /// which is now deprecated.
-            public static let docsReleaseBaseURL = "https://github.com/mihaelamj/cupertino-docs/releases/download"
-
-            /// Approximate database zip file size for progress display when Content-Length is unknown.
-            /// v1.0.0 bundle is ~833 MB (search.db + samples.db + packages.db, DEFLATE-compressed).
-            public static let approximateZipSize: Int64 = 850 * 1024 * 1024
-        }
-
-        // MARK: - Display Names
-
-        public enum DisplayName {
-            /// Swift.org display name (for log messages and UI)
-            public static let swiftOrg = "Swift.org"
-
-            /// Apple display name
-            public static let apple = "Apple"
-
-            // MARK: Documentation Type Display Names
-
-            /// Apple Documentation display name
-            public static let appleDocs = "Apple Documentation"
-
-            /// Swift.org Documentation display name
-            public static let swiftOrgDocs = "Swift.org Documentation"
-
-            /// Swift Evolution Proposals display name
-            public static let swiftEvolution = "Swift Evolution Proposals"
-
-            /// Swift Package Documentation display name
-            public static let swiftPackages = "Swift Package Documentation"
-
-            /// All Documentation display name
-            public static let allDocs = "All Documentation"
-
-            // MARK: Fetch Type Display Names
-
-            /// Swift Package Metadata display name
-            public static let packageMetadata = "Swift Package Metadata"
-
-            /// Apple Sample Code display name
-            public static let sampleCode = "Apple Sample Code"
-
-            /// Apple Archive Documentation display name
-            public static let archive = "Apple Archive Documentation"
-
-            /// Human Interface Guidelines display name
-            public static let humanInterfaceGuidelines = "Human Interface Guidelines"
-        }
-
-        // MARK: - GitHub Organizations
-
-        public enum GitHubOrg {
-            /// Apple organization name (lowercase for comparisons)
-            public static let apple = "apple"
-
-            /// Apple organization display name
-            public static let appleDisplay = "Apple"
-
-            /// SwiftLang organization name (lowercase for comparisons)
-            public static let swiftlang = "swiftlang"
-
-            /// SwiftLang organization display name
-            public static let swiftlangDisplay = "SwiftLang"
-
-            /// Swift Server organization name (lowercase for comparisons)
-            public static let swiftServer = "swift-server"
-
-            /// Swift Server organization display name
-            public static let swiftServerDisplay = "Swift Server"
-
-            /// All official Swift organization names (lowercase)
-            public static let officialOrgs = [apple, swiftlang, swiftServer]
-        }
-
-        // MARK: - Logging
-
-        public enum Logging {
-            /// Main subsystem identifier for logging
-            public static let subsystem = "com.cupertino.cli"
-        }
-
-        // MARK: - Source Prefixes
-
-        /// Source prefixes used for filtering search queries.
-        /// Users can prefix their search with these to filter by source type.
-        /// Example: "swift-evolution actors" searches only Swift Evolution for "actors"
-        public enum SourcePrefix {
-            /// Apple Developer Documentation source prefix
-            public static let appleDocs = "apple-docs"
-
-            /// Swift Book (The Swift Programming Language) source prefix
-            public static let swiftBook = "swift-book"
-
-            /// Swift.org documentation source prefix
-            public static let swiftOrg = "swift-org"
-
-            /// Swift Evolution proposals source prefix
-            public static let swiftEvolution = "swift-evolution"
-
-            /// Swift package documentation source prefix
-            public static let packages = "packages"
-
-            /// Apple sample code source prefix (short form)
-            public static let samples = "samples"
-
-            /// Apple sample code source prefix (long form, for backward compatibility)
-            public static let appleSampleCode = "apple-sample-code"
-
-            /// Apple archive documentation source prefix
-            public static let appleArchive = "apple-archive"
-
-            /// Human Interface Guidelines source prefix
-            public static let hig = "hig"
-
-            /// Search all sources at once
-            public static let all = "all"
-
-            /// All known source prefixes for query detection
-            public static let allPrefixes: [String] = [
-                appleDocs,
-                swiftBook,
-                swiftOrg,
-                swiftEvolution,
-                packages,
-                samples,
-                appleSampleCode,
-                appleArchive,
-                hig,
-                all,
-            ]
-
-            // MARK: - Source Display Names
-
-            /// Display name for Apple Documentation
-            public static let nameAppleDocs = "Apple Documentation"
-            /// Display name for Sample Code
-            public static let nameSamples = "Sample Code"
-            /// Display name for Human Interface Guidelines
-            public static let nameHIG = "Human Interface Guidelines"
-            /// Display name for Apple Archive
-            public static let nameArchive = "Apple Archive"
-            /// Display name for Swift Evolution
-            public static let nameSwiftEvolution = "Swift Evolution"
-            /// Display name for Swift.org
-            public static let nameSwiftOrg = "Swift.org"
-            /// Display name for Swift Book
-            public static let nameSwiftBook = "Swift Book"
-            /// Display name for Swift Packages
-            public static let namePackages = "Swift Packages"
-
-            // MARK: - Source Emojis
-
-            /// Emoji for Apple Documentation
-            public static let emojiAppleDocs = "📚"
-            /// Emoji for Sample Code
-            public static let emojiSamples = "📦"
-            /// Emoji for Human Interface Guidelines
-            public static let emojiHIG = "🎨"
-            /// Emoji for Apple Archive
-            public static let emojiArchive = "📜"
-            /// Emoji for Swift Evolution
-            public static let emojiSwiftEvolution = "🔄"
-            /// Emoji for Swift.org
-            public static let emojiSwiftOrg = "🦅"
-            /// Emoji for Swift Book
-            public static let emojiSwiftBook = "📖"
-            /// Emoji for Swift Packages
-            public static let emojiPackages = "📦"
-
-            // MARK: - Source Info (Unified Metadata)
-
-            /// Complete metadata for a search source
-            public struct SourceInfo: Sendable {
-                public let key: String
-                public let name: String
-                public let emoji: String
-
-                public init(key: String, name: String, emoji: String) {
-                    self.key = key
-                    self.name = name
-                    self.emoji = emoji
-                }
-            }
-
-            /// Apple Documentation source info
-            public static let infoAppleDocs = SourceInfo(
-                key: appleDocs,
-                name: nameAppleDocs,
-                emoji: emojiAppleDocs
-            )
-
-            /// Apple Archive source info
-            public static let infoArchive = SourceInfo(
-                key: appleArchive,
-                name: nameArchive,
-                emoji: emojiArchive
-            )
-
-            /// Sample Code source info
-            public static let infoSamples = SourceInfo(
-                key: samples,
-                name: nameSamples,
-                emoji: emojiSamples
-            )
-
-            /// Human Interface Guidelines source info
-            public static let infoHIG = SourceInfo(
-                key: hig,
-                name: nameHIG,
-                emoji: emojiHIG
-            )
-
-            /// Swift Evolution source info
-            public static let infoSwiftEvolution = SourceInfo(
-                key: swiftEvolution,
-                name: nameSwiftEvolution,
-                emoji: emojiSwiftEvolution
-            )
-
-            /// Swift.org source info
-            public static let infoSwiftOrg = SourceInfo(
-                key: swiftOrg,
-                name: nameSwiftOrg,
-                emoji: emojiSwiftOrg
-            )
-
-            /// Swift Book source info
-            public static let infoSwiftBook = SourceInfo(
-                key: swiftBook,
-                name: nameSwiftBook,
-                emoji: emojiSwiftBook
-            )
-
-            /// Swift Packages source info
-            public static let infoPackages = SourceInfo(
-                key: packages,
-                name: namePackages,
-                emoji: emojiPackages
-            )
-
-            /// All source infos in display order
-            public static let allSourceInfos: [SourceInfo] = [
-                infoAppleDocs,
-                infoArchive,
-                infoSamples,
-                infoHIG,
-                infoSwiftEvolution,
-                infoSwiftOrg,
-                infoSwiftBook,
-                infoPackages,
-            ]
-        }
-
-        // MARK: - URLs
-
-        public enum BaseURL {
-            // MARK: Apple Developer
-
-            /// Base Apple Developer URL
-            public static let appleDeveloper = "https://developer.apple.com"
-
-            /// Apple Developer Documentation
-            public static let appleDeveloperDocs = "https://developer.apple.com/documentation/"
-
-            /// Apple Archive Documentation
-            public static let appleArchive = "https://developer.apple.com/library/archive/"
-
-            /// Apple Human Interface Guidelines
-            public static let appleHIG = "https://developer.apple.com/design/human-interface-guidelines/"
-
-            /// Apple Sample Code List (rendered HTML page)
-            public static let appleSampleCode = "https://developer.apple.com/documentation/samplecode/"
-
-            /// Apple Sample Code List (raw JSON catalog).
-            /// Used by `SampleCodeDownloader.writeCatalogJSON` to dump fresh
-            /// metadata next to the downloaded zips so `cupertino save`
-            /// indexes from on-disk freshness instead of the embedded
-            /// snapshot (#214).
-            public static let appleSampleCodeJSON = "https://developer.apple.com/tutorials/data/documentation/samplecode.json"
-
-            /// Apple Developer Account
-            public static let appleDeveloperAccount = "https://developer.apple.com/account/"
-
-            // MARK: Swift.org
-
-            /// Swift.org Documentation Base (www.swift.org for general docs)
-            public static let swiftOrg = "https://www.swift.org/documentation/"
-
-            /// Swift Book Documentation (hosted at docs.swift.org)
-            public static let swiftBook = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/"
-
-            /// Swift Book base URL (without specific path)
-            public static let swiftBookBase = "https://docs.swift.org/swift-book"
-
-            /// Swift.org base URL (without path)
-            public static let swiftOrgBase = "https://swift.org"
-
-            // MARK: Swift Evolution
-
-            /// Swift Evolution Proposals on GitHub
-            public static let swiftEvolution = "https://github.com/swiftlang/swift-evolution"
-
-            // MARK: Swift Package Index
-
-            /// Swift Package Index
-            public static let swiftPackageIndex = "https://swiftpackageindex.com"
-
-            // MARK: GitHub
-
-            /// GitHub base URL
-            public static let github = "https://github.com"
-
-            /// GitHub API Base
-            public static let githubAPI = "https://api.github.com"
-
-            /// GitHub API Repos Endpoint Template (use with owner/repo)
-            public static let githubAPIRepos = "https://api.github.com/repos"
-
-            /// GitHub Raw Content Base URL
-            public static let githubRaw = "https://raw.githubusercontent.com"
-
-            /// SwiftPackageIndex Package List
-            public static let swiftPackageList =
-                "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/packages.json"
-        }
-
-        // MARK: - URL Templates
-
-        public enum URLTemplate {
-            /// GitHub repository URL template
-            /// Usage: URLTemplate.githubRepo(owner: "apple", repo: "swift")
-            public static func githubRepo(owner: String, repo: String) -> String {
-                "\(BaseURL.github)/\(owner)/\(repo)"
-            }
-
-            /// GitHub repository URL (raw string format for pattern matching contexts)
-            /// Usage: `url: "\(Shared.Constants.URLTemplate.githubRepoFormat(owner: owner, repo: repo))"`
-            public static func githubRepoFormat(owner: String, repo: String) -> String {
-                githubRepo(owner: owner, repo: repo)
+        /// Swift Server organization name (lowercase for comparisons)
+        public static let swiftServer = "swift-server"
+
+        /// Swift Server organization display name
+        public static let swiftServerDisplay = "Swift Server"
+
+        /// All official Swift organization names (lowercase)
+        public static let officialOrgs = [apple, swiftlang, swiftServer]
+    }
+
+    // MARK: - Logging
+
+    public enum Logging {
+        /// Main subsystem identifier for logging
+        public static let subsystem = "com.cupertino.cli"
+    }
+
+    // MARK: - Source Prefixes
+
+    /// Source prefixes used for filtering search queries.
+    /// Users can prefix their search with these to filter by source type.
+    /// Example: "swift-evolution actors" searches only Swift Evolution for "actors"
+    public enum SourcePrefix {
+        /// Apple Developer Documentation source prefix
+        public static let appleDocs = "apple-docs"
+
+        /// Swift Book (The Swift Programming Language) source prefix
+        public static let swiftBook = "swift-book"
+
+        /// Swift.org documentation source prefix
+        public static let swiftOrg = "swift-org"
+
+        /// Swift Evolution proposals source prefix
+        public static let swiftEvolution = "swift-evolution"
+
+        /// Swift package documentation source prefix
+        public static let packages = "packages"
+
+        /// Apple sample code source prefix (short form)
+        public static let samples = "samples"
+
+        /// Apple sample code source prefix (long form, for backward compatibility)
+        public static let appleSampleCode = "apple-sample-code"
+
+        /// Apple archive documentation source prefix
+        public static let appleArchive = "apple-archive"
+
+        /// Human Interface Guidelines source prefix
+        public static let hig = "hig"
+
+        /// Search all sources at once
+        public static let all = "all"
+
+        /// All known source prefixes for query detection
+        public static let allPrefixes: [String] = [
+            appleDocs,
+            swiftBook,
+            swiftOrg,
+            swiftEvolution,
+            packages,
+            samples,
+            appleSampleCode,
+            appleArchive,
+            hig,
+            all,
+        ]
+
+        // MARK: - Source Display Names
+
+        /// Display name for Apple Documentation
+        public static let nameAppleDocs = "Apple Documentation"
+        /// Display name for Sample Code
+        public static let nameSamples = "Sample Code"
+        /// Display name for Human Interface Guidelines
+        public static let nameHIG = "Human Interface Guidelines"
+        /// Display name for Apple Archive
+        public static let nameArchive = "Apple Archive"
+        /// Display name for Swift Evolution
+        public static let nameSwiftEvolution = "Swift Evolution"
+        /// Display name for Swift.org
+        public static let nameSwiftOrg = "Swift.org"
+        /// Display name for Swift Book
+        public static let nameSwiftBook = "Swift Book"
+        /// Display name for Swift Packages
+        public static let namePackages = "Swift Packages"
+
+        // MARK: - Source Emojis
+
+        /// Emoji for Apple Documentation
+        public static let emojiAppleDocs = "📚"
+        /// Emoji for Sample Code
+        public static let emojiSamples = "📦"
+        /// Emoji for Human Interface Guidelines
+        public static let emojiHIG = "🎨"
+        /// Emoji for Apple Archive
+        public static let emojiArchive = "📜"
+        /// Emoji for Swift Evolution
+        public static let emojiSwiftEvolution = "🔄"
+        /// Emoji for Swift.org
+        public static let emojiSwiftOrg = "🦅"
+        /// Emoji for Swift Book
+        public static let emojiSwiftBook = "📖"
+        /// Emoji for Swift Packages
+        public static let emojiPackages = "📦"
+
+        // MARK: - Source Info (Unified Metadata)
+
+        /// Complete metadata for a search source
+        public struct SourceInfo: Sendable {
+            public let key: String
+            public let name: String
+            public let emoji: String
+
+            public init(key: String, name: String, emoji: String) {
+                self.key = key
+                self.name = name
+                self.emoji = emoji
             }
         }
 
-        // MARK: - Regex Patterns
+        /// Apple Documentation source info
+        public static let infoAppleDocs = SourceInfo(
+            key: appleDocs,
+            name: nameAppleDocs,
+            emoji: emojiAppleDocs
+        )
 
-        public enum Pattern {
-            /// GitHub URL pattern: https://github.com/owner/repo or https://github.com/owner/repo.git
-            public static let githubURL = #"https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$"#
+        /// Apple Archive source info
+        public static let infoArchive = SourceInfo(
+            key: appleArchive,
+            name: nameArchive,
+            emoji: emojiArchive
+        )
 
-            /// GitHub URL pattern (lenient): Matches various GitHub URL formats
-            public static let githubURLLenient = #"https://github\.com/([^/\s\)\"]+)/([^/\s\)\"\.]+)"#
+        /// Sample Code source info
+        public static let infoSamples = SourceInfo(
+            key: samples,
+            name: nameSamples,
+            emoji: emojiSamples
+        )
 
-            /// HTML anchor tag href extraction
-            public static let htmlHref = #"<a[^>]*href=[\"']([^\"']*)[\"']"#
+        /// Human Interface Guidelines source info
+        public static let infoHIG = SourceInfo(
+            key: hig,
+            name: nameHIG,
+            emoji: emojiHIG
+        )
 
-            /// Swift Evolution proposal number
-            public static let seProposalNumber = #"^(?:SE-)?(\d{4})"#
+        /// Swift Evolution source info
+        public static let infoSwiftEvolution = SourceInfo(
+            key: swiftEvolution,
+            name: nameSwiftEvolution,
+            emoji: emojiSwiftEvolution
+        )
 
-            /// Swift Evolution status in markdown (supports both "* Status:" and "- Status:")
-            public static let seStatus = #"[\*\-] Status:\s*\*\*([^\*]+)\*\*"#
+        /// Swift.org source info
+        public static let infoSwiftOrg = SourceInfo(
+            key: swiftOrg,
+            name: nameSwiftOrg,
+            emoji: emojiSwiftOrg
+        )
 
-            /// HTML pre/code block with language
-            public static let htmlCodeBlockWithLanguage =
-                #"<pre[^>]*>\s*<code\s+class=[\"'](?:language-)?(\w+)[\"'][^>]*>(.*?)</code>\s*</pre>"#
+        /// Swift Book source info
+        public static let infoSwiftBook = SourceInfo(
+            key: swiftBook,
+            name: nameSwiftBook,
+            emoji: emojiSwiftBook
+        )
 
-            /// Swift Evolution reference (SE-NNNN)
-            public static let seReference = #"(SE-\d+)"#
+        /// Swift Packages source info
+        public static let infoPackages = SourceInfo(
+            key: packages,
+            name: namePackages,
+            emoji: emojiPackages
+        )
 
-            /// Swift Evolution or Swift Testing reference (SE-NNNN or ST-NNNN)
-            public static let evolutionReference = #"((?:SE|ST)-\d+)"#
+        /// All source infos in display order
+        public static let allSourceInfos: [SourceInfo] = [
+            infoAppleDocs,
+            infoArchive,
+            infoSamples,
+            infoHIG,
+            infoSwiftEvolution,
+            infoSwiftOrg,
+            infoSwiftBook,
+            infoPackages,
+        ]
+    }
+
+    // MARK: - URLs
+
+    public enum BaseURL {
+        // MARK: Apple Developer
+
+        /// Base Apple Developer URL
+        public static let appleDeveloper = "https://developer.apple.com"
+
+        /// Apple Developer Documentation
+        public static let appleDeveloperDocs = "https://developer.apple.com/documentation/"
+
+        /// Apple Archive Documentation
+        public static let appleArchive = "https://developer.apple.com/library/archive/"
+
+        /// Apple Human Interface Guidelines
+        public static let appleHIG = "https://developer.apple.com/design/human-interface-guidelines/"
+
+        /// Apple Sample Code List (rendered HTML page)
+        public static let appleSampleCode = "https://developer.apple.com/documentation/samplecode/"
+
+        /// Apple Sample Code List (raw JSON catalog).
+        /// Used by `SampleCodeDownloader.writeCatalogJSON` to dump fresh
+        /// metadata next to the downloaded zips so `cupertino save`
+        /// indexes from on-disk freshness instead of the embedded
+        /// snapshot (#214).
+        public static let appleSampleCodeJSON = "https://developer.apple.com/tutorials/data/documentation/samplecode.json"
+
+        /// Apple Developer Account
+        public static let appleDeveloperAccount = "https://developer.apple.com/account/"
+
+        // MARK: Swift.org
+
+        /// Swift.org Documentation Base (www.swift.org for general docs)
+        public static let swiftOrg = "https://www.swift.org/documentation/"
+
+        /// Swift Book Documentation (hosted at docs.swift.org)
+        public static let swiftBook = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/"
+
+        /// Swift Book base URL (without specific path)
+        public static let swiftBookBase = "https://docs.swift.org/swift-book"
+
+        /// Swift.org base URL (without path)
+        public static let swiftOrgBase = "https://swift.org"
+
+        // MARK: Swift Evolution
+
+        /// Swift Evolution Proposals on GitHub
+        public static let swiftEvolution = "https://github.com/swiftlang/swift-evolution"
+
+        // MARK: Swift Package Index
+
+        /// Swift Package Index
+        public static let swiftPackageIndex = "https://swiftpackageindex.com"
+
+        // MARK: GitHub
+
+        /// GitHub base URL
+        public static let github = "https://github.com"
+
+        /// GitHub API Base
+        public static let githubAPI = "https://api.github.com"
+
+        /// GitHub API Repos Endpoint Template (use with owner/repo)
+        public static let githubAPIRepos = "https://api.github.com/repos"
+
+        /// GitHub Raw Content Base URL
+        public static let githubRaw = "https://raw.githubusercontent.com"
+
+        /// SwiftPackageIndex Package List
+        public static let swiftPackageList =
+            "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/packages.json"
+    }
+
+    // MARK: - URL Templates
+
+    public enum URLTemplate {
+        /// GitHub repository URL template
+        /// Usage: URLTemplate.githubRepo(owner: "apple", repo: "swift")
+        public static func githubRepo(owner: String, repo: String) -> String {
+            "\(BaseURL.github)/\(owner)/\(repo)"
         }
 
-        // MARK: - HTTP Headers
-
-        public enum HTTPHeader {
-            /// GitHub API Accept header
-            public static let githubAccept = "application/vnd.github.v3+json"
-
-            /// Authorization header name
-            public static let authorization = "Authorization"
-
-            /// Accept header name
-            public static let accept = "Accept"
-
-            /// User-Agent header name
-            public static let userAgent = "User-Agent"
+        /// GitHub repository URL (raw string format for pattern matching contexts)
+        /// Usage: `url: "\(Shared.Constants.URLTemplate.githubRepoFormat(owner: owner, repo: repo))"`
+        public static func githubRepoFormat(owner: String, repo: String) -> String {
+            githubRepo(owner: owner, repo: repo)
         }
+    }
 
-        // MARK: - Environment Variables
+    // MARK: - Regex Patterns
 
-        public enum EnvVar {
-            /// GitHub token environment variable
-            public static let githubToken = "GITHUB_TOKEN"
+    public enum Pattern {
+        /// GitHub URL pattern: https://github.com/owner/repo or https://github.com/owner/repo.git
+        public static let githubURL = #"https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$"#
 
-            /// Cupertino docs token environment variable (for database releases)
-            public static let cupertinoDocsToken = "CUPERTINO_DOCS_TOKEN"
-        }
+        /// GitHub URL pattern (lenient): Matches various GitHub URL formats
+        public static let githubURLLenient = #"https://github\.com/([^/\s\)\"]+)/([^/\s\)\"\.]+)"#
 
-        // MARK: - Search Constants
+        /// HTML anchor tag href extraction
+        public static let htmlHref = #"<a[^>]*href=[\"']([^\"']*)[\"']"#
 
-        /// Search-related constants shared by CLI and MCP
-        public enum Search {
-            // MARK: Resource URI Schemes
+        /// Swift Evolution proposal number
+        public static let seProposalNumber = #"^(?:SE-)?(\d{4})"#
 
-            /// Apple documentation resource URI scheme
-            public static let appleDocsScheme = "apple-docs://"
+        /// Swift Evolution status in markdown (supports both "* Status:" and "- Status:")
+        public static let seStatus = #"[\*\-] Status:\s*\*\*([^\*]+)\*\*"#
 
-            /// Apple archive documentation resource URI scheme
-            public static let appleArchiveScheme = "apple-archive://"
+        /// HTML pre/code block with language
+        public static let htmlCodeBlockWithLanguage =
+            #"<pre[^>]*>\s*<code\s+class=[\"'](?:language-)?(\w+)[\"'][^>]*>(.*?)</code>\s*</pre>"#
 
-            /// Swift Evolution proposal resource URI scheme
-            public static let swiftEvolutionScheme = "swift-evolution://"
+        /// Swift Evolution reference (SE-NNNN)
+        public static let seReference = #"(SE-\d+)"#
 
-            /// Human Interface Guidelines resource URI scheme
-            public static let higScheme = "hig://"
+        /// Swift Evolution or Swift Testing reference (SE-NNNN or ST-NNNN)
+        public static let evolutionReference = #"((?:SE|ST)-\d+)"#
+    }
 
-            // MARK: Tool Names
+    // MARK: - HTTP Headers
 
-            /// Unified search tool name (replaces search_docs, search_hig, search_all, search_samples)
-            public static let toolSearch = "search"
+    public enum HTTPHeader {
+        /// GitHub API Accept header
+        public static let githubAccept = "application/vnd.github.v3+json"
 
-            /// List frameworks tool name
-            public static let toolListFrameworks = "list_frameworks"
+        /// Authorization header name
+        public static let authorization = "Authorization"
 
-            /// Read document tool name
-            public static let toolReadDocument = "read_document"
+        /// Accept header name
+        public static let accept = "Accept"
 
-            // MARK: Sample Code Tool Names
+        /// User-Agent header name
+        public static let userAgent = "User-Agent"
+    }
 
-            /// List samples tool name
-            public static let toolListSamples = "list_samples"
+    // MARK: - Environment Variables
 
-            /// Read sample tool name
-            public static let toolReadSample = "read_sample"
+    public enum EnvVar {
+        /// GitHub token environment variable
+        public static let githubToken = "GITHUB_TOKEN"
 
-            /// Read sample file tool name
-            public static let toolReadSampleFile = "read_sample_file"
+        /// Cupertino docs token environment variable (for database releases)
+        public static let cupertinoDocsToken = "CUPERTINO_DOCS_TOKEN"
+    }
 
-            // MARK: Semantic Search Tool Names (#81)
+    // MARK: - Search Constants
 
-            /// Search symbols tool name (semantic code search)
-            public static let toolSearchSymbols = "search_symbols"
+    /// Search-related constants shared by CLI and MCP
+    public enum Search {
+        // MARK: Resource URI Schemes
 
-            /// Search property wrappers tool name
-            public static let toolSearchPropertyWrappers = "search_property_wrappers"
+        /// Apple documentation resource URI scheme
+        public static let appleDocsScheme = "apple-docs://"
 
-            /// Search concurrency patterns tool name
-            public static let toolSearchConcurrency = "search_concurrency"
+        /// Apple archive documentation resource URI scheme
+        public static let appleArchiveScheme = "apple-archive://"
 
-            /// Search protocol conformances tool name
-            public static let toolSearchConformances = "search_conformances"
+        /// Swift Evolution proposal resource URI scheme
+        public static let swiftEvolutionScheme = "swift-evolution://"
 
-            // MARK: Swift Evolution
+        /// Human Interface Guidelines resource URI scheme
+        public static let higScheme = "hig://"
 
-            /// Swift Evolution proposal ID prefix
-            public static let sePrefix = "SE-"
+        // MARK: Tool Names
 
-            /// Swift Testing proposal ID prefix
-            public static let stPrefix = "ST-"
+        /// Unified search tool name (replaces search_docs, search_hig, search_all, search_samples)
+        public static let toolSearch = "search"
 
-            // MARK: JSON Schema
+        /// List frameworks tool name
+        public static let toolListFrameworks = "list_frameworks"
 
-            /// JSON Schema type: object
-            public static let schemaTypeObject = "object"
+        /// Read document tool name
+        public static let toolReadDocument = "read_document"
 
-            /// JSON Schema parameter: query
-            public static let schemaParamQuery = "query"
+        // MARK: Sample Code Tool Names
 
-            /// JSON Schema parameter: source
-            public static let schemaParamSource = "source"
+        /// List samples tool name
+        public static let toolListSamples = "list_samples"
 
-            /// JSON Schema parameter: framework
-            public static let schemaParamFramework = "framework"
+        /// Read sample tool name
+        public static let toolReadSample = "read_sample"
 
-            /// JSON Schema parameter: language
-            public static let schemaParamLanguage = "language"
+        /// Read sample file tool name
+        public static let toolReadSampleFile = "read_sample_file"
 
-            /// JSON Schema parameter: include_archive
-            public static let schemaParamIncludeArchive = "include_archive"
+        // MARK: Semantic Search Tool Names (#81)
 
-            /// JSON Schema parameter: platform (for HIG)
-            public static let schemaParamPlatform = "platform"
+        /// Search symbols tool name (semantic code search)
+        public static let toolSearchSymbols = "search_symbols"
 
-            /// JSON Schema parameter: category (for HIG)
-            public static let schemaParamCategory = "category"
+        /// Search property wrappers tool name
+        public static let toolSearchPropertyWrappers = "search_property_wrappers"
 
-            /// JSON Schema parameter: limit
-            public static let schemaParamLimit = "limit"
+        /// Search concurrency patterns tool name
+        public static let toolSearchConcurrency = "search_concurrency"
 
-            /// JSON Schema parameter: uri
-            public static let schemaParamURI = "uri"
+        /// Search protocol conformances tool name
+        public static let toolSearchConformances = "search_conformances"
 
-            /// JSON Schema parameter: format
-            public static let schemaParamFormat = "format"
+        // MARK: Swift Evolution
 
-            /// JSON Schema parameter: project_id
-            public static let schemaParamProjectId = "project_id"
+        /// Swift Evolution proposal ID prefix
+        public static let sePrefix = "SE-"
 
-            /// JSON Schema parameter: file_path
-            public static let schemaParamFilePath = "file_path"
+        /// Swift Testing proposal ID prefix
+        public static let stPrefix = "ST-"
 
-            /// JSON Schema parameter: search_files
-            public static let schemaParamSearchFiles = "search_files"
+        // MARK: JSON Schema
 
-            /// JSON Schema parameter: min_ios
-            public static let schemaParamMinIOS = "min_ios"
+        /// JSON Schema type: object
+        public static let schemaTypeObject = "object"
 
-            /// JSON Schema parameter: min_macos
-            public static let schemaParamMinMacOS = "min_macos"
+        /// JSON Schema parameter: query
+        public static let schemaParamQuery = "query"
 
-            /// JSON Schema parameter: min_tvos
-            public static let schemaParamMinTvOS = "min_tvos"
+        /// JSON Schema parameter: source
+        public static let schemaParamSource = "source"
 
-            /// JSON Schema parameter: min_watchos
-            public static let schemaParamMinWatchOS = "min_watchos"
+        /// JSON Schema parameter: framework
+        public static let schemaParamFramework = "framework"
 
-            /// JSON Schema parameter: min_visionos
-            public static let schemaParamMinVisionOS = "min_visionos"
+        /// JSON Schema parameter: language
+        public static let schemaParamLanguage = "language"
 
-            // MARK: Semantic Search Parameters (#81)
+        /// JSON Schema parameter: include_archive
+        public static let schemaParamIncludeArchive = "include_archive"
 
-            /// JSON Schema parameter: kind (symbol kind)
-            public static let schemaParamKind = "kind"
+        /// JSON Schema parameter: platform (for HIG)
+        public static let schemaParamPlatform = "platform"
 
-            /// JSON Schema parameter: is_async (async functions filter)
-            public static let schemaParamIsAsync = "is_async"
+        /// JSON Schema parameter: category (for HIG)
+        public static let schemaParamCategory = "category"
 
-            /// JSON Schema parameter: wrapper (property wrapper name)
-            public static let schemaParamWrapper = "wrapper"
+        /// JSON Schema parameter: limit
+        public static let schemaParamLimit = "limit"
 
-            /// JSON Schema parameter: pattern (concurrency pattern)
-            public static let schemaParamPattern = "pattern"
+        /// JSON Schema parameter: uri
+        public static let schemaParamURI = "uri"
 
-            /// JSON Schema parameter: protocol (protocol conformance)
-            public static let schemaParamProtocol = "protocol"
+        /// JSON Schema parameter: format
+        public static let schemaParamFormat = "format"
 
-            /// Format value: json
-            public static let formatValueJSON = "json"
+        /// JSON Schema parameter: project_id
+        public static let schemaParamProjectId = "project_id"
 
-            /// Format value: markdown
-            public static let formatValueMarkdown = "markdown"
+        /// JSON Schema parameter: file_path
+        public static let schemaParamFilePath = "file_path"
 
-            // MARK: Messages & Tips
+        /// JSON Schema parameter: search_files
+        public static let schemaParamSearchFiles = "search_files"
 
-            /// Tip for using resources/read
-            public static let tipUseResourcesRead =
-                "💡 **Tip:** Use `resources/read` with the URI to get the full document content."
+        /// JSON Schema parameter: min_ios
+        public static let schemaParamMinIOS = "min_ios"
 
-            /// Tip for filtering by framework
-            public static let tipFilterByFramework =
-                "💡 **Tip:** Use `search` with the `framework` parameter to filter results."
+        /// JSON Schema parameter: min_macos
+        public static let schemaParamMinMacOS = "min_macos"
 
-            /// No results found message
-            public static let messageNoResults = """
-            _No results found. Try different keywords or check available frameworks \
-            using `list_frameworks`._
+        /// JSON Schema parameter: min_tvos
+        public static let schemaParamMinTvOS = "min_tvos"
 
-            💡 **Try other sources:** Use `source` parameter: samples, hig, apple-archive, \
-            swift-evolution, swift-org, swift-book, packages, or `all`.
+        /// JSON Schema parameter: min_watchos
+        public static let schemaParamMinWatchOS = "min_watchos"
+
+        /// JSON Schema parameter: min_visionos
+        public static let schemaParamMinVisionOS = "min_visionos"
+
+        // MARK: Semantic Search Parameters (#81)
+
+        /// JSON Schema parameter: kind (symbol kind)
+        public static let schemaParamKind = "kind"
+
+        /// JSON Schema parameter: is_async (async functions filter)
+        public static let schemaParamIsAsync = "is_async"
+
+        /// JSON Schema parameter: wrapper (property wrapper name)
+        public static let schemaParamWrapper = "wrapper"
+
+        /// JSON Schema parameter: pattern (concurrency pattern)
+        public static let schemaParamPattern = "pattern"
+
+        /// JSON Schema parameter: protocol (protocol conformance)
+        public static let schemaParamProtocol = "protocol"
+
+        /// Format value: json
+        public static let formatValueJSON = "json"
+
+        /// Format value: markdown
+        public static let formatValueMarkdown = "markdown"
+
+        // MARK: Messages & Tips
+
+        /// Tip for using resources/read
+        public static let tipUseResourcesRead =
+            "💡 **Tip:** Use `resources/read` with the URI to get the full document content."
+
+        /// Tip for filtering by framework
+        public static let tipFilterByFramework =
+            "💡 **Tip:** Use `search` with the `framework` parameter to filter results."
+
+        /// No results found message
+        public static let messageNoResults = """
+        _No results found. Try different keywords or check available frameworks \
+        using `list_frameworks`._
+
+        💡 **Try other sources:** Use `source` parameter: samples, hig, apple-archive, \
+        swift-evolution, swift-org, swift-book, packages, or `all`.
+        """
+
+        /// No frameworks found message
+        public static func messageNoFrameworks(buildIndexCommand: String) -> String {
             """
-
-            /// No frameworks found message
-            public static func messageNoFrameworks(buildIndexCommand: String) -> String {
-                """
-                _No frameworks found. The search index may be empty. \
-                Run `\(buildIndexCommand)` to index your documentation._
-                """
-            }
-
-            /// Tip for exploring other sources when results are limited
-            public static let tipExploreOtherSources = """
-            💡 **Need more?** Try these additional sources:
-            - `search` with `source: apple-archive` for foundational guides \
-            (Core Animation, Quartz 2D, KVO/KVC, threading)
-            - `search` with `source: samples` for working code examples
+            _No frameworks found. The search index may be empty. \
+            Run `\(buildIndexCommand)` to index your documentation._
             """
-
-            /// Tip for archive when no results
-            public static let tipTryArchive = """
-            💡 **Tip:** For conceptual/foundational topics, try `search` with \
-            `source: apple-archive` to search Apple Archive legacy programming guides.
-            """
-
-            /// Tip for platform availability filters
-            public static let tipPlatformFilters = """
-            💡 **Tip:** Filter by platform: `\(schemaParamMinIOS)`, `\(schemaParamMinMacOS)`, \
-            `\(schemaParamMinTvOS)`, `\(schemaParamMinWatchOS)`, `\(schemaParamMinVisionOS)`
-            """
-
-            /// All available source values (excluding 'all')
-            public static let availableSources: [String] = [
-                SourcePrefix.appleDocs,
-                SourcePrefix.samples,
-                SourcePrefix.hig,
-                SourcePrefix.appleArchive,
-                SourcePrefix.swiftEvolution,
-                SourcePrefix.swiftOrg,
-                SourcePrefix.swiftBook,
-                SourcePrefix.packages,
-            ]
-
-            /// Get all sources except the specified one(s)
-            public static func otherSources(excluding current: String?) -> [String] {
-                let excluded = current ?? ""
-                return availableSources.filter { $0 != excluded }
-            }
-
-            /// Comprehensive tips showing all available search capabilities
-            public static let tipSearchCapabilities = """
-            💡 **Dig deeper:** Use `source` parameter to search: \(availableSources.joined(separator: ", ")), or `all`.
-            """
-
-            /// Tip for semantic code search tools (#81)
-            public static let tipSemanticSearch = """
-            🔍 **AST search:** Use `\(toolSearchSymbols)`, `\(toolSearchPropertyWrappers)`, \
-            `\(toolSearchConcurrency)`, or `\(toolSearchConformances)` for semantic code \
-            discovery via AST extraction.
-            """
-
-            /// Generate tip showing other sources for a specific search
-            public static func tipOtherSources(excluding current: String?) -> String {
-                let others = otherSources(excluding: current)
-                return "💡 **Other sources:** \(others.joined(separator: ", ")), or `all`"
-            }
-
-            // MARK: Formatting
-
-            /// Score number format (2 decimal places)
-            public static let formatScore = "%.2f"
         }
 
-        // MARK: - CLI Commands
+        /// Tip for exploring other sources when results are limited
+        public static let tipExploreOtherSources = """
+        💡 **Need more?** Try these additional sources:
+        - `search` with `source: apple-archive` for foundational guides \
+        (Core Animation, Quartz 2D, KVO/KVC, threading)
+        - `search` with `source: samples` for working code examples
+        """
 
-        public enum Command {
-            /// Build index command name
-            public static let buildIndex = "build-index"
+        /// Tip for archive when no results
+        public static let tipTryArchive = """
+        💡 **Tip:** For conceptual/foundational topics, try `search` with \
+        `source: apple-archive` to search Apple Archive legacy programming guides.
+        """
 
-            /// Crawl command name
-            public static let crawl = "crawl"
+        /// Tip for platform availability filters
+        public static let tipPlatformFilters = """
+        💡 **Tip:** Filter by platform: `\(schemaParamMinIOS)`, `\(schemaParamMinMacOS)`, \
+        `\(schemaParamMinTvOS)`, `\(schemaParamMinWatchOS)`, `\(schemaParamMinVisionOS)`
+        """
 
-            /// Serve command name (MCP)
-            public static let serve = "serve"
+        /// All available source values (excluding 'all')
+        public static let availableSources: [String] = [
+            SourcePrefix.appleDocs,
+            SourcePrefix.samples,
+            SourcePrefix.hig,
+            SourcePrefix.appleArchive,
+            SourcePrefix.swiftEvolution,
+            SourcePrefix.swiftOrg,
+            SourcePrefix.swiftBook,
+            SourcePrefix.packages,
+        ]
+
+        /// Get all sources except the specified one(s)
+        public static func otherSources(excluding current: String?) -> [String] {
+            let excluded = current ?? ""
+            return availableSources.filter { $0 != excluded }
         }
 
-        // MARK: - Messages
+        /// Comprehensive tips showing all available search capabilities
+        public static let tipSearchCapabilities = """
+        💡 **Dig deeper:** Use `source` parameter to search: \(availableSources.joined(separator: ", ")), or `all`.
+        """
 
-        public enum Message {
-            // MARK: GitHub Token Instructions
+        /// Tip for semantic code search tools (#81)
+        public static let tipSemanticSearch = """
+        🔍 **AST search:** Use `\(toolSearchSymbols)`, `\(toolSearchPropertyWrappers)`, \
+        `\(toolSearchConcurrency)`, or `\(toolSearchConformances)` for semantic code \
+        discovery via AST extraction.
+        """
 
-            /// Export GitHub token instruction (for bash shell)
-            public static let exportGitHubToken = "export GITHUB_TOKEN=your_token_here"
-
-            /// GitHub rate limit without token
-            public static let rateLimitWithoutToken = "Without token: 60 requests/hour"
-
-            /// GitHub rate limit with token
-            public static let rateLimitWithToken = "With token: 5000 requests/hour"
-
-            /// Tip about setting GitHub token
-            public static let gitHubTokenTip = "💡 Tip: Set GITHUB_TOKEN environment variable for higher rate limits"
+        /// Generate tip showing other sources for a specific search
+        public static func tipOtherSources(excluding current: String?) -> String {
+            let others = otherSources(excluding: current)
+            return "💡 **Other sources:** \(others.joined(separator: ", ")), or `all`"
         }
 
-        // MARK: - Delays and Timeouts
+        // MARK: Formatting
 
-        /// Network delays and timeout values
-        public enum Delay {
-            /// Delay between Swift Evolution proposal fetches
-            /// Rationale: GitHub API rate limiting (60 req/hour without token)
-            public static let swiftEvolution: Duration = .milliseconds(500)
+        /// Score number format (2 decimal places)
+        public static let formatScore = "%.2f"
+    }
 
-            /// Delay between sample code page loads
-            /// Rationale: Avoid overwhelming Apple's servers
-            public static let sampleCodeBetweenPages: Duration = .seconds(1)
+    // MARK: - CLI Commands
 
-            /// Wait time for sample code page to load completely
-            /// Rationale: JavaScript-heavy pages need time to render
-            public static let sampleCodePageLoad: Duration = .seconds(5)
+    public enum Command {
+        /// Build index command name
+        public static let buildIndex = "build-index"
 
-            /// Delay after sample code page interaction
-            /// Rationale: Wait for UI state to update
-            public static let sampleCodeInteraction: Duration = .seconds(3)
+        /// Crawl command name
+        public static let crawl = "crawl"
 
-            /// Delay before sample code download
-            /// Rationale: Ensure download link is ready
-            public static let sampleCodeDownload: Duration = .seconds(2)
+        /// Serve command name (MCP)
+        public static let serve = "serve"
+    }
 
-            /// Rate limit delay for package fetching (high priority packages)
-            /// Rationale: GitHub API secondary rate limits
-            public static let packageFetchHighPriority: Duration = .seconds(5)
+    // MARK: - Messages
 
-            /// Rate limit delay for package fetching (normal priority)
-            /// Rationale: Balance speed vs API limits
-            public static let packageFetchNormal: Duration = .seconds(1.2)
+    public enum Message {
+        // MARK: GitHub Token Instructions
 
-            /// Rate limit delay for package star count (high priority)
-            /// Rationale: Star count fetches are lighter, can be faster
-            public static let packageStarsHighPriority: Duration = .seconds(2)
+        /// Export GitHub token instruction (for bash shell)
+        public static let exportGitHubToken = "export GITHUB_TOKEN=your_token_here"
 
-            /// Rate limit delay for package star count (normal)
-            /// Rationale: Minimize total fetch time
-            public static let packageStarsNormal: Duration = .seconds(0.5)
+        /// GitHub rate limit without token
+        public static let rateLimitWithoutToken = "Without token: 60 requests/hour"
 
-            /// Delay between archive page fetches
-            /// Rationale: Respectful crawling of Apple's archive servers
-            public static let archivePage: Duration = .milliseconds(500)
+        /// GitHub rate limit with token
+        public static let rateLimitWithToken = "With token: 5000 requests/hour"
 
-            /// Base pause before retry after failure. Used as the base for
-            /// exponential backoff (1s → 3s → 9s …) so successive retries
-            /// span enough time to outlast typical Apple JSON-API rate-limit
-            /// bursts (#209). The original 2026-04-30 recrawl saw 192/360k
-            /// pages fail at fixed 1-second intervals; a retry minutes later
-            /// recovered 187/192 — confirming the failures were rate-limit
-            /// windows the fixed delay never escaped.
-            public static let retryPause: Duration = .seconds(1)
+        /// Tip about setting GitHub token
+        public static let gitHubTokenTip = "💡 Tip: Set GITHUB_TOKEN environment variable for higher rate limits"
+    }
 
-            /// Multiplier for exponential retry backoff (#209). With base
-            /// 1s and multiplier 3, attempts wait 1s, 3s, 9s — total 13s of
-            /// retry-window coverage instead of the previous 3s.
-            public static let retryBackoffMultiplier: Double = 3.0
+    // MARK: - Delays and Timeouts
 
-            /// Cap on a single retry sleep (#209). Prevents runaway sleeps
-            /// if maxRetries is ever bumped well past 3.
-            public static let retryBackoffMax: Duration = .seconds(30)
+    /// Network delays and timeout values
+    public enum Delay {
+        /// Delay between Swift Evolution proposal fetches
+        /// Rationale: GitHub API rate limiting (60 req/hour without token)
+        public static let swiftEvolution: Duration = .milliseconds(500)
 
-            /// Compute the sleep duration for the n-th retry (1-indexed):
-            /// `base * multiplier^(attempt - 1)`, capped at `retryBackoffMax`.
-            ///
-            /// With defaults (base 1s, multiplier 3): attempt 1 → 1s,
-            /// attempt 2 → 3s, attempt 3 → 9s. Total wait across 3 retries:
-            /// 13s — long enough to outlast typical Apple rate-limit bursts
-            /// (#209). Returns `.zero` for attempt < 1 so the helper is
-            /// safe to call unconditionally.
-            public static func retryBackoff(
-                attempt: Int,
-                base: Duration = retryPause,
-                multiplier: Double = retryBackoffMultiplier,
-                maxDelay: Duration = retryBackoffMax
-            ) -> Duration {
-                guard attempt >= 1 else { return .zero }
+        /// Delay between sample code page loads
+        /// Rationale: Avoid overwhelming Apple's servers
+        public static let sampleCodeBetweenPages: Duration = .seconds(1)
 
-                // Reduce the base Duration to a Double of seconds so we can
-                // multiply by `multiplier^(attempt-1)`. Foundation's Duration
-                // doesn't expose direct fractional-second multiplication.
-                let parts = base.components
-                let baseSeconds = Double(parts.seconds) + Double(parts.attoseconds) / 1e18
-                let factor = pow(multiplier, Double(attempt - 1))
-                let computed = baseSeconds * factor
+        /// Wait time for sample code page to load completely
+        /// Rationale: JavaScript-heavy pages need time to render
+        public static let sampleCodePageLoad: Duration = .seconds(5)
 
-                let capParts = maxDelay.components
-                let capSeconds = Double(capParts.seconds) + Double(capParts.attoseconds) / 1e18
+        /// Delay after sample code page interaction
+        /// Rationale: Wait for UI state to update
+        public static let sampleCodeInteraction: Duration = .seconds(3)
 
-                let bounded = min(computed, capSeconds)
-                let wholeSeconds = Int64(bounded)
-                let fractional = bounded - Double(wholeSeconds)
-                let attoseconds = Int64(fractional * 1e18)
-                return Duration(secondsComponent: wholeSeconds, attosecondsComponent: attoseconds)
-            }
+        /// Delay before sample code download
+        /// Rationale: Ensure download link is ready
+        public static let sampleCodeDownload: Duration = .seconds(2)
+
+        /// Rate limit delay for package fetching (high priority packages)
+        /// Rationale: GitHub API secondary rate limits
+        public static let packageFetchHighPriority: Duration = .seconds(5)
+
+        /// Rate limit delay for package fetching (normal priority)
+        /// Rationale: Balance speed vs API limits
+        public static let packageFetchNormal: Duration = .seconds(1.2)
+
+        /// Rate limit delay for package star count (high priority)
+        /// Rationale: Star count fetches are lighter, can be faster
+        public static let packageStarsHighPriority: Duration = .seconds(2)
+
+        /// Rate limit delay for package star count (normal)
+        /// Rationale: Minimize total fetch time
+        public static let packageStarsNormal: Duration = .seconds(0.5)
+
+        /// Delay between archive page fetches
+        /// Rationale: Respectful crawling of Apple's archive servers
+        public static let archivePage: Duration = .milliseconds(500)
+
+        /// Base pause before retry after failure. Used as the base for
+        /// exponential backoff (1s → 3s → 9s …) so successive retries
+        /// span enough time to outlast typical Apple JSON-API rate-limit
+        /// bursts (#209). The original 2026-04-30 recrawl saw 192/360k
+        /// pages fail at fixed 1-second intervals; a retry minutes later
+        /// recovered 187/192 — confirming the failures were rate-limit
+        /// windows the fixed delay never escaped.
+        public static let retryPause: Duration = .seconds(1)
+
+        /// Multiplier for exponential retry backoff (#209). With base
+        /// 1s and multiplier 3, attempts wait 1s, 3s, 9s — total 13s of
+        /// retry-window coverage instead of the previous 3s.
+        public static let retryBackoffMultiplier: Double = 3.0
+
+        /// Cap on a single retry sleep (#209). Prevents runaway sleeps
+        /// if maxRetries is ever bumped well past 3.
+        public static let retryBackoffMax: Duration = .seconds(30)
+
+        /// Compute the sleep duration for the n-th retry (1-indexed):
+        /// `base * multiplier^(attempt - 1)`, capped at `retryBackoffMax`.
+        ///
+        /// With defaults (base 1s, multiplier 3): attempt 1 → 1s,
+        /// attempt 2 → 3s, attempt 3 → 9s. Total wait across 3 retries:
+        /// 13s — long enough to outlast typical Apple rate-limit bursts
+        /// (#209). Returns `.zero` for attempt < 1 so the helper is
+        /// safe to call unconditionally.
+        public static func retryBackoff(
+            attempt: Int,
+            base: Duration = retryPause,
+            multiplier: Double = retryBackoffMultiplier,
+            maxDelay: Duration = retryBackoffMax
+        ) -> Duration {
+            guard attempt >= 1 else { return .zero }
+
+            // Reduce the base Duration to a Double of seconds so we can
+            // multiply by `multiplier^(attempt-1)`. Foundation's Duration
+            // doesn't expose direct fractional-second multiplication.
+            let parts = base.components
+            let baseSeconds = Double(parts.seconds) + Double(parts.attoseconds) / 1e18
+            let factor = pow(multiplier, Double(attempt - 1))
+            let computed = baseSeconds * factor
+
+            let capParts = maxDelay.components
+            let capSeconds = Double(capParts.seconds) + Double(capParts.attoseconds) / 1e18
+
+            let bounded = min(computed, capSeconds)
+            let wholeSeconds = Int64(bounded)
+            let fractional = bounded - Double(wholeSeconds)
+            let attoseconds = Int64(fractional * 1e18)
+            return Duration(secondsComponent: wholeSeconds, attosecondsComponent: attoseconds)
         }
+    }
+
+    /// Timeout values for operations
+    public enum Timeout {
+        /// Timeout for page loading in crawler
+        /// Rationale: Complex pages can take time, but 30s is reasonable limit
+        public static let pageLoad: Duration = .seconds(30)
+
+        /// Maximum time to wait for WKWebView navigation
+        /// Rationale: Matches page load timeout for consistency
+        public static let webViewNavigation: Duration = .seconds(30)
+
+        /// Time to wait for JavaScript execution
+        /// Rationale: Allow JS to populate dynamic content
+        public static let javascriptWait: Duration = .seconds(5)
+
+        /// Time to wait for JavaScript in HIG SPA
+        /// Rationale: HIG pages are simpler, 3s is sufficient
+        public static let higJavascriptWait: Duration = .seconds(3)
+    }
+
+    // MARK: - Intervals
+
+    /// Periodic operation intervals
+    public enum Interval {
+        /// Auto-save interval for crawler state
+        /// Rationale: Balance between data safety and I/O overhead
+        public static let autoSave: TimeInterval = 30.0
+
+        /// Log progress every N items
+        /// Rationale: Enough to show progress without spamming logs
+        public static let progressLogEvery: Int = 50
+
+        /// Recycle WKWebView every N pages to prevent memory buildup
+        /// Rationale: Prevents WebKit memory leaks during long crawl sessions
+        public static let webViewRecycleEvery: Int = 50
+    }
+
+    // MARK: - Content Limits
+
+    /// Content size and length limits
+    public enum ContentLimit {
+        /// Maximum length for summary extraction (characters)
+        /// Rationale: Enough for declaration + overview of properties/methods
+        public static let summaryMaxLength: Int = 1500
+
+        /// Maximum content preview length (characters)
+        /// Rationale: Shorter preview for quick display
+        public static let previewMaxLength: Int = 200
+    }
+
+    // MARK: - Swift Evolution
+
+    /// Swift Evolution repository configuration
+    public enum SwiftEvolution {
+        /// Swift Evolution repository (owner/repo format)
+        public static let repository = "swiftlang/swift-evolution"
+
+        /// Default branch to fetch from
+        public static let branch = "main"
+
+        /// Repository owner
+        public static let owner = "swiftlang"
+
+        /// Repository name
+        public static let repo = "swift-evolution"
+
+        /// Subdirectory path for Swift Evolution proposals
+        public static let proposalsSubdirectory = "proposals"
+
+        /// Subdirectory path for Swift Testing proposals
+        public static let testingSubdirectory = "proposals/testing"
+
+        /// Proposal ID prefix for Swift Evolution
+        public static let seIDPrefix = "SE"
+
+        /// Proposal ID prefix for Swift Testing
+        public static let stIDPrefix = "ST"
+    }
+
+    // MARK: - Priority Packages
+
+    /// Critical Apple packages that should always be included
+    public enum CriticalApplePackages {
+        /// List of critical Apple package repository names
+        /// These are the most commonly used Apple packages and should be prioritized
+        public static let repositories: [String] = [
+            "swift",
+            "swift-algorithms",
+            "swift-argument-parser",
+            "swift-asn1",
+            "swift-async-algorithms",
+            "swift-atomics",
+            "swift-cassandra-client",
+            "swift-certificates",
+            "swift-cluster-membership",
+            "swift-collections",
+            "swift-crypto",
+            "swift-distributed-actors",
+            "swift-docc",
+            "swift-driver",
+            "swift-format",
+            "swift-log",
+            "swift-metrics",
+            "swift-nio",
+            "swift-nio-http2",
+            "swift-nio-ssl",
+            "swift-nio-transport-services",
+            "swift-numerics",
+            "swift-openapi-generator",
+            "swift-openapi-runtime",
+            "swift-openapi-urlsession",
+            "swift-package-manager",
+            "swift-protobuf",
+            "swift-service-context",
+            "swift-system",
+            "swift-testing",
+            "sourcekit-lsp",
+        ]
+    }
+
+    /// Well-known ecosystem packages
+    public enum KnownEcosystemPackages {
+        /// List of well-known ecosystem packages (owner/repo format)
+        /// Note: Excludes deprecated packages (Alamofire, RxSwift, etc.)
+        public static let repositories: [String] = [
+            "vapor/vapor",
+            "vapor/swift-getting-started-web-server",
+            "pointfreeco/swift-composable-architecture",
+            "pointfreeco/swift-custom-dump",
+            "pointfreeco/swift-dependencies",
+        ]
+    }
+
+    // MARK: - CLI Help Strings
+
+    /// Help text for CLI commands and options
+    public enum HelpText {
+        /// Apple documentation directory help text
+        public static let docsDir = "Apple documentation directory"
+
+        /// Swift Evolution proposals directory help text
+        public static let evolutionDir = "Swift Evolution proposals directory"
+
+        /// Search database path help text
+        public static let searchDB = "Search database path"
+
+        /// MCP server abstract description
+        public static let mcpAbstract =
+            "MCP Server for Apple Documentation, Swift Evolution, Swift Packages, and Code Samples"
+    }
+
+    // MARK: - Host Domain Identifiers
+
+    /// Domain identifiers for URL classification
+    public enum HostDomain {
+        /// Swift.org domain identifier
+        public static let swiftOrg = "swift.org"
+
+        /// Apple.com domain identifier
+        public static let appleCom = "apple.com"
+    }
+
+    // MARK: - Path Components
+
+    /// Common path components for URL classification
+    public enum PathComponent {
+        /// Swift Book path component
+        public static let swiftBook = "swift-book"
+
+        /// Swift.org framework identifier
+        public static let swiftOrgFramework = "swift-org"
+    }
+
+    // MARK: - URL Cleanup Patterns
 
-        /// Timeout values for operations
-        public enum Timeout {
-            /// Timeout for page loading in crawler
-            /// Rationale: Complex pages can take time, but 30s is reasonable limit
-            public static let pageLoad: Duration = .seconds(30)
-
-            /// Maximum time to wait for WKWebView navigation
-            /// Rationale: Matches page load timeout for consistency
-            public static let webViewNavigation: Duration = .seconds(30)
-
-            /// Time to wait for JavaScript execution
-            /// Rationale: Allow JS to populate dynamic content
-            public static let javascriptWait: Duration = .seconds(5)
-
-            /// Time to wait for JavaScript in HIG SPA
-            /// Rationale: HIG pages are simpler, 3s is sufficient
-            public static let higJavascriptWait: Duration = .seconds(3)
-        }
-
-        // MARK: - Intervals
-
-        /// Periodic operation intervals
-        public enum Interval {
-            /// Auto-save interval for crawler state
-            /// Rationale: Balance between data safety and I/O overhead
-            public static let autoSave: TimeInterval = 30.0
-
-            /// Log progress every N items
-            /// Rationale: Enough to show progress without spamming logs
-            public static let progressLogEvery: Int = 50
-
-            /// Recycle WKWebView every N pages to prevent memory buildup
-            /// Rationale: Prevents WebKit memory leaks during long crawl sessions
-            public static let webViewRecycleEvery: Int = 50
-        }
-
-        // MARK: - Content Limits
-
-        /// Content size and length limits
-        public enum ContentLimit {
-            /// Maximum length for summary extraction (characters)
-            /// Rationale: Enough for declaration + overview of properties/methods
-            public static let summaryMaxLength: Int = 1500
-
-            /// Maximum content preview length (characters)
-            /// Rationale: Shorter preview for quick display
-            public static let previewMaxLength: Int = 200
-        }
-
-        // MARK: - Swift Evolution
-
-        /// Swift Evolution repository configuration
-        public enum SwiftEvolution {
-            /// Swift Evolution repository (owner/repo format)
-            public static let repository = "swiftlang/swift-evolution"
-
-            /// Default branch to fetch from
-            public static let branch = "main"
-
-            /// Repository owner
-            public static let owner = "swiftlang"
-
-            /// Repository name
-            public static let repo = "swift-evolution"
-
-            /// Subdirectory path for Swift Evolution proposals
-            public static let proposalsSubdirectory = "proposals"
-
-            /// Subdirectory path for Swift Testing proposals
-            public static let testingSubdirectory = "proposals/testing"
-
-            /// Proposal ID prefix for Swift Evolution
-            public static let seIDPrefix = "SE"
-
-            /// Proposal ID prefix for Swift Testing
-            public static let stIDPrefix = "ST"
-        }
-
-        // MARK: - Priority Packages
-
-        /// Critical Apple packages that should always be included
-        public enum CriticalApplePackages {
-            /// List of critical Apple package repository names
-            /// These are the most commonly used Apple packages and should be prioritized
-            public static let repositories: [String] = [
-                "swift",
-                "swift-algorithms",
-                "swift-argument-parser",
-                "swift-asn1",
-                "swift-async-algorithms",
-                "swift-atomics",
-                "swift-cassandra-client",
-                "swift-certificates",
-                "swift-cluster-membership",
-                "swift-collections",
-                "swift-crypto",
-                "swift-distributed-actors",
-                "swift-docc",
-                "swift-driver",
-                "swift-format",
-                "swift-log",
-                "swift-metrics",
-                "swift-nio",
-                "swift-nio-http2",
-                "swift-nio-ssl",
-                "swift-nio-transport-services",
-                "swift-numerics",
-                "swift-openapi-generator",
-                "swift-openapi-runtime",
-                "swift-openapi-urlsession",
-                "swift-package-manager",
-                "swift-protobuf",
-                "swift-service-context",
-                "swift-system",
-                "swift-testing",
-                "sourcekit-lsp",
-            ]
-        }
-
-        /// Well-known ecosystem packages
-        public enum KnownEcosystemPackages {
-            /// List of well-known ecosystem packages (owner/repo format)
-            /// Note: Excludes deprecated packages (Alamofire, RxSwift, etc.)
-            public static let repositories: [String] = [
-                "vapor/vapor",
-                "vapor/swift-getting-started-web-server",
-                "pointfreeco/swift-composable-architecture",
-                "pointfreeco/swift-custom-dump",
-                "pointfreeco/swift-dependencies",
-            ]
-        }
-
-        // MARK: - CLI Help Strings
-
-        /// Help text for CLI commands and options
-        public enum HelpText {
-            /// Apple documentation directory help text
-            public static let docsDir = "Apple documentation directory"
-
-            /// Swift Evolution proposals directory help text
-            public static let evolutionDir = "Swift Evolution proposals directory"
-
-            /// Search database path help text
-            public static let searchDB = "Search database path"
-
-            /// MCP server abstract description
-            public static let mcpAbstract =
-                "MCP Server for Apple Documentation, Swift Evolution, Swift Packages, and Code Samples"
-        }
-
-        // MARK: - Host Domain Identifiers
-
-        /// Domain identifiers for URL classification
-        public enum HostDomain {
-            /// Swift.org domain identifier
-            public static let swiftOrg = "swift.org"
-
-            /// Apple.com domain identifier
-            public static let appleCom = "apple.com"
-        }
-
-        // MARK: - Path Components
-
-        /// Common path components for URL classification
-        public enum PathComponent {
-            /// Swift Book path component
-            public static let swiftBook = "swift-book"
+    /// URL patterns for cleanup and normalization
+    public enum URLCleanupPattern {
+        /// Swift.org base URL for cleanup
+        public static let swiftOrgWWW = "https://www.swift.org/"
+    }
 
-            /// Swift.org framework identifier
-            public static let swiftOrgFramework = "swift-org"
-        }
+    // MARK: - JSON-RPC Message Fields
 
-        // MARK: - URL Cleanup Patterns
+    /// Field names for JSON-RPC message parsing
+    public enum JSONRPCField {
+        /// ID field
+        public static let id = "id"
 
-        /// URL patterns for cleanup and normalization
-        public enum URLCleanupPattern {
-            /// Swift.org base URL for cleanup
-            public static let swiftOrgWWW = "https://www.swift.org/"
-        }
+        /// Method field
+        public static let method = "method"
 
-        // MARK: - JSON-RPC Message Fields
+        /// Error field
+        public static let error = "error"
 
-        /// Field names for JSON-RPC message parsing
-        public enum JSONRPCField {
-            /// ID field
-            public static let id = "id"
+        /// Result field
+        public static let result = "result"
+    }
 
-            /// Method field
-            public static let method = "method"
+    // MARK: - Error Messages
 
-            /// Error field
-            public static let error = "error"
+    /// Error message constants
+    public enum ErrorMessage {
+        /// Invalid JSON-RPC message type error
+        public static let invalidJSONRPCMessage = "Unable to determine JSON-RPC message type"
+    }
 
-            /// Result field
-            public static let result = "result"
-        }
+    // MARK: - JavaScript Code
 
-        // MARK: - Error Messages
+    public enum JavaScript {
+        /// Get the full HTML content of the current document
+        public static let getDocumentHTML = "document.documentElement.outerHTML"
+    }
 
-        /// Error message constants
-        public enum ErrorMessage {
-            /// Invalid JSON-RPC message type error
-            public static let invalidJSONRPCMessage = "Unable to determine JSON-RPC message type"
-        }
+    // MARK: - Default Limits
 
-        // MARK: - JavaScript Code
+    public enum Limit {
+        // MARK: Crawler Limits
 
-        public enum JavaScript {
-            /// Get the full HTML content of the current document
-            public static let getDocumentHTML = "document.documentElement.outerHTML"
-        }
+        /// Default maximum number of pages to crawl. Effectively uncapped —
+        /// 1 million is well above Apple's full developer docs (~70k pages),
+        /// Swift Evolution (~500), Swift.org, HIG, and the archive combined,
+        /// so a default crawl runs to queue exhaustion rather than hitting
+        /// an artificial limit. Override with `--max-pages` if you need a
+        /// smaller bounded crawl for testing.
+        public static let defaultMaxPages = 1000000
 
-        // MARK: - Default Limits
+        // MARK: File Size Limits
 
-        public enum Limit {
-            // MARK: Crawler Limits
+        /// Maximum file size for indexing (1 MiB)
+        public static let maxIndexableFileSize = 1048576
 
-            /// Default maximum number of pages to crawl. Effectively uncapped —
-            /// 1 million is well above Apple's full developer docs (~70k pages),
-            /// Swift Evolution (~500), Swift.org, HIG, and the archive combined,
-            /// so a default crawl runs to queue exhaustion rather than hitting
-            /// an artificial limit. Override with `--max-pages` if you need a
-            /// smaller bounded crawl for testing.
-            public static let defaultMaxPages = 1000000
+        // MARK: Search Limits
 
-            // MARK: File Size Limits
+        /// Default search result limit
+        public static let defaultSearchLimit = 20
 
-            /// Maximum file size for indexing (1 MiB)
-            public static let maxIndexableFileSize = 1048576
+        /// Default list result limit (for listing samples, etc.)
+        public static let defaultListLimit = 50
 
-            // MARK: Search Limits
+        /// Maximum search result limit
+        public static let maxSearchLimit = 100
 
-            /// Default search result limit
-            public static let defaultSearchLimit = 20
+        /// Teaser result limit (for showing hints from alternate sources)
+        public static let teaserLimit = 2
 
-            /// Default list result limit (for listing samples, etc.)
-            public static let defaultListLimit = 50
+        // MARK: Display Limits
 
-            /// Maximum search result limit
-            public static let maxSearchLimit = 100
+        /// Number of top packages to display
+        public static let topPackagesDisplay = 20
 
-            /// Teaser result limit (for showing hints from alternate sources)
-            public static let teaserLimit = 2
+        /// Maximum length for summary text in search results
+        public static let summaryTruncationLength = 800
+    }
 
-            // MARK: Display Limits
+    // MARK: - Database Schema
 
-            /// Number of top packages to display
-            public static let topPackagesDisplay = 20
+    public enum Database {
+        // MARK: Table Names
 
-            /// Maximum length for summary text in search results
-            public static let summaryTruncationLength = 800
-        }
+        /// Main FTS5 search table name
+        public static let tableDocsFTS = "docs_fts"
 
-        // MARK: - Database Schema
+        /// Documents metadata table name
+        public static let tableDocsMetadata = "docs_metadata"
 
-        public enum Database {
-            // MARK: Table Names
+        /// Packages table name
+        public static let tablePackages = "packages"
 
-            /// Main FTS5 search table name
-            public static let tableDocsFTS = "docs_fts"
+        /// Package dependencies table name
+        public static let tablePackageDependencies = "package_dependencies"
 
-            /// Documents metadata table name
-            public static let tableDocsMetadata = "docs_metadata"
+        // MARK: Column Names - docs_metadata
 
-            /// Packages table name
-            public static let tablePackages = "packages"
+        /// URI column (primary key)
+        public static let colURI = "uri"
 
-            /// Package dependencies table name
-            public static let tablePackageDependencies = "package_dependencies"
+        /// Framework column
+        public static let colFramework = "framework"
 
-            // MARK: Column Names - docs_metadata
+        /// File path column
+        public static let colFilePath = "file_path"
 
-            /// URI column (primary key)
-            public static let colURI = "uri"
+        /// Content hash column
+        public static let colContentHash = "content_hash"
 
-            /// Framework column
-            public static let colFramework = "framework"
+        /// Last crawled timestamp column
+        public static let colLastCrawled = "last_crawled"
 
-            /// File path column
-            public static let colFilePath = "file_path"
+        /// Word count column
+        public static let colWordCount = "word_count"
 
-            /// Content hash column
-            public static let colContentHash = "content_hash"
+        /// Source type column
+        public static let colSourceType = "source_type"
 
-            /// Last crawled timestamp column
-            public static let colLastCrawled = "last_crawled"
+        /// Package ID column (foreign key)
+        public static let colPackageID = "package_id"
 
-            /// Word count column
-            public static let colWordCount = "word_count"
+        // MARK: Column Names - docs_fts
 
-            /// Source type column
-            public static let colSourceType = "source_type"
+        /// Title column (FTS)
+        public static let colTitle = "title"
 
-            /// Package ID column (foreign key)
-            public static let colPackageID = "package_id"
+        /// Summary column (FTS)
+        public static let colSummary = "summary"
 
-            // MARK: Column Names - docs_fts
+        /// Content column (FTS)
+        public static let colContent = "content"
 
-            /// Title column (FTS)
-            public static let colTitle = "title"
+        // MARK: Column Names - packages
 
-            /// Summary column (FTS)
-            public static let colSummary = "summary"
+        /// Package ID column
+        public static let colID = "id"
 
-            /// Content column (FTS)
-            public static let colContent = "content"
+        /// Package name column
+        public static let colName = "name"
 
-            // MARK: Column Names - packages
+        /// Package owner column
+        public static let colOwner = "owner"
 
-            /// Package ID column
-            public static let colID = "id"
+        /// Repository URL column
+        public static let colRepositoryURL = "repository_url"
 
-            /// Package name column
-            public static let colName = "name"
+        /// Documentation URL column
+        public static let colDocumentationURL = "documentation_url"
 
-            /// Package owner column
-            public static let colOwner = "owner"
+        /// Stars count column
+        public static let colStars = "stars"
 
-            /// Repository URL column
-            public static let colRepositoryURL = "repository_url"
+        /// Last updated timestamp column
+        public static let colLastUpdated = "last_updated"
 
-            /// Documentation URL column
-            public static let colDocumentationURL = "documentation_url"
+        /// Is Apple official flag column
+        public static let colIsAppleOfficial = "is_apple_official"
 
-            /// Stars count column
-            public static let colStars = "stars"
+        /// Description column
+        public static let colDescription = "description"
 
-            /// Last updated timestamp column
-            public static let colLastUpdated = "last_updated"
+        // MARK: Index Names
 
-            /// Is Apple official flag column
-            public static let colIsAppleOfficial = "is_apple_official"
+        /// Framework index name
+        public static let idxFramework = "idx_framework"
 
-            /// Description column
-            public static let colDescription = "description"
+        /// Source type index name
+        public static let idxSourceType = "idx_source_type"
 
-            // MARK: Index Names
+        /// Package owner index name
+        public static let idxPackageOwner = "idx_package_owner"
 
-            /// Framework index name
-            public static let idxFramework = "idx_framework"
+        /// Package official flag index name
+        public static let idxPackageOfficial = "idx_package_official"
 
-            /// Source type index name
-            public static let idxSourceType = "idx_source_type"
+        // MARK: Default Values
 
-            /// Package owner index name
-            public static let idxPackageOwner = "idx_package_owner"
+        /// Default source type for Apple documentation
+        public static let defaultSourceTypeApple = "apple"
 
-            /// Package official flag index name
-            public static let idxPackageOfficial = "idx_package_official"
+        // MARK: SQL Functions
 
-            // MARK: Default Values
+        /// BM25 ranking function name
+        public static let funcBM25 = "bm25"
 
-            /// Default source type for Apple documentation
-            public static let defaultSourceTypeApple = "apple"
+        /// COUNT aggregate function
+        public static let funcCount = "COUNT"
+    }
 
-            // MARK: SQL Functions
+    // MARK: - Priority Package List
 
-            /// BM25 ranking function name
-            public static let funcBM25 = "bm25"
+    public enum PriorityPackage {
+        /// Priority package list version
+        public static let version = "1.0"
 
-            /// COUNT aggregate function
-            public static let funcCount = "COUNT"
-        }
+        // MARK: Tier Descriptions
 
-        // MARK: - Priority Package List
+        /// Tier 1 description (Apple official packages)
+        public static let tier1Description = "Apple official packages - always crawled first"
 
-        public enum PriorityPackage {
-            /// Priority package list version
-            public static let version = "1.0"
+        /// Tier 2 description (SwiftLang packages)
+        public static let tier2Description = "SwiftLang official packages - core Swift tooling and infrastructure"
 
-            // MARK: Tier Descriptions
+        /// Tier 3 description (Swift Server packages)
+        public static let tier3Description = "Swift Server Work Group packages - mentioned in Swift.org docs"
 
-            /// Tier 1 description (Apple official packages)
-            public static let tier1Description = "Apple official packages - always crawled first"
+        /// Tier 4 description (Ecosystem packages)
+        public static let tier4Description = "Popular ecosystem packages mentioned in Swift.org documentation"
 
-            /// Tier 2 description (SwiftLang packages)
-            public static let tier2Description = "SwiftLang official packages - core Swift tooling and infrastructure"
+        // MARK: Package List Metadata
 
-            /// Tier 3 description (Swift Server packages)
-            public static let tier3Description = "Swift Server Work Group packages - mentioned in Swift.org docs"
+        /// Package list description
+        public static let listDescription = """
+        Priority Swift packages to always include in documentation crawling. \
+        Auto-generated from Swift.org documentation analysis.
+        """
 
-            /// Tier 4 description (Ecosystem packages)
-            public static let tier4Description = "Popular ecosystem packages mentioned in Swift.org documentation"
+        /// Update policy for priority package list
+        public static let updatePolicy = "Regenerate this list whenever Swift.org documentation is re-crawled"
 
-            // MARK: Package List Metadata
+        /// Data sources for priority package list
+        public static let sources: [String] = [
+            "Swift.org official documentation",
+            "Apple developer ecosystem",
+            "Swift Evolution proposals",
+        ]
 
-            /// Package list description
-            public static let listDescription = """
-            Priority Swift packages to always include in documentation crawling. \
-            Auto-generated from Swift.org documentation analysis.
-            """
-
-            /// Update policy for priority package list
-            public static let updatePolicy = "Regenerate this list whenever Swift.org documentation is re-crawled"
-
-            /// Data sources for priority package list
-            public static let sources: [String] = [
-                "Swift.org official documentation",
-                "Apple developer ecosystem",
-                "Swift Evolution proposals",
-            ]
-
-            /// Notes about priority package list
-            public static let notes: [String] = [
-                "This file is automatically generated by analyzing Swift.org documentation",
-                "Packages are categorized by source and importance",
-                "Tier 1 (Apple official) should always be crawled",
-                "Tier 2 (SwiftLang) provides core Swift tooling",
-                "Tier 3 (Server) for server-side Swift applications",
-                "Tier 4 (Ecosystem) includes popular community packages",
-                "Re-generate this file when Swift.org docs are updated",
-            ]
-        }
+        /// Notes about priority package list
+        public static let notes: [String] = [
+            "This file is automatically generated by analyzing Swift.org documentation",
+            "Packages are categorized by source and importance",
+            "Tier 1 (Apple official) should always be crawled",
+            "Tier 2 (SwiftLang) provides core Swift tooling",
+            "Tier 3 (Server) for server-side Swift applications",
+            "Tier 4 (Ecosystem) includes popular community packages",
+            "Re-generate this file when Swift.org docs are updated",
+        ]
     }
 }

--- a/Packages/Sources/Shared/Constants/Shared.swift
+++ b/Packages/Sources/Shared/Constants/Shared.swift
@@ -1,6 +1,35 @@
 import Foundation
 
-/// Namespace for shared types and utilities
+// MARK: - Shared Namespace
+
+/// Namespace for cross-cutting types shared between every SPM target in the
+/// monorepo. Each sub-namespace mirrors one folder under `Sources/Shared/`:
+///
+/// - `Shared.Constants.*` — `Sources/Shared/Constants/` (paths, file names,
+///                          URL patterns, limits, MCP defaults,
+///                          `BinaryConfig`).
+/// - `Shared.Utils.*`     — `Sources/Shared/Utils/` (Shared.Utils.JSONCoding, Shared.Utils.PathResolver,
+///                          Formatting, FTSQuery, SchemaVersion, URL helpers).
+/// - `Shared.Models.*`    — `Sources/Shared/Models/` (crawl + document +
+///                          package data structures, cleanup result /
+///                          statistics types, URL utilities).
+///
+/// The `Configuration/` and `Core/` subfolders stay flat under `Shared` for
+/// now — `Shared.Configuration` is already a top-level aggregate struct (the
+/// bundle of CrawlerConfiguration + ChangeDetectionConfiguration + Output)
+/// and renaming it requires deciding what to call the existing aggregate;
+/// that lands in a follow-up.
 public enum Shared {
-    // Namespace root - types defined in extensions
+    /// Cupertino-wide constants: paths, file names, URL patterns, limits,
+    /// MCP defaults, plus `Shared.Constants.BinaryConfig` for the
+    /// next-to-binary JSON config file.
+    public enum Constants {}
+
+    /// Pure utility namespaces (`Shared.Utils.JSONCoding`, `Shared.Utils.PathResolver`, `Formatting`,
+    /// `FTSQuery`, `SchemaVersion`). Each is itself a caseless enum.
+    public enum Utils {}
+
+    /// Cross-cutting data structures used by crawler, indexer, search, MCP,
+    /// and the CLI. Most are `Codable` value types serialised to disk.
+    public enum Models {}
 }

--- a/Packages/Sources/Shared/Models/Crawl.swift
+++ b/Packages/Sources/Shared/Models/Crawl.swift
@@ -1,288 +1,301 @@
 import Foundation
+import SharedConstants
 import SharedUtils
 
 // MARK: - Crawl Metadata
 
 /// Metadata tracking crawl state and statistics
-public struct CrawlMetadata: Codable, Sendable {
-    public var pages: [String: PageMetadata] // URL -> metadata
-    public var frameworks: [String: FrameworkStats] // framework name -> stats
-    public var lastCrawl: Date?
-    public var stats: CrawlStatistics
-    public var crawlState: CrawlSessionState? // Resume state
+extension Shared.Models {
+    public struct CrawlMetadata: Codable, Sendable {
+        public var pages: [String: PageMetadata] // URL -> metadata
+        public var frameworks: [String: FrameworkStats] // framework name -> stats
+        public var lastCrawl: Date?
+        public var stats: CrawlStatistics
+        public var crawlState: CrawlSessionState? // Resume state
 
-    public init(
-        pages: [String: PageMetadata] = [:],
-        frameworks: [String: FrameworkStats] = [:],
-        lastCrawl: Date? = nil,
-        stats: CrawlStatistics = CrawlStatistics(),
-        crawlState: CrawlSessionState? = nil
-    ) {
-        self.pages = pages
-        self.frameworks = frameworks
-        self.lastCrawl = lastCrawl
-        self.stats = stats
-        self.crawlState = crawlState
-    }
-
-    /// Save metadata to file
-    public func save(to url: URL) throws {
-        try JSONCoding.encode(self, to: url)
-    }
-
-    /// Load metadata from file
-    public static func load(from url: URL) throws -> CrawlMetadata {
-        try JSONCoding.decode(CrawlMetadata.self, from: url)
-    }
-
-    /// Get statistics grouped by framework
-    public func statsByFramework() -> [String: FrameworkStats] {
-        // If frameworks dict is populated, return it
-        if !frameworks.isEmpty {
-            return frameworks
+        public init(
+            pages: [String: PageMetadata] = [:],
+            frameworks: [String: FrameworkStats] = [:],
+            lastCrawl: Date? = nil,
+            stats: CrawlStatistics = CrawlStatistics(),
+            crawlState: CrawlSessionState? = nil
+        ) {
+            self.pages = pages
+            self.frameworks = frameworks
+            self.lastCrawl = lastCrawl
+            self.stats = stats
+            self.crawlState = crawlState
         }
 
-        // Otherwise compute from pages
-        var stats: [String: FrameworkStats] = [:]
-        for (_, page) in pages {
-            let framework = page.framework.lowercased()
-            if var existing = stats[framework] {
-                existing.pageCount += 1
-                existing.lastCrawled = max(existing.lastCrawled ?? .distantPast, page.lastCrawled)
-                stats[framework] = existing
-            } else {
-                stats[framework] = FrameworkStats(
-                    name: page.framework,
-                    pageCount: 1,
-                    lastCrawled: page.lastCrawled
-                )
+        /// Save metadata to file
+        public func save(to url: URL) throws {
+            try Shared.Utils.JSONCoding.encode(self, to: url)
+        }
+
+        /// Load metadata from file
+        public static func load(from url: URL) throws -> CrawlMetadata {
+            try Shared.Utils.JSONCoding.decode(CrawlMetadata.self, from: url)
+        }
+
+        /// Get statistics grouped by framework
+        public func statsByFramework() -> [String: FrameworkStats] {
+            // If frameworks dict is populated, return it
+            if !frameworks.isEmpty {
+                return frameworks
             }
+
+            // Otherwise compute from pages
+            var stats: [String: FrameworkStats] = [:]
+            for (_, page) in pages {
+                let framework = page.framework.lowercased()
+                if var existing = stats[framework] {
+                    existing.pageCount += 1
+                    existing.lastCrawled = max(existing.lastCrawled ?? .distantPast, page.lastCrawled)
+                    stats[framework] = existing
+                } else {
+                    stats[framework] = FrameworkStats(
+                        name: page.framework,
+                        pageCount: 1,
+                        lastCrawled: page.lastCrawled
+                    )
+                }
+            }
+            return stats
         }
-        return stats
-    }
 
-    // MARK: - Codable
+        // MARK: - Codable
 
-    /// Custom decoder to handle missing fields in old metadata files
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        /// Custom decoder to handle missing fields in old metadata files
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        // Decode with defaults for missing fields
-        pages = try container.decodeIfPresent([String: PageMetadata].self, forKey: .pages) ?? [:]
-        frameworks = try container.decodeIfPresent([String: FrameworkStats].self, forKey: .frameworks) ?? [:]
-        lastCrawl = try container.decodeIfPresent(Date.self, forKey: .lastCrawl)
-        stats = try container.decodeIfPresent(CrawlStatistics.self, forKey: .stats) ?? CrawlStatistics()
-        crawlState = try container.decodeIfPresent(CrawlSessionState.self, forKey: .crawlState)
-    }
+            // Decode with defaults for missing fields
+            pages = try container.decodeIfPresent([String: PageMetadata].self, forKey: .pages) ?? [:]
+            frameworks = try container.decodeIfPresent([String: FrameworkStats].self, forKey: .frameworks) ?? [:]
+            lastCrawl = try container.decodeIfPresent(Date.self, forKey: .lastCrawl)
+            stats = try container.decodeIfPresent(CrawlStatistics.self, forKey: .stats) ?? CrawlStatistics()
+            crawlState = try container.decodeIfPresent(CrawlSessionState.self, forKey: .crawlState)
+        }
 
-    private enum CodingKeys: String, CodingKey {
-        case pages, frameworks, lastCrawl, stats, crawlState
+        private enum CodingKeys: String, CodingKey {
+            case pages, frameworks, lastCrawl, stats, crawlState
+        }
     }
 }
 
 // MARK: - Framework Stats
 
 /// Statistics for a single framework
-public struct FrameworkStats: Codable, Sendable {
-    public var name: String
-    public var pageCount: Int
-    public var newPages: Int
-    public var updatedPages: Int
-    public var errors: Int
-    public var lastCrawled: Date?
-    public var crawlStatus: CrawlStatus
+extension Shared.Models {
+    public struct FrameworkStats: Codable, Sendable {
+        public var name: String
+        public var pageCount: Int
+        public var newPages: Int
+        public var updatedPages: Int
+        public var errors: Int
+        public var lastCrawled: Date?
+        public var crawlStatus: CrawlStatus
 
-    public enum CrawlStatus: String, Codable, Sendable {
-        case notStarted = "not_started"
-        case inProgress = "in_progress"
-        case complete
-        case partial
-        case failed
-    }
+        public enum CrawlStatus: String, Codable, Sendable {
+            case notStarted = "not_started"
+            case inProgress = "in_progress"
+            case complete
+            case partial
+            case failed
+        }
 
-    public init(
-        name: String,
-        pageCount: Int = 0,
-        newPages: Int = 0,
-        updatedPages: Int = 0,
-        errors: Int = 0,
-        lastCrawled: Date? = nil,
-        crawlStatus: CrawlStatus = .notStarted
-    ) {
-        self.name = name
-        self.pageCount = pageCount
-        self.newPages = newPages
-        self.updatedPages = updatedPages
-        self.errors = errors
-        self.lastCrawled = lastCrawled
-        self.crawlStatus = crawlStatus
-    }
+        public init(
+            name: String,
+            pageCount: Int = 0,
+            newPages: Int = 0,
+            updatedPages: Int = 0,
+            errors: Int = 0,
+            lastCrawled: Date? = nil,
+            crawlStatus: CrawlStatus = .notStarted
+        ) {
+            self.name = name
+            self.pageCount = pageCount
+            self.newPages = newPages
+            self.updatedPages = updatedPages
+            self.errors = errors
+            self.lastCrawled = lastCrawled
+            self.crawlStatus = crawlStatus
+        }
 
-    // MARK: - Codable
+        // MARK: - Codable
 
-    /// Custom decoder to handle missing fields in old metadata files
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        /// Custom decoder to handle missing fields in old metadata files
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        // Provide defaults for missing fields
-        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
-        pageCount = try container.decodeIfPresent(Int.self, forKey: .pageCount) ?? 0
-        newPages = try container.decodeIfPresent(Int.self, forKey: .newPages) ?? 0
-        updatedPages = try container.decodeIfPresent(Int.self, forKey: .updatedPages) ?? 0
-        errors = try container.decodeIfPresent(Int.self, forKey: .errors) ?? 0
-        lastCrawled = try container.decodeIfPresent(Date.self, forKey: .lastCrawled)
-        crawlStatus = try container.decodeIfPresent(CrawlStatus.self, forKey: .crawlStatus) ?? .notStarted
-    }
+            // Provide defaults for missing fields
+            name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+            pageCount = try container.decodeIfPresent(Int.self, forKey: .pageCount) ?? 0
+            newPages = try container.decodeIfPresent(Int.self, forKey: .newPages) ?? 0
+            updatedPages = try container.decodeIfPresent(Int.self, forKey: .updatedPages) ?? 0
+            errors = try container.decodeIfPresent(Int.self, forKey: .errors) ?? 0
+            lastCrawled = try container.decodeIfPresent(Date.self, forKey: .lastCrawled)
+            crawlStatus = try container.decodeIfPresent(CrawlStatus.self, forKey: .crawlStatus) ?? .notStarted
+        }
 
-    private enum CodingKeys: String, CodingKey {
-        case name, pageCount, newPages, updatedPages, errors, lastCrawled, crawlStatus
+        private enum CodingKeys: String, CodingKey {
+            case name, pageCount, newPages, updatedPages, errors, lastCrawled, crawlStatus
+        }
     }
 }
 
 // MARK: - Page Metadata
 
 /// Metadata for a single crawled page
-public struct PageMetadata: Codable, Sendable {
-    public let url: String
-    public let framework: String
-    public let filePath: String
-    public let contentHash: String
-    public let depth: Int
-    public let lastCrawled: Date
+extension Shared.Models {
+    public struct PageMetadata: Codable, Sendable {
+        public let url: String
+        public let framework: String
+        public let filePath: String
+        public let contentHash: String
+        public let depth: Int
+        public let lastCrawled: Date
 
-    public init(
-        url: String,
-        framework: String,
-        filePath: String,
-        contentHash: String,
-        depth: Int,
-        lastCrawled: Date = Date()
-    ) {
-        self.url = url
-        self.framework = framework
-        self.filePath = filePath
-        self.contentHash = contentHash
-        self.depth = depth
-        self.lastCrawled = lastCrawled
-    }
+        public init(
+            url: String,
+            framework: String,
+            filePath: String,
+            contentHash: String,
+            depth: Int,
+            lastCrawled: Date = Date()
+        ) {
+            self.url = url
+            self.framework = framework
+            self.filePath = filePath
+            self.contentHash = contentHash
+            self.depth = depth
+            self.lastCrawled = lastCrawled
+        }
 
-    // MARK: - Codable
+        // MARK: - Codable
 
-    /// Custom decoder to handle missing fields in old metadata files
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        /// Custom decoder to handle missing fields in old metadata files
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        // Provide defaults for missing fields
-        url = try container.decodeIfPresent(String.self, forKey: .url) ?? ""
-        framework = try container.decodeIfPresent(String.self, forKey: .framework) ?? "unknown"
-        filePath = try container.decodeIfPresent(String.self, forKey: .filePath) ?? ""
-        contentHash = try container.decodeIfPresent(String.self, forKey: .contentHash) ?? ""
-        depth = try container.decodeIfPresent(Int.self, forKey: .depth) ?? 0
-        lastCrawled = try container.decodeIfPresent(Date.self, forKey: .lastCrawled) ?? Date()
-    }
+            // Provide defaults for missing fields
+            url = try container.decodeIfPresent(String.self, forKey: .url) ?? ""
+            framework = try container.decodeIfPresent(String.self, forKey: .framework) ?? "unknown"
+            filePath = try container.decodeIfPresent(String.self, forKey: .filePath) ?? ""
+            contentHash = try container.decodeIfPresent(String.self, forKey: .contentHash) ?? ""
+            depth = try container.decodeIfPresent(Int.self, forKey: .depth) ?? 0
+            lastCrawled = try container.decodeIfPresent(Date.self, forKey: .lastCrawled) ?? Date()
+        }
 
-    private enum CodingKeys: String, CodingKey {
-        case url, framework, filePath, contentHash, depth, lastCrawled
+        private enum CodingKeys: String, CodingKey {
+            case url, framework, filePath, contentHash, depth, lastCrawled
+        }
     }
 }
 
 // MARK: - Crawl Statistics
 
 /// Statistics for a crawl session
-public struct CrawlStatistics: Codable, Sendable {
-    public var totalPages: Int
-    public var newPages: Int
-    public var updatedPages: Int
-    public var skippedPages: Int
-    public var errors: Int
-    public var startTime: Date?
-    public var endTime: Date?
+extension Shared.Models {
+    public struct CrawlStatistics: Codable, Sendable {
+        public var totalPages: Int
+        public var newPages: Int
+        public var updatedPages: Int
+        public var skippedPages: Int
+        public var errors: Int
+        public var startTime: Date?
+        public var endTime: Date?
 
-    public init(
-        totalPages: Int = 0,
-        newPages: Int = 0,
-        updatedPages: Int = 0,
-        skippedPages: Int = 0,
-        errors: Int = 0,
-        startTime: Date? = nil,
-        endTime: Date? = nil
-    ) {
-        self.totalPages = totalPages
-        self.newPages = newPages
-        self.updatedPages = updatedPages
-        self.skippedPages = skippedPages
-        self.errors = errors
-        self.startTime = startTime
-        self.endTime = endTime
-    }
-
-    /// Duration of the crawl in seconds
-    public var duration: TimeInterval? {
-        guard let start = startTime, let end = endTime else {
-            return nil
+        public init(
+            totalPages: Int = 0,
+            newPages: Int = 0,
+            updatedPages: Int = 0,
+            skippedPages: Int = 0,
+            errors: Int = 0,
+            startTime: Date? = nil,
+            endTime: Date? = nil
+        ) {
+            self.totalPages = totalPages
+            self.newPages = newPages
+            self.updatedPages = updatedPages
+            self.skippedPages = skippedPages
+            self.errors = errors
+            self.startTime = startTime
+            self.endTime = endTime
         }
-        return end.timeIntervalSince(start)
-    }
 
-    // MARK: - Codable
+        /// Duration of the crawl in seconds
+        public var duration: TimeInterval? {
+            guard let start = startTime, let end = endTime else {
+                return nil
+            }
+            return end.timeIntervalSince(start)
+        }
 
-    /// Custom decoder to handle missing fields in old metadata files
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // MARK: - Codable
 
-        // Provide defaults for missing fields
-        totalPages = try container.decodeIfPresent(Int.self, forKey: .totalPages) ?? 0
-        newPages = try container.decodeIfPresent(Int.self, forKey: .newPages) ?? 0
-        updatedPages = try container.decodeIfPresent(Int.self, forKey: .updatedPages) ?? 0
-        skippedPages = try container.decodeIfPresent(Int.self, forKey: .skippedPages) ?? 0
-        errors = try container.decodeIfPresent(Int.self, forKey: .errors) ?? 0
-        startTime = try container.decodeIfPresent(Date.self, forKey: .startTime)
-        endTime = try container.decodeIfPresent(Date.self, forKey: .endTime)
-    }
+        /// Custom decoder to handle missing fields in old metadata files
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    private enum CodingKeys: String, CodingKey {
-        case totalPages, newPages, updatedPages, skippedPages, errors, startTime, endTime
+            // Provide defaults for missing fields
+            totalPages = try container.decodeIfPresent(Int.self, forKey: .totalPages) ?? 0
+            newPages = try container.decodeIfPresent(Int.self, forKey: .newPages) ?? 0
+            updatedPages = try container.decodeIfPresent(Int.self, forKey: .updatedPages) ?? 0
+            skippedPages = try container.decodeIfPresent(Int.self, forKey: .skippedPages) ?? 0
+            errors = try container.decodeIfPresent(Int.self, forKey: .errors) ?? 0
+            startTime = try container.decodeIfPresent(Date.self, forKey: .startTime)
+            endTime = try container.decodeIfPresent(Date.self, forKey: .endTime)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case totalPages, newPages, updatedPages, skippedPages, errors, startTime, endTime
+        }
     }
 }
 
 // MARK: - Crawl Session State
 
 /// Represents the complete state of a crawl session for resuming
-public struct CrawlSessionState: Codable, Sendable {
-    public var visited: Set<String> // Visited URL strings
-    public var queue: [QueuedURL] // Pending URLs to crawl
-    public var startURL: String
-    public var outputDirectory: String // Where files are being saved
-    public var sessionStartTime: Date
-    public var lastSaveTime: Date
-    public var isActive: Bool
+extension Shared.Models {
+    public struct CrawlSessionState: Codable, Sendable {
+        public var visited: Set<String> // Visited URL strings
+        public var queue: [QueuedURL] // Pending URLs to crawl
+        public var startURL: String
+        public var outputDirectory: String // Where files are being saved
+        public var sessionStartTime: Date
+        public var lastSaveTime: Date
+        public var isActive: Bool
 
-    public init(
-        visited: Set<String> = [],
-        queue: [QueuedURL] = [],
-        startURL: String,
-        outputDirectory: String,
-        sessionStartTime: Date = Date(),
-        lastSaveTime: Date = Date(),
-        isActive: Bool = true
-    ) {
-        self.visited = visited
-        self.queue = queue
-        self.startURL = startURL
-        self.outputDirectory = outputDirectory
-        self.sessionStartTime = sessionStartTime
-        self.lastSaveTime = lastSaveTime
-        self.isActive = isActive
+        public init(
+            visited: Set<String> = [],
+            queue: [QueuedURL] = [],
+            startURL: String,
+            outputDirectory: String,
+            sessionStartTime: Date = Date(),
+            lastSaveTime: Date = Date(),
+            isActive: Bool = true
+        ) {
+            self.visited = visited
+            self.queue = queue
+            self.startURL = startURL
+            self.outputDirectory = outputDirectory
+            self.sessionStartTime = sessionStartTime
+            self.lastSaveTime = lastSaveTime
+            self.isActive = isActive
+        }
     }
 }
 
 /// Represents a URL in the crawl queue with depth information
-public struct QueuedURL: Codable, Sendable, Hashable {
-    public let url: String
-    public let depth: Int
+extension Shared.Models {
+    public struct QueuedURL: Codable, Sendable, Hashable {
+        public let url: String
+        public let depth: Int
 
-    public init(url: String, depth: Int) {
-        self.url = url
-        self.depth = depth
+        public init(url: String, depth: Int) {
+            self.url = url
+            self.depth = depth
+        }
     }
 }

--- a/Packages/Sources/Shared/Models/HashUtilities.swift
+++ b/Packages/Sources/Shared/Models/HashUtilities.swift
@@ -1,20 +1,23 @@
 import CryptoKit
 import Foundation
+import SharedConstants
 
 // MARK: - Hash Utilities
 
 /// Utilities for content hashing
-public enum HashUtilities {
-    /// Compute SHA-256 hash of a string
-    public static func sha256(of string: String) -> String {
-        let data = Data(string.utf8)
-        let hash = SHA256.hash(data: data)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
-    }
+extension Shared.Models {
+    public enum HashUtilities {
+        /// Compute SHA-256 hash of a string
+        public static func sha256(of string: String) -> String {
+            let data = Data(string.utf8)
+            let hash = SHA256.hash(data: data)
+            return hash.compactMap { String(format: "%02x", $0) }.joined()
+        }
 
-    /// Compute SHA-256 hash of data
-    public static func sha256(of data: Data) -> String {
-        let hash = SHA256.hash(data: data)
-        return hash.compactMap { String(format: "%02x", $0) }.joined()
+        /// Compute SHA-256 hash of data
+        public static func sha256(of data: Data) -> String {
+            let hash = SHA256.hash(data: data)
+            return hash.compactMap { String(format: "%02x", $0) }.joined()
+        }
     }
 }

--- a/Packages/Sources/Shared/Models/Page.swift
+++ b/Packages/Sources/Shared/Models/Page.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import SharedConstants
 
 // MARK: - Structured Documentation Page
 
@@ -7,571 +8,575 @@ import Foundation
 /// This model is designed to be populated from both Apple JSON API and HTML sources
 /// and is suitable for database storage and querying
 // swiftlint:disable:next type_body_length
-public struct StructuredDocumentationPage: Codable, Sendable, Identifiable, Hashable {
-    public let id: UUID
-    public let url: URL
-    public let title: String
-    public let kind: Kind
-    public let source: Source
-
-    // Content
-    public let abstract: String?
-    public let declaration: Declaration?
-    public let overview: String?
-    public let sections: [Section]
-    public let codeExamples: [CodeExample]
-
-    // Apple-specific metadata (nil for non-Apple sources)
-    public let language: String? // Programming language (swift, objc, etc.)
-    public let platforms: [String]?
-    public let module: String?
-    public let conformsTo: [String]? // Protocols this type conforms to
-    public let inheritedBy: [String]? // Types that inherit from this
-    public let conformingTypes: [String]? // Types that conform to this protocol
-
-    /// Raw markdown from original source (HTML conversion)
-    public let rawMarkdown: String?
-
-    // Crawl metadata
-    public let crawledAt: Date
-    public let contentHash: String
-    /// Hops from the start URL when this page was discovered. nil for
-    /// pages saved by binaries that pre-date depth stamping.
-    public let crawlDepth: Int?
-
-    public init(
-        id: UUID = UUID(),
-        url: URL,
-        title: String,
-        kind: Kind,
-        source: Source,
-        abstract: String? = nil,
-        declaration: Declaration? = nil,
-        overview: String? = nil,
-        sections: [Section] = [],
-        codeExamples: [CodeExample] = [],
-        language: String? = nil,
-        platforms: [String]? = nil,
-        module: String? = nil,
-        conformsTo: [String]? = nil,
-        inheritedBy: [String]? = nil,
-        conformingTypes: [String]? = nil,
-        rawMarkdown: String? = nil,
-        crawledAt: Date = Date(),
-        contentHash: String = "",
-        crawlDepth: Int? = nil
-    ) {
-        self.id = id
-        self.url = url
-        self.title = title
-        self.kind = kind
-        self.source = source
-        self.abstract = abstract
-        self.declaration = declaration
-        self.overview = overview
-        self.sections = sections
-        self.codeExamples = codeExamples
-        self.language = language
-        self.platforms = platforms
-        self.module = module
-        self.conformsTo = conformsTo
-        self.inheritedBy = inheritedBy
-        self.conformingTypes = conformingTypes
-        self.rawMarkdown = rawMarkdown
-        self.crawledAt = crawledAt
-        self.contentHash = contentHash
-        self.crawlDepth = crawlDepth
-    }
-
-    // MARK: - Codable
-
-    /// Custom decoder to handle missing "id" field in old JSON files
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        url = try container.decode(URL.self, forKey: .url)
-        // Derive a deterministic id if missing (older records lack this field).
-        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? Self.deterministicID(for: url)
-        title = try container.decode(String.self, forKey: .title)
-        kind = try container.decode(Kind.self, forKey: .kind)
-        source = try container.decode(Source.self, forKey: .source)
-        abstract = try container.decodeIfPresent(String.self, forKey: .abstract)
-        declaration = try container.decodeIfPresent(Declaration.self, forKey: .declaration)
-        overview = try container.decodeIfPresent(String.self, forKey: .overview)
-        sections = try container.decode([Section].self, forKey: .sections)
-        codeExamples = try container.decode([CodeExample].self, forKey: .codeExamples)
-        language = try container.decodeIfPresent(String.self, forKey: .language)
-        platforms = try container.decodeIfPresent([String].self, forKey: .platforms)
-        module = try container.decodeIfPresent(String.self, forKey: .module)
-        conformsTo = try container.decodeIfPresent([String].self, forKey: .conformsTo)
-        inheritedBy = try container.decodeIfPresent([String].self, forKey: .inheritedBy)
-        conformingTypes = try container.decodeIfPresent([String].self, forKey: .conformingTypes)
-        rawMarkdown = try container.decodeIfPresent(String.self, forKey: .rawMarkdown)
-        crawledAt = try container.decode(Date.self, forKey: .crawledAt)
-        contentHash = try container.decode(String.self, forKey: .contentHash)
-        crawlDepth = try container.decodeIfPresent(Int.self, forKey: .crawlDepth)
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id, url, title, kind, source
-        case abstract, declaration, overview, sections, codeExamples
-        case language, platforms, module
-        case conformsTo, inheritedBy, conformingTypes
-        case rawMarkdown, crawledAt, contentHash, crawlDepth
-    }
-
-    // MARK: - Nested Types
-
-    /// The kind/type of documentation page
-    public enum Kind: String, Codable, Sendable, CaseIterable {
-        case `protocol`
-        case `class`
-        case `struct`
-        case `enum`
-        case function
-        case property
-        case method
-        case `operator`
-        case typeAlias = "typealias"
-        case macro
-        case article
-        case tutorial
-        case collection // API collection (index page)
-        case framework
-        case unknown
-    }
-
-    /// The source of the documentation
-    public enum Source: String, Codable, Sendable {
-        case appleJSON // Apple's JSON API
-        case appleWebKit // WKWebView rendered HTML
-        case swiftOrg // Swift.org documentation
-        case github // GitHub README/docs
-        case custom // Other sources
-    }
-
-    /// A code declaration with optional language
-    public struct Declaration: Codable, Sendable, Hashable {
-        public let code: String
-        public let language: String?
-
-        public init(code: String, language: String? = "swift") {
-            self.code = code
-            self.language = language
-        }
-    }
-
-    /// A documentation section with title and content
-    public struct Section: Codable, Sendable, Hashable {
+extension Shared.Models {
+    public struct StructuredDocumentationPage: Codable, Sendable, Identifiable, Hashable {
+        public let id: UUID
+        public let url: URL
         public let title: String
-        public let content: String
-        public let items: [Item]?
+        public let kind: Kind
+        public let source: Source
 
-        public init(title: String, content: String = "", items: [Item]? = nil) {
+        // Content
+        public let abstract: String?
+        public let declaration: Declaration?
+        public let overview: String?
+        public let sections: [Section]
+        public let codeExamples: [CodeExample]
+
+        // Apple-specific metadata (nil for non-Apple sources)
+        public let language: String? // Programming language (swift, objc, etc.)
+        public let platforms: [String]?
+        public let module: String?
+        public let conformsTo: [String]? // Protocols this type conforms to
+        public let inheritedBy: [String]? // Types that inherit from this
+        public let conformingTypes: [String]? // Types that conform to this protocol
+
+        /// Raw markdown from original source (HTML conversion)
+        public let rawMarkdown: String?
+
+        // Crawl metadata
+        public let crawledAt: Date
+        public let contentHash: String
+        /// Hops from the start URL when this page was discovered. nil for
+        /// pages saved by binaries that pre-date depth stamping.
+        public let crawlDepth: Int?
+
+        public init(
+            id: UUID = UUID(),
+            url: URL,
+            title: String,
+            kind: Kind,
+            source: Source,
+            abstract: String? = nil,
+            declaration: Declaration? = nil,
+            overview: String? = nil,
+            sections: [Section] = [],
+            codeExamples: [CodeExample] = [],
+            language: String? = nil,
+            platforms: [String]? = nil,
+            module: String? = nil,
+            conformsTo: [String]? = nil,
+            inheritedBy: [String]? = nil,
+            conformingTypes: [String]? = nil,
+            rawMarkdown: String? = nil,
+            crawledAt: Date = Date(),
+            contentHash: String = "",
+            crawlDepth: Int? = nil
+        ) {
+            self.id = id
+            self.url = url
             self.title = title
-            self.content = content
-            self.items = items
-        }
-
-        /// An item within a section (e.g., a method in "Instance Methods")
-        public struct Item: Codable, Sendable, Hashable {
-            public let name: String
-            public let description: String?
-            public let url: URL?
-
-            public init(name: String, description: String? = nil, url: URL? = nil) {
-                self.name = name
-                self.description = description
-                self.url = url
-            }
-        }
-    }
-
-    /// A code example with optional syntax highlighting
-    public struct CodeExample: Codable, Sendable, Hashable {
-        public let code: String
-        public let language: String?
-        public let caption: String?
-
-        public init(code: String, language: String? = "swift", caption: String? = nil) {
-            self.code = code
+            self.kind = kind
+            self.source = source
+            self.abstract = abstract
+            self.declaration = declaration
+            self.overview = overview
+            self.sections = sections
+            self.codeExamples = codeExamples
             self.language = language
-            self.caption = caption
-        }
-    }
-
-    // MARK: - Computed Properties
-
-    /// Generate markdown representation of this page
-    public var markdown: String {
-        var result = "---\n"
-        result += "source: \(url.absoluteString)\n"
-        result += "crawled: \(ISO8601DateFormatter().string(from: crawledAt))\n"
-        result += "kind: \(kind.rawValue)\n"
-        result += "---\n\n"
-
-        result += "# \(title)\n\n"
-
-        if kind != .article, kind != .tutorial, kind != .collection {
-            result += "**\(kind.rawValue.capitalized)**\n\n"
+            self.platforms = platforms
+            self.module = module
+            self.conformsTo = conformsTo
+            self.inheritedBy = inheritedBy
+            self.conformingTypes = conformingTypes
+            self.rawMarkdown = rawMarkdown
+            self.crawledAt = crawledAt
+            self.contentHash = contentHash
+            self.crawlDepth = crawlDepth
         }
 
-        if let abstract, !abstract.isEmpty {
-            result += "\(abstract)\n\n"
+        // MARK: - Codable
+
+        /// Custom decoder to handle missing "id" field in old JSON files
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            url = try container.decode(URL.self, forKey: .url)
+            // Derive a deterministic id if missing (older records lack this field).
+            id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? Self.deterministicID(for: url)
+            title = try container.decode(String.self, forKey: .title)
+            kind = try container.decode(Kind.self, forKey: .kind)
+            source = try container.decode(Source.self, forKey: .source)
+            abstract = try container.decodeIfPresent(String.self, forKey: .abstract)
+            declaration = try container.decodeIfPresent(Declaration.self, forKey: .declaration)
+            overview = try container.decodeIfPresent(String.self, forKey: .overview)
+            sections = try container.decode([Section].self, forKey: .sections)
+            codeExamples = try container.decode([CodeExample].self, forKey: .codeExamples)
+            language = try container.decodeIfPresent(String.self, forKey: .language)
+            platforms = try container.decodeIfPresent([String].self, forKey: .platforms)
+            module = try container.decodeIfPresent(String.self, forKey: .module)
+            conformsTo = try container.decodeIfPresent([String].self, forKey: .conformsTo)
+            inheritedBy = try container.decodeIfPresent([String].self, forKey: .inheritedBy)
+            conformingTypes = try container.decodeIfPresent([String].self, forKey: .conformingTypes)
+            rawMarkdown = try container.decodeIfPresent(String.self, forKey: .rawMarkdown)
+            crawledAt = try container.decode(Date.self, forKey: .crawledAt)
+            contentHash = try container.decode(String.self, forKey: .contentHash)
+            crawlDepth = try container.decodeIfPresent(Int.self, forKey: .crawlDepth)
         }
 
-        if let declaration {
-            result += "## Declaration\n\n"
-            result += "```\(declaration.language ?? "")\n"
-            result += "\(declaration.code)\n"
-            result += "```\n\n"
+        private enum CodingKeys: String, CodingKey {
+            case id, url, title, kind, source
+            case abstract, declaration, overview, sections, codeExamples
+            case language, platforms, module
+            case conformsTo, inheritedBy, conformingTypes
+            case rawMarkdown, crawledAt, contentHash, crawlDepth
         }
 
-        if let overview, !overview.isEmpty {
-            result += "## Overview\n\n"
-            result += "\(overview)\n\n"
+        // MARK: - Nested Types
+
+        /// The kind/type of documentation page
+        public enum Kind: String, Codable, Sendable, CaseIterable {
+            case `protocol`
+            case `class`
+            case `struct`
+            case `enum`
+            case function
+            case property
+            case method
+            case `operator`
+            case typeAlias = "typealias"
+            case macro
+            case article
+            case tutorial
+            case collection // API collection (index page)
+            case framework
+            case unknown
         }
 
-        for example in codeExamples {
-            if let caption = example.caption {
-                result += "\(caption)\n\n"
+        /// The source of the documentation
+        public enum Source: String, Codable, Sendable {
+            case appleJSON // Apple's JSON API
+            case appleWebKit // WKWebView rendered HTML
+            case swiftOrg // Swift.org documentation
+            case github // GitHub README/docs
+            case custom // Other sources
+        }
+
+        /// A code declaration with optional language
+        public struct Declaration: Codable, Sendable, Hashable {
+            public let code: String
+            public let language: String?
+
+            public init(code: String, language: String? = "swift") {
+                self.code = code
+                self.language = language
             }
-            result += "```\(example.language ?? "")\n"
-            result += "\(example.code)\n"
-            result += "```\n\n"
         }
 
-        for section in sections {
-            result += "## \(section.title)\n\n"
-            if !section.content.isEmpty {
-                result += "\(section.content)\n\n"
+        /// A documentation section with title and content
+        public struct Section: Codable, Sendable, Hashable {
+            public let title: String
+            public let content: String
+            public let items: [Item]?
+
+            public init(title: String, content: String = "", items: [Item]? = nil) {
+                self.title = title
+                self.content = content
+                self.items = items
             }
-            if let items = section.items {
-                for item in items {
-                    result += "- **\(item.name)**"
-                    if let desc = item.description {
-                        result += ": \(desc)"
+
+            /// An item within a section (e.g., a method in "Instance Methods")
+            public struct Item: Codable, Sendable, Hashable {
+                public let name: String
+                public let description: String?
+                public let url: URL?
+
+                public init(name: String, description: String? = nil, url: URL? = nil) {
+                    self.name = name
+                    self.description = description
+                    self.url = url
+                }
+            }
+        }
+
+        /// A code example with optional syntax highlighting
+        public struct CodeExample: Codable, Sendable, Hashable {
+            public let code: String
+            public let language: String?
+            public let caption: String?
+
+            public init(code: String, language: String? = "swift", caption: String? = nil) {
+                self.code = code
+                self.language = language
+                self.caption = caption
+            }
+        }
+
+        // MARK: - Computed Properties
+
+        /// Generate markdown representation of this page
+        public var markdown: String {
+            var result = "---\n"
+            result += "source: \(url.absoluteString)\n"
+            result += "crawled: \(ISO8601DateFormatter().string(from: crawledAt))\n"
+            result += "kind: \(kind.rawValue)\n"
+            result += "---\n\n"
+
+            result += "# \(title)\n\n"
+
+            if kind != .article, kind != .tutorial, kind != .collection {
+                result += "**\(kind.rawValue.capitalized)**\n\n"
+            }
+
+            if let abstract, !abstract.isEmpty {
+                result += "\(abstract)\n\n"
+            }
+
+            if let declaration {
+                result += "## Declaration\n\n"
+                result += "```\(declaration.language ?? "")\n"
+                result += "\(declaration.code)\n"
+                result += "```\n\n"
+            }
+
+            if let overview, !overview.isEmpty {
+                result += "## Overview\n\n"
+                result += "\(overview)\n\n"
+            }
+
+            for example in codeExamples {
+                if let caption = example.caption {
+                    result += "\(caption)\n\n"
+                }
+                result += "```\(example.language ?? "")\n"
+                result += "\(example.code)\n"
+                result += "```\n\n"
+            }
+
+            for section in sections {
+                result += "## \(section.title)\n\n"
+                if !section.content.isEmpty {
+                    result += "\(section.content)\n\n"
+                }
+                if let items = section.items {
+                    for item in items {
+                        result += "- **\(item.name)**"
+                        if let desc = item.description {
+                            result += ": \(desc)"
+                        }
+                        result += "\n"
                     }
                     result += "\n"
                 }
+            }
+
+            if let conforms = conformsTo, !conforms.isEmpty {
+                result += "## Conforms To\n\n"
+                for proto in conforms {
+                    result += "- \(proto)\n"
+                }
                 result += "\n"
             }
+
+            if let inheritedBy, !inheritedBy.isEmpty {
+                result += "## Inherited By\n\n"
+                for type in inheritedBy {
+                    result += "- \(type)\n"
+                }
+                result += "\n"
+            }
+
+            if let conforming = conformingTypes, !conforming.isEmpty {
+                result += "## Conforming Types\n\n"
+                for type in conforming {
+                    result += "- \(type)\n"
+                }
+                result += "\n"
+            }
+
+            return result
         }
 
-        if let conforms = conformsTo, !conforms.isEmpty {
-            result += "## Conforms To\n\n"
-            for proto in conforms {
-                result += "- \(proto)\n"
-            }
-            result += "\n"
-        }
+        // MARK: - Declaration Parsing Helpers
 
-        if let inheritedBy, !inheritedBy.isEmpty {
-            result += "## Inherited By\n\n"
-            for type in inheritedBy {
-                result += "- \(type)\n"
-            }
-            result += "\n"
-        }
+        /// Extracts @attributes from a declaration string
+        /// Returns array of attributes like ["@MainActor", "@Sendable", "@available(iOS 15.0, *)"]
+        public var extractedAttributes: [String] {
+            guard let decl = declaration?.code else { return [] }
 
-        if let conforming = conformingTypes, !conforming.isEmpty {
-            result += "## Conforming Types\n\n"
-            for type in conforming {
-                result += "- \(type)\n"
-            }
-            result += "\n"
-        }
+            var attributes: [String] = []
+            var index = decl.startIndex
 
-        return result
-    }
-
-    // MARK: - Declaration Parsing Helpers
-
-    /// Extracts @attributes from a declaration string
-    /// Returns array of attributes like ["@MainActor", "@Sendable", "@available(iOS 15.0, *)"]
-    public var extractedAttributes: [String] {
-        guard let decl = declaration?.code else { return [] }
-
-        var attributes: [String] = []
-        var index = decl.startIndex
-
-        while index < decl.endIndex {
-            // Skip whitespace and newlines
-            while index < decl.endIndex, decl[index].isWhitespace || decl[index].isNewline {
-                index = decl.index(after: index)
-            }
-
-            guard index < decl.endIndex, decl[index] == "@" else { break }
-
-            // Found an attribute, extract it
-            let attrStart = index
-            index = decl.index(after: index)
-
-            // Read attribute name
-            while index < decl.endIndex, decl[index].isLetter || decl[index].isNumber || decl[index] == "_" {
-                index = decl.index(after: index)
-            }
-
-            // Handle parenthesized arguments like @available(iOS 15.0, *)
-            if index < decl.endIndex, decl[index] == "(" {
-                var parenDepth = 1
-                index = decl.index(after: index)
-                while index < decl.endIndex, parenDepth > 0 {
-                    if decl[index] == "(" { parenDepth += 1 } else if decl[index] == ")" { parenDepth -= 1 }
+            while index < decl.endIndex {
+                // Skip whitespace and newlines
+                while index < decl.endIndex, decl[index].isWhitespace || decl[index].isNewline {
                     index = decl.index(after: index)
                 }
-            }
 
-            let attr = String(decl[attrStart..<index])
-            if !attr.isEmpty {
-                attributes.append(attr)
-            }
-        }
+                guard index < decl.endIndex, decl[index] == "@" else { break }
 
-        return attributes
-    }
+                // Found an attribute, extract it
+                let attrStart = index
+                index = decl.index(after: index)
 
-    /// Returns the declaration with @attributes stripped and collapsed to single line
-    /// Used for kind inference pattern matching
-    public var normalizedDeclaration: String? {
-        guard let decl = declaration?.code.trimmingCharacters(in: .whitespacesAndNewlines),
-              !decl.isEmpty else {
-            return nil
-        }
+                // Read attribute name
+                while index < decl.endIndex, decl[index].isLetter || decl[index].isNumber || decl[index] == "_" {
+                    index = decl.index(after: index)
+                }
 
-        // Collapse multi-line to single line
-        var normalized = decl
-            .replacingOccurrences(of: "\r\n", with: " ")
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\r", with: " ")
+                // Handle parenthesized arguments like @available(iOS 15.0, *)
+                if index < decl.endIndex, decl[index] == "(" {
+                    var parenDepth = 1
+                    index = decl.index(after: index)
+                    while index < decl.endIndex, parenDepth > 0 {
+                        if decl[index] == "(" { parenDepth += 1 } else if decl[index] == ")" { parenDepth -= 1 }
+                        index = decl.index(after: index)
+                    }
+                }
 
-        // Strip leading @attributes
-        while true {
-            normalized = normalized.trimmingCharacters(in: .whitespaces)
-            guard normalized.hasPrefix("@") else { break }
-
-            // Find end of attribute (including parenthesized args)
-            var index = normalized.index(after: normalized.startIndex)
-
-            // Skip attribute name
-            while index < normalized.endIndex,
-                  normalized[index].isLetter || normalized[index].isNumber || normalized[index] == "_" {
-                index = normalized.index(after: index)
-            }
-
-            // Skip parenthesized arguments
-            if index < normalized.endIndex, normalized[index] == "(" {
-                var parenDepth = 1
-                index = normalized.index(after: index)
-                while index < normalized.endIndex, parenDepth > 0 {
-                    if normalized[index] == "(" { parenDepth += 1 } else if normalized[index] == ")" { parenDepth -= 1 }
-                    index = normalized.index(after: index)
+                let attr = String(decl[attrStart..<index])
+                if !attr.isEmpty {
+                    attributes.append(attr)
                 }
             }
 
-            normalized = String(normalized[index...])
+            return attributes
         }
 
-        // Collapse multiple spaces to single space
-        while normalized.contains("  ") {
-            normalized = normalized.replacingOccurrences(of: "  ", with: " ")
+        /// Returns the declaration with @attributes stripped and collapsed to single line
+        /// Used for kind inference pattern matching
+        public var normalizedDeclaration: String? {
+            guard let decl = declaration?.code.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !decl.isEmpty else {
+                return nil
+            }
+
+            // Collapse multi-line to single line
+            var normalized = decl
+                .replacingOccurrences(of: "\r\n", with: " ")
+                .replacingOccurrences(of: "\n", with: " ")
+                .replacingOccurrences(of: "\r", with: " ")
+
+            // Strip leading @attributes
+            while true {
+                normalized = normalized.trimmingCharacters(in: .whitespaces)
+                guard normalized.hasPrefix("@") else { break }
+
+                // Find end of attribute (including parenthesized args)
+                var index = normalized.index(after: normalized.startIndex)
+
+                // Skip attribute name
+                while index < normalized.endIndex,
+                      normalized[index].isLetter || normalized[index].isNumber || normalized[index] == "_" {
+                    index = normalized.index(after: index)
+                }
+
+                // Skip parenthesized arguments
+                if index < normalized.endIndex, normalized[index] == "(" {
+                    var parenDepth = 1
+                    index = normalized.index(after: index)
+                    while index < normalized.endIndex, parenDepth > 0 {
+                        if normalized[index] == "(" { parenDepth += 1 } else if normalized[index] == ")" { parenDepth -= 1 }
+                        index = normalized.index(after: index)
+                    }
+                }
+
+                normalized = String(normalized[index...])
+            }
+
+            // Collapse multiple spaces to single space
+            while normalized.contains("  ") {
+                normalized = normalized.replacingOccurrences(of: "  ", with: " ")
+            }
+
+            return normalized.trimmingCharacters(in: .whitespaces)
         }
 
-        return normalized.trimmingCharacters(in: .whitespaces)
-    }
+        // MARK: - Heuristic Kind Inference
 
-    // MARK: - Heuristic Kind Inference
+        /// Infers the correct kind from declaration code when Apple's API returns "unknown"
+        /// This heuristic improves search ranking by correctly classifying docs marked as "unknown"
+        public var inferredKind: Kind {
+            // Stage 1: Trust Apple's kind if not unknown
+            guard kind == .unknown else { return kind }
 
-    /// Infers the correct kind from declaration code when Apple's API returns "unknown"
-    /// This heuristic improves search ranking by correctly classifying docs marked as "unknown"
-    public var inferredKind: Kind {
-        // Stage 1: Trust Apple's kind if not unknown
-        guard kind == .unknown else { return kind }
+            // Stage 2: No declaration = article (guides, tutorials, conceptual docs)
+            guard let decl = normalizedDeclaration, !decl.isEmpty else {
+                return .article
+            }
 
-        // Stage 2: No declaration = article (guides, tutorials, conceptual docs)
-        guard let decl = normalizedDeclaration, !decl.isEmpty else {
-            return .article
+            // Stage 3: Pattern matching on normalized declaration
+            // Order matters: check most specific patterns first
+
+            // Macros (Swift 5.9+) - check before stripping @ since these ARE the declaration
+            if let rawDecl = declaration?.code,
+               rawDecl.contains("@freestanding") || rawDecl.contains("@attached") {
+                return .macro
+            }
+
+            // Type declarations (handle modifiers like public, final, open, etc.)
+            if decl.hasPrefix("protocol ") || decl.contains(" protocol ") { return .protocol }
+            if decl.hasPrefix("struct ") || decl.contains(" struct ") { return .struct }
+            if decl.hasPrefix("class ") || decl.contains(" class ") { return .class }
+            if decl.hasPrefix("enum ") || decl.contains(" enum ") { return .enum }
+            if decl.hasPrefix("actor ") || decl.contains(" actor ") { return .class } // actors are class-like
+
+            // Enum cases (often appear as separate docs)
+            if decl.hasPrefix("case ") || decl.contains(" case ") { return .enum }
+
+            // Associated types (protocol requirements)
+            if decl.hasPrefix("associatedtype ") || decl.contains(" associatedtype ") { return .typeAlias }
+
+            // Properties (var/let) - including static
+            if decl.hasPrefix("var ") || decl.hasPrefix("let ") { return .property }
+            if decl.hasPrefix("static var ") || decl.hasPrefix("static let ") { return .property }
+            if decl.hasPrefix("class var ") || decl.hasPrefix("class let ") { return .property }
+            if decl.contains(" var ") || decl.contains(" let ") { return .property }
+
+            // Subscripts
+            if decl.hasPrefix("subscript") || decl.contains(" subscript") { return .method }
+
+            // Methods and initializers
+            if decl.hasPrefix("func ") || decl.contains(" func ") { return .method }
+            // Initializers: init(, init?(, init!(, init<T>
+            if decl.hasPrefix("init(") || decl.hasPrefix("init?")
+                || decl.hasPrefix("init!") || decl.hasPrefix("init<") { return .method }
+            if decl.contains(" init(") || decl.contains(" init?")
+                || decl.contains(" init!") || decl.contains(" init<") { return .method }
+            if decl.hasPrefix("deinit") { return .method }
+            if decl.hasPrefix("static func ") || decl.hasPrefix("class func ") { return .method }
+
+            // REST API types (OpenAPI object declarations)
+            if decl.hasPrefix("object ") { return .struct }
+
+            // Type aliases (can have public/internal modifiers)
+            if decl.hasPrefix("typealias ") || decl.contains(" typealias ") { return .typeAlias }
+
+            // Operators
+            if decl.hasPrefix("operator ") || decl.contains(" operator ") { return .operator }
+            if decl.hasPrefix("prefix ") || decl.contains(" prefix ") { return .operator }
+            if decl.hasPrefix("postfix ") || decl.contains(" postfix ") { return .operator }
+            if decl.hasPrefix("infix ") || decl.contains(" infix ") { return .operator }
+
+            // Still unknown after all heuristics
+            return .unknown
         }
 
-        // Stage 3: Pattern matching on normalized declaration
-        // Order matters: check most specific patterns first
+        // MARK: - Deterministic Identity & Content Hashing
 
-        // Macros (Swift 5.9+) - check before stripping @ since these ARE the declaration
-        if let rawDecl = declaration?.code,
-           rawDecl.contains("@freestanding") || rawDecl.contains("@attached") {
-            return .macro
+        /// Derive a stable UUID from the page URL.
+        /// Same URL → same UUID across runs and machines. Use this anywhere a
+        /// `StructuredDocumentationPage` is constructed so persisted records are
+        /// reproducible.
+        public static func deterministicID(for url: URL) -> UUID {
+            let digest = SHA256.hash(data: Data(url.absoluteString.utf8))
+            let bytes = Array(digest.prefix(16))
+            let hex = bytes.map { String(format: "%02x", $0) }.joined()
+            var formatted = hex
+            formatted.insert("-", at: formatted.index(formatted.startIndex, offsetBy: 8))
+            formatted.insert("-", at: formatted.index(formatted.startIndex, offsetBy: 13))
+            formatted.insert("-", at: formatted.index(formatted.startIndex, offsetBy: 18))
+            formatted.insert("-", at: formatted.index(formatted.startIndex, offsetBy: 23))
+            return UUID(uuidString: formatted) ?? UUID()
         }
 
-        // Type declarations (handle modifiers like public, final, open, etc.)
-        if decl.hasPrefix("protocol ") || decl.contains(" protocol ") { return .protocol }
-        if decl.hasPrefix("struct ") || decl.contains(" struct ") { return .struct }
-        if decl.hasPrefix("class ") || decl.contains(" class ") { return .class }
-        if decl.hasPrefix("enum ") || decl.contains(" enum ") { return .enum }
-        if decl.hasPrefix("actor ") || decl.contains(" actor ") { return .class } // actors are class-like
+        /// SHA-256 over the page's semantic content fields, in a stable encoding.
+        /// Excludes `id`, `crawledAt`, `contentHash`, and `rawMarkdown` (the last
+        /// is derived from the structured fields and embeds `crawledAt`).
+        /// Two crawls of the same Apple-side content produce the same hash.
+        public var canonicalContentHash: String {
+            let payload = CanonicalPayload(
+                url: url,
+                title: title,
+                kind: kind,
+                source: source,
+                abstract: abstract,
+                declaration: declaration,
+                overview: overview,
+                sections: sections,
+                codeExamples: codeExamples,
+                language: language,
+                platforms: platforms,
+                module: module,
+                conformsTo: conformsTo,
+                inheritedBy: inheritedBy,
+                conformingTypes: conformingTypes
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            guard let data = try? encoder.encode(payload) else { return "" }
+            return HashUtilities.sha256(of: data)
+        }
 
-        // Enum cases (often appear as separate docs)
-        if decl.hasPrefix("case ") || decl.contains(" case ") { return .enum }
+        private struct CanonicalPayload: Encodable {
+            let url: URL
+            let title: String
+            let kind: Kind
+            let source: Source
+            let abstract: String?
+            let declaration: Declaration?
+            let overview: String?
+            let sections: [Section]
+            let codeExamples: [CodeExample]
+            let language: String?
+            let platforms: [String]?
+            let module: String?
+            let conformsTo: [String]?
+            let inheritedBy: [String]?
+            let conformingTypes: [String]?
+        }
 
-        // Associated types (protocol requirements)
-        if decl.hasPrefix("associatedtype ") || decl.contains(" associatedtype ") { return .typeAlias }
-
-        // Properties (var/let) - including static
-        if decl.hasPrefix("var ") || decl.hasPrefix("let ") { return .property }
-        if decl.hasPrefix("static var ") || decl.hasPrefix("static let ") { return .property }
-        if decl.hasPrefix("class var ") || decl.hasPrefix("class let ") { return .property }
-        if decl.contains(" var ") || decl.contains(" let ") { return .property }
-
-        // Subscripts
-        if decl.hasPrefix("subscript") || decl.contains(" subscript") { return .method }
-
-        // Methods and initializers
-        if decl.hasPrefix("func ") || decl.contains(" func ") { return .method }
-        // Initializers: init(, init?(, init!(, init<T>
-        if decl.hasPrefix("init(") || decl.hasPrefix("init?")
-            || decl.hasPrefix("init!") || decl.hasPrefix("init<") { return .method }
-        if decl.contains(" init(") || decl.contains(" init?")
-            || decl.contains(" init!") || decl.contains(" init<") { return .method }
-        if decl.hasPrefix("deinit") { return .method }
-        if decl.hasPrefix("static func ") || decl.hasPrefix("class func ") { return .method }
-
-        // REST API types (OpenAPI object declarations)
-        if decl.hasPrefix("object ") { return .struct }
-
-        // Type aliases (can have public/internal modifiers)
-        if decl.hasPrefix("typealias ") || decl.contains(" typealias ") { return .typeAlias }
-
-        // Operators
-        if decl.hasPrefix("operator ") || decl.contains(" operator ") { return .operator }
-        if decl.hasPrefix("prefix ") || decl.contains(" prefix ") { return .operator }
-        if decl.hasPrefix("postfix ") || decl.contains(" postfix ") { return .operator }
-        if decl.hasPrefix("infix ") || decl.contains(" infix ") { return .operator }
-
-        // Still unknown after all heuristics
-        return .unknown
-    }
-
-    // MARK: - Deterministic Identity & Content Hashing
-
-    /// Derive a stable UUID from the page URL.
-    /// Same URL → same UUID across runs and machines. Use this anywhere a
-    /// `StructuredDocumentationPage` is constructed so persisted records are
-    /// reproducible.
-    public static func deterministicID(for url: URL) -> UUID {
-        let digest = SHA256.hash(data: Data(url.absoluteString.utf8))
-        let bytes = Array(digest.prefix(16))
-        let hex = bytes.map { String(format: "%02x", $0) }.joined()
-        var formatted = hex
-        formatted.insert("-", at: formatted.index(formatted.startIndex, offsetBy: 8))
-        formatted.insert("-", at: formatted.index(formatted.startIndex, offsetBy: 13))
-        formatted.insert("-", at: formatted.index(formatted.startIndex, offsetBy: 18))
-        formatted.insert("-", at: formatted.index(formatted.startIndex, offsetBy: 23))
-        return UUID(uuidString: formatted) ?? UUID()
-    }
-
-    /// SHA-256 over the page's semantic content fields, in a stable encoding.
-    /// Excludes `id`, `crawledAt`, `contentHash`, and `rawMarkdown` (the last
-    /// is derived from the structured fields and embeds `crawledAt`).
-    /// Two crawls of the same Apple-side content produce the same hash.
-    public var canonicalContentHash: String {
-        let payload = CanonicalPayload(
-            url: url,
-            title: title,
-            kind: kind,
-            source: source,
-            abstract: abstract,
-            declaration: declaration,
-            overview: overview,
-            sections: sections,
-            codeExamples: codeExamples,
-            language: language,
-            platforms: platforms,
-            module: module,
-            conformsTo: conformsTo,
-            inheritedBy: inheritedBy,
-            conformingTypes: conformingTypes
-        )
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        guard let data = try? encoder.encode(payload) else { return "" }
-        return HashUtilities.sha256(of: data)
-    }
-
-    private struct CanonicalPayload: Encodable {
-        let url: URL
-        let title: String
-        let kind: Kind
-        let source: Source
-        let abstract: String?
-        let declaration: Declaration?
-        let overview: String?
-        let sections: [Section]
-        let codeExamples: [CodeExample]
-        let language: String?
-        let platforms: [String]?
-        let module: String?
-        let conformsTo: [String]?
-        let inheritedBy: [String]?
-        let conformingTypes: [String]?
-    }
-
-    /// Return a copy with `contentHash` replaced. Use after constructing a
-    /// page with `contentHash: ""` to stamp `canonicalContentHash` in one step.
-    public func with(contentHash newHash: String) -> StructuredDocumentationPage {
-        StructuredDocumentationPage(
-            id: id,
-            url: url,
-            title: title,
-            kind: kind,
-            source: source,
-            abstract: abstract,
-            declaration: declaration,
-            overview: overview,
-            sections: sections,
-            codeExamples: codeExamples,
-            language: language,
-            platforms: platforms,
-            module: module,
-            conformsTo: conformsTo,
-            inheritedBy: inheritedBy,
-            conformingTypes: conformingTypes,
-            rawMarkdown: rawMarkdown,
-            crawledAt: crawledAt,
-            contentHash: newHash,
-            crawlDepth: crawlDepth
-        )
+        /// Return a copy with `contentHash` replaced. Use after constructing a
+        /// page with `contentHash: ""` to stamp `canonicalContentHash` in one step.
+        public func with(contentHash newHash: String) -> StructuredDocumentationPage {
+            StructuredDocumentationPage(
+                id: id,
+                url: url,
+                title: title,
+                kind: kind,
+                source: source,
+                abstract: abstract,
+                declaration: declaration,
+                overview: overview,
+                sections: sections,
+                codeExamples: codeExamples,
+                language: language,
+                platforms: platforms,
+                module: module,
+                conformsTo: conformsTo,
+                inheritedBy: inheritedBy,
+                conformingTypes: conformingTypes,
+                rawMarkdown: rawMarkdown,
+                crawledAt: crawledAt,
+                contentHash: newHash,
+                crawlDepth: crawlDepth
+            )
+        }
     }
 }
 
 // MARK: - Documentation Page (Crawl Metadata)
 
 /// Represents a single documentation page
-public struct DocumentationPage: Codable, Sendable, Identifiable {
-    public let id: UUID
-    public let url: URL
-    public let framework: String
-    public let title: String
-    public let filePath: URL
-    public let contentHash: String
-    public let depth: Int
-    public let lastCrawled: Date
+extension Shared.Models {
+    public struct DocumentationPage: Codable, Sendable, Identifiable {
+        public let id: UUID
+        public let url: URL
+        public let framework: String
+        public let title: String
+        public let filePath: URL
+        public let contentHash: String
+        public let depth: Int
+        public let lastCrawled: Date
 
-    public init(
-        id: UUID = UUID(),
-        url: URL,
-        framework: String,
-        title: String,
-        filePath: URL,
-        contentHash: String,
-        depth: Int,
-        lastCrawled: Date = Date()
-    ) {
-        self.id = id
-        self.url = url
-        self.framework = framework
-        self.title = title
-        self.filePath = filePath
-        self.contentHash = contentHash
-        self.depth = depth
-        self.lastCrawled = lastCrawled
+        public init(
+            id: UUID = UUID(),
+            url: URL,
+            framework: String,
+            title: String,
+            filePath: URL,
+            contentHash: String,
+            depth: Int,
+            lastCrawled: Date = Date()
+        ) {
+            self.id = id
+            self.url = url
+            self.framework = framework
+            self.title = title
+            self.filePath = filePath
+            self.contentHash = contentHash
+            self.depth = depth
+            self.lastCrawled = lastCrawled
+        }
     }
 }

--- a/Packages/Sources/Shared/Models/Sample.swift
+++ b/Packages/Sources/Shared/Models/Sample.swift
@@ -1,98 +1,105 @@
 import Foundation
+import SharedConstants
 
 // MARK: - Sample Code Cleanup Models
 
 /// Progress update for sample code cleanup
-public struct CleanupProgress: Sendable {
-    public let current: Int
-    public let total: Int
-    public let currentFile: String
-    public let originalSize: Int64
-    public let cleanedSize: Int64
+extension Shared.Models {
+    public struct CleanupProgress: Sendable {
+        public let current: Int
+        public let total: Int
+        public let currentFile: String
+        public let originalSize: Int64
+        public let cleanedSize: Int64
 
-    public var percentage: Double {
-        guard total > 0 else { return 0 }
-        return Double(current) / Double(total) * 100.0
-    }
+        public var percentage: Double {
+            guard total > 0 else { return 0 }
+            return Double(current) / Double(total) * 100.0
+        }
 
-    public init(
-        current: Int,
-        total: Int,
-        currentFile: String,
-        originalSize: Int64,
-        cleanedSize: Int64
-    ) {
-        self.current = current
-        self.total = total
-        self.currentFile = currentFile
-        self.originalSize = originalSize
-        self.cleanedSize = cleanedSize
+        public init(
+            current: Int,
+            total: Int,
+            currentFile: String,
+            originalSize: Int64,
+            cleanedSize: Int64
+        ) {
+            self.current = current
+            self.total = total
+            self.currentFile = currentFile
+            self.originalSize = originalSize
+            self.cleanedSize = cleanedSize
+        }
     }
 }
 
 /// Statistics from sample code cleanup operation
-public struct CleanupStatistics: Sendable {
-    public let totalArchives: Int
-    public let cleanedArchives: Int
-    public let skippedArchives: Int
-    public let errors: Int
-    public let originalTotalSize: Int64
-    public let cleanedTotalSize: Int64
-    public let totalItemsRemoved: Int
-    public var duration: TimeInterval?
+extension Shared.Models {
+    public struct CleanupStatistics: Sendable {
+        public let totalArchives: Int
+        public let cleanedArchives: Int
+        public let skippedArchives: Int
+        public let errors: Int
+        public let originalTotalSize: Int64
+        public let cleanedTotalSize: Int64
+        public let totalItemsRemoved: Int
+        public var duration: TimeInterval?
 
-    public var spaceSaved: Int64 {
-        originalTotalSize - cleanedTotalSize
-    }
+        public var spaceSaved: Int64 {
+            originalTotalSize - cleanedTotalSize
+        }
 
-    public var spaceSavedPercentage: Double {
-        guard originalTotalSize > 0 else { return 0 }
-        return Double(spaceSaved) / Double(originalTotalSize) * 100.0
-    }
+        public var spaceSavedPercentage: Double {
+            guard originalTotalSize > 0 else { return 0 }
+            return Double(spaceSaved) / Double(originalTotalSize) * 100.0
+        }
 
-    public init(
-        totalArchives: Int,
-        cleanedArchives: Int,
-        skippedArchives: Int,
-        errors: Int,
-        originalTotalSize: Int64,
-        cleanedTotalSize: Int64,
-        totalItemsRemoved: Int = 0,
-        duration: TimeInterval? = nil
-    ) {
-        self.totalArchives = totalArchives
-        self.cleanedArchives = cleanedArchives
-        self.skippedArchives = skippedArchives
-        self.errors = errors
-        self.originalTotalSize = originalTotalSize
-        self.cleanedTotalSize = cleanedTotalSize
-        self.totalItemsRemoved = totalItemsRemoved
-        self.duration = duration
+        public init(
+            totalArchives: Int,
+            cleanedArchives: Int,
+            skippedArchives: Int,
+            errors: Int,
+            originalTotalSize: Int64,
+            cleanedTotalSize: Int64,
+            totalItemsRemoved: Int = 0,
+            duration: TimeInterval? = nil
+        ) {
+            self.totalArchives = totalArchives
+            self.cleanedArchives = cleanedArchives
+            self.skippedArchives = skippedArchives
+            self.errors = errors
+            self.originalTotalSize = originalTotalSize
+            self.cleanedTotalSize = cleanedTotalSize
+            self.totalItemsRemoved = totalItemsRemoved
+            self.duration = duration
+        }
     }
 }
 
 /// Result of cleaning a single archive
-public struct CleanupResult: Sendable {
-    public let filename: String
-    public let originalSize: Int64
-    public let cleanedSize: Int64
-    public let itemsRemoved: Int
-    public let success: Bool
-    public let errorMessage: String?
+extension Shared.Models {
+    public struct CleanupResult: Sendable {
+        public let filename: String
+        public let originalSize: Int64
+        public let cleanedSize: Int64
+        public let itemsRemoved: Int
+        public let success: Bool
+        public let errorMessage: String?
 
-    public init(
-        filename: String,
-        originalSize: Int64,
-        cleanedSize: Int64,
-        itemsRemoved: Int,
-        success: Bool,
-        errorMessage: String? = nil
-    ) {
-        self.filename = filename
-        self.originalSize = originalSize
-        self.cleanedSize = cleanedSize
-        self.itemsRemoved = itemsRemoved
-        self.success = success
-        self.errorMessage = errorMessage
+        public init(
+            filename: String,
+            originalSize: Int64,
+            cleanedSize: Int64,
+            itemsRemoved: Int,
+            success: Bool,
+            errorMessage: String? = nil
+        ) {
+            self.filename = filename
+            self.originalSize = originalSize
+            self.cleanedSize = cleanedSize
+            self.itemsRemoved = itemsRemoved
+            self.success = success
+            self.errorMessage = errorMessage
+        }
     }
 }

--- a/Packages/Sources/Shared/Models/SwiftPackage.swift
+++ b/Packages/Sources/Shared/Models/SwiftPackage.swift
@@ -1,113 +1,124 @@
 import Foundation
+import SharedConstants
 
 // MARK: - Package Documentation Models
 
 /// Reference to a Swift package for documentation download
-public struct PackageReference: Codable, Sendable, Hashable {
-    public let owner: String
-    public let repo: String
-    public let url: String
-    public let priority: PackagePriority
+extension Shared.Models {
+    public struct PackageReference: Codable, Sendable, Hashable {
+        public let owner: String
+        public let repo: String
+        public let url: String
+        public let priority: PackagePriority
 
-    public init(owner: String, repo: String, url: String, priority: PackagePriority) {
-        self.owner = owner
-        self.repo = repo
-        self.url = url
-        self.priority = priority
+        public init(owner: String, repo: String, url: String, priority: PackagePriority) {
+            self.owner = owner
+            self.repo = repo
+            self.url = url
+            self.priority = priority
+        }
     }
 }
 
 /// Priority level for package documentation
-public enum PackagePriority: String, Codable, Sendable {
-    case appleOfficial
-    case ecosystem
-    case community
+extension Shared.Models {
+    public enum PackagePriority: String, Codable, Sendable {
+        case appleOfficial
+        case ecosystem
+        case community
+    }
 }
 
 /// Detected documentation site for a package
-public struct DocumentationSite: Codable, Sendable, Hashable {
-    public let type: DocumentationType
-    public let baseURL: URL
+extension Shared.Models {
+    public struct DocumentationSite: Codable, Sendable, Hashable {
+        public let type: DocumentationType
+        public let baseURL: URL
 
-    public init(type: DocumentationType, baseURL: URL) {
-        self.type = type
-        self.baseURL = baseURL
-    }
+        public init(type: DocumentationType, baseURL: URL) {
+            self.type = type
+            self.baseURL = baseURL
+        }
 
-    /// Type of documentation site
-    public enum DocumentationType: String, Codable, Sendable {
-        case githubPages
-        case customDomain
-        case githubWiki
-        case readmeOnly
+        /// Type of documentation site
+        public enum DocumentationType: String, Codable, Sendable {
+            case githubPages
+            case customDomain
+            case githubWiki
+            case readmeOnly
+        }
     }
 }
 
 /// Progress information for package documentation downloads
-public struct PackageDownloadProgress: Sendable {
-    public let currentPackage: String
-    public let completed: Int
-    public let total: Int
-    public let status: String
+extension Shared.Models {
+    public struct PackageDownloadProgress: Sendable {
+        public let currentPackage: String
+        public let completed: Int
+        public let total: Int
+        public let status: String
 
-    public init(currentPackage: String, completed: Int, total: Int, status: String) {
-        self.currentPackage = currentPackage
-        self.completed = completed
-        self.total = total
-        self.status = status
-    }
+        public init(currentPackage: String, completed: Int, total: Int, status: String) {
+            self.currentPackage = currentPackage
+            self.completed = completed
+            self.total = total
+            self.status = status
+        }
 
-    /// Progress percentage (0-100)
-    public var percentage: Double {
-        guard total > 0 else { return 0 }
-        return (Double(completed) / Double(total)) * 100.0
+        /// Progress percentage (0-100)
+        public var percentage: Double {
+            guard total > 0 else { return 0 }
+            return (Double(completed) / Double(total)) * 100.0
+        }
     }
 }
 
 /// Statistics for package documentation downloads
-public struct PackageDownloadStatistics: Sendable {
-    public var totalPackages: Int
-    public var newPackages: Int
-    public var updatedPackages: Int
-    public var totalFilesSaved: Int
-    public var totalBytesSaved: Int64
-    public var successfulDocs: Int
-    public var errors: Int
-    public var startTime: Date?
-    public var endTime: Date?
+extension Shared.Models {
+    public struct PackageDownloadStatistics: Sendable {
+        public var totalPackages: Int
+        public var newPackages: Int
+        public var updatedPackages: Int
+        public var totalFilesSaved: Int
+        public var totalBytesSaved: Int64
+        public var successfulDocs: Int
+        public var errors: Int
+        public var startTime: Date?
+        public var endTime: Date?
 
-    public init(
-        totalPackages: Int = 0,
-        newPackages: Int = 0,
-        updatedPackages: Int = 0,
-        totalFilesSaved: Int = 0,
-        totalBytesSaved: Int64 = 0,
-        successfulDocs: Int = 0,
-        errors: Int = 0,
-        startTime: Date? = nil,
-        endTime: Date? = nil
-    ) {
-        self.totalPackages = totalPackages
-        self.newPackages = newPackages
-        self.updatedPackages = updatedPackages
-        self.totalFilesSaved = totalFilesSaved
-        self.totalBytesSaved = totalBytesSaved
-        self.successfulDocs = successfulDocs
-        self.errors = errors
-        self.startTime = startTime
-        self.endTime = endTime
-    }
-
-    /// Total successful packages (new + updated)
-    public var successfulPackages: Int {
-        newPackages + updatedPackages
-    }
-
-    /// Duration of the download in seconds
-    public var duration: TimeInterval? {
-        guard let start = startTime, let end = endTime else {
-            return nil
+        public init(
+            totalPackages: Int = 0,
+            newPackages: Int = 0,
+            updatedPackages: Int = 0,
+            totalFilesSaved: Int = 0,
+            totalBytesSaved: Int64 = 0,
+            successfulDocs: Int = 0,
+            errors: Int = 0,
+            startTime: Date? = nil,
+            endTime: Date? = nil
+        ) {
+            self.totalPackages = totalPackages
+            self.newPackages = newPackages
+            self.updatedPackages = updatedPackages
+            self.totalFilesSaved = totalFilesSaved
+            self.totalBytesSaved = totalBytesSaved
+            self.successfulDocs = successfulDocs
+            self.errors = errors
+            self.startTime = startTime
+            self.endTime = endTime
         }
-        return end.timeIntervalSince(start)
+
+        /// Total successful packages (new + updated)
+        public var successfulPackages: Int {
+            newPackages + updatedPackages
+        }
+
+        /// Duration of the download in seconds
+        public var duration: TimeInterval? {
+            guard let start = startTime, let end = endTime else {
+                return nil
+            }
+            return end.timeIntervalSince(start)
+        }
     }
 }

--- a/Packages/Sources/Shared/Models/URLUtilities.swift
+++ b/Packages/Sources/Shared/Models/URLUtilities.swift
@@ -4,150 +4,152 @@ import SharedConstants
 // MARK: - URL Utilities
 
 /// Utilities for URL manipulation
-public enum URLUtilities {
-    /// Returns a normalized copy of `url` with fragment and query stripped,
-    /// path lowercased, and underscores replaced with dashes in sub-page
-    /// segments within `/documentation/` paths.
-    ///
-    /// Applies underscore-to-dash replacement only to path segments at depth
-    /// ≥ 3 (sub-page level). Framework slugs at depth 2 are preserved because
-    /// at least two Apple frameworks (`installer_js`,
-    /// `professional_video_applications`) use underscores canonically and
-    /// their dash forms return 404. This resolves the 31 duplicate URI
-    /// clusters in search.db (#285).
-    ///
-    /// - Parameter url: The URL to normalize.
-    /// - Returns: The normalized URL, or `nil` if `url` cannot be decomposed
-    ///   into URL components.
-    public static func normalize(_ url: URL) -> URL? {
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        components?.fragment = nil
-        components?.query = nil
-        if let path = components?.path {
-            components?.path = normalizeDocPath(path.lowercased())
-        }
-        return components?.url
-    }
-
-    // Replace underscores with dashes in sub-page path segments only.
-    // Framework slugs at depth 2 after /documentation/ use underscores
-    // canonically (installer_js, professional_video_applications) and must
-    // be left untouched.
-    private static func normalizeDocPath(_ path: String) -> String {
-        let parts = path.components(separatedBy: "/")
-        guard let docIdx = parts.firstIndex(of: "documentation"),
-              docIdx + 2 < parts.count else { return path }
-
-        let normalizeFromIdx = docIdx + 2
-        return parts
-            .enumerated()
-            .map { index, part in
-                index >= normalizeFromIdx ? String(part.map { $0 == "_" ? "-" : $0 }) : part
+extension Shared.Models {
+    public enum URLUtilities {
+        /// Returns a normalized copy of `url` with fragment and query stripped,
+        /// path lowercased, and underscores replaced with dashes in sub-page
+        /// segments within `/documentation/` paths.
+        ///
+        /// Applies underscore-to-dash replacement only to path segments at depth
+        /// ≥ 3 (sub-page level). Framework slugs at depth 2 are preserved because
+        /// at least two Apple frameworks (`installer_js`,
+        /// `professional_video_applications`) use underscores canonically and
+        /// their dash forms return 404. This resolves the 31 duplicate URI
+        /// clusters in search.db (#285).
+        ///
+        /// - Parameter url: The URL to normalize.
+        /// - Returns: The normalized URL, or `nil` if `url` cannot be decomposed
+        ///   into URL components.
+        public static func normalize(_ url: URL) -> URL? {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            components?.fragment = nil
+            components?.query = nil
+            if let path = components?.path {
+                components?.path = normalizeDocPath(path.lowercased())
             }
-            .joined(separator: "/")
-    }
-
-    /// Extract framework name from documentation URL (Apple or Swift.org)
-    public static func extractFramework(from url: URL) -> String {
-        let pathComponents = url.pathComponents
-
-        // Handle docs.swift.org URLs (e.g., /swift-book/documentation/the-swift-programming-language/*)
-        if url.host?.contains(Shared.Constants.HostDomain.swiftOrg) == true {
-            if pathComponents.contains(Shared.Constants.PathComponent.swiftBook) {
-                return Shared.Constants.PathComponent.swiftBook
-            }
-            return Shared.Constants.PathComponent.swiftOrgFramework
+            return components?.url
         }
 
-        // Handle developer.apple.com URLs (e.g., /documentation/swiftui/*)
-        if let docIndex = pathComponents.firstIndex(of: "documentation"),
-           docIndex + 1 < pathComponents.count {
-            return pathComponents[docIndex + 1].lowercased()
+        /// Replace underscores with dashes in sub-page path segments only.
+        /// Framework slugs at depth 2 after /documentation/ use underscores
+        /// canonically (installer_js, professional_video_applications) and must
+        /// be left untouched.
+        private static func normalizeDocPath(_ path: String) -> String {
+            let parts = path.components(separatedBy: "/")
+            guard let docIdx = parts.firstIndex(of: "documentation"),
+                  docIdx + 2 < parts.count else { return path }
+
+            let normalizeFromIdx = docIdx + 2
+            return parts
+                .enumerated()
+                .map { index, part in
+                    index >= normalizeFromIdx ? String(part.map { $0 == "_" ? "-" : $0 }) : part
+                }
+                .joined(separator: "/")
         }
 
-        return "root"
-    }
+        /// Extract framework name from documentation URL (Apple or Swift.org)
+        public static func extractFramework(from url: URL) -> String {
+            let pathComponents = url.pathComponents
 
-    /// Generate filename from URL.
-    ///
-    /// Output is the basename only (no `.json` extension, no framework dir).
-    /// Length is capped at `maxFilenameBytes` so that `<filename>.json` fits
-    /// within the 255-byte filesystem limit on macOS HFS+/APFS. Long
-    /// auto-generated DocC slugs (e.g. Metal shader encoders with dozens of
-    /// named parameters) get truncated and appended with an 8-char SHA-1
-    /// suffix to keep collision-resistant uniqueness.
-    public static func filename(from url: URL) -> String {
-        // Canonicalize first so case-variant URLs collapse to identical filenames.
-        // Without this, the disambiguator hash below (computed from
-        // `originalCleaned`) diverges for case-variants like
-        // `/documentation/Swift/withTaskGroup(...)` vs the all-lowercase form,
-        // producing two distinct URIs in the index for the same Apple page (#283).
-        let canonical = URLUtilities.normalize(url) ?? url
-        var cleaned = canonical.absoluteString
-        let originalCleaned = cleaned
-
-        // Remove known domain prefixes
-        cleaned = cleaned
-            .replacingOccurrences(of: "\(Shared.Constants.BaseURL.appleDeveloper)/", with: "")
-            .replacingOccurrences(of: "\(Shared.Constants.BaseURL.swiftOrg)", with: "")
-            .replacingOccurrences(of: Shared.Constants.URLCleanupPattern.swiftOrgWWW, with: "")
-
-        // Check if URL contains special characters that would cause collisions
-        // (operators, subscripts, etc.)
-        let hasSpecialChars = cleaned.rangeOfCharacter(from: CharacterSet(charactersIn: "()[]<>:,")) != nil
-
-        // Normalize to safe filename
-        cleaned = cleaned
-            .lowercased()
-            .replacingOccurrences(of: "[^a-z0-9._-]+", with: "_", options: .regularExpression)
-            .replacingOccurrences(of: "_+", with: "_", options: .regularExpression)
-            .replacingOccurrences(of: "^_+|_+$", with: "", options: .regularExpression)
-
-        // If special characters were present, append a hash to ensure uniqueness
-        // This prevents collisions like:
-        //   - .../Text → documentation_swiftui_text
-        //   - .../Text/+(_:_:) → documentation_swiftui_text (collision!)
-        // With hash:
-        //   - .../Text → documentation_swiftui_text
-        //   - .../Text/+(_:_:) → documentation_swiftui_text_a1b2c3d4
-        if hasSpecialChars {
-            let hash = HashUtilities.sha256(of: originalCleaned)
-            let shortHash = String(hash.prefix(8))
-            cleaned = "\(cleaned)_\(shortHash)"
-        }
-
-        // Cap length so that `<filename>.json` (5-byte extension) fits within
-        // the 255-byte filesystem basename limit. Without this, deeply-named
-        // Apple symbols (e.g. MPSSVGF.encodeReprojection(...) with 12+ named
-        // parameters) generate 280+ char filenames that fail to save with
-        // POSIX errno 63 "File name too long".
-        let maxFilenameBytes = 240
-        if cleaned.utf8.count > maxFilenameBytes {
-            let hash = HashUtilities.sha256(of: originalCleaned)
-            let shortHash = String(hash.prefix(8))
-            let suffix = "_\(shortHash)"
-
-            // Strip any prior hash suffix so we don't end up with two
-            let withoutPriorSuffix: String = if hasSpecialChars, cleaned.hasSuffix(suffix) {
-                String(cleaned.dropLast(suffix.count))
-            } else {
-                cleaned
+            // Handle docs.swift.org URLs (e.g., /swift-book/documentation/the-swift-programming-language/*)
+            if url.host?.contains(Shared.Constants.HostDomain.swiftOrg) == true {
+                if pathComponents.contains(Shared.Constants.PathComponent.swiftBook) {
+                    return Shared.Constants.PathComponent.swiftBook
+                }
+                return Shared.Constants.PathComponent.swiftOrgFramework
             }
 
-            // Slugs are ASCII-only after the regex normalization above, so
-            // String.prefix on character count == byte count.
-            let availableBytes = maxFilenameBytes - suffix.utf8.count
-            var truncated = String(withoutPriorSuffix.prefix(availableBytes))
-
-            // Don't end on a trailing underscore — looks ugly, complicates
-            // collision behavior with the suffix separator.
-            while truncated.hasSuffix("_") {
-                truncated = String(truncated.dropLast())
+            // Handle developer.apple.com URLs (e.g., /documentation/swiftui/*)
+            if let docIndex = pathComponents.firstIndex(of: "documentation"),
+               docIndex + 1 < pathComponents.count {
+                return pathComponents[docIndex + 1].lowercased()
             }
 
-            cleaned = truncated + suffix
+            return "root"
         }
 
-        return cleaned.isEmpty ? "index" : cleaned
+        /// Generate filename from URL.
+        ///
+        /// Output is the basename only (no `.json` extension, no framework dir).
+        /// Length is capped at `maxFilenameBytes` so that `<filename>.json` fits
+        /// within the 255-byte filesystem limit on macOS HFS+/APFS. Long
+        /// auto-generated DocC slugs (e.g. Metal shader encoders with dozens of
+        /// named parameters) get truncated and appended with an 8-char SHA-1
+        /// suffix to keep collision-resistant uniqueness.
+        public static func filename(from url: URL) -> String {
+            // Canonicalize first so case-variant URLs collapse to identical filenames.
+            // Without this, the disambiguator hash below (computed from
+            // `originalCleaned`) diverges for case-variants like
+            // `/documentation/Swift/withTaskGroup(...)` vs the all-lowercase form,
+            // producing two distinct URIs in the index for the same Apple page (#283).
+            let canonical = URLUtilities.normalize(url) ?? url
+            var cleaned = canonical.absoluteString
+            let originalCleaned = cleaned
+
+            // Remove known domain prefixes
+            cleaned = cleaned
+                .replacingOccurrences(of: "\(Shared.Constants.BaseURL.appleDeveloper)/", with: "")
+                .replacingOccurrences(of: "\(Shared.Constants.BaseURL.swiftOrg)", with: "")
+                .replacingOccurrences(of: Shared.Constants.URLCleanupPattern.swiftOrgWWW, with: "")
+
+            // Check if URL contains special characters that would cause collisions
+            // (operators, subscripts, etc.)
+            let hasSpecialChars = cleaned.rangeOfCharacter(from: CharacterSet(charactersIn: "()[]<>:,")) != nil
+
+            // Normalize to safe filename
+            cleaned = cleaned
+                .lowercased()
+                .replacingOccurrences(of: "[^a-z0-9._-]+", with: "_", options: .regularExpression)
+                .replacingOccurrences(of: "_+", with: "_", options: .regularExpression)
+                .replacingOccurrences(of: "^_+|_+$", with: "", options: .regularExpression)
+
+            // If special characters were present, append a hash to ensure uniqueness
+            // This prevents collisions like:
+            //   - .../Text → documentation_swiftui_text
+            //   - .../Text/+(_:_:) → documentation_swiftui_text (collision!)
+            // With hash:
+            //   - .../Text → documentation_swiftui_text
+            //   - .../Text/+(_:_:) → documentation_swiftui_text_a1b2c3d4
+            if hasSpecialChars {
+                let hash = HashUtilities.sha256(of: originalCleaned)
+                let shortHash = String(hash.prefix(8))
+                cleaned = "\(cleaned)_\(shortHash)"
+            }
+
+            // Cap length so that `<filename>.json` (5-byte extension) fits within
+            // the 255-byte filesystem basename limit. Without this, deeply-named
+            // Apple symbols (e.g. MPSSVGF.encodeReprojection(...) with 12+ named
+            // parameters) generate 280+ char filenames that fail to save with
+            // POSIX errno 63 "File name too long".
+            let maxFilenameBytes = 240
+            if cleaned.utf8.count > maxFilenameBytes {
+                let hash = HashUtilities.sha256(of: originalCleaned)
+                let shortHash = String(hash.prefix(8))
+                let suffix = "_\(shortHash)"
+
+                // Strip any prior hash suffix so we don't end up with two
+                let withoutPriorSuffix: String = if hasSpecialChars, cleaned.hasSuffix(suffix) {
+                    String(cleaned.dropLast(suffix.count))
+                } else {
+                    cleaned
+                }
+
+                // Slugs are ASCII-only after the regex normalization above, so
+                // String.prefix on character count == byte count.
+                let availableBytes = maxFilenameBytes - suffix.utf8.count
+                var truncated = String(withoutPriorSuffix.prefix(availableBytes))
+
+                // Don't end on a trailing underscore — looks ugly, complicates
+                // collision behavior with the suffix separator.
+                while truncated.hasSuffix("_") {
+                    truncated = String(truncated.dropLast())
+                }
+
+                cleaned = truncated + suffix
+            }
+
+            return cleaned.isEmpty ? "index" : cleaned
+        }
     }
 }

--- a/Packages/Sources/Shared/Utils/FTSQuery.swift
+++ b/Packages/Sources/Shared/Utils/FTSQuery.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SharedConstants
 
-extension Shared {
+extension Shared.Utils {
     /// Pure string helpers for building SQLite FTS5 MATCH queries from
     /// natural-language input. Lifted out of `Search.PackageQuery` (#192 E)
     /// in #238 so `SampleIndex` can reuse the exact same tokenization +

--- a/Packages/Sources/Shared/Utils/Formatting.swift
+++ b/Packages/Sources/Shared/Utils/Formatting.swift
@@ -3,7 +3,7 @@ import SharedConstants
 
 // MARK: - Formatting Utilities
 
-extension Shared {
+extension Shared.Utils {
     /// Shared formatting utilities
     public enum Formatting {
         // MARK: - Byte Formatting

--- a/Packages/Sources/Shared/Utils/JSONCoding.swift
+++ b/Packages/Sources/Shared/Utils/JSONCoding.swift
@@ -1,74 +1,77 @@
 import Foundation
+import SharedConstants
 
 // MARK: - Unified JSON Encoding/Decoding
 
 /// Centralized JSON encoding/decoding utilities with consistent date strategies
 /// This ensures all JSON operations use the same date format (ISO8601)
-public enum JSONCoding {
-    // MARK: - Standard Encoders
+extension Shared.Utils {
+    public enum JSONCoding {
+        // MARK: - Standard Encoders
 
-    /// Standard JSON encoder with ISO8601 date encoding
-    public static func encoder() -> JSONEncoder {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        return encoder
-    }
+        /// Standard JSON encoder with ISO8601 date encoding
+        public static func encoder() -> JSONEncoder {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            return encoder
+        }
 
-    /// Pretty-printed JSON encoder with ISO8601 date encoding
-    public static func prettyEncoder() -> JSONEncoder {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        return encoder
-    }
+        /// Pretty-printed JSON encoder with ISO8601 date encoding
+        public static func prettyEncoder() -> JSONEncoder {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            return encoder
+        }
 
-    // MARK: - Standard Decoders
+        // MARK: - Standard Decoders
 
-    /// Standard JSON decoder with ISO8601 date decoding
-    public static func decoder() -> JSONDecoder {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        return decoder
-    }
+        /// Standard JSON decoder with ISO8601 date decoding
+        public static func decoder() -> JSONDecoder {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return decoder
+        }
 
-    // MARK: - Convenience Methods
+        // MARK: - Convenience Methods
 
-    /// Encode to JSON Data with standard encoder
-    public static func encode(_ value: some Encodable) throws -> Data {
-        try encoder().encode(value)
-    }
+        /// Encode to JSON Data with standard encoder
+        public static func encode(_ value: some Encodable) throws -> Data {
+            try encoder().encode(value)
+        }
 
-    /// Encode to pretty-printed JSON Data
-    public static func encodePretty(_ value: some Encodable) throws -> Data {
-        try prettyEncoder().encode(value)
-    }
+        /// Encode to pretty-printed JSON Data
+        public static func encodePretty(_ value: some Encodable) throws -> Data {
+            try prettyEncoder().encode(value)
+        }
 
-    /// Decode from JSON Data with standard decoder
-    public static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
-        try decoder().decode(type, from: data)
-    }
+        /// Decode from JSON Data with standard decoder
+        public static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+            try decoder().decode(type, from: data)
+        }
 
-    /// Decode from JSON file with standard decoder
-    public static func decode<T: Decodable>(_ type: T.Type, from url: URL) throws -> T {
-        let data = try Data(contentsOf: url)
-        return try decode(type, from: data)
-    }
+        /// Decode from JSON file with standard decoder
+        public static func decode<T: Decodable>(_ type: T.Type, from url: URL) throws -> T {
+            let data = try Data(contentsOf: url)
+            return try decode(type, from: data)
+        }
 
-    /// Encode to JSON file with pretty-printed encoder
-    public static func encode(_ value: some Encodable, to url: URL) throws {
-        let data = try encodePretty(value)
+        /// Encode to JSON file with pretty-printed encoder
+        public static func encode(_ value: some Encodable, to url: URL) throws {
+            let data = try encodePretty(value)
 
-        // Ensure directory exists
-        let directory = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(
-            at: directory,
-            withIntermediateDirectories: true
-        )
+            // Ensure directory exists
+            let directory = url.deletingLastPathComponent()
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
 
-        // Atomic write: writes to a temp file in the same directory and renames
-        // over `url`. Guarantees the on-disk file is always either the previous
-        // version or the new one, never half-written — so a kill mid-save can't
-        // leave metadata.json corrupt and make a multi-day crawl unresumable.
-        try data.write(to: url, options: .atomic)
+            // Atomic write: writes to a temp file in the same directory and renames
+            // over `url`. Guarantees the on-disk file is always either the previous
+            // version or the new one, never half-written — so a kill mid-save can't
+            // leave metadata.json corrupt and make a multi-day crawl unresumable.
+            try data.write(to: url, options: .atomic)
+        }
     }
 }

--- a/Packages/Sources/Shared/Utils/PathResolver.swift
+++ b/Packages/Sources/Shared/Utils/PathResolver.swift
@@ -5,75 +5,77 @@ import SharedConstants
 
 /// Centralized path resolution for database files and directories.
 /// Consolidates path resolution logic used across CLI commands and tool providers.
-public enum PathResolver {
-    // MARK: - Search Database
+extension Shared.Utils {
+    public enum PathResolver {
+        // MARK: - Search Database
 
-    /// Resolve the search database path.
-    /// - Parameter customPath: Optional custom path (supports ~ expansion)
-    /// - Returns: Resolved URL to the search database
-    public static func searchDatabase(_ customPath: String? = nil) -> URL {
-        if let customPath {
-            return URL(fileURLWithPath: customPath).expandingTildeInPath
+        /// Resolve the search database path.
+        /// - Parameter customPath: Optional custom path (supports ~ expansion)
+        /// - Returns: Resolved URL to the search database
+        public static func searchDatabase(_ customPath: String? = nil) -> URL {
+            if let customPath {
+                return URL(fileURLWithPath: customPath).expandingTildeInPath
+            }
+            return Shared.Constants.defaultSearchDatabase
         }
-        return Shared.Constants.defaultSearchDatabase
-    }
 
-    // MARK: - Directory Resolution
+        // MARK: - Directory Resolution
 
-    /// Resolve a documentation directory path.
-    /// - Parameter customPath: Optional custom path (supports ~ expansion)
-    /// - Parameter defaultPath: Default path if custom is not provided
-    /// - Returns: Resolved URL to the directory
-    public static func directory(_ customPath: String? = nil, default defaultPath: URL) -> URL {
-        if let customPath {
-            return URL(fileURLWithPath: customPath).expandingTildeInPath
+        /// Resolve a documentation directory path.
+        /// - Parameter customPath: Optional custom path (supports ~ expansion)
+        /// - Parameter defaultPath: Default path if custom is not provided
+        /// - Returns: Resolved URL to the directory
+        public static func directory(_ customPath: String? = nil, default defaultPath: URL) -> URL {
+            if let customPath {
+                return URL(fileURLWithPath: customPath).expandingTildeInPath
+            }
+            return defaultPath
         }
-        return defaultPath
-    }
 
-    /// Resolve the docs directory.
-    public static func docsDirectory(_ customPath: String? = nil) -> URL {
-        directory(customPath, default: Shared.Constants.defaultDocsDirectory)
-    }
+        /// Resolve the docs directory.
+        public static func docsDirectory(_ customPath: String? = nil) -> URL {
+            directory(customPath, default: Shared.Constants.defaultDocsDirectory)
+        }
 
-    /// Resolve the Swift Evolution directory.
-    public static func evolutionDirectory(_ customPath: String? = nil) -> URL {
-        directory(customPath, default: Shared.Constants.defaultSwiftEvolutionDirectory)
-    }
+        /// Resolve the Swift Evolution directory.
+        public static func evolutionDirectory(_ customPath: String? = nil) -> URL {
+            directory(customPath, default: Shared.Constants.defaultSwiftEvolutionDirectory)
+        }
 
-    /// Resolve the HIG directory.
-    public static func higDirectory(_ customPath: String? = nil) -> URL {
-        directory(customPath, default: Shared.Constants.defaultHIGDirectory)
-    }
+        /// Resolve the HIG directory.
+        public static func higDirectory(_ customPath: String? = nil) -> URL {
+            directory(customPath, default: Shared.Constants.defaultHIGDirectory)
+        }
 
-    /// Resolve the sample code directory.
-    public static func sampleCodeDirectory(_ customPath: String? = nil) -> URL {
-        directory(customPath, default: Shared.Constants.defaultSampleCodeDirectory)
-    }
+        /// Resolve the sample code directory.
+        public static func sampleCodeDirectory(_ customPath: String? = nil) -> URL {
+            directory(customPath, default: Shared.Constants.defaultSampleCodeDirectory)
+        }
 
-    // MARK: - Path Expansion
+        // MARK: - Path Expansion
 
-    /// Expand a path string with tilde support.
-    /// - Parameter path: Path string (may include ~)
-    /// - Returns: Expanded URL
-    public static func expand(_ path: String) -> URL {
-        URL(fileURLWithPath: path).expandingTildeInPath
-    }
+        /// Expand a path string with tilde support.
+        /// - Parameter path: Path string (may include ~)
+        /// - Returns: Expanded URL
+        public static func expand(_ path: String) -> URL {
+            URL(fileURLWithPath: path).expandingTildeInPath
+        }
 
-    // MARK: - Validation
+        // MARK: - Validation
 
-    /// Check if a path exists.
-    /// - Parameter url: URL to check
-    /// - Returns: true if the path exists
-    public static func exists(_ url: URL) -> Bool {
-        FileManager.default.fileExists(atPath: url.path)
-    }
+        /// Check if a path exists.
+        /// - Parameter url: URL to check
+        /// - Returns: true if the path exists
+        public static func exists(_ url: URL) -> Bool {
+            FileManager.default.fileExists(atPath: url.path)
+        }
 
-    /// Check if a path exists and is a directory.
-    /// - Parameter url: URL to check
-    /// - Returns: true if the path exists and is a directory
-    public static func isDirectory(_ url: URL) -> Bool {
-        var isDir: ObjCBool = false
-        return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
+        /// Check if a path exists and is a directory.
+        /// - Parameter url: URL to check
+        /// - Returns: true if the path exists and is a directory
+        public static func isDirectory(_ url: URL) -> Bool {
+            var isDir: ObjCBool = false
+            return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
+        }
     }
 }

--- a/Packages/Sources/Shared/Utils/SchemaVersion.swift
+++ b/Packages/Sources/Shared/Utils/SchemaVersion.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SharedConstants
 
-extension Shared {
+extension Shared.Utils {
     /// Date-based schema version stamp for cupertino's local databases
     /// (search.db, packages.db, samples.db). #234.
     ///

--- a/Packages/Sources/TUI/Views/HomeView.swift
+++ b/Packages/Sources/TUI/Views/HomeView.swift
@@ -34,7 +34,7 @@ struct HomeView {
         result += renderPaddedLine("Quick Stats", width: width)
         let selected = " \(stats.selectedPackages) pkgs"
         let downloaded = " \(stats.downloadedPackages) dl"
-        let totalSize = " \(Shared.Formatting.formatBytes(stats.totalSize))"
+        let totalSize = " \(Shared.Utils.Formatting.formatBytes(stats.totalSize))"
         let statsLine = "•\(selected) •\(downloaded) •\(totalSize)"
         result += renderPaddedLine(statsLine, width: width)
         result += Box.teeRight + String(repeating: Box.horizontal, count: width - 2) + Box.teeLeft + "\r\n"

--- a/Packages/Sources/TUI/Views/LibraryView.swift
+++ b/Packages/Sources/TUI/Views/LibraryView.swift
@@ -61,7 +61,7 @@ struct LibraryView {
         let icon = "*"
         let name = artifact.name
         let itemsText = "\(artifact.itemCount) items"
-        let sizeText = Shared.Formatting.formatBytes(artifact.sizeBytes)
+        let sizeText = Shared.Utils.Formatting.formatBytes(artifact.sizeBytes)
 
         // Calculate widths (no emojis)
         let iconWidth = icon.count

--- a/Packages/Tests/CLICommandTests/FetchTests/CrawlTests.swift
+++ b/Packages/Tests/CLICommandTests/FetchTests/CrawlTests.swift
@@ -70,7 +70,7 @@ struct WebCrawlTests {
         let metadataFile = tempDir.appendingPathComponent("metadata.json")
         #expect(FileManager.default.fileExists(atPath: metadataFile.path), "Metadata should exist")
 
-        let metadata = try CrawlMetadata.load(from: metadataFile)
+        let metadata = try Shared.Models.CrawlMetadata.load(from: metadataFile)
         #expect(!metadata.pages.isEmpty, "Metadata should contain pages")
         #expect(metadata.stats.totalPages == 1, "Metadata stats should match")
 

--- a/Packages/Tests/CLICommandTests/FetchTests/ResumeTests.swift
+++ b/Packages/Tests/CLICommandTests/FetchTests/ResumeTests.swift
@@ -50,8 +50,8 @@ struct ResumeAndStartCleanTests {
         queue: [(url: String, depth: Int)],
         isActive: Bool = true
     ) throws {
-        let queued = queue.map { QueuedURL(url: $0.url, depth: $0.depth) }
-        let crawlState = CrawlSessionState(
+        let queued = queue.map { Shared.Models.QueuedURL(url: $0.url, depth: $0.depth) }
+        let crawlState = Shared.Models.CrawlSessionState(
             visited: visited,
             queue: queued,
             startURL: startURL,
@@ -60,7 +60,7 @@ struct ResumeAndStartCleanTests {
             lastSaveTime: Date(timeIntervalSince1970: 1700000500),
             isActive: isActive
         )
-        var metadata = CrawlMetadata()
+        var metadata = Shared.Models.CrawlMetadata()
         metadata.crawlState = crawlState
         metadata.stats.totalPages = visited.count
         metadata.stats.newPages = visited.count
@@ -99,7 +99,7 @@ struct ResumeAndStartCleanTests {
         )
 
         // Sanity: crawlState is there before the wipe.
-        let before = try CrawlMetadata.load(from: file)
+        let before = try Shared.Models.CrawlMetadata.load(from: file)
         #expect(before.crawlState != nil)
         #expect(before.crawlState?.isActive == true)
         #expect(before.crawlState?.visited.count == 3)
@@ -111,7 +111,7 @@ struct ResumeAndStartCleanTests {
         // crawlState is gone; the other fields are intact (so we don't lose
         // accumulated stats / page hashes — those are what change-detection
         // uses to skip unchanged pages on the resumed run).
-        let after = try CrawlMetadata.load(from: file)
+        let after = try Shared.Models.CrawlMetadata.load(from: file)
         #expect(after.crawlState == nil)
         #expect(after.stats.totalPages == 3, "stats must survive --start-clean")
         #expect(after.stats.newPages == 3, "stats must survive --start-clean")
@@ -136,13 +136,13 @@ struct ResumeAndStartCleanTests {
         // The file must be valid JSON parsable as CrawlMetadata — if it's
         // truncated or corrupt, the next `cupertino fetch` will throw at
         // load time and the user is locked out of resume.
-        let reloaded = try CrawlMetadata.load(from: file)
+        let reloaded = try Shared.Models.CrawlMetadata.load(from: file)
         #expect(reloaded.crawlState == nil)
 
         // And running --start-clean a second time on the already-cleaned file
         // is also a no-throw no-op.
         try Ingest.Session.clearSavedSession(at: tempDir)
-        let twiceCleaned = try CrawlMetadata.load(from: file)
+        let twiceCleaned = try Shared.Models.CrawlMetadata.load(from: file)
         #expect(twiceCleaned.crawlState == nil)
     }
 
@@ -157,9 +157,9 @@ struct ResumeAndStartCleanTests {
         savedURLs: [String],
         erroredURLs: [String]
     ) throws {
-        var pages: [String: PageMetadata] = [:]
+        var pages: [String: Shared.Models.PageMetadata] = [:]
         for url in savedURLs {
-            pages[url] = PageMetadata(
+            pages[url] = Shared.Models.PageMetadata(
                 url: url,
                 framework: "test",
                 filePath: "/tmp/foo.json",
@@ -168,13 +168,13 @@ struct ResumeAndStartCleanTests {
             )
         }
         let visited = Set(savedURLs + erroredURLs)
-        let crawlState = CrawlSessionState(
+        let crawlState = Shared.Models.CrawlSessionState(
             visited: visited,
             queue: [],
             startURL: "https://example.com/",
             outputDirectory: outputDirectory
         )
-        var metadata = CrawlMetadata()
+        var metadata = Shared.Models.CrawlMetadata()
         metadata.crawlState = crawlState
         metadata.pages = pages
         try metadata.save(to: file)
@@ -208,7 +208,7 @@ struct ResumeAndStartCleanTests {
 
         try Ingest.Session.requeueErroredURLs(at: tempDir, maxDepth: 15)
 
-        let after = try CrawlMetadata.load(from: file)
+        let after = try Shared.Models.CrawlMetadata.load(from: file)
         #expect(after.crawlState?.queue.isEmpty == true, "queue should remain empty")
         #expect(after.crawlState?.visited.count == 3)
     }
@@ -243,7 +243,7 @@ struct ResumeAndStartCleanTests {
 
         try Ingest.Session.requeueErroredURLs(at: tempDir, maxDepth: 15)
 
-        let after = try CrawlMetadata.load(from: file)
+        let after = try Shared.Models.CrawlMetadata.load(from: file)
         let queueURLs = Set(after.crawlState?.queue.map(\.url) ?? [])
         #expect(queueURLs == [erroredA, erroredB])
         #expect(
@@ -318,7 +318,7 @@ struct ResumeAndStartCleanTests {
 
         try Ingest.Session.requeueFromBaseline(at: tempDir, baselineDir: baselineDir, maxDepth: 15)
 
-        let after = try CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
+        let after = try Shared.Models.CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
         let queueURLs = Set(after.crawlState?.queue.map(\.url) ?? [])
         #expect(queueURLs.count == 2)
         #expect(queueURLs.contains("https://developer.apple.com/documentation/swift/dictionary"))
@@ -351,7 +351,7 @@ struct ResumeAndStartCleanTests {
 
         try Ingest.Session.requeueFromBaseline(at: tempDir, baselineDir: baselineDir, maxDepth: 15)
 
-        let after = try CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
+        let after = try Shared.Models.CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
         // Already known case-insensitively → should NOT be injected.
         #expect(
             after.crawlState?.queue.isEmpty == true,
@@ -374,7 +374,7 @@ struct ResumeAndStartCleanTests {
         let nonExistent = tempDir.appendingPathComponent("nope")
         try Ingest.Session.requeueFromBaseline(at: tempDir, baselineDir: nonExistent, maxDepth: 15)
 
-        let after = try CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
+        let after = try Shared.Models.CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
         #expect(after.crawlState?.queue.isEmpty == true)
     }
 
@@ -393,7 +393,7 @@ struct ResumeAndStartCleanTests {
         )
 
         try Ingest.Session.requeueFromBaseline(at: tempDir, baselineDir: baselineDir, maxDepth: 15)
-        let after = try CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
+        let after = try Shared.Models.CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
         #expect(after.crawlState?.queue.isEmpty == true)
     }
 
@@ -432,7 +432,7 @@ struct ResumeAndStartCleanTests {
 
         try Ingest.Session.requeueFromBaseline(at: tempDir, baselineDir: baselineDir, maxDepth: 15)
 
-        let after = try CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
+        let after = try Shared.Models.CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
         let queueURLs = (after.crawlState?.queue ?? []).map(\.url)
         #expect(queueURLs == ["https://developer.apple.com/documentation/swift/array"])
     }
@@ -462,7 +462,7 @@ struct ResumeAndStartCleanTests {
 
         try Ingest.Session.requeueFromBaseline(at: tempDir, baselineDir: baselineDir, maxDepth: 15)
 
-        let after = try CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
+        let after = try Shared.Models.CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
         let queue = after.crawlState?.queue ?? []
         #expect(queue.count == 2)
         #expect(
@@ -477,12 +477,12 @@ struct ResumeAndStartCleanTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         // Write a metadata.json with no crawlState (e.g. cleared by --start-clean).
-        var metadata = CrawlMetadata()
+        var metadata = Shared.Models.CrawlMetadata()
         try metadata.save(to: Self.metadataFile(in: tempDir))
 
         // Should not throw and should not synthesize a crawlState.
         try Ingest.Session.requeueErroredURLs(at: tempDir, maxDepth: 15)
-        let after = try CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
+        let after = try Shared.Models.CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
         #expect(after.crawlState == nil)
     }
 
@@ -533,7 +533,7 @@ struct ResumeAndStartCleanTests {
 
         // Empty metadata — no crawlState field.
         let file = Self.metadataFile(in: tempDir)
-        let metadata = CrawlMetadata()
+        let metadata = Shared.Models.CrawlMetadata()
         try metadata.save(to: file)
 
         let config = Shared.ChangeDetectionConfiguration(
@@ -735,7 +735,7 @@ struct ResumeAndStartCleanTests {
         framework: String,
         filename: String,
         foreignFilePath: String
-    ) throws -> PageMetadata {
+    ) throws -> Shared.Models.PageMetadata {
         // Make the actual file on disk under outputDir/framework/.
         let frameworkDir = outputDir.appendingPathComponent(framework)
         try FileManager.default.createDirectory(at: frameworkDir, withIntermediateDirectories: true)
@@ -744,7 +744,7 @@ struct ResumeAndStartCleanTests {
 
         // PageMetadata records the *foreign* path — same basename / framework
         // as the on-disk file, but a host-specific absolute prefix.
-        return PageMetadata(
+        return Shared.Models.PageMetadata(
             url: "https://developer.apple.com/documentation/\(framework)",
             framework: framework,
             filePath: foreignFilePath,
@@ -763,7 +763,7 @@ struct ResumeAndStartCleanTests {
         // Build a metadata fixture: 3 pages whose `filePath` strings are from
         // a different machine, but whose actual files exist under outputDir.
         // This is the rsync-from-another-host scenario — exact bug we hit on Claw.
-        var metadata = CrawlMetadata()
+        var metadata = Shared.Models.CrawlMetadata()
         let frameworks = ["accessibility", "swiftui", "foundation"]
         for fw in frameworks {
             let page = try Self.writeFixturePagesAndFile(
@@ -786,9 +786,9 @@ struct ResumeAndStartCleanTests {
         defer { try? FileManager.default.removeItem(at: outputDir) }
 
         // 5 page entries, but no files on disk → genuinely lying metadata
-        var metadata = CrawlMetadata()
+        var metadata = Shared.Models.CrawlMetadata()
         for fw in ["a", "b", "c", "d", "e"] {
-            metadata.pages["https://x/\(fw)"] = PageMetadata(
+            metadata.pages["https://x/\(fw)"] = Shared.Models.PageMetadata(
                 url: "https://x/\(fw)",
                 framework: fw,
                 filePath: "/anywhere/\(fw)/file.json",
@@ -812,15 +812,15 @@ struct ResumeAndStartCleanTests {
         // which is the right behavior at runtime but breaks this test.)
         let foreignRoot = "/__nonexistent-foreign-host-\(UUID().uuidString)"
         let outputDir = URL(fileURLWithPath: "/__nonexistent-target-host-\(UUID().uuidString)/cupertino/docs")
-        var metadata = CrawlMetadata()
-        metadata.pages["u1"] = PageMetadata(
+        var metadata = Shared.Models.CrawlMetadata()
+        metadata.pages["u1"] = Shared.Models.PageMetadata(
             url: "u1",
             framework: "accessibility",
             filePath: "\(foreignRoot)/cupertino/docs/accessibility/documentation_accessibility.json",
             contentHash: "h1",
             depth: 0
         )
-        metadata.pages["u2"] = PageMetadata(
+        metadata.pages["u2"] = Shared.Models.PageMetadata(
             url: "u2",
             framework: "swiftui",
             filePath: "\(foreignRoot)/some/swiftui/documentation_swiftui.json",
@@ -844,8 +844,8 @@ struct ResumeAndStartCleanTests {
     @Test("rebasePagePaths is idempotent — running twice does not change paths")
     func rebasePathsIdempotent() {
         let outputDir = URL(fileURLWithPath: "/Volumes/ClawSSD/.cupertino/docs")
-        var metadata = CrawlMetadata()
-        metadata.pages["u1"] = PageMetadata(
+        var metadata = Shared.Models.CrawlMetadata()
+        metadata.pages["u1"] = Shared.Models.PageMetadata(
             url: "u1",
             framework: "accessibility",
             filePath: "/Volumes/ClawSSD/.cupertino/docs/accessibility/documentation_accessibility.json",
@@ -872,7 +872,7 @@ struct ResumeAndStartCleanTests {
         // Stage 1: build a metadata.json that looks like it came from another
         // host. crawlState marks the session active; pages dict has foreign
         // filePaths but the actual files exist under outputDir.
-        var metadata = CrawlMetadata()
+        var metadata = Shared.Models.CrawlMetadata()
         for fw in ["accessibility", "swiftui", "foundation"] {
             let page = try Self.writeFixturePagesAndFile(
                 outputDir: outputDir,
@@ -882,12 +882,12 @@ struct ResumeAndStartCleanTests {
             )
             metadata.pages[page.url] = page
         }
-        metadata.crawlState = CrawlSessionState(
+        metadata.crawlState = Shared.Models.CrawlSessionState(
             visited: [
                 "https://developer.apple.com/documentation/accessibility",
                 "https://developer.apple.com/documentation/swiftui",
             ],
-            queue: [QueuedURL(url: "https://developer.apple.com/documentation/foundation", depth: 0)],
+            queue: [Shared.Models.QueuedURL(url: "https://developer.apple.com/documentation/foundation", depth: 0)],
             startURL: "https://developer.apple.com/documentation/",
             outputDirectory: "/Users/foreign/.cupertino/docs",
             sessionStartTime: Date(),
@@ -982,7 +982,7 @@ struct ResumeAndStartCleanTests {
             startURL: Self.seedURL
         )
 
-        let metadata = try CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
+        let metadata = try Shared.Models.CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
         #expect(metadata.crawlState != nil)
         let queue = metadata.crawlState?.queue ?? []
         #expect(queue.count == 3)
@@ -1015,7 +1015,7 @@ struct ResumeAndStartCleanTests {
             startURL: Self.seedURL
         )
 
-        let metadata = try CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
+        let metadata = try Shared.Models.CrawlMetadata.load(from: Self.metadataFile(in: tempDir))
         #expect(metadata.crawlState?.queue.count == 2)
     }
 
@@ -1048,7 +1048,7 @@ struct ResumeAndStartCleanTests {
             startURL: Self.seedURL
         )
 
-        let metadata = try CrawlMetadata.load(from: metaFile)
+        let metadata = try Shared.Models.CrawlMetadata.load(from: metaFile)
         let queue = metadata.crawlState?.queue ?? []
         #expect(queue.count == 4)
         // New URLs at the front, queued at depth 0 so descent follows

--- a/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
+++ b/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
@@ -49,7 +49,7 @@ struct SaveCommandTests {
         let searchDbPath = tempDir.appendingPathComponent("search.db")
         let searchIndex = try await Search.Index(dbPath: searchDbPath)
 
-        let metadata = try CrawlMetadata.load(from: tempDir.appendingPathComponent("metadata.json"))
+        let metadata = try Shared.Models.CrawlMetadata.load(from: tempDir.appendingPathComponent("metadata.json"))
         let builder = Search.IndexBuilder(
             searchIndex: searchIndex,
             metadata: metadata,
@@ -103,7 +103,7 @@ struct SaveCommandTests {
         let searchDbPath = tempDir.appendingPathComponent("search.db")
         let searchIndex = try await Search.Index(dbPath: searchDbPath)
 
-        let metadata = try CrawlMetadata.load(from: tempDir.appendingPathComponent("metadata.json"))
+        let metadata = try Shared.Models.CrawlMetadata.load(from: tempDir.appendingPathComponent("metadata.json"))
         let builder = Search.IndexBuilder(
             searchIndex: searchIndex,
             metadata: metadata,
@@ -142,7 +142,7 @@ struct SaveCommandTests {
         let searchIndex = try await Search.Index(dbPath: searchDbPath)
 
         // Create empty metadata
-        let emptyMetadata = CrawlMetadata()
+        let emptyMetadata = Shared.Models.CrawlMetadata()
         let metadataFile = tempDir.appendingPathComponent("metadata.json")
         try emptyMetadata.save(to: metadataFile)
 
@@ -179,7 +179,7 @@ struct SaveCommandTests {
         try FileManager.default.createDirectory(at: evolutionDir, withIntermediateDirectories: true)
 
         // Create minimal metadata
-        let metadata = CrawlMetadata()
+        let metadata = Shared.Models.CrawlMetadata()
         let metadataFile = baseDir.appendingPathComponent("metadata.json")
         try metadata.save(to: metadataFile)
 
@@ -234,7 +234,7 @@ struct SaveCommandTests {
         try FileManager.default.createDirectory(at: swiftDir, withIntermediateDirectories: true)
 
         // Create test JSON files (StructuredDocumentationPage format)
-        let arrayPage = try StructuredDocumentationPage(
+        let arrayPage = try Shared.Models.StructuredDocumentationPage(
             url: #require(URL(string: "https://developer.apple.com/documentation/swift/array")),
             title: "Array",
             kind: .struct,
@@ -243,9 +243,9 @@ struct SaveCommandTests {
             rawMarkdown: "# Array\n\nAn ordered collection of elements."
         )
         let arrayDoc = swiftDir.appendingPathComponent("array.json")
-        try JSONCoding.encode(arrayPage, to: arrayDoc)
+        try Shared.Utils.JSONCoding.encode(arrayPage, to: arrayDoc)
 
-        let dictPage = try StructuredDocumentationPage(
+        let dictPage = try Shared.Models.StructuredDocumentationPage(
             url: #require(URL(string: "https://developer.apple.com/documentation/swift/dictionary")),
             title: "Dictionary",
             kind: .struct,
@@ -254,13 +254,13 @@ struct SaveCommandTests {
             rawMarkdown: "# Dictionary\n\nA collection of key-value pairs."
         )
         let dictDoc = swiftDir.appendingPathComponent("dictionary.json")
-        try JSONCoding.encode(dictPage, to: dictDoc)
+        try Shared.Utils.JSONCoding.encode(dictPage, to: dictDoc)
 
         // Create swiftui directory
         let swiftuiDir = tempDir.appendingPathComponent("docs/swiftui")
         try FileManager.default.createDirectory(at: swiftuiDir, withIntermediateDirectories: true)
 
-        let viewPage = try StructuredDocumentationPage(
+        let viewPage = try Shared.Models.StructuredDocumentationPage(
             url: #require(URL(string: "https://developer.apple.com/documentation/swiftui/view")),
             title: "View",
             kind: .protocol,
@@ -269,7 +269,7 @@ struct SaveCommandTests {
             rawMarkdown: "# View\n\nA piece of user interface."
         )
         let viewDoc = swiftuiDir.appendingPathComponent("view.json")
-        try JSONCoding.encode(viewPage, to: viewDoc)
+        try Shared.Utils.JSONCoding.encode(viewPage, to: viewDoc)
 
         // Build index WITHOUT metadata.json
         let searchDbPath = tempDir.appendingPathComponent("search.db")
@@ -314,7 +314,7 @@ struct SaveCommandTests {
         let nestedDir = tempDir.appendingPathComponent("docs/foundation/collections")
         try FileManager.default.createDirectory(at: nestedDir, withIntermediateDirectories: true)
 
-        let nestedPage = try StructuredDocumentationPage(
+        let nestedPage = try Shared.Models.StructuredDocumentationPage(
             url: #require(URL(string: "https://developer.apple.com/documentation/foundation/nsarray")),
             title: "NSArray",
             kind: .class,
@@ -323,7 +323,7 @@ struct SaveCommandTests {
             rawMarkdown: "# NSArray\n\nFoundation array class."
         )
         let nestedDoc = nestedDir.appendingPathComponent("array.json")
-        try JSONCoding.encode(nestedPage, to: nestedDoc)
+        try Shared.Utils.JSONCoding.encode(nestedPage, to: nestedDoc)
 
         // Build index
         let searchDbPath = tempDir.appendingPathComponent("search.db")

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -51,14 +51,14 @@ struct MCPCommandTests {
         try "# Swift\n\nTest content about Swift language.".write(to: testFile, atomically: true, encoding: .utf8)
 
         // Create metadata.json for the test file
-        let pageMetadata = PageMetadata(
+        let pageMetadata = Shared.Models.PageMetadata(
             url: "https://developer.apple.com/documentation/swift",
             framework: "swift",
             filePath: testFile.path,
             contentHash: "test-hash",
             depth: 0
         )
-        let metadata = CrawlMetadata(pages: [pageMetadata.url: pageMetadata])
+        let metadata = Shared.Models.CrawlMetadata(pages: [pageMetadata.url: pageMetadata])
         let metadataFile = tempDir.appendingPathComponent("metadata.json")
         try metadata.save(to: metadataFile)
 
@@ -385,7 +385,7 @@ struct MCPServerIntegrationTests {
         let searchDbPath = tempDir.appendingPathComponent("search.db")
         let searchIndex = try await Search.Index(dbPath: searchDbPath)
 
-        let metadata = try CrawlMetadata.load(from: tempDir.appendingPathComponent("metadata.json"))
+        let metadata = try Shared.Models.CrawlMetadata.load(from: tempDir.appendingPathComponent("metadata.json"))
         let builder = Search.IndexBuilder(
             searchIndex: searchIndex,
             metadata: metadata,

--- a/Packages/Tests/CleanupTests/SampleCodeCleanerTests.swift
+++ b/Packages/Tests/CleanupTests/SampleCodeCleanerTests.swift
@@ -1,15 +1,16 @@
 @testable import Cleanup
 import Foundation
+import SharedConstants
 @testable import SharedCore
+import SharedModels
 import Testing
 import TestSupport
-import SharedModels
 
 // MARK: - SampleCodeCleaner Tests
 
 @Test("CleanupProgress percentage calculation")
 func cleanupProgressPercentage() {
-    let progress = CleanupProgress(
+    let progress = Shared.Models.CleanupProgress(
         current: 50,
         total: 100,
         currentFile: "test.zip",
@@ -23,7 +24,7 @@ func cleanupProgressPercentage() {
 
 @Test("CleanupProgress handles zero total")
 func cleanupProgressZeroTotal() {
-    let progress = CleanupProgress(
+    let progress = Shared.Models.CleanupProgress(
         current: 0,
         total: 0,
         currentFile: "test.zip",
@@ -37,7 +38,7 @@ func cleanupProgressZeroTotal() {
 
 @Test("CleanupStatistics space saved calculation")
 func cleanupStatisticsSpaceSaved() {
-    let stats = CleanupStatistics(
+    let stats = Shared.Models.CleanupStatistics(
         totalArchives: 10,
         cleanedArchives: 8,
         skippedArchives: 2,
@@ -53,7 +54,7 @@ func cleanupStatisticsSpaceSaved() {
 
 @Test("CleanupStatistics handles zero original size")
 func cleanupStatisticsZeroSize() {
-    let stats = CleanupStatistics(
+    let stats = Shared.Models.CleanupStatistics(
         totalArchives: 0,
         cleanedArchives: 0,
         skippedArchives: 0,
@@ -69,7 +70,7 @@ func cleanupStatisticsZeroSize() {
 
 @Test("CleanupResult initialization")
 func cleanupResultInit() {
-    let result = CleanupResult(
+    let result = Shared.Models.CleanupResult(
         filename: "test.zip",
         originalSize: 1000,
         cleanedSize: 500,
@@ -88,7 +89,7 @@ func cleanupResultInit() {
 
 @Test("CleanupResult with error")
 func cleanupResultWithError() {
-    let result = CleanupResult(
+    let result = Shared.Models.CleanupResult(
         filename: "test.zip",
         originalSize: 1000,
         cleanedSize: 1000,

--- a/Packages/Tests/CoreTests/CrawlerTests.swift
+++ b/Packages/Tests/CoreTests/CrawlerTests.swift
@@ -50,7 +50,7 @@ struct CrawlerTests {
     @Test("URLUtilities normalize preserves path but removes trailing slash")
     func urlNormalizePreservesPath() throws {
         let url = try #require(URL(string: "https://example.com/path/"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         // Normalization removes fragments, query params, and trailing slashes
         #expect(normalized?.path == "/path")
@@ -59,7 +59,7 @@ struct CrawlerTests {
     @Test("URLUtilities normalize removes fragments")
     func urlNormalizeRemovesFragments() throws {
         let url = try #require(URL(string: "https://example.com/path#section"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         #expect(normalized?.fragment == nil)
         #expect(try !#require(normalized?.absoluteString.contains("#")))
@@ -68,7 +68,7 @@ struct CrawlerTests {
     @Test("URLUtilities normalize removes query parameters")
     func urlNormalizeRemovesQueryParams() throws {
         let url = try #require(URL(string: "https://example.com/path?param=value"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         #expect(normalized?.query == nil)
         #expect(try !#require(normalized?.absoluteString.contains("?")))
@@ -79,15 +79,15 @@ struct CrawlerTests {
         let uppercase = try #require(URL(string: "https://developer.apple.com/documentation/Cinematic/CNAssetInfo-2ata2"))
         let lowercase = try #require(URL(string: "https://developer.apple.com/documentation/cinematic/cnassetinfo-2ata2"))
 
-        #expect(URLUtilities.normalize(uppercase) == URLUtilities.normalize(lowercase))
-        #expect(URLUtilities.normalize(uppercase)?.path == "/documentation/cinematic/cnassetinfo-2ata2")
+        #expect(Shared.Models.URLUtilities.normalize(uppercase) == Shared.Models.URLUtilities.normalize(lowercase))
+        #expect(Shared.Models.URLUtilities.normalize(uppercase)?.path == "/documentation/cinematic/cnassetinfo-2ata2")
     }
 
     @Test("URLUtilities normalize preserves method disambiguator dashes")
     func urlNormalizePreservesMethodDisambiguatorDashes() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/Cinematic/CNAssetInfo-2ata2"))
 
-        #expect(URLUtilities.normalize(url)?.lastPathComponent == "cnassetinfo-2ata2")
+        #expect(Shared.Models.URLUtilities.normalize(url)?.lastPathComponent == "cnassetinfo-2ata2")
     }
 
     @Test("URLUtilities normalize keeps underscores intact (installer_js safety)")
@@ -98,7 +98,7 @@ struct CrawlerTests {
         // entire installer_js framework on every crawl. Verify we never make
         // that change.
         let url = try #require(URL(string: "https://developer.apple.com/documentation/installer_js/license"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         #expect(normalized?.path == "/documentation/installer_js/license")
         #expect(try !#require(normalized?.absoluteString.contains("installer-js")))
@@ -107,7 +107,7 @@ struct CrawlerTests {
     @Test("URLUtilities normalize converts underscore sub-page slug to dash")
     func urlNormalizeConvertsUnderscoreSubpageToDash() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/corelocation/getting_heading_and_course_information"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         #expect(normalized?.path == "/documentation/corelocation/getting-heading-and-course-information")
     }
@@ -118,7 +118,7 @@ struct CrawlerTests {
         // The framework slug "driverkit" at depth 2 must be left untouched;
         // only "driverkit_constants" at depth 3 is collapsed to dashes.
         let url = try #require(URL(string: "https://developer.apple.com/documentation/driverkit/driverkit_constants"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         #expect(normalized?.path == "/documentation/driverkit/driverkit-constants")
     }
@@ -126,7 +126,7 @@ struct CrawlerTests {
     @Test("URLUtilities normalize converts underscores at multiple sub-page depths")
     func urlNormalizeConvertsUnderscoresAtMultipleDepths() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/swiftui/some_class/some_method"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         #expect(normalized?.path == "/documentation/swiftui/some-class/some-method")
     }
@@ -134,7 +134,7 @@ struct CrawlerTests {
     @Test("URLUtilities normalize does not touch non-documentation URL underscores")
     func urlNormalizeDoesNotTouchNonDocsPaths() throws {
         let url = try #require(URL(string: "https://developer.apple.com/videos/play/wwdc2023/10_video"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         #expect(normalized?.path == "/videos/play/wwdc2023/10_video")
     }
@@ -142,7 +142,7 @@ struct CrawlerTests {
     @Test("URLUtilities normalize strips fragment and query and collapses sub-page underscore")
     func urlNormalizeStripsFragmentQueryAndNormalizesUnderscore() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/swiftui/some_method?foo=1#bar"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         #expect(normalized?.path == "/documentation/swiftui/some-method")
         #expect(normalized?.query == nil)
@@ -152,7 +152,7 @@ struct CrawlerTests {
     @Test("URLUtilities normalize lowercases before collapsing underscore to dash")
     func urlNormalizeLowercasesBeforeCollapsingUnderscore() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/SwiftUI/Some_Method"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         #expect(normalized?.path == "/documentation/swiftui/some-method")
     }
@@ -162,7 +162,7 @@ struct CrawlerTests {
         // Regression: normalizeDocPath used to trap with "Range requires lowerBound <= upperBound"
         // when documentation was found but had fewer than 2 following path segments.
         let url = try #require(URL(string: "https://developer.apple.com/documentation"))
-        let normalized = URLUtilities.normalize(url)
+        let normalized = Shared.Models.URLUtilities.normalize(url)
 
         #expect(normalized?.path == "/documentation")
     }
@@ -172,7 +172,7 @@ struct CrawlerTests {
     @Test("URLUtilities extracts framework from Apple docs URL")
     func extractFrameworkFromAppleDocs() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/swift/array"))
-        let framework = URLUtilities.extractFramework(from: url)
+        let framework = Shared.Models.URLUtilities.extractFramework(from: url)
 
         #expect(framework == "swift")
     }
@@ -180,7 +180,7 @@ struct CrawlerTests {
     @Test("URLUtilities extracts framework from nested path")
     func extractFrameworkFromNestedPath() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/uikit/uiview/animator"))
-        let framework = URLUtilities.extractFramework(from: url)
+        let framework = Shared.Models.URLUtilities.extractFramework(from: url)
 
         #expect(framework == "uikit")
     }
@@ -188,7 +188,7 @@ struct CrawlerTests {
     @Test("URLUtilities returns root for non-documentation URLs")
     func extractFrameworkReturnsRootForNonDocs() throws {
         let url = try #require(URL(string: "https://example.com/some/path"))
-        let framework = URLUtilities.extractFramework(from: url)
+        let framework = Shared.Models.URLUtilities.extractFramework(from: url)
 
         #expect(framework == "root")
     }
@@ -198,7 +198,7 @@ struct CrawlerTests {
     @Test("URLUtilities generates filename from URL")
     func generateFilenameFromURL() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/swift/array"))
-        let filename = URLUtilities.filename(from: url)
+        let filename = Shared.Models.URLUtilities.filename(from: url)
 
         #expect(filename.contains("array"))
         #expect(!filename.contains("/")) // No slashes in filename
@@ -207,7 +207,7 @@ struct CrawlerTests {
     @Test("URLUtilities handles complex paths in filename")
     func generateFilenameFromComplexPath() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/uikit/uiview/1622417-addsubview"))
-        let filename = URLUtilities.filename(from: url)
+        let filename = Shared.Models.URLUtilities.filename(from: url)
 
         #expect(!filename.isEmpty)
         #expect(!filename.contains("/"))
@@ -219,8 +219,8 @@ struct CrawlerTests {
     func hashUtilitiesConsistentHash() {
         let content = "Test content for hashing"
 
-        let hash1 = HashUtilities.sha256(of: content)
-        let hash2 = HashUtilities.sha256(of: content)
+        let hash1 = Shared.Models.HashUtilities.sha256(of: content)
+        let hash2 = Shared.Models.HashUtilities.sha256(of: content)
 
         #expect(hash1 == hash2)
         #expect(hash1.count == 64) // SHA256 produces 64 hex characters
@@ -231,15 +231,15 @@ struct CrawlerTests {
         let content1 = "Content A"
         let content2 = "Content B"
 
-        let hash1 = HashUtilities.sha256(of: content1)
-        let hash2 = HashUtilities.sha256(of: content2)
+        let hash1 = Shared.Models.HashUtilities.sha256(of: content1)
+        let hash2 = Shared.Models.HashUtilities.sha256(of: content2)
 
         #expect(hash1 != hash2)
     }
 
     @Test("HashUtilities SHA256 handles empty string")
     func hashUtilitiesEmptyString() {
-        let hash = HashUtilities.sha256(of: "")
+        let hash = Shared.Models.HashUtilities.sha256(of: "")
 
         #expect(!hash.isEmpty)
         #expect(hash.count == 64)
@@ -249,7 +249,7 @@ struct CrawlerTests {
 
     @Test("CrawlStatistics initializes with zeros")
     func statisticsInitializesWithZeros() {
-        let stats = CrawlStatistics()
+        let stats = Shared.Models.CrawlStatistics()
 
         #expect(stats.totalPages == 0)
         #expect(stats.newPages == 0)
@@ -260,7 +260,7 @@ struct CrawlerTests {
 
     @Test("CrawlStatistics is Codable")
     func statisticsIsCodable() throws {
-        var stats = CrawlStatistics()
+        var stats = Shared.Models.CrawlStatistics()
         stats.totalPages = 100
         stats.newPages = 50
         stats.updatedPages = 30
@@ -273,7 +273,7 @@ struct CrawlerTests {
         let data = try encoder.encode(stats)
 
         let decoder = JSONDecoder()
-        let decoded = try decoder.decode(CrawlStatistics.self, from: data)
+        let decoded = try decoder.decode(Shared.Models.CrawlStatistics.self, from: data)
 
         #expect(decoded.totalPages == 100)
         #expect(decoded.newPages == 50)
@@ -286,7 +286,7 @@ struct CrawlerTests {
 
     @Test("CrawlProgress calculates percentage")
     func progressCalculatesPercentage() throws {
-        let stats = CrawlStatistics()
+        let stats = Shared.Models.CrawlStatistics()
         let progress = try CrawlProgress(
             currentURL: #require(URL(string: "https://example.com")),
             visitedCount: 10,
@@ -388,16 +388,16 @@ struct CrawlerTests {
         let lapackURL = try #require(URL(string: "https://developer.apple.com/documentation/accelerate/lapack-functions"))
 
         // The URL should normalize correctly
-        let normalized = URLUtilities.normalize(lapackURL)
+        let normalized = Shared.Models.URLUtilities.normalize(lapackURL)
         #expect(normalized != nil)
         #expect(normalized?.absoluteString == "https://developer.apple.com/documentation/accelerate/lapack-functions")
 
         // Framework extraction should work
-        let framework = URLUtilities.extractFramework(from: lapackURL)
+        let framework = Shared.Models.URLUtilities.extractFramework(from: lapackURL)
         #expect(framework == "accelerate")
 
         // Filename generation should work
-        let filename = URLUtilities.filename(from: lapackURL)
+        let filename = Shared.Models.URLUtilities.filename(from: lapackURL)
         #expect(filename.contains("lapack-functions") || filename.contains("lapack_functions"))
     }
 

--- a/Packages/Tests/CoreTests/CupertinoCoreTests.swift
+++ b/Packages/Tests/CoreTests/CupertinoCoreTests.swift
@@ -338,7 +338,7 @@ private func logTestStart(config: Shared.Configuration) {
     print("   Output: \(config.crawler.outputDirectory.path)")
 }
 
-private func verifyBasicStats(_ stats: CrawlStatistics) throws {
+private func verifyBasicStats(_ stats: Shared.Models.CrawlStatistics) throws {
     #expect(stats.totalPages > 0, "Should have crawled at least 1 page")
     #expect(stats.newPages > 0, "Should have at least 1 new page")
     print("   ✅ Crawled \(stats.totalPages) page(s)")
@@ -394,7 +394,7 @@ private func verifyMetadata(_ metadataFile: URL) throws {
     #expect(FileManager.default.fileExists(atPath: metadataFile.path), "Metadata file should be created")
 
     if FileManager.default.fileExists(atPath: metadataFile.path) {
-        let metadata = try CrawlMetadata.load(from: metadataFile)
+        let metadata = try Shared.Models.CrawlMetadata.load(from: metadataFile)
         #expect(!metadata.pages.isEmpty, "Metadata should contain page information")
         print("   ✅ Metadata created with \(metadata.pages.count) page(s)")
     }
@@ -436,15 +436,15 @@ func crawlerStateLoadsExistingMetadata() async throws {
     try "# Doc 2".write(to: doc2Path, atomically: true, encoding: .utf8)
 
     // Create initial metadata with some pages (file paths must match real files)
-    var metadata = CrawlMetadata()
-    metadata.pages["https://example.com/doc1"] = PageMetadata(
+    var metadata = Shared.Models.CrawlMetadata()
+    metadata.pages["https://example.com/doc1"] = Shared.Models.PageMetadata(
         url: "https://example.com/doc1",
         framework: "test",
         filePath: doc1Path.path,
         contentHash: "hash1",
         depth: 0
     )
-    metadata.pages["https://example.com/doc2"] = PageMetadata(
+    metadata.pages["https://example.com/doc2"] = Shared.Models.PageMetadata(
         url: "https://example.com/doc2",
         framework: "test",
         filePath: doc2Path.path,
@@ -503,8 +503,8 @@ func crawlerStateShouldRecrawlContentChanged() async throws {
     // Create file and metadata
     try "Original content".write(to: outputFile, atomically: true, encoding: .utf8)
 
-    var metadata = CrawlMetadata()
-    metadata.pages["https://example.com/doc"] = PageMetadata(
+    var metadata = Shared.Models.CrawlMetadata()
+    metadata.pages["https://example.com/doc"] = Shared.Models.PageMetadata(
         url: "https://example.com/doc",
         framework: "test",
         filePath: outputFile.path,
@@ -544,8 +544,8 @@ func crawlerStateShouldRecrawlSkipsUnchanged() async throws {
     // Create file and metadata
     try "Content".write(to: outputFile, atomically: true, encoding: .utf8)
 
-    var metadata = CrawlMetadata()
-    metadata.pages["https://example.com/doc"] = PageMetadata(
+    var metadata = Shared.Models.CrawlMetadata()
+    metadata.pages["https://example.com/doc"] = Shared.Models.PageMetadata(
         url: "https://example.com/doc",
         framework: "test",
         filePath: outputFile.path,
@@ -583,8 +583,8 @@ func crawlerStateShouldRecrawlMissingFile() async throws {
     let outputFile = tempDir.appendingPathComponent("missing.md")
 
     // Create metadata but NOT the file
-    var metadata = CrawlMetadata()
-    metadata.pages["https://example.com/doc"] = PageMetadata(
+    var metadata = Shared.Models.CrawlMetadata()
+    metadata.pages["https://example.com/doc"] = Shared.Models.PageMetadata(
         url: "https://example.com/doc",
         framework: "test",
         filePath: outputFile.path,
@@ -624,8 +624,8 @@ func crawlerStateForceRecrawl() async throws {
     // Create file and metadata
     try "Content".write(to: outputFile, atomically: true, encoding: .utf8)
 
-    var metadata = CrawlMetadata()
-    metadata.pages["https://example.com/doc"] = PageMetadata(
+    var metadata = Shared.Models.CrawlMetadata()
+    metadata.pages["https://example.com/doc"] = Shared.Models.PageMetadata(
         url: "https://example.com/doc",
         framework: "test",
         filePath: outputFile.path,
@@ -665,8 +665,8 @@ func crawlerStateDisabledChangeDetection() async throws {
     // Create file and metadata
     try "Content".write(to: outputFile, atomically: true, encoding: .utf8)
 
-    var metadata = CrawlMetadata()
-    metadata.pages["https://example.com/doc"] = PageMetadata(
+    var metadata = Shared.Models.CrawlMetadata()
+    metadata.pages["https://example.com/doc"] = Shared.Models.PageMetadata(
         url: "https://example.com/doc",
         framework: "test",
         filePath: outputFile.path,
@@ -829,7 +829,7 @@ func crawlerStateFinalizeAndSave() async throws {
         depth: 0
     )
 
-    let stats = CrawlStatistics(
+    let stats = Shared.Models.CrawlStatistics(
         totalPages: 5,
         newPages: 3,
         updatedPages: 1,
@@ -846,7 +846,7 @@ func crawlerStateFinalizeAndSave() async throws {
     #expect(FileManager.default.fileExists(atPath: metadataFile.path))
 
     // Verify we can load it back
-    let loadedMetadata = try CrawlMetadata.load(from: metadataFile)
+    let loadedMetadata = try Shared.Models.CrawlMetadata.load(from: metadataFile)
     #expect(loadedMetadata.pages.count == 1)
     #expect(loadedMetadata.stats.totalPages == 5)
     #expect(loadedMetadata.lastCrawl != nil)
@@ -921,9 +921,9 @@ func hashUtilitiesSHA256Consistency() {
     let content2 = "Hello, World!"
     let content3 = "Different content"
 
-    let hash1 = HashUtilities.sha256(of: content1)
-    let hash2 = HashUtilities.sha256(of: content2)
-    let hash3 = HashUtilities.sha256(of: content3)
+    let hash1 = Shared.Models.HashUtilities.sha256(of: content1)
+    let hash2 = Shared.Models.HashUtilities.sha256(of: content2)
+    let hash3 = Shared.Models.HashUtilities.sha256(of: content3)
 
     // Same content should produce same hash
     #expect(hash1 == hash2)

--- a/Packages/Tests/CoreTests/RefResolverTests.swift
+++ b/Packages/Tests/CoreTests/RefResolverTests.swift
@@ -2,6 +2,7 @@
 @testable import CoreJSONParser
 import CoreProtocols
 import Foundation
+import SharedConstants
 @testable import SharedCore
 import SharedModels
 import Testing
@@ -143,13 +144,13 @@ struct RefResolverEndToEnd {
         // Page A: lists Page B in its sections (so Page B's title gets harvested
         // from A's items). A's rawMarkdown contains a doc:// marker pointing to B.
         let pageBURL = URL(string: "https://developer.apple.com/documentation/StoreKit/AnyTransaction")!
-        let pageA = StructuredDocumentationPage(
+        let pageA = Shared.Models.StructuredDocumentationPage(
             url: URL(string: "https://developer.apple.com/documentation/StoreKit")!,
             title: "StoreKit",
             kind: .framework,
             source: .appleJSON,
             sections: [
-                StructuredDocumentationPage.Section(
+                Shared.Models.StructuredDocumentationPage.Section(
                     title: "Topics",
                     items: [
                         .init(name: "AnyTransaction", description: nil, url: pageBURL),
@@ -161,7 +162,7 @@ struct RefResolverEndToEnd {
             crawledAt: Date(),
             contentHash: "hashA"
         )
-        let pageB = StructuredDocumentationPage(
+        let pageB = Shared.Models.StructuredDocumentationPage(
             url: pageBURL,
             title: "AnyTransaction",
             kind: .struct,
@@ -201,7 +202,7 @@ struct RefResolverEndToEnd {
         let pageAData = try Data(contentsOf: tmp.appendingPathComponent("storekit_a.json"))
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        let pageA = try decoder.decode(StructuredDocumentationPage.self, from: pageAData)
+        let pageA = try decoder.decode(Shared.Models.StructuredDocumentationPage.self, from: pageAData)
         #expect(pageA.rawMarkdown?.contains("[AnyTransaction]") == true)
         #expect(pageA.rawMarkdown?.contains("Phantom") == true) // still present, unresolved
         #expect(pageA.contentHash == "hashA") // resolve-refs must NOT bump contentHash
@@ -329,10 +330,10 @@ struct RefResolverNetwork {
         #expect(url?.absoluteString == "https://developer.apple.com/documentation/storekit/anytransaction")
     }
 
-    private static func loadPageA(in tmp: URL) throws -> StructuredDocumentationPage {
+    private static func loadPageA(in tmp: URL) throws -> Shared.Models.StructuredDocumentationPage {
         let data = try Data(contentsOf: tmp.appendingPathComponent("storekit_a.json"))
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        return try decoder.decode(StructuredDocumentationPage.self, from: data)
+        return try decoder.decode(Shared.Models.StructuredDocumentationPage.self, from: data)
     }
 }

--- a/Packages/Tests/CoreTests/ResolverPipelineTests.swift
+++ b/Packages/Tests/CoreTests/ResolverPipelineTests.swift
@@ -12,7 +12,7 @@ import Testing
 
 @Test("ResolvedPackagesStore.checksum: same inputs yield same checksum")
 func checksumStable() {
-    let seeds: [PackageReference] = [
+    let seeds: [Shared.Models.PackageReference] = [
         .init(owner: "apple", repo: "swift-nio", url: "https://github.com/apple/swift-nio", priority: .appleOfficial),
         .init(owner: "vapor", repo: "vapor", url: "https://github.com/vapor/vapor", priority: .ecosystem),
     ]
@@ -42,7 +42,7 @@ func checksumSeedOrderAgnostic() {
 
 @Test("ResolvedPackagesStore.checksum: adding a seed changes the checksum")
 func checksumAddedSeedInvalidates() {
-    let base: [PackageReference] = [
+    let base: [Shared.Models.PackageReference] = [
         .init(owner: "apple", repo: "swift-nio", url: "", priority: .appleOfficial),
     ]
     let extended = base + [
@@ -55,7 +55,7 @@ func checksumAddedSeedInvalidates() {
 
 @Test("ResolvedPackagesStore.checksum: adding an exclusion changes the checksum")
 func checksumAddedExclusionInvalidates() {
-    let seeds: [PackageReference] = [
+    let seeds: [Shared.Models.PackageReference] = [
         .init(owner: "apple", repo: "swift-nio", url: "", priority: .appleOfficial),
     ]
     let a = Core.ResolvedPackagesStore.checksum(seeds: seeds, exclusions: [])
@@ -226,7 +226,7 @@ func resolverSeedIsSelfParent() async throws {
     )
 
     let resolver = Core.PackageDependencyResolver(canonicalizer: canonicalizer)
-    let seeds: [PackageReference] = [
+    let seeds: [Shared.Models.PackageReference] = [
         .init(owner: "apple", repo: "only-seed", url: "https://github.com/apple/only-seed", priority: .appleOfficial),
     ]
     // No Package.swift will be found for a fake repo → missing manifest, seed still
@@ -254,7 +254,7 @@ func resolverExcludesSeed() async throws {
         canonicalizer: canonicalizer,
         exclusions: ["apple/only-seed"]
     )
-    let seeds: [PackageReference] = [
+    let seeds: [Shared.Models.PackageReference] = [
         .init(owner: "apple", repo: "only-seed", url: "https://github.com/apple/only-seed", priority: .appleOfficial),
     ]
     let (packages, stats) = await resolver.resolve(seeds: seeds)
@@ -454,7 +454,7 @@ struct ResolverNetworkIntegration {
             concurrency: 4
         )
 
-        let seeds: [PackageReference] = [
+        let seeds: [Shared.Models.PackageReference] = [
             .init(
                 owner: "pointfreeco",
                 repo: "swift-composable-architecture",
@@ -493,7 +493,7 @@ struct ResolverNetworkIntegration {
             rootDirectory: tempDir.appendingPathComponent("manifests")
         )
 
-        let seeds: [PackageReference] = [
+        let seeds: [Shared.Models.PackageReference] = [
             .init(
                 owner: "pointfreeco",
                 repo: "swift-dependencies",
@@ -544,7 +544,7 @@ func resolverCanonicalizeDedupes() async throws {
     )
 
     let resolver = Core.PackageDependencyResolver(canonicalizer: canonicalizer)
-    let seeds: [PackageReference] = [
+    let seeds: [Shared.Models.PackageReference] = [
         .init(owner: "fakealias", repo: "only", url: "https://github.com/fakealias/only", priority: .appleOfficial),
         .init(owner: "canonicalfake", repo: "only", url: "https://github.com/canonicalfake/only", priority: .appleOfficial),
     ]

--- a/Packages/Tests/DistributionTests/BackupTests.swift
+++ b/Packages/Tests/DistributionTests/BackupTests.swift
@@ -1,8 +1,8 @@
 @testable import Distribution
 import Foundation
+import SharedConstants
 @testable import SharedCore
 import Testing
-import SharedConstants
 
 // MARK: - Backup-existing-DBs (#249)
 

--- a/Packages/Tests/DistributionTests/InstalledVersionTests.swift
+++ b/Packages/Tests/DistributionTests/InstalledVersionTests.swift
@@ -1,8 +1,8 @@
 @testable import Distribution
 import Foundation
+import SharedConstants
 @testable import SharedCore
 import Testing
-import SharedConstants
 
 // MARK: - Status classification (#168, lifted to Distribution in #246)
 

--- a/Packages/Tests/DistributionTests/SetupProgressTests.swift
+++ b/Packages/Tests/DistributionTests/SetupProgressTests.swift
@@ -1,8 +1,8 @@
 import Foundation
-@testable import SharedCore
-import Testing
 import SharedConstants
+@testable import SharedCore
 import SharedUtils
+import Testing
 
 // MARK: - Progress Output Capture
 
@@ -125,9 +125,9 @@ struct SetupProgressFormatTests {
     @Test("Byte formatting")
     func byteFormatting() {
         // Test the shared formatting utility
-        let kb = Shared.Formatting.formatBytes(1024)
-        let mb = Shared.Formatting.formatBytes(1024 * 1024)
-        let gb = Shared.Formatting.formatBytes(1024 * 1024 * 1024)
+        let kb = Shared.Utils.Formatting.formatBytes(1024)
+        let mb = Shared.Utils.Formatting.formatBytes(1024 * 1024)
+        let gb = Shared.Utils.Formatting.formatBytes(1024 * 1024 * 1024)
 
         #expect(kb.contains("KB") || kb.contains("1"))
         #expect(mb.contains("MB") || mb.contains("1"))
@@ -324,7 +324,7 @@ private final class TestDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
 
         // If size unknown, show indeterminate progress
         guard totalBytesExpectedToWrite > 0 else {
-            let downloaded = Shared.Formatting.formatBytes(totalBytesWritten)
+            let downloaded = Shared.Utils.Formatting.formatBytes(totalBytesWritten)
             let output = "\(clearLine)   \(currentSpinner) Downloading... \(downloaded)"
             onProgress(output)
             return
@@ -336,8 +336,8 @@ private final class TestDownloadDelegate: NSObject, URLSessionDownloadDelegate, 
 
         let bar = String(repeating: "█", count: filled) + String(repeating: "░", count: empty)
         let percent = String(format: "%3.0f%%", progress * 100)
-        let downloaded = Shared.Formatting.formatBytes(totalBytesWritten)
-        let total = Shared.Formatting.formatBytes(totalBytesExpectedToWrite)
+        let downloaded = Shared.Utils.Formatting.formatBytes(totalBytesWritten)
+        let total = Shared.Utils.Formatting.formatBytes(totalBytesExpectedToWrite)
 
         let output = "\(clearLine)   \(currentSpinner) [\(bar)] \(percent) (\(downloaded)/\(total))"
         onProgress(output)

--- a/Packages/Tests/IngestTests/SessionTests.swift
+++ b/Packages/Tests/IngestTests/SessionTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 @testable import Ingest
+import SharedConstants
 @testable import SharedCore
 import Testing
-import SharedConstants
 
 // MARK: - Ingest.Session smoke tests (#247 sub-PR 4a)
 
@@ -39,7 +39,7 @@ struct CheckForSessionSmokeTests {
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
 
-        let url = URL(string: "https://example.com/")!
+        let url = try #require(URL(string: "https://example.com/"))
         #expect(Ingest.Session.checkForSession(at: dir, matching: url) == nil)
     }
 }

--- a/Packages/Tests/MCP/SupportTests/DocsResourceProviderMalformedURLSkipTests.swift
+++ b/Packages/Tests/MCP/SupportTests/DocsResourceProviderMalformedURLSkipTests.swift
@@ -42,21 +42,21 @@ struct DocsResourceProviderMalformedURLSkipTests {
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
 
-        let goodPage = PageMetadata(
+        let goodPage = Shared.Models.PageMetadata(
             url: "https://developer.apple.com/documentation/swiftui/list",
             framework: "swiftui",
             filePath: "/dev/null",
             contentHash: "good",
             depth: 0
         )
-        let badPage = PageMetadata(
+        let badPage = Shared.Models.PageMetadata(
             url: "",
             framework: "swiftui",
             filePath: "/dev/null",
             contentHash: "bad",
             depth: 0
         )
-        let metadata = CrawlMetadata(pages: [
+        let metadata = Shared.Models.CrawlMetadata(pages: [
             "https://developer.apple.com/documentation/swiftui/list": goodPage,
             "": badPage,
         ])
@@ -88,14 +88,14 @@ struct DocsResourceProviderMalformedURLSkipTests {
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
 
-        let badPage = PageMetadata(
+        let badPage = Shared.Models.PageMetadata(
             url: "",
             framework: "swiftui",
             filePath: "/dev/null",
             contentHash: "bad",
             depth: 0
         )
-        let metadata = CrawlMetadata(pages: ["": badPage])
+        let metadata = Shared.Models.CrawlMetadata(pages: ["": badPage])
 
         let provider = makeProvider(in: tempRoot)
         await provider.injectMetadataForTesting(metadata)

--- a/Packages/Tests/MockAIAgentTests/MCPIntegrationTests.swift
+++ b/Packages/Tests/MockAIAgentTests/MCPIntegrationTests.swift
@@ -338,7 +338,7 @@ struct TimeoutError: Error {}
 ///    `~/.cupertino-dev/`. That keeps day-to-day development data away
 ///    from the production `~/.cupertino/`. Integration tests run inside a
 ///    test bundle where `Bundle.main.executableURL` is the test runner
-///    (not cupertino), so `Shared.BinaryConfig.shared` resolves to
+///    (not cupertino), so `Shared.Constants.BinaryConfig.shared` resolves to
 ///    `~/.cupertino/`. The path mismatch makes the test create a
 ///    fixture DB at `~/.cupertino/samples.db` while the spawned cupertino
 ///    looks for `~/.cupertino-dev/samples.db`. This fixture moves the

--- a/Packages/Tests/SampleIndexTests/SampleIndexBasePathDerivationTests.swift
+++ b/Packages/Tests/SampleIndexTests/SampleIndexBasePathDerivationTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 @testable import SampleIndex
+import SharedConstants
 import SharedCore
 import Testing
-import SharedConstants
 
 /// Companion to `BasePathDerivationTests` in SharedTests, covering the
 /// SampleIndex-side defaults. Asserts that the samples database path and the

--- a/Packages/Tests/SearchTests/CodeExampleSymbolsTests.swift
+++ b/Packages/Tests/SearchTests/CodeExampleSymbolsTests.swift
@@ -1,9 +1,10 @@
 import Foundation
 @testable import Search
+import SharedConstants
 import SharedCore
+import SharedModels
 import SQLite3
 import Testing
-import SharedModels
 
 // AST extraction over stored `doc_code_examples` (#192 section D).
 //
@@ -192,13 +193,13 @@ struct CodeExampleSymbolsTests {
         let uri = "apple-docs://swiftui/observable"
         let index = try await Search.Index(dbPath: dbPath)
 
-        let page = try StructuredDocumentationPage(
+        let page = try Shared.Models.StructuredDocumentationPage(
             url: #require(URL(string: "https://developer.apple.com/documentation/swiftui/observable")),
             title: "Observable",
             kind: .protocol,
             source: .appleJSON,
             abstract: "An object that announces changes to its properties.",
-            declaration: StructuredDocumentationPage.Declaration(code: "@MainActor public protocol Observable {}"),
+            declaration: Shared.Models.StructuredDocumentationPage.Declaration(code: "@MainActor public protocol Observable {}"),
             language: "swift",
             crawledAt: Date(),
             contentHash: "test"

--- a/Packages/Tests/SearchTests/CupertinoSearchTests.swift
+++ b/Packages/Tests/SearchTests/CupertinoSearchTests.swift
@@ -1,9 +1,9 @@
 import Foundation
 @testable import Search
+import SharedConstants
 @testable import SharedCore
 import Testing
 import TestSupport
-import SharedConstants
 
 // MARK: - Test Helpers
 

--- a/Packages/Tests/SearchTests/DocKindTests.swift
+++ b/Packages/Tests/SearchTests/DocKindTests.swift
@@ -1,9 +1,9 @@
 // swiftlint:disable identifier_name
 import Foundation
 @testable import Search
+import SharedConstants
 @testable import SharedCore
 import Testing
-import SharedConstants
 
 // MARK: - DocKind taxonomy (#192 section C1)
 

--- a/Packages/Tests/SearchTests/IndexBuilderDeduplicationTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderDeduplicationTests.swift
@@ -1,8 +1,9 @@
 import Foundation
 @testable import Search
+import SharedConstants
 import SharedCore
-import Testing
 import SharedModels
+import Testing
 
 // Regression coverage for `Search.IndexBuilder.deduplicateDocFilesByCanonicalURL`
 // (#200). The dedup helper reads `crawledAt` out of saved
@@ -31,18 +32,18 @@ struct IndexBuilderDeduplicationTests {
         // vs dash framework variants pre-fix). Distinct filenames so the test
         // is FS-case-insensitivity-independent (macOS HFS+ default would
         // otherwise collapse them before dedup runs).
-        let sharedCanonicalURL = URL(string: "https://developer.apple.com/documentation/swiftui/list")!
+        let sharedCanonicalURL = try #require(URL(string: "https://developer.apple.com/documentation/swiftui/list"))
 
         let older = try writeFixtureDoc(
             url: sharedCanonicalURL,
-            crawledAt: Date(timeIntervalSince1970: 1_700_000_000),
+            crawledAt: Date(timeIntervalSince1970: 1700000000),
             into: docsDir,
             framework: "swiftui",
             name: "list"
         )
         let newer = try writeFixtureDoc(
             url: sharedCanonicalURL,
-            crawledAt: Date(timeIntervalSince1970: 1_800_000_000),
+            crawledAt: Date(timeIntervalSince1970: 1800000000),
             into: docsDir,
             framework: "swiftui",
             name: "list-copy"
@@ -53,7 +54,7 @@ struct IndexBuilderDeduplicationTests {
         // (i.e. the JSON decode silently fails because `.iso8601` isn't set),
         // it would now incorrectly keep `older`. With `.iso8601` working,
         // dedup reads `crawledAt` from the JSON directly and keeps `newer`.
-        let inFuture = Date().addingTimeInterval(86_400)
+        let inFuture = Date().addingTimeInterval(86400)
         try FileManager.default.setAttributes(
             [.modificationDate: inFuture],
             ofItemAtPath: older.path
@@ -83,7 +84,7 @@ struct IndexBuilderDeduplicationTests {
         try FileManager.default.createDirectory(at: docsDir, withIntermediateDirectories: true)
 
         let file = try writeFixtureDoc(
-            url: URL(string: "https://developer.apple.com/documentation/swiftui/list")!,
+            url: #require(URL(string: "https://developer.apple.com/documentation/swiftui/list")),
             crawledAt: Date(),
             into: docsDir,
             framework: "swiftui",
@@ -114,14 +115,14 @@ struct IndexBuilderDeduplicationTests {
         try FileManager.default.createDirectory(at: docsDir, withIntermediateDirectories: true)
 
         let listView = try writeFixtureDoc(
-            url: URL(string: "https://developer.apple.com/documentation/swiftui/list")!,
+            url: #require(URL(string: "https://developer.apple.com/documentation/swiftui/list")),
             crawledAt: Date(),
             into: docsDir,
             framework: "swiftui",
             name: "list"
         )
         let textField = try writeFixtureDoc(
-            url: URL(string: "https://developer.apple.com/documentation/swiftui/textfield")!,
+            url: #require(URL(string: "https://developer.apple.com/documentation/swiftui/textfield")),
             crawledAt: Date(),
             into: docsDir,
             framework: "swiftui",
@@ -151,9 +152,9 @@ struct IndexBuilderDeduplicationTests {
         let docsDir = tempRoot.appendingPathComponent("docs")
         try FileManager.default.createDirectory(at: docsDir, withIntermediateDirectories: true)
 
-        let knownDate = Date(timeIntervalSince1970: 1_750_000_000)
+        let knownDate = Date(timeIntervalSince1970: 1750000000)
         let file = try writeFixtureDoc(
-            url: URL(string: "https://developer.apple.com/documentation/swiftui/view")!,
+            url: #require(URL(string: "https://developer.apple.com/documentation/swiftui/view")),
             crawledAt: knownDate,
             into: docsDir,
             framework: "swiftui",
@@ -188,7 +189,7 @@ private func writeFixtureDoc(
     let frameworkDir = directory.appendingPathComponent(framework)
     try FileManager.default.createDirectory(at: frameworkDir, withIntermediateDirectories: true)
 
-    let page = StructuredDocumentationPage(
+    let page = Shared.Models.StructuredDocumentationPage(
         url: url,
         title: "Sample",
         kind: .struct,

--- a/Packages/Tests/SearchTests/IndexBuilderMalformedURLSkipTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderMalformedURLSkipTests.swift
@@ -1,8 +1,9 @@
 import Foundation
 @testable import Search
+import SharedConstants
 import SharedCore
-import Testing
 import SharedModels
+import Testing
 
 // Covers the malformed-URL skip path added to
 // `Search.IndexBuilder.indexAppleDocsFromMetadata` in PR #288. The skip
@@ -40,14 +41,14 @@ struct IndexBuilderMalformedURLSkipTests {
         try "# Good page\n\nHello, well-formed.".write(to: goodFile, atomically: true, encoding: .utf8)
         try "# Bad page\n\nHello, malformed-key.".write(to: badFile, atomically: true, encoding: .utf8)
 
-        let goodMetadata = PageMetadata(
+        let goodMetadata = Shared.Models.PageMetadata(
             url: "https://developer.apple.com/documentation/swiftui/list",
             framework: "swiftui",
             filePath: goodFile.path,
             contentHash: "good-hash",
             depth: 0
         )
-        let badMetadata = PageMetadata(
+        let badMetadata = Shared.Models.PageMetadata(
             url: "",
             framework: "swiftui",
             filePath: badFile.path,
@@ -55,7 +56,7 @@ struct IndexBuilderMalformedURLSkipTests {
             depth: 0
         )
 
-        let crawlMetadata = CrawlMetadata(
+        let crawlMetadata = Shared.Models.CrawlMetadata(
             pages: [
                 "https://developer.apple.com/documentation/swiftui/list": goodMetadata,
                 "": badMetadata,
@@ -92,14 +93,14 @@ struct IndexBuilderMalformedURLSkipTests {
         let onlyFile = docsDir.appendingPathComponent("only.md")
         try "# Bad page".write(to: onlyFile, atomically: true, encoding: .utf8)
 
-        let onlyMetadata = PageMetadata(
+        let onlyMetadata = Shared.Models.PageMetadata(
             url: "",
             framework: "swiftui",
             filePath: onlyFile.path,
             contentHash: "h",
             depth: 0
         )
-        let crawlMetadata = CrawlMetadata(pages: ["": onlyMetadata])
+        let crawlMetadata = Shared.Models.CrawlMetadata(pages: ["": onlyMetadata])
 
         let dbPath = tempRoot.appendingPathComponent("search.db")
         let index = try await Search.Index(dbPath: dbPath)

--- a/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
@@ -1,12 +1,13 @@
 import Core
+import CoreProtocols
 import Foundation
 import Logging
 @testable import Search
+import SharedConstants
 import SharedCore
+import SharedModels
 import SQLite3
 import Testing
-import SharedModels
-import CoreProtocols
 
 // End-to-end test that a real `Search.IndexBuilder` run on a fixture
 // directory of structured JSON docs produces populated `doc_symbols` rows,
@@ -83,13 +84,13 @@ private func writeFixtureDoc(framework: String, name: String, into directory: UR
     let frameworkDir = directory.appendingPathComponent(framework)
     try FileManager.default.createDirectory(at: frameworkDir, withIntermediateDirectories: true)
 
-    let page = StructuredDocumentationPage(
+    let page = Shared.Models.StructuredDocumentationPage(
         url: URL(string: "https://developer.apple.com/documentation/\(framework)/\(name)")!,
         title: "Sample page",
         kind: .protocol,
         source: .appleJSON,
         abstract: "An example doc with both a declaration and a Swift code block.",
-        declaration: StructuredDocumentationPage.Declaration(code: "public protocol DeclaredProtocol {}"),
+        declaration: Shared.Models.StructuredDocumentationPage.Declaration(code: "public protocol DeclaredProtocol {}"),
         overview: "Overview text.",
         sections: [],
         codeExamples: [

--- a/Packages/Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift
@@ -1,9 +1,10 @@
 import Foundation
 @testable import Search
+import SharedConstants
 import SharedCore
-import Testing
 import SharedModels
 import SharedUtils
+import Testing
 
 // Truth-table coverage for `Search.IndexBuilder.titleLooksLikeHTTPErrorTemplate`,
 // the indexer-side defense added as a belt-and-suspenders to PR #289's
@@ -120,12 +121,12 @@ struct IndexBuilderJavaScriptFallbackDefenseTests {
 
     private static func makePage(
         title: String = "AVCustomMediaSelectionScheme",
-        kind: StructuredDocumentationPage.Kind = .class,
-        source: StructuredDocumentationPage.Source = .appleJSON,
+        kind: Shared.Models.StructuredDocumentationPage.Kind = .class,
+        source: Shared.Models.StructuredDocumentationPage.Source = .appleJSON,
         overview: String? = nil,
         rawMarkdown: String? = nil
-    ) -> StructuredDocumentationPage {
-        StructuredDocumentationPage(
+    ) -> Shared.Models.StructuredDocumentationPage {
+        Shared.Models.StructuredDocumentationPage(
             url: URL.knownGood("https://developer.apple.com/documentation/test"),
             title: title,
             kind: kind,

--- a/Packages/Tests/SearchTests/PackageIndexTests.swift
+++ b/Packages/Tests/SearchTests/PackageIndexTests.swift
@@ -1,12 +1,12 @@
 // swiftlint:disable identifier_name
 @testable import Core
+@testable import CorePackageIndexing
+import CoreProtocols
 import Foundation
 @testable import Search
 import SharedCore
 import SQLite3
 import Testing
-import CoreProtocols
-@testable import CorePackageIndexing
 
 // MARK: - PackageIndexTests
 

--- a/Packages/Tests/SearchTests/SmartQueryIntentRoutingTests.swift
+++ b/Packages/Tests/SearchTests/SmartQueryIntentRoutingTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 @testable import Search
+import SharedConstants
 import SharedCore
 import Testing
-import SharedConstants
 
 // Intent routing for cross-source smart query (#254).
 //

--- a/Packages/Tests/SearchTests/VersionFilterTests.swift
+++ b/Packages/Tests/SearchTests/VersionFilterTests.swift
@@ -112,14 +112,14 @@ struct VersionFilterTests {
 
     // MARK: - Platform-Specific Filters (Parameterized)
 
-    struct PlatformTestCase: Sendable {
+    struct PlatformTestCase {
         let name: String
         let platform: Platform
         let apiVersion: String
         let excludedTarget: String
         let matchingTarget: String
 
-        enum Platform: Sendable {
+        enum Platform {
             case iOS, macOS, tvOS, watchOS, visionOS
         }
     }

--- a/Packages/Tests/ServicesTests/ServicesTests.swift
+++ b/Packages/Tests/ServicesTests/ServicesTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 @testable import Services
+import SharedConstants
 @testable import SharedCore
 import Testing
-import SharedConstants
 
 // MARK: - Services Tests
 

--- a/Packages/Tests/Shared/CoreTests/BinaryConfigTests.swift
+++ b/Packages/Tests/Shared/CoreTests/BinaryConfigTests.swift
@@ -10,7 +10,7 @@ struct BinaryConfigTests {
 
     @Test("nil search directory yields empty config")
     func nilDirectory() {
-        let config = Shared.BinaryConfig.load(from: nil)
+        let config = Shared.Constants.BinaryConfig.load(from: nil)
         #expect(config.baseDirectory == nil)
         #expect(config.resolvedBaseDirectory == nil)
     }
@@ -19,7 +19,7 @@ struct BinaryConfigTests {
     func missingFile() throws {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let config = Shared.BinaryConfig.load(from: dir)
+        let config = Shared.Constants.BinaryConfig.load(from: dir)
         #expect(config.baseDirectory == nil)
         #expect(config.resolvedBaseDirectory == nil)
     }
@@ -29,7 +29,7 @@ struct BinaryConfigTests {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try Self.writeConfig(in: dir, contents: #"{"baseDirectory":"/var/tmp/cupertino-dev"}"#)
-        let config = Shared.BinaryConfig.load(from: dir)
+        let config = Shared.Constants.BinaryConfig.load(from: dir)
         #expect(config.baseDirectory == "/var/tmp/cupertino-dev")
         #expect(config.resolvedBaseDirectory?.path == "/var/tmp/cupertino-dev")
     }
@@ -39,7 +39,7 @@ struct BinaryConfigTests {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try Self.writeConfig(in: dir, contents: #"{"baseDirectory":"~/.cupertino-dev"}"#)
-        let config = Shared.BinaryConfig.load(from: dir)
+        let config = Shared.Constants.BinaryConfig.load(from: dir)
         let expected = ("~/.cupertino-dev" as NSString).expandingTildeInPath
         #expect(config.resolvedBaseDirectory?.path == expected)
         #expect(config.resolvedBaseDirectory?.path.hasPrefix("~") == false)
@@ -50,7 +50,7 @@ struct BinaryConfigTests {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try Self.writeConfig(in: dir, contents: "{}")
-        let config = Shared.BinaryConfig.load(from: dir)
+        let config = Shared.Constants.BinaryConfig.load(from: dir)
         #expect(config.baseDirectory == nil)
         #expect(config.resolvedBaseDirectory == nil)
     }
@@ -60,7 +60,7 @@ struct BinaryConfigTests {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try Self.writeConfig(in: dir, contents: #"{"baseDirectory":""}"#)
-        let config = Shared.BinaryConfig.load(from: dir)
+        let config = Shared.Constants.BinaryConfig.load(from: dir)
         #expect(config.baseDirectory == "")
         #expect(config.resolvedBaseDirectory == nil)
     }
@@ -70,7 +70,7 @@ struct BinaryConfigTests {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try Self.writeConfig(in: dir, contents: "{ this is not valid")
-        let config = Shared.BinaryConfig.load(from: dir)
+        let config = Shared.Constants.BinaryConfig.load(from: dir)
         #expect(config.baseDirectory == nil)
         #expect(config.resolvedBaseDirectory == nil)
     }
@@ -83,13 +83,13 @@ struct BinaryConfigTests {
             in: dir,
             contents: #"{"baseDirectory":"/tmp/x","futureKey":"ignored","another":42}"#
         )
-        let config = Shared.BinaryConfig.load(from: dir)
+        let config = Shared.Constants.BinaryConfig.load(from: dir)
         #expect(config.baseDirectory == "/tmp/x")
     }
 
     @Test("file name constant is cupertino.config.json")
     func fileNameConstant() {
-        #expect(Shared.BinaryConfig.fileName == "cupertino.config.json")
+        #expect(Shared.Constants.BinaryConfig.fileName == "cupertino.config.json")
     }
 
     // MARK: - Helpers
@@ -102,7 +102,7 @@ struct BinaryConfigTests {
     }
 
     private static func writeConfig(in dir: URL, contents: String) throws {
-        let url = dir.appendingPathComponent(Shared.BinaryConfig.fileName)
+        let url = dir.appendingPathComponent(Shared.Constants.BinaryConfig.fileName)
         try contents.write(to: url, atomically: true, encoding: .utf8)
     }
 }

--- a/Packages/Tests/Shared/CoreTests/JSONCodingTests.swift
+++ b/Packages/Tests/Shared/CoreTests/JSONCodingTests.swift
@@ -1,15 +1,16 @@
 // swiftlint:disable type_body_length
 import Foundation
+import SharedConstants
 @testable import SharedCore
 import SharedUtils
 import Testing
 import TestSupport
 
-// MARK: - JSONCoding Tests
+// MARK: - Shared.Utils.JSONCoding Tests
 
-/// Tests for the unified JSONCoding utility
+/// Tests for the unified Shared.Utils.JSONCoding utility
 /// Ensures consistent date encoding/decoding across the codebase
-@Suite("JSONCoding Utility Tests")
+@Suite("Shared.Utils.JSONCoding Utility Tests")
 struct JSONCodingTests {
     // MARK: - Test Models
 
@@ -38,7 +39,7 @@ struct JSONCodingTests {
         let date = Date(timeIntervalSince1970: 1700000000) // 2023-11-14T22:13:20Z
         let model = ModelWithDate(name: "Test", createdAt: date, count: 42)
 
-        let encoder = JSONCoding.encoder()
+        let encoder = Shared.Utils.JSONCoding.encoder()
         let data = try encoder.encode(model)
         let jsonString = try #require(String(data: data, encoding: .utf8))
 
@@ -51,7 +52,7 @@ struct JSONCodingTests {
     func prettyEncoderFormatsOutput() throws {
         let model = ModelWithoutDate(name: "Test", value: 123)
 
-        let encoder = JSONCoding.prettyEncoder()
+        let encoder = Shared.Utils.JSONCoding.prettyEncoder()
         let data = try encoder.encode(model)
         let jsonString = try #require(String(data: data, encoding: .utf8))
 
@@ -64,7 +65,7 @@ struct JSONCodingTests {
     func prettyEncoderUsesSortedKeys() throws {
         let model = ModelWithoutDate(name: "Test", value: 123)
 
-        let encoder = JSONCoding.prettyEncoder()
+        let encoder = Shared.Utils.JSONCoding.prettyEncoder()
         let data = try encoder.encode(model)
         let jsonString = try #require(String(data: data, encoding: .utf8))
 
@@ -87,7 +88,7 @@ struct JSONCodingTests {
         """
         let data = Data(jsonString.utf8)
 
-        let decoder = JSONCoding.decoder()
+        let decoder = Shared.Utils.JSONCoding.decoder()
         let model = try decoder.decode(ModelWithDate.self, from: data)
 
         #expect(model.name == "Test")
@@ -107,7 +108,7 @@ struct JSONCodingTests {
         """
         let data = Data(jsonString.utf8)
 
-        let decoder = JSONCoding.decoder()
+        let decoder = Shared.Utils.JSONCoding.decoder()
 
         // Should throw because we're sending Double timestamp but expecting ISO8601 string
         #expect(throws: (any Error).self) {
@@ -122,7 +123,7 @@ struct JSONCodingTests {
         let date = Date(timeIntervalSince1970: 1700000000)
         let model = ModelWithDate(name: "Test", createdAt: date, count: 42)
 
-        let data = try JSONCoding.encode(model)
+        let data = try Shared.Utils.JSONCoding.encode(model)
         let jsonString = try #require(String(data: data, encoding: .utf8))
 
         #expect(jsonString.contains("Test"))
@@ -134,7 +135,7 @@ struct JSONCodingTests {
     func convenienceEncodePrettyMethodWorks() throws {
         let model = ModelWithoutDate(name: "Test", value: 123)
 
-        let data = try JSONCoding.encodePretty(model)
+        let data = try Shared.Utils.JSONCoding.encodePretty(model)
         let jsonString = try #require(String(data: data, encoding: .utf8))
 
         #expect(jsonString.contains("\n"), "Should be pretty-printed")
@@ -153,7 +154,7 @@ struct JSONCodingTests {
         """
         let data = Data(jsonString.utf8)
 
-        let model = try JSONCoding.decode(ModelWithDate.self, from: data)
+        let model = try Shared.Utils.JSONCoding.decode(ModelWithDate.self, from: data)
 
         #expect(model.name == "Test")
         #expect(model.count == 42)
@@ -176,7 +177,7 @@ struct JSONCodingTests {
         let model = ModelWithDate(name: "Test", createdAt: date, count: 42)
 
         // Encode to file (should create directory automatically)
-        try JSONCoding.encode(model, to: filePath)
+        try Shared.Utils.JSONCoding.encode(model, to: filePath)
 
         // Verify directory was created
         #expect(FileManager.default.fileExists(atPath: subdirPath.path))
@@ -211,7 +212,7 @@ struct JSONCodingTests {
         try Data(jsonString.utf8).write(to: tempFile)
 
         // Decode from file
-        let model = try JSONCoding.decode(ModelWithDate.self, from: tempFile)
+        let model = try Shared.Utils.JSONCoding.decode(ModelWithDate.self, from: tempFile)
 
         #expect(model.name == "FileTest")
         #expect(model.count == 99)
@@ -226,10 +227,10 @@ struct JSONCodingTests {
         let original = ModelWithDate(name: "RoundTrip", createdAt: date, count: 777)
 
         // Encode
-        let data = try JSONCoding.encode(original)
+        let data = try Shared.Utils.JSONCoding.encode(original)
 
         // Decode
-        let decoded = try JSONCoding.decode(ModelWithDate.self, from: data)
+        let decoded = try Shared.Utils.JSONCoding.decode(ModelWithDate.self, from: data)
 
         #expect(decoded == original)
     }
@@ -247,10 +248,10 @@ struct JSONCodingTests {
         let original = ModelWithDate(name: "FileRoundTrip", createdAt: date, count: 888)
 
         // Save to file
-        try JSONCoding.encode(original, to: tempFile)
+        try Shared.Utils.JSONCoding.encode(original, to: tempFile)
 
         // Load from file
-        let loaded = try JSONCoding.decode(ModelWithDate.self, from: tempFile)
+        let loaded = try Shared.Utils.JSONCoding.decode(ModelWithDate.self, from: tempFile)
 
         #expect(loaded == original)
     }
@@ -270,10 +271,10 @@ struct JSONCodingTests {
         )
 
         // Encode
-        let data = try JSONCoding.encode(original)
+        let data = try Shared.Utils.JSONCoding.encode(original)
 
         // Decode
-        let decoded = try JSONCoding.decode(NestedModelWithDates.self, from: data)
+        let decoded = try Shared.Utils.JSONCoding.decode(NestedModelWithDates.self, from: data)
 
         #expect(decoded == original)
         #expect(decoded.metadata.name == "Nested")
@@ -286,8 +287,8 @@ struct JSONCodingTests {
         struct EmptyModel: Codable, Equatable {}
 
         let original = EmptyModel()
-        let data = try JSONCoding.encode(original)
-        let decoded = try JSONCoding.decode(EmptyModel.self, from: data)
+        let data = try Shared.Utils.JSONCoding.encode(original)
+        let decoded = try Shared.Utils.JSONCoding.decode(EmptyModel.self, from: data)
 
         #expect(decoded == original)
     }
@@ -303,13 +304,13 @@ struct JSONCodingTests {
         let withoutDate = ModelWithOptionalDate(name: "NoDate", date: nil)
 
         // Test with date
-        let data1 = try JSONCoding.encode(withDate)
-        let decoded1 = try JSONCoding.decode(ModelWithOptionalDate.self, from: data1)
+        let data1 = try Shared.Utils.JSONCoding.encode(withDate)
+        let decoded1 = try Shared.Utils.JSONCoding.decode(ModelWithOptionalDate.self, from: data1)
         #expect(decoded1 == withDate)
 
         // Test without date
-        let data2 = try JSONCoding.encode(withoutDate)
-        let decoded2 = try JSONCoding.decode(ModelWithOptionalDate.self, from: data2)
+        let data2 = try Shared.Utils.JSONCoding.encode(withoutDate)
+        let decoded2 = try Shared.Utils.JSONCoding.decode(ModelWithOptionalDate.self, from: data2)
         #expect(decoded2 == withoutDate)
     }
 
@@ -321,8 +322,8 @@ struct JSONCodingTests {
             ModelWithDate(name: "Third", createdAt: Date(timeIntervalSince1970: 1700002000), count: 3),
         ]
 
-        let data = try JSONCoding.encode(models)
-        let decoded = try JSONCoding.decode([ModelWithDate].self, from: data)
+        let data = try Shared.Utils.JSONCoding.encode(models)
+        let decoded = try Shared.Utils.JSONCoding.decode([ModelWithDate].self, from: data)
 
         #expect(decoded.count == 3)
         #expect(decoded[0] == models[0])
@@ -337,8 +338,8 @@ struct JSONCodingTests {
             "modified": Date(timeIntervalSince1970: 1700001000),
         ]
 
-        let data = try JSONCoding.encode(dict)
-        let decoded = try JSONCoding.decode([String: Date].self, from: data)
+        let data = try Shared.Utils.JSONCoding.encode(dict)
+        let decoded = try Shared.Utils.JSONCoding.decode([String: Date].self, from: data)
 
         #expect(decoded.count == 2)
         #expect(try abs(#require(decoded["created"]?.timeIntervalSince1970) - 1700000000) < 1.0)
@@ -353,14 +354,14 @@ struct JSONCodingTests {
         let model = ModelWithDate(name: "Test", createdAt: date, count: 42)
 
         // Encode with standard encoder
-        let standardData = try JSONCoding.encode(model)
+        let standardData = try Shared.Utils.JSONCoding.encode(model)
 
         // Encode with pretty encoder
-        let prettyData = try JSONCoding.encodePretty(model)
+        let prettyData = try Shared.Utils.JSONCoding.encodePretty(model)
 
         // Both should decode to the same model
-        let decodedFromStandard = try JSONCoding.decode(ModelWithDate.self, from: standardData)
-        let decodedFromPretty = try JSONCoding.decode(ModelWithDate.self, from: prettyData)
+        let decodedFromStandard = try Shared.Utils.JSONCoding.decode(ModelWithDate.self, from: standardData)
+        let decodedFromPretty = try Shared.Utils.JSONCoding.decode(ModelWithDate.self, from: prettyData)
 
         #expect(decodedFromStandard == model)
         #expect(decodedFromPretty == model)
@@ -372,7 +373,7 @@ struct JSONCodingTests {
         let date = Date(timeIntervalSince1970: 1700000000)
         let model = ModelWithDate(name: "Test", createdAt: date, count: 42)
 
-        let data = try JSONCoding.encode(model)
+        let data = try Shared.Utils.JSONCoding.encode(model)
 
         // Verify it's valid JSON by parsing with standard JSONSerialization
         let jsonObject = try JSONSerialization.jsonObject(with: data)
@@ -394,7 +395,7 @@ struct JSONCodingTests {
         let invalidJSON = Data("{ this is not valid json }".utf8)
 
         #expect(throws: (any Error).self) {
-            _ = try JSONCoding.decode(ModelWithDate.self, from: invalidJSON)
+            _ = try Shared.Utils.JSONCoding.decode(ModelWithDate.self, from: invalidJSON)
         }
     }
 
@@ -409,7 +410,7 @@ struct JSONCodingTests {
         let data = Data(jsonString.utf8)
 
         #expect(throws: (any Error).self) {
-            _ = try JSONCoding.decode(ModelWithoutDate.self, from: data)
+            _ = try Shared.Utils.JSONCoding.decode(ModelWithoutDate.self, from: data)
         }
     }
 
@@ -419,14 +420,14 @@ struct JSONCodingTests {
             .appendingPathComponent("does-not-exist-\(UUID().uuidString).json")
 
         #expect(throws: (any Error).self) {
-            _ = try JSONCoding.decode(ModelWithDate.self, from: nonExistentFile)
+            _ = try Shared.Utils.JSONCoding.decode(ModelWithDate.self, from: nonExistentFile)
         }
     }
 
     // MARK: - Atomic Write Tests
 
     //
-    // Regression test for the v1.0 atomic-write fix in `JSONCoding.encode(_:to:)`.
+    // Regression test for the v1.0 atomic-write fix in `Shared.Utils.JSONCoding.encode(_:to:)`.
     // A multi-day Apple-docs crawl saves `metadata.json` (often several MB) every
     // 30s. Before the fix, that write went via `Data.write(to:)` without `.atomic`,
     // so a kill mid-save could leave a half-written file → resume on next launch
@@ -473,7 +474,7 @@ struct JSONCodingTests {
         defer { try? FileManager.default.removeItem(at: tempFile) }
 
         // Seed v0 so the first reader iteration always finds something.
-        try JSONCoding.encode(LargePayload.make(version: 0), to: tempFile)
+        try Shared.Utils.JSONCoding.encode(LargePayload.make(version: 0), to: tempFile)
 
         let writeIterations = 200
         let readerCount = 8
@@ -493,7 +494,7 @@ struct JSONCodingTests {
             group.addTask {
                 for version in 1...writeIterations {
                     do {
-                        try JSONCoding.encode(LargePayload.make(version: version), to: tempFile)
+                        try Shared.Utils.JSONCoding.encode(LargePayload.make(version: version), to: tempFile)
                     } catch {
                         await corruption.record("writer threw at v=\(version): \(error)")
                         return
@@ -508,7 +509,7 @@ struct JSONCodingTests {
                 group.addTask {
                     for _ in 0..<(writeIterations * 2) {
                         do {
-                            let loaded = try JSONCoding.decode(LargePayload.self, from: tempFile)
+                            let loaded = try Shared.Utils.JSONCoding.decode(LargePayload.self, from: tempFile)
                             // Sanity: payload made by `.make()` always has `count` entries.
                             if loaded.entries.count != 2000 {
                                 await corruption.record(

--- a/Packages/Tests/Shared/CoreTests/ModelsTests.swift
+++ b/Packages/Tests/Shared/CoreTests/ModelsTests.swift
@@ -1,14 +1,15 @@
+import CoreProtocols
 import Foundation
+import SharedConstants
 @testable import SharedCore
 import SharedModels
 import Testing
-import CoreProtocols
 
 // MARK: - DocumentationPage Tests
 
 @Test("DocumentationPage initializes with all required fields")
 func documentationPageInitialization() throws {
-    let page = try DocumentationPage(
+    let page = try Shared.Models.DocumentationPage(
         url: #require(URL(string: "https://developer.apple.com/documentation/swift")),
         framework: "Swift",
         title: "Swift Documentation",
@@ -26,7 +27,7 @@ func documentationPageInitialization() throws {
 
 @Test("DocumentationPage is Codable")
 func documentationPageCodable() throws {
-    let originalPage = try DocumentationPage(
+    let originalPage = try Shared.Models.DocumentationPage(
         url: #require(URL(string: "https://developer.apple.com/documentation/swift/array")),
         framework: "Swift",
         title: "Array",
@@ -41,7 +42,7 @@ func documentationPageCodable() throws {
 
     // Decode
     let decoder = JSONDecoder()
-    let decodedPage = try decoder.decode(DocumentationPage.self, from: data)
+    let decodedPage = try decoder.decode(Shared.Models.DocumentationPage.self, from: data)
 
     #expect(decodedPage.url == originalPage.url)
     #expect(decodedPage.framework == originalPage.framework)
@@ -52,7 +53,7 @@ func documentationPageCodable() throws {
 
 @Test("DocumentationPage generates unique IDs")
 func documentationPageUniqueIDs() throws {
-    let page1 = try DocumentationPage(
+    let page1 = try Shared.Models.DocumentationPage(
         url: #require(URL(string: "https://example.com/doc1")),
         framework: "Test",
         title: "Doc 1",
@@ -61,7 +62,7 @@ func documentationPageUniqueIDs() throws {
         depth: 0
     )
 
-    let page2 = try DocumentationPage(
+    let page2 = try Shared.Models.DocumentationPage(
         url: #require(URL(string: "https://example.com/doc2")),
         framework: "Test",
         title: "Doc 2",
@@ -77,7 +78,7 @@ func documentationPageUniqueIDs() throws {
 
 @Test("CrawlMetadata initializes with empty state")
 func crawlMetadataInitialization() {
-    let metadata = CrawlMetadata()
+    let metadata = Shared.Models.CrawlMetadata()
 
     #expect(metadata.pages.isEmpty)
     #expect(metadata.lastCrawl == nil)
@@ -87,8 +88,8 @@ func crawlMetadataInitialization() {
 
 @Test("CrawlMetadata is Codable")
 func crawlMetadataCodable() throws {
-    var metadata = CrawlMetadata()
-    metadata.pages["https://example.com"] = PageMetadata(
+    var metadata = Shared.Models.CrawlMetadata()
+    metadata.pages["https://example.com"] = Shared.Models.PageMetadata(
         url: "https://example.com",
         framework: "test",
         filePath: "/test.md",
@@ -102,7 +103,7 @@ func crawlMetadataCodable() throws {
     let data = try encoder.encode(metadata)
 
     let decoder = JSONDecoder()
-    let decoded = try decoder.decode(CrawlMetadata.self, from: data)
+    let decoded = try decoder.decode(Shared.Models.CrawlMetadata.self, from: data)
 
     #expect(decoded.pages.count == 1)
     #expect(decoded.stats.totalPages == 10)
@@ -114,15 +115,15 @@ func crawlMetadataSaveLoad() throws {
         .appendingPathComponent("test-\(UUID().uuidString).json")
     defer { try? FileManager.default.removeItem(at: tempFile) }
 
-    var metadata = CrawlMetadata()
-    metadata.pages["https://example.com/doc1"] = PageMetadata(
+    var metadata = Shared.Models.CrawlMetadata()
+    metadata.pages["https://example.com/doc1"] = Shared.Models.PageMetadata(
         url: "https://example.com/doc1",
         framework: "swift",
         filePath: "/docs/doc1.md",
         contentHash: "hash1",
         depth: 1
     )
-    metadata.pages["https://example.com/doc2"] = PageMetadata(
+    metadata.pages["https://example.com/doc2"] = Shared.Models.PageMetadata(
         url: "https://example.com/doc2",
         framework: "uikit",
         filePath: "/docs/doc2.md",
@@ -139,7 +140,7 @@ func crawlMetadataSaveLoad() throws {
     #expect(FileManager.default.fileExists(atPath: tempFile.path))
 
     // Load
-    let loaded = try CrawlMetadata.load(from: tempFile)
+    let loaded = try Shared.Models.CrawlMetadata.load(from: tempFile)
 
     #expect(loaded.pages.count == 2)
     #expect(loaded.stats.totalPages == 2)
@@ -151,7 +152,7 @@ func crawlMetadataSaveLoad() throws {
 
 @Test("PageMetadata initializes correctly")
 func pageMetadataInitialization() {
-    let metadata = PageMetadata(
+    let metadata = Shared.Models.PageMetadata(
         url: "https://developer.apple.com/documentation/swift/array",
         framework: "Swift",
         filePath: "/docs/swift/array.md",
@@ -168,7 +169,7 @@ func pageMetadataInitialization() {
 
 @Test("PageMetadata is Codable")
 func pageMetadataCodable() throws {
-    let original = PageMetadata(
+    let original = Shared.Models.PageMetadata(
         url: "https://example.com",
         framework: "test",
         filePath: "/test.md",
@@ -180,7 +181,7 @@ func pageMetadataCodable() throws {
     let data = try encoder.encode(original)
 
     let decoder = JSONDecoder()
-    let decoded = try decoder.decode(PageMetadata.self, from: data)
+    let decoded = try decoder.decode(Shared.Models.PageMetadata.self, from: data)
 
     #expect(decoded.url == original.url)
     #expect(decoded.framework == original.framework)
@@ -193,7 +194,7 @@ func pageMetadataCodable() throws {
 
 @Test("CrawlStatistics initializes with zeros")
 func crawlStatisticsInitialization() {
-    let stats = CrawlStatistics()
+    let stats = Shared.Models.CrawlStatistics()
 
     #expect(stats.totalPages == 0)
     #expect(stats.newPages == 0)
@@ -204,7 +205,7 @@ func crawlStatisticsInitialization() {
 
 @Test("CrawlStatistics is Codable")
 func crawlStatisticsCodable() throws {
-    let stats = CrawlStatistics(
+    let stats = Shared.Models.CrawlStatistics(
         totalPages: 100,
         newPages: 50,
         updatedPages: 30,
@@ -218,7 +219,7 @@ func crawlStatisticsCodable() throws {
     let data = try encoder.encode(stats)
 
     let decoder = JSONDecoder()
-    let decoded = try decoder.decode(CrawlStatistics.self, from: data)
+    let decoded = try decoder.decode(Shared.Models.CrawlStatistics.self, from: data)
 
     #expect(decoded.totalPages == 100)
     #expect(decoded.newPages == 50)
@@ -232,7 +233,7 @@ func crawlStatisticsDuration() {
     let startTime = Date()
     let endTime = startTime.addingTimeInterval(300) // 5 minutes
 
-    let stats = CrawlStatistics(
+    let stats = Shared.Models.CrawlStatistics(
         totalPages: 10,
         newPages: 10,
         updatedPages: 0,
@@ -249,7 +250,7 @@ func crawlStatisticsDuration() {
 
 @Test("CrawlStatistics duration is nil when times not set")
 func crawlStatisticsNoDuration() {
-    let stats = CrawlStatistics(
+    let stats = Shared.Models.CrawlStatistics(
         totalPages: 10,
         newPages: 10,
         updatedPages: 0,
@@ -268,8 +269,8 @@ func crawlStatisticsNoDuration() {
 // MARK: - StructuredDocumentationPage Declaration and Kind Tests
 
 // Helper type alias for brevity
-private typealias Page = StructuredDocumentationPage
-private typealias Kind = StructuredDocumentationPage.Kind
+private typealias Page = Shared.Models.StructuredDocumentationPage
+private typealias Kind = Shared.Models.StructuredDocumentationPage.Kind
 
 @Test("StructuredDocumentationPage extracts @attributes from declaration")
 func structuredPageExtractsAttributes() throws {
@@ -692,9 +693,9 @@ func withContentHashPreservesFields() throws {
 func normalizeLowercasesPathAndStripsFragmentQuery() throws {
     let mixed = try #require(URL(string: "https://developer.apple.com/documentation/Cinematic/CNAssetInfo-2ata2?lang=en#topic"))
     let lower = try #require(URL(string: "https://developer.apple.com/documentation/cinematic/cnassetinfo-2ata2"))
-    #expect(URLUtilities.normalize(mixed) == URLUtilities.normalize(lower))
+    #expect(Shared.Models.URLUtilities.normalize(mixed) == Shared.Models.URLUtilities.normalize(lower))
     #expect(
-        URLUtilities.normalize(mixed)?.absoluteString
+        Shared.Models.URLUtilities.normalize(mixed)?.absoluteString
             == "https://developer.apple.com/documentation/cinematic/cnassetinfo-2ata2"
     )
 }
@@ -702,8 +703,8 @@ func normalizeLowercasesPathAndStripsFragmentQuery() throws {
 @Test("URLUtilities.normalize is idempotent")
 func normalizeIsIdempotent() throws {
     let url = try #require(URL(string: "https://developer.apple.com/documentation/SwiftUI/View"))
-    let once = try #require(URLUtilities.normalize(url))
-    let twice = try #require(URLUtilities.normalize(once))
+    let once = try #require(Shared.Models.URLUtilities.normalize(url))
+    let twice = try #require(Shared.Models.URLUtilities.normalize(once))
     #expect(once == twice)
 }
 
@@ -712,7 +713,7 @@ func normalizePreservesUnderscoresInPath() throws {
     // installer_js is a real Apple framework that uses underscore in its
     // canonical URL path. Normalize must not collapse it.
     let url = try #require(URL(string: "https://developer.apple.com/documentation/installer_js/system"))
-    let normalized = URLUtilities.normalize(url)
+    let normalized = Shared.Models.URLUtilities.normalize(url)
     #expect(normalized?.absoluteString == "https://developer.apple.com/documentation/installer_js/system")
 }
 

--- a/Packages/Tests/Shared/CoreTests/SchemaVersionTests.swift
+++ b/Packages/Tests/Shared/CoreTests/SchemaVersionTests.swift
@@ -4,11 +4,11 @@ import SharedConstants
 import SharedUtils
 import Testing
 
-@Suite("Shared.SchemaVersion (#234)")
+@Suite("Shared.Utils.SchemaVersion (#234)")
 struct SchemaVersionTests {
     @Test("make produces fixed-width 12-character string")
     func makeFixedWidth() {
-        let version = Shared.SchemaVersion.make(
+        let version = Shared.Utils.SchemaVersion.make(
             year: 2026, month: 5, day: 4, hour: 22, minute: 40
         )
         #expect(version == "202605042240")
@@ -17,7 +17,7 @@ struct SchemaVersionTests {
 
     @Test("make zero-pads single-digit components")
     func makeZeroPads() {
-        let version = Shared.SchemaVersion.make(
+        let version = Shared.Utils.SchemaVersion.make(
             year: 2026, month: 1, day: 9, hour: 7, minute: 3
         )
         #expect(version == "202601090703")
@@ -26,7 +26,7 @@ struct SchemaVersionTests {
 
     @Test("now produces a 12-character string")
     func nowIsFixedWidth() {
-        let value = Shared.SchemaVersion.now()
+        let value = Shared.Utils.SchemaVersion.now()
         #expect(value.count == 12)
         #expect(value.allSatisfy { $0.isASCII && $0.isHexDigit }) // all 0-9
     }
@@ -38,12 +38,12 @@ struct SchemaVersionTests {
         let date = try #require(calendar.date(from: DateComponents(
             year: 2026, month: 5, day: 4, hour: 22, minute: 40
         )))
-        #expect(Shared.SchemaVersion.now(date: date) == "202605042240")
+        #expect(Shared.Utils.SchemaVersion.now(date: date) == "202605042240")
     }
 
     @Test("components inverts make for valid input")
     func componentsRoundTrip() {
-        let parts = Shared.SchemaVersion.components(from: "202605042240")
+        let parts = Shared.Utils.SchemaVersion.components(from: "202605042240")
         #expect(parts?.year == 2026)
         #expect(parts?.month == 5)
         #expect(parts?.day == 4)
@@ -53,60 +53,60 @@ struct SchemaVersionTests {
 
     @Test("components rejects non-12-char strings")
     func componentsRejectsShort() {
-        #expect(Shared.SchemaVersion.components(from: "20260504") == nil)
-        #expect(Shared.SchemaVersion.components(from: "2026050422401") == nil)
-        #expect(Shared.SchemaVersion.components(from: "") == nil)
+        #expect(Shared.Utils.SchemaVersion.components(from: "20260504") == nil)
+        #expect(Shared.Utils.SchemaVersion.components(from: "2026050422401") == nil)
+        #expect(Shared.Utils.SchemaVersion.components(from: "") == nil)
     }
 
     @Test("components rejects non-canonical month/day/hour/minute")
     func componentsRejectsOutOfRange() {
-        #expect(Shared.SchemaVersion.components(from: "202613042240") == nil) // month 13
-        #expect(Shared.SchemaVersion.components(from: "202605322240") == nil) // day 32
-        #expect(Shared.SchemaVersion.components(from: "202605042440") == nil) // hour 24
-        #expect(Shared.SchemaVersion.components(from: "202605042260") == nil) // minute 60
+        #expect(Shared.Utils.SchemaVersion.components(from: "202613042240") == nil) // month 13
+        #expect(Shared.Utils.SchemaVersion.components(from: "202605322240") == nil) // day 32
+        #expect(Shared.Utils.SchemaVersion.components(from: "202605042440") == nil) // hour 24
+        #expect(Shared.Utils.SchemaVersion.components(from: "202605042260") == nil) // minute 60
     }
 
     @Test("components rejects pre-1970 year")
     func componentsRejectsAncient() {
-        #expect(Shared.SchemaVersion.components(from: "196905042240") == nil)
+        #expect(Shared.Utils.SchemaVersion.components(from: "196905042240") == nil)
     }
 
     @Test("dateOnlyInt32 returns YYYYMMDD only")
     func dateOnlyInt32Works() {
-        #expect(Shared.SchemaVersion.dateOnlyInt32(from: "202605042240") == 20260504)
+        #expect(Shared.Utils.SchemaVersion.dateOnlyInt32(from: "202605042240") == 20260504)
     }
 
     @Test("dateOnlyInt32 returns 0 for invalid input")
     func dateOnlyInt32Invalid() {
-        #expect(Shared.SchemaVersion.dateOnlyInt32(from: "garbage") == 0)
+        #expect(Shared.Utils.SchemaVersion.dateOnlyInt32(from: "garbage") == 0)
     }
 
     @Test("iso8601Now produces a Z-suffixed UTC timestamp")
     func iso8601NowFormat() {
-        let value = Shared.SchemaVersion.iso8601Now()
+        let value = Shared.Utils.SchemaVersion.iso8601Now()
         #expect(value.hasSuffix("Z"))
         #expect(value.contains("T"))
     }
 
     @Test("Two versions are lex-comparable in chronological order")
     func lexOrderingMatchesChronology() {
-        let earlier = Shared.SchemaVersion.make(
+        let earlier = Shared.Utils.SchemaVersion.make(
             year: 2026, month: 5, day: 4, hour: 22, minute: 40
         )
-        let later = Shared.SchemaVersion.make(
+        let later = Shared.Utils.SchemaVersion.make(
             year: 2026, month: 5, day: 4, hour: 22, minute: 41
         )
         #expect(earlier < later)
     }
 }
 
-// MARK: - Shared.FTSQuery (#238)
+// MARK: - Shared.Utils.FTSQuery (#238)
 
-@Suite("Shared.FTSQuery (#238)")
+@Suite("Shared.Utils.FTSQuery (#238)")
 struct FTSQueryTests {
     @Test("Stopwords removed, remaining tokens OR-joined")
     func stopwordsAndOR() {
-        let query = Shared.FTSQuery.build(question: "how do I animate a swiftui list")
+        let query = Shared.Utils.FTSQuery.build(question: "how do I animate a swiftui list")
         // After stopword strip: animate, swiftui, list
         #expect(query.contains("\"animate\""))
         #expect(query.contains("\"swiftui\""))
@@ -121,14 +121,14 @@ struct FTSQueryTests {
 
     @Test("Empty / stopword-only question yields empty FTS string")
     func emptyAndOnlyStopwords() {
-        #expect(Shared.FTSQuery.build(question: "") == "")
-        #expect(Shared.FTSQuery.build(question: "   ") == "")
-        #expect(Shared.FTSQuery.build(question: "how do I a the") == "")
+        #expect(Shared.Utils.FTSQuery.build(question: "") == "")
+        #expect(Shared.Utils.FTSQuery.build(question: "   ") == "")
+        #expect(Shared.Utils.FTSQuery.build(question: "how do I a the") == "")
     }
 
     @Test("Dotted identifiers survive tokenization")
     func dottedIdentifiers() {
-        let tokens = Shared.FTSQuery.tokens(from: "swift-nio.EventLoop foo")
+        let tokens = Shared.Utils.FTSQuery.tokens(from: "swift-nio.EventLoop foo")
         // Dash splits, dots within preserved
         #expect(tokens.contains("nio.EventLoop") || tokens.contains("EventLoop"))
         #expect(tokens.contains("swift"))
@@ -137,7 +137,7 @@ struct FTSQueryTests {
 
     @Test("Single-character tokens dropped")
     func dropsSingleChars() {
-        let tokens = Shared.FTSQuery.tokens(from: "a x foo")
+        let tokens = Shared.Utils.FTSQuery.tokens(from: "a x foo")
         #expect(!tokens.contains("a"))
         #expect(!tokens.contains("x"))
         #expect(tokens.contains("foo"))

--- a/Packages/Tests/Shared/CoreTests/URLUtilitiesFilenameTests.swift
+++ b/Packages/Tests/Shared/CoreTests/URLUtilitiesFilenameTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SharedConstants
 @testable import SharedCore
 import SharedModels
 import Testing
@@ -19,7 +20,7 @@ struct URLUtilitiesFilenameTests {
     private let jsonExtensionBytes = ".json".utf8.count
 
     private func filenameWithExtension(for url: URL) -> String {
-        URLUtilities.filename(from: url) + ".json"
+        Shared.Models.URLUtilities.filename(from: url) + ".json"
     }
 
     // MARK: - Exact failing URLs from the 2026-04-30 error log
@@ -79,8 +80,8 @@ struct URLUtilitiesFilenameTests {
 
     @Test("Two near-identical overloads still produce different filenames")
     func nearIdenticalOverloadsAreUnique() {
-        let firstName = URLUtilities.filename(from: Self.mpssvgfReprojection12)
-        let secondName = URLUtilities.filename(from: Self.mpssvgfReprojection14)
+        let firstName = Shared.Models.URLUtilities.filename(from: Self.mpssvgfReprojection12)
+        let secondName = Shared.Models.URLUtilities.filename(from: Self.mpssvgfReprojection14)
         #expect(
             firstName != secondName,
             "filename collision between two distinct Apple URLs:\n  \(firstName)\n  \(secondName)"
@@ -96,14 +97,14 @@ struct URLUtilitiesFilenameTests {
             #require(URL(string: "https://developer.apple.com/documentation/swift/array")),
             #require(URL(string: "https://developer.apple.com/documentation/swiftui/view")),
         ]
-        let names = urls.map(URLUtilities.filename)
+        let names = urls.map(Shared.Models.URLUtilities.filename)
         #expect(Set(names).count == names.count, "duplicate filenames: \(names)")
     }
 
     @Test("Same URL produces same filename (deterministic)")
     func filenameIsDeterministic() {
-        let firstCall = URLUtilities.filename(from: Self.mpssvgfReprojection12)
-        let secondCall = URLUtilities.filename(from: Self.mpssvgfReprojection12)
+        let firstCall = Shared.Models.URLUtilities.filename(from: Self.mpssvgfReprojection12)
+        let secondCall = Shared.Models.URLUtilities.filename(from: Self.mpssvgfReprojection12)
         #expect(firstCall == secondCall)
     }
 
@@ -112,14 +113,14 @@ struct URLUtilitiesFilenameTests {
     @Test("Short URLs are not truncated and preserve their natural form")
     func shortURLsUntruncated() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/swift/array"))
-        let name = URLUtilities.filename(from: url)
+        let name = Shared.Models.URLUtilities.filename(from: url)
         #expect(name == "documentation_swift_array")
     }
 
     @Test("Operator URLs at moderate length keep their hash disambiguator and are not double-suffixed")
     func operatorURLKeepsSingleHash() throws {
         let url = try #require(URL(string: "https://developer.apple.com/documentation/swift/int/+(_:_:)"))
-        let name = URLUtilities.filename(from: url)
+        let name = Shared.Models.URLUtilities.filename(from: url)
         let underscoreCount = name.filter { $0 == "_" }.count
         #expect(name.contains("documentation_swift_int"))
         #expect(underscoreCount > 0)
@@ -131,7 +132,7 @@ struct URLUtilitiesFilenameTests {
 
     @Test("Truncated filenames do not end on a trailing underscore before .json")
     func truncatedFilenameNoTrailingUnderscore() {
-        let name = URLUtilities.filename(from: Self.mpssvgfReprojection12)
+        let name = Shared.Models.URLUtilities.filename(from: Self.mpssvgfReprojection12)
         // Should end with `_<8 hex chars>` — not `_` immediately before that.
         let parts = name.split(separator: "_")
         let last = parts.last.map(String.init) ?? ""
@@ -142,7 +143,7 @@ struct URLUtilitiesFilenameTests {
 
     @Test("Filename never returns empty string")
     func filenameNeverEmpty() throws {
-        let name = try URLUtilities.filename(from: #require(URL(string: "https://developer.apple.com/")))
+        let name = try Shared.Models.URLUtilities.filename(from: #require(URL(string: "https://developer.apple.com/")))
         #expect(!name.isEmpty)
     }
 
@@ -161,7 +162,7 @@ struct URLUtilitiesFilenameTests {
         let lower = try #require(
             URL(string: "https://developer.apple.com/documentation/swift/withtaskgroup(of:returning:isolation:body:)")
         )
-        #expect(URLUtilities.filename(from: capital) == URLUtilities.filename(from: lower))
+        #expect(Shared.Models.URLUtilities.filename(from: capital) == Shared.Models.URLUtilities.filename(from: lower))
     }
 
     @Test("Case-variant operator URL pair: filename is identical (Observation/Observable() vs lowercase)")
@@ -172,7 +173,7 @@ struct URLUtilitiesFilenameTests {
         let lower = try #require(
             URL(string: "https://developer.apple.com/documentation/observation/observable()")
         )
-        #expect(URLUtilities.filename(from: capital) == URLUtilities.filename(from: lower))
+        #expect(Shared.Models.URLUtilities.filename(from: capital) == Shared.Models.URLUtilities.filename(from: lower))
     }
 
     @Test("Case-variant plain URL pair: filename is identical")
@@ -183,6 +184,6 @@ struct URLUtilitiesFilenameTests {
         let lower = try #require(
             URL(string: "https://developer.apple.com/documentation/cinematic/cnassetinfo-2ata2")
         )
-        #expect(URLUtilities.filename(from: capital) == URLUtilities.filename(from: lower))
+        #expect(Shared.Models.URLUtilities.filename(from: capital) == Shared.Models.URLUtilities.filename(from: lower))
     }
 }

--- a/Packages/Tests/TUITests/AppStateTests.swift
+++ b/Packages/Tests/TUITests/AppStateTests.swift
@@ -1,8 +1,8 @@
 @testable import Core
+import CoreProtocols
 import Foundation
 import Testing
 import TestSupport
-import CoreProtocols
 @testable import TUI
 
 // MARK: - AppState Tests

--- a/Packages/Tests/TUITests/InfrastructureTests.swift
+++ b/Packages/Tests/TUITests/InfrastructureTests.swift
@@ -1,9 +1,9 @@
 @testable import Core
+import CoreProtocols
 import Foundation
 import Testing
 import TestSupport
 @testable import TUI
-import CoreProtocols
 
 // MARK: - Colors Tests
 

--- a/Packages/Tests/TUITests/InputHandlerTests.swift
+++ b/Packages/Tests/TUITests/InputHandlerTests.swift
@@ -1,8 +1,8 @@
 @testable import Core
+import CoreProtocols
 import Foundation
 import Testing
 import TestSupport
-import CoreProtocols
 @testable import TUI
 
 // MARK: - InputHandler Tests

--- a/Packages/Tests/TUITests/PackageEntryTests.swift
+++ b/Packages/Tests/TUITests/PackageEntryTests.swift
@@ -1,8 +1,8 @@
 @testable import Core
+import CoreProtocols
 import Foundation
 import Testing
 import TestSupport
-import CoreProtocols
 @testable import TUI
 
 // MARK: - PackageEntry Tests

--- a/Packages/Tests/TUITests/ViewRouterTests.swift
+++ b/Packages/Tests/TUITests/ViewRouterTests.swift
@@ -1,9 +1,9 @@
 @testable import Core
+import CoreProtocols
 import Foundation
 import Testing
 import TestSupport
 @testable import TUI
-import CoreProtocols
 
 // MARK: - ViewRouter Tests
 

--- a/Packages/Tests/TUITests/ViewTests.swift
+++ b/Packages/Tests/TUITests/ViewTests.swift
@@ -1,7 +1,7 @@
 @testable import Core
+import CoreProtocols
 import Foundation
 import Testing
-import CoreProtocols
 @testable import TUI
 
 // MARK: - HomeView Tests


### PR DESCRIPTION
Adds three sub-namespaces to `Shared` and moves every public type from its file-scope position into the sub-namespace that mirrors its folder on disk. External callers across the monorepo now read every `Shared.*` type through its qualified path.

## New layout

| Folder | Namespace | Contents |
|---|---|---|
| `Sources/Shared/Constants/` | `Shared.Constants.*` | The existing constants tree + `BinaryConfig` (folded in). |
| `Sources/Shared/Utils/` | `Shared.Utils.*` | `JSONCoding`, `PathResolver`, `FTSQuery`, `Formatting`, `SchemaVersion`. `URLExtensions` stays at file scope (extends `URL` itself). |
| `Sources/Shared/Models/` | `Shared.Models.*` | `CrawlMetadata`, `FrameworkStats`, `PageMetadata`, `CrawlStatistics`, `CrawlSessionState`, `QueuedURL`, `CleanupProgress`, `CleanupStatistics`, `CleanupResult`, `StructuredDocumentationPage`, `DocumentationPage`, `URLUtilities`, `HashUtilities`, `PackageReference`, `PackagePriority`, `DocumentationSite`, `PackageDownloadProgress`, `PackageDownloadStatistics`. |

`Shared.Configuration.*` and `Shared.Core.*` are **deferred** to a follow-up. The existing `Shared.Configuration` aggregate struct (the bundle of `CrawlerConfiguration` + `ChangeDetectionConfiguration` + `Output`) collides with making `Configuration` a namespace — renaming that aggregate is a separate naming call.

## Mechanics

- `Sources/Shared/Constants/Shared.swift` now declares the three sub-namespace enums (`Constants`, `Utils`, `Models`) alongside the existing root.
- `Constants.swift` converted its outer `extension Shared { public enum Constants { ... } }` wrapper to a flat `extension Shared.Constants { ... }` — body content (Directory, FileName, BinaryURL, etc.) is unchanged.
- `BinaryConfig.swift` retargets to `extension Shared.Constants` so the struct now lives at `Shared.Constants.BinaryConfig`.
- Each Utils file converted: file-scope enums (`JSONCoding`, `PathResolver`) wrapped in `extension Shared.Utils { ... }`; the three files that already had `extension Shared` (FTSQuery, Formatting, SchemaVersion) retargeted to `extension Shared.Utils`.
- Each Models file's file-scope public types wrapped **individually** in `extension Shared.Models { ... }` so file-scope helper extensions stay where they are.
- **60+ external caller files swept** across Core, Search, Cleanup, MCP, CLI, CoreProtocols, Ingest, RemoteSync, ReleaseTool, plus every test target. Sweep is string- and comment-aware so MARK comments and print strings stay intact. Two stragglers inside string interpolations (`"...\(URLUtilities.filename(...))..."`) had to be patched manually because the string-aware parser skipped the whole interpolation block.
- `import SharedConstants` and `import SharedModels` added to every file that newly references a relocated type but didn't already import the right module.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Previous: #348 (ASTIndexer + Logging + Resources), #350 (MCP).

## Next slices

- **Shared.Configuration + Shared.Core** follow-up — needs to decide what to rename the existing `Shared.Configuration` aggregate struct so that `Configuration` can become a namespace enum.
- Infrastructure layer (`Core.Protocols.*`, `MCP.SharedTools.*`, RemoteSync residue, Diagnostics, Distribution).
- Features layer.
- Apps layer (CLI commands as `Command.<Name>`).