### PR TITLE
refactor(CLI): nest every <Name>Command under the Command namespace; rewrite callers + tests

### DIFF
--- a/Packages/Sources/CLI/Commands/CleanupCommand.swift
+++ b/Packages/Sources/CLI/Commands/CleanupCommand.swift
@@ -8,113 +8,115 @@ import SharedUtils
 
 // MARK: - Cleanup Command
 
-struct CleanupCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "cleanup",
-        abstract: "Clean up downloaded sample code archives",
-        discussion: """
-        Removes unnecessary files from sample code ZIP archives to reduce disk space.
+extension Command {
+    struct Cleanup: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "cleanup",
+            abstract: "Clean up downloaded sample code archives",
+            discussion: """
+            Removes unnecessary files from sample code ZIP archives to reduce disk space.
 
-        Files removed:
-        • .git folders (often 7+ MB each)
-        • .DS_Store files
-        • xcuserdata folders
-        • DerivedData folders
-        • Build artifacts
-        • Pods folders
-        • .swiftpm folders
+            Files removed:
+            • .git folders (often 7+ MB each)
+            • .DS_Store files
+            • xcuserdata folders
+            • DerivedData folders
+            • Build artifacts
+            • Pods folders
+            • .swiftpm folders
 
-        This can reduce storage from ~26GB to ~2-3GB for a full sample code download.
-        """
-    )
-
-    @Option(
-        name: .long,
-        help: "Sample code directory to clean (default: \(Shared.Constants.defaultSampleCodeDirectory.path))"
-    )
-    var sampleCodeDir: String?
-
-    @Flag(
-        name: .long,
-        help: "Dry run - show what would be cleaned without modifying files"
-    )
-    var dryRun: Bool = false
-
-    @Flag(
-        name: .long,
-        help: "Keep original ZIP files (saves cleaned versions with .cleaned.zip suffix)"
-    )
-    var keepOriginals: Bool = false
-
-    mutating func run() async throws {
-        let directory: URL
-        if let customDir = sampleCodeDir {
-            directory = URL(fileURLWithPath: customDir).expandingTildeInPath
-        } else {
-            directory = Shared.Constants.defaultSampleCodeDirectory
-        }
-
-        guard FileManager.default.fileExists(atPath: directory.path) else {
-            Logging.Log.error("Sample code directory not found: \(directory.path)")
-            Logging.Log.error("Run 'cupertino fetch --type code' first to download sample code.")
-            throw ExitCode.failure
-        }
-
-        if dryRun {
-            Logging.Log.output("🔍 Cupertino - Cleanup Dry Run")
-            Logging.Log.output("")
-            Logging.Log.output("   Directory: \(directory.path)")
-            Logging.Log.output("   (No files will be modified)")
-            Logging.Log.output("")
-        } else {
-            Logging.Log.output("🧹 Cupertino - Cleaning Sample Code Archives")
-            Logging.Log.output("")
-            Logging.Log.output("   Directory: \(directory.path)")
-            if keepOriginals {
-                Logging.Log.output("   Mode: Keep originals (cleaned files saved as .cleaned.zip)")
-            } else {
-                Logging.Log.output("   Mode: Replace originals")
-            }
-            Logging.Log.output("")
-        }
-
-        let cleaner = SampleCodeCleaner(
-            sampleCodeDirectory: directory,
-            dryRun: dryRun,
-            keepOriginals: keepOriginals
+            This can reduce storage from ~26GB to ~2-3GB for a full sample code download.
+            """
         )
 
-        let stats = try await cleaner.cleanup { progress in
-            let percent = String(format: "%.1f", progress.percentage)
-            let saved = Shared.Utils.Formatting.formatBytes(progress.originalSize - progress.cleanedSize)
-            Logging.Log.output("   [\(percent)%] \(progress.currentFile) (saved \(saved))")
-        }
+        @Option(
+            name: .long,
+            help: "Sample code directory to clean (default: \(Shared.Constants.defaultSampleCodeDirectory.path))"
+        )
+        var sampleCodeDir: String?
 
-        Logging.Log.output("")
+        @Flag(
+            name: .long,
+            help: "Dry run - show what would be cleaned without modifying files"
+        )
+        var dryRun: Bool = false
 
-        if dryRun {
-            Logging.Log.output("📊 Dry Run Summary:")
-        } else {
-            Logging.Log.output("✅ Cleanup completed!")
-        }
+        @Flag(
+            name: .long,
+            help: "Keep original ZIP files (saves cleaned versions with .cleaned.zip suffix)"
+        )
+        var keepOriginals: Bool = false
 
-        Logging.Log.output("   Total archives: \(stats.totalArchives)")
-        Logging.Log.output("   Cleaned: \(stats.cleanedArchives)")
-        Logging.Log.output("   Skipped (already clean): \(stats.skippedArchives)")
-        Logging.Log.output("   Errors: \(stats.errors)")
-        Logging.Log.output("   Items to remove: \(stats.totalItemsRemoved)")
-        Logging.Log.output("")
-        Logging.Log.output("   Original size: \(Shared.Utils.Formatting.formatBytes(stats.originalTotalSize))")
-        if !dryRun {
-            Logging.Log.output("   Cleaned size: \(Shared.Utils.Formatting.formatBytes(stats.cleanedTotalSize))")
-            Logging.Log.output(
-                "   Space saved: \(Shared.Utils.Formatting.formatBytes(stats.spaceSaved)) " +
-                    "(\(String(format: "%.1f", stats.spaceSavedPercentage))%)"
+        mutating func run() async throws {
+            let directory: URL
+            if let customDir = sampleCodeDir {
+                directory = URL(fileURLWithPath: customDir).expandingTildeInPath
+            } else {
+                directory = Shared.Constants.defaultSampleCodeDirectory
+            }
+
+            guard FileManager.default.fileExists(atPath: directory.path) else {
+                Logging.Log.error("Sample code directory not found: \(directory.path)")
+                Logging.Log.error("Run 'cupertino fetch --type code' first to download sample code.")
+                throw ExitCode.failure
+            }
+
+            if dryRun {
+                Logging.Log.output("🔍 Cupertino - Cleanup Dry Run")
+                Logging.Log.output("")
+                Logging.Log.output("   Directory: \(directory.path)")
+                Logging.Log.output("   (No files will be modified)")
+                Logging.Log.output("")
+            } else {
+                Logging.Log.output("🧹 Cupertino - Cleaning Sample Code Archives")
+                Logging.Log.output("")
+                Logging.Log.output("   Directory: \(directory.path)")
+                if keepOriginals {
+                    Logging.Log.output("   Mode: Keep originals (cleaned files saved as .cleaned.zip)")
+                } else {
+                    Logging.Log.output("   Mode: Replace originals")
+                }
+                Logging.Log.output("")
+            }
+
+            let cleaner = SampleCodeCleaner(
+                sampleCodeDirectory: directory,
+                dryRun: dryRun,
+                keepOriginals: keepOriginals
             )
-        }
 
-        if let duration = stats.duration {
-            Logging.Log.output("   Duration: \(Int(duration))s")
+            let stats = try await cleaner.cleanup { progress in
+                let percent = String(format: "%.1f", progress.percentage)
+                let saved = Shared.Utils.Formatting.formatBytes(progress.originalSize - progress.cleanedSize)
+                Logging.Log.output("   [\(percent)%] \(progress.currentFile) (saved \(saved))")
+            }
+
+            Logging.Log.output("")
+
+            if dryRun {
+                Logging.Log.output("📊 Dry Run Summary:")
+            } else {
+                Logging.Log.output("✅ Cleanup completed!")
+            }
+
+            Logging.Log.output("   Total archives: \(stats.totalArchives)")
+            Logging.Log.output("   Cleaned: \(stats.cleanedArchives)")
+            Logging.Log.output("   Skipped (already clean): \(stats.skippedArchives)")
+            Logging.Log.output("   Errors: \(stats.errors)")
+            Logging.Log.output("   Items to remove: \(stats.totalItemsRemoved)")
+            Logging.Log.output("")
+            Logging.Log.output("   Original size: \(Shared.Utils.Formatting.formatBytes(stats.originalTotalSize))")
+            if !dryRun {
+                Logging.Log.output("   Cleaned size: \(Shared.Utils.Formatting.formatBytes(stats.cleanedTotalSize))")
+                Logging.Log.output(
+                    "   Space saved: \(Shared.Utils.Formatting.formatBytes(stats.spaceSaved)) " +
+                        "(\(String(format: "%.1f", stats.spaceSavedPercentage))%)"
+                )
+            }
+
+            if let duration = stats.duration {
+                Logging.Log.output("   Duration: \(Int(duration))s")
+            }
         }
     }
 }

--- a/Packages/Sources/CLI/Commands/Command.swift
+++ b/Packages/Sources/CLI/Commands/Command.swift
@@ -1,0 +1,15 @@
+import ArgumentParser
+
+// MARK: - Command Namespace
+
+/// Namespace for every CLI subcommand. Each subcommand lives as
+/// `Command.<Name>` (matching its `<Name>Command.swift` filename minus the
+/// "Command" suffix), e.g. `Command.Cleanup`, `Command.Doctor`,
+/// `Command.Search`. `swift-argument-parser` conformance stays on the
+/// individual structs; the namespace is just an organising shell.
+///
+/// The root `AsyncParsableCommand` (the entry point that holds
+/// `subcommands: [...]`) is `Cupertino` in `Cupertino.swift` — it doesn't
+/// live under `Command` because it isn't a subcommand itself, it's the
+/// dispatcher.
+enum Command {}

--- a/Packages/Sources/CLI/Commands/DoctorCommand.swift
+++ b/Packages/Sources/CLI/Commands/DoctorCommand.swift
@@ -26,381 +26,383 @@ private struct CorpusEntry {
     let fetchType: String
 }
 
-struct DoctorCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "doctor",
-        abstract: "Check MCP server health and configuration",
-        discussion: """
-        Verifies that the MCP server can start and all required components
-        are available and properly configured.
+extension Command {
+    struct Doctor: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "doctor",
+            abstract: "Check MCP server health and configuration",
+            discussion: """
+            Verifies that the MCP server can start and all required components
+            are available and properly configured.
 
-        Checks:
-        • Server initialization
-        • Resource providers
-        • Tool providers
-        • Database connectivity
-        • Documentation directories
-        """
-    )
+            Checks:
+            • Server initialization
+            • Resource providers
+            • Tool providers
+            • Database connectivity
+            • Documentation directories
+            """
+        )
 
-    @Option(name: .long, help: ArgumentHelp(Shared.Constants.HelpText.docsDir))
-    var docsDir: String = Shared.Constants.defaultDocsDirectory.path
+        @Option(name: .long, help: ArgumentHelp(Shared.Constants.HelpText.docsDir))
+        var docsDir: String = Shared.Constants.defaultDocsDirectory.path
 
-    @Option(name: .long, help: ArgumentHelp(Shared.Constants.HelpText.evolutionDir))
-    var evolutionDir: String = Shared.Constants.defaultSwiftEvolutionDirectory.path
+        @Option(name: .long, help: ArgumentHelp(Shared.Constants.HelpText.evolutionDir))
+        var evolutionDir: String = Shared.Constants.defaultSwiftEvolutionDirectory.path
 
-    @Option(name: .long, help: ArgumentHelp(Shared.Constants.HelpText.searchDB))
-    var searchDB: String = Shared.Constants.defaultSearchDatabase.path
+        @Option(name: .long, help: ArgumentHelp(Shared.Constants.HelpText.searchDB))
+        var searchDB: String = Shared.Constants.defaultSearchDatabase.path
 
-    @Flag(
-        name: .long,
-        help: """
-        Run the `cupertino save` preflight check only — print which \
-        sources are present, which lack availability annotations, what \
-        would be skipped — without running the regular doctor health \
-        suite. Read-only, no DB writes. (#232)
-        """
-    )
-    var save: Bool = false
+        @Flag(
+            name: .long,
+            help: """
+            Run the `cupertino save` preflight check only — print which \
+            sources are present, which lack availability annotations, what \
+            would be skipped — without running the regular doctor health \
+            suite. Read-only, no DB writes. (#232)
+            """
+        )
+        var save: Bool = false
 
-    mutating func run() async throws {
-        // #232: --save flag short-circuits to the SaveCommand preflight,
-        // so users can ask `is save ready?` without committing to running
-        // it. Identical output to what `cupertino save` would print as
-        // its preflight summary.
-        if save {
-            Logging.Log.output("🔍 `cupertino save` preflight check\n")
-            let lines = Indexer.Preflight.preflightLines(
-                buildDocs: true,
-                buildPackages: true,
-                buildSamples: true
-            )
-            for line in lines {
-                Logging.Log.output(line)
+        mutating func run() async throws {
+            // #232: --save flag short-circuits to the Command.Save preflight,
+            // so users can ask `is save ready?` without committing to running
+            // it. Identical output to what `cupertino save` would print as
+            // its preflight summary.
+            if save {
+                Logging.Log.output("🔍 `cupertino save` preflight check\n")
+                let lines = Indexer.Preflight.preflightLines(
+                    buildDocs: true,
+                    buildPackages: true,
+                    buildSamples: true
+                )
+                for line in lines {
+                    Logging.Log.output(line)
+                }
+                return
             }
-            return
-        }
 
-        Logging.Log.output("🏥 MCP Server Health Check")
-        Logging.Log.output("")
+            Logging.Log.output("🏥 MCP Server Health Check")
+            Logging.Log.output("")
 
-        var allChecks = true
+            var allChecks = true
 
-        // Check server initialization
-        allChecks = checkServerInitialization() && allChecks
+            // Check server initialization
+            allChecks = checkServerInitialization() && allChecks
 
-        // Check documentation directories
-        allChecks = checkDocumentationDirectories() && allChecks
+            // Check documentation directories
+            allChecks = checkDocumentationDirectories() && allChecks
 
-        // Check packages (filesystem state)
-        await checkPackages()
+            // Check packages (filesystem state)
+            await checkPackages()
 
-        // Check packages.db (#192 F1)
-        allChecks = checkPackagesDatabase() && allChecks
+            // Check packages.db (#192 F1)
+            allChecks = checkPackagesDatabase() && allChecks
 
-        // Check samples.db (sample code index built by `cupertino save --samples`)
-        checkSamplesDatabase()
+            // Check samples.db (sample code index built by `cupertino save --samples`)
+            checkSamplesDatabase()
 
-        // Check search database + schema version (#192 F2)
-        allChecks = await checkSearchDatabase() && allChecks
+            // Check search database + schema version (#192 F2)
+            allChecks = await checkSearchDatabase() && allChecks
 
-        // Check resource providers
-        allChecks = checkResourceProviders() && allChecks
+            // Check resource providers
+            allChecks = checkResourceProviders() && allChecks
 
-        // Schema versions across all three DBs (#234)
-        printSchemaVersions()
+            // Schema versions across all three DBs (#234)
+            printSchemaVersions()
 
-        // Summary
-        Logging.Log.output("")
-        if allChecks {
-            Logging.Log.output("✅ All checks passed - MCP server ready")
-        } else {
-            Logging.Log.output("⚠️  Some checks failed - see above for details")
-            throw ExitCode(1)
-        }
-    }
-
-    /// Read and print `PRAGMA user_version` for each of cupertino's
-    /// three local databases (#234). Each DB stores the version in the
-    /// SQLite header, so reading is cheap and works without
-    /// instantiating any actor. Missing files are reported but don't
-    /// fail the check — they're already covered by the per-DB sections
-    /// above.
-    private func printSchemaVersions() {
-        Logging.Log.output("")
-        Logging.Log.output("8. Schema versions (#234)")
-        Logging.Log.output("")
-        let entries: [(String, URL)] = [
-            ("search.db", URL(fileURLWithPath: searchDB).expandingTildeInPath),
-            ("packages.db", Shared.Constants.defaultPackagesDatabase),
-            ("samples.db", SampleIndex.defaultDatabasePath),
-        ]
-        for (label, url) in entries {
-            guard FileManager.default.fileExists(atPath: url.path) else {
-                Logging.Log.output("   ⚠ \(label): not built")
-                continue
-            }
-            let version = Diagnostics.Probes.userVersion(at: url) ?? 0
-            let formatted = Diagnostics.SchemaVersion.format(version)
-            Logging.Log.output("   ✓ \(label): \(formatted)")
-        }
-    }
-
-    private func checkServerInitialization() -> Bool {
-        Logging.Log.output("✅ MCP Server")
-        Logging.Log.output("   ✓ Server can initialize")
-        Logging.Log.output("   ✓ Transport: stdio")
-        Logging.Log.output("   ✓ Protocol version: \(MCPProtocolVersion)")
-        Logging.Log.output("")
-        return true
-    }
-
-    /// Filesystem check for raw corpus directories. These are *inputs* for
-    /// `cupertino save`; they're optional once `search.db` is built (a user
-    /// who ran `cupertino setup` has the DB but no source dirs, and that's
-    /// fine). All five directories are warnings-only — missing dirs don't
-    /// fail doctor. The query-correctness truth lives in `search.db` and is
-    /// reported by `checkSearchDatabase`.
-    private func checkDocumentationDirectories() -> Bool {
-        let docsURL = URL(fileURLWithPath: docsDir).expandingTildeInPath
-        let evolutionURL = URL(fileURLWithPath: evolutionDir).expandingTildeInPath
-        let higURL = Shared.Constants.defaultHIGDirectory
-        let swiftOrgURL = Shared.Constants.defaultSwiftOrgDirectory
-        let archiveURL = Shared.Constants.defaultArchiveDirectory
-
-        Logging.Log.output("📂 Raw corpus directories (input for `cupertino save`)")
-
-        let entries: [CorpusEntry] = [
-            CorpusEntry(label: "Apple docs", url: docsURL, suffix: "files", fetchType: "docs"),
-            CorpusEntry(label: "Swift Evolution", url: evolutionURL, suffix: "proposals", fetchType: "evolution"),
-            CorpusEntry(label: "Swift.org", url: swiftOrgURL, suffix: "pages", fetchType: "swift"),
-            CorpusEntry(label: "HIG", url: higURL, suffix: "pages", fetchType: "hig"),
-            CorpusEntry(label: "Apple Archive", url: archiveURL, suffix: "guides", fetchType: "archive"),
-        ]
-
-        for entry in entries {
-            if FileManager.default.fileExists(atPath: entry.url.path) {
-                let count = Diagnostics.Probes.countCorpusFiles(in: entry.url)
-                Logging.Log.output("   ✓ \(entry.label): \(entry.url.path) (\(count) \(entry.suffix))")
+            // Summary
+            Logging.Log.output("")
+            if allChecks {
+                Logging.Log.output("✅ All checks passed - MCP server ready")
             } else {
-                Logging.Log.output("   ⚠  \(entry.label): \(entry.url.path) (not found)")
-                Logging.Log.output("     → Run: cupertino fetch --type \(entry.fetchType)  (only needed to rebuild from scratch)")
+                Logging.Log.output("⚠️  Some checks failed - see above for details")
+                throw ExitCode(1)
             }
         }
 
-        Logging.Log.output("")
-        // Filesystem state is informational. The hard fail is whether
-        // search.db has indexed data, which `checkSearchDatabase` enforces.
-        return true
-    }
-
-    private func checkSearchDatabase() async -> Bool {
-        let searchDBURL = URL(fileURLWithPath: searchDB).expandingTildeInPath
-
-        Logging.Log.output("🔍 Search Index")
-
-        guard FileManager.default.fileExists(atPath: searchDBURL.path) else {
-            Logging.Log.output("   ✗ Database: \(searchDBURL.path) (not found)")
-            Logging.Log.output("     → Run: cupertino setup  (or `cupertino save` if building locally)")
+        /// Read and print `PRAGMA user_version` for each of cupertino's
+        /// three local databases (#234). Each DB stores the version in the
+        /// SQLite header, so reading is cheap and works without
+        /// instantiating any actor. Missing files are reported but don't
+        /// fail the check — they're already covered by the per-DB sections
+        /// above.
+        private func printSchemaVersions() {
             Logging.Log.output("")
-            return false
-        }
-
-        let fileSize = (try? FileManager.default.attributesOfItem(atPath: searchDBURL.path)[.size] as? UInt64) ?? 0
-        Logging.Log.output("   ✓ Database: \(searchDBURL.path)")
-        Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
-
-        if !reportSchemaVersion(at: searchDBURL) {
-            return false
-        }
-
-        do {
-            let searchIndex = try await Search.Index(dbPath: searchDBURL)
-            let frameworks = try await searchIndex.listFrameworks()
-            Logging.Log.output("   ✓ Frameworks: \(frameworks.count)")
-            await searchIndex.disconnect()
-            return reportIndexedSources(at: searchDBURL)
-        } catch {
-            Logging.Log.output("   ✗ Database error: \(error)")
-            Logging.Log.output("     → rm \(searchDBURL.path) && cupertino save")
+            Logging.Log.output("8. Schema versions (#234)")
             Logging.Log.output("")
-            return false
-        }
-    }
-
-    /// Read `PRAGMA user_version` and compare against the binary's expected
-    /// schema. Returns false on mismatch (with a precise rebuild hint), true
-    /// on match or unreadable. Read BEFORE opening via `Search.Index` because
-    /// migrating from an incompatible version throws during init, and the
-    /// user wants to know which version they're stuck on.
-    private func reportSchemaVersion(at searchDBURL: URL) -> Bool {
-        let onDiskVersion = Diagnostics.Probes.userVersion(at: searchDBURL)
-        let expected = Search.Index.schemaVersion
-        guard let onDiskVersion else {
-            Logging.Log.output("   ⚠  Schema version: could not read PRAGMA user_version")
-            return true
-        }
-        if onDiskVersion == expected {
-            Logging.Log.output("   ✓ Schema version: \(onDiskVersion) (matches installed binary)")
-            return true
-        }
-        if onDiskVersion < expected {
-            Logging.Log.output("   ✗ Schema version: \(onDiskVersion) (binary expects \(expected), rebuild required)")
-            Logging.Log.output("     → rm \(searchDBURL.path) && cupertino save")
-        } else {
-            Logging.Log.output("   ✗ Schema version: \(onDiskVersion) (newer than binary — expected \(expected))")
-            Logging.Log.output("     → Upgrade cupertino: brew upgrade cupertino")
-        }
-        Logging.Log.output("")
-        return false
-    }
-
-    /// Per-source indexed counts via direct sqlite read. This is the truth
-    /// for "can my MCP answer queries about source X?". Hard-fails if the DB
-    /// opens but has zero indexed rows (silent-empty MCP otherwise).
-    private func reportIndexedSources(at searchDBURL: URL) -> Bool {
-        let perSource = Diagnostics.Probes.perSourceCounts(at: searchDBURL)
-        if !perSource.isEmpty {
-            Logging.Log.output("   📚 Indexed sources:")
-            for (source, count) in perSource {
-                Logging.Log.output("     ✓ \(source): \(count) entries")
+            let entries: [(String, URL)] = [
+                ("search.db", URL(fileURLWithPath: searchDB).expandingTildeInPath),
+                ("packages.db", Shared.Constants.defaultPackagesDatabase),
+                ("samples.db", SampleIndex.defaultDatabasePath),
+            ]
+            for (label, url) in entries {
+                guard FileManager.default.fileExists(atPath: url.path) else {
+                    Logging.Log.output("   ⚠ \(label): not built")
+                    continue
+                }
+                let version = Diagnostics.Probes.userVersion(at: url) ?? 0
+                let formatted = Diagnostics.SchemaVersion.format(version)
+                Logging.Log.output("   ✓ \(label): \(formatted)")
             }
         }
-        Logging.Log.output("")
-        let totalIndexed = perSource.reduce(0) { $0 + $1.count }
-        if totalIndexed == 0 {
-            Logging.Log.output("   ✗ Search index is empty (0 rows in docs_metadata)")
-            Logging.Log.output("     → Rebuild: rm \(searchDBURL.path) && cupertino setup")
+
+        private func checkServerInitialization() -> Bool {
+            Logging.Log.output("✅ MCP Server")
+            Logging.Log.output("   ✓ Server can initialize")
+            Logging.Log.output("   ✓ Transport: stdio")
+            Logging.Log.output("   ✓ Protocol version: \(MCPProtocolVersion)")
             Logging.Log.output("")
-            return false
-        }
-        return true
-    }
-
-    /// Report `samples.db` presence, size, and row counts (sample projects +
-    /// indexed source files). Built by `cupertino save --samples` after sample-code
-    /// download + cleanup. Missing is a warning (server runs without it; the
-    /// sample-code search just isn't available).
-    private func checkSamplesDatabase() {
-        let samplesDBURL = SampleIndex.defaultDatabasePath
-
-        Logging.Log.output("🧪 Sample Code Index (samples.db)")
-
-        guard FileManager.default.fileExists(atPath: samplesDBURL.path) else {
-            Logging.Log.output("   ⚠  Database: \(samplesDBURL.path) (not found)")
-            Logging.Log.output("     → Run: cupertino fetch --type samples && cupertino cleanup && cupertino save --samples")
-            Logging.Log.output("")
-            return
-        }
-
-        let fileSize = (try? FileManager.default.attributesOfItem(atPath: samplesDBURL.path)[.size] as? UInt64) ?? 0
-        Logging.Log.output("   ✓ Database: \(samplesDBURL.path)")
-        Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
-
-        let projectCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM projects;")
-        let fileCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM files;")
-        let symbolCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM file_symbols;")
-        if let projectCount { Logging.Log.output("   ✓ Projects: \(projectCount)") }
-        if let fileCount { Logging.Log.output("   ✓ Indexed files: \(fileCount)") }
-        if let symbolCount { Logging.Log.output("   ✓ Indexed symbols: \(symbolCount)") }
-        Logging.Log.output("")
-    }
-
-    /// #192 F1. Report `packages.db` presence, size, and row counts (packages,
-    /// files). Schema version tracked via the bundle-wide
-    /// `Shared.Constants.App.databaseVersion` constant rather than a PRAGMA
-    /// (packages.db is downloaded as part of the v1.0+ bundle, not migrated).
-    private func checkPackagesDatabase() -> Bool {
-        let packagesDBURL = Shared.Constants.defaultPackagesDatabase
-
-        Logging.Log.output("📦 Packages Index (packages.db)")
-
-        guard FileManager.default.fileExists(atPath: packagesDBURL.path) else {
-            Logging.Log.output("   ⚠  Database: \(packagesDBURL.path) (not found)")
-            Logging.Log.output("     → Run: cupertino setup  (downloads the pre-built packages index)")
-            Logging.Log.output("     Expected version: \(Shared.Constants.App.databaseVersion)")
-            Logging.Log.output("")
-            // Missing packages.db is a warning, not a failure — server still
-            // runs, just without the packages tool. Doctor summary stays green.
             return true
         }
 
-        let fileSize = (try? FileManager.default.attributesOfItem(atPath: packagesDBURL.path)[.size] as? UInt64) ?? 0
-        Logging.Log.output("   ✓ Database: \(packagesDBURL.path)")
-        Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
+        /// Filesystem check for raw corpus directories. These are *inputs* for
+        /// `cupertino save`; they're optional once `search.db` is built (a user
+        /// who ran `cupertino setup` has the DB but no source dirs, and that's
+        /// fine). All five directories are warnings-only — missing dirs don't
+        /// fail doctor. The query-correctness truth lives in `search.db` and is
+        /// reported by `checkSearchDatabase`.
+        private func checkDocumentationDirectories() -> Bool {
+            let docsURL = URL(fileURLWithPath: docsDir).expandingTildeInPath
+            let evolutionURL = URL(fileURLWithPath: evolutionDir).expandingTildeInPath
+            let higURL = Shared.Constants.defaultHIGDirectory
+            let swiftOrgURL = Shared.Constants.defaultSwiftOrgDirectory
+            let archiveURL = Shared.Constants.defaultArchiveDirectory
 
-        let packageCount = Diagnostics.Probes.rowCount(at: packagesDBURL, sql: "SELECT COUNT(*) FROM packages;")
-        let fileCount = Diagnostics.Probes.rowCount(at: packagesDBURL, sql: "SELECT COUNT(*) FROM package_files;")
-        if let packageCount { Logging.Log.output("   ✓ Packages: \(packageCount)") }
-        if let fileCount { Logging.Log.output("   ✓ Indexed files: \(fileCount)") }
-        Logging.Log.output("   ℹ  Bundled version: \(Shared.Constants.App.databaseVersion)")
-        Logging.Log.output("")
-        return true
-    }
+            Logging.Log.output("📂 Raw corpus directories (input for `cupertino save`)")
 
-    private func checkPackages() async {
-        let packagesDir = Shared.Constants.defaultPackagesDirectory
-        let userSelectionsURL = Shared.Constants.defaultBaseDirectory
-            .appendingPathComponent(Shared.Constants.FileName.selectedPackages)
+            let entries: [CorpusEntry] = [
+                CorpusEntry(label: "Apple docs", url: docsURL, suffix: "files", fetchType: "docs"),
+                CorpusEntry(label: "Swift Evolution", url: evolutionURL, suffix: "proposals", fetchType: "evolution"),
+                CorpusEntry(label: "Swift.org", url: swiftOrgURL, suffix: "pages", fetchType: "swift"),
+                CorpusEntry(label: "HIG", url: higURL, suffix: "pages", fetchType: "hig"),
+                CorpusEntry(label: "Apple Archive", url: archiveURL, suffix: "guides", fetchType: "archive"),
+            ]
 
-        Logging.Log.output("📦 Swift Packages")
-
-        // Load selected URLs once and derive the canonical "owner/repo" key
-        // set so we can compare against on-disk READMEs by NAME, not by count.
-        let selectedURLs: Set<String>
-        if FileManager.default.fileExists(atPath: userSelectionsURL.path) {
-            selectedURLs = Diagnostics.Probes.userSelectedPackageURLs(from: userSelectionsURL)
-            Logging.Log.output("   ✓ User selections: \(userSelectionsURL.path)")
-            Logging.Log.output("     \(selectedURLs.count) packages selected")
-        } else {
-            selectedURLs = []
-            Logging.Log.output("   ⚠  User selections: not configured")
-            Logging.Log.output("     → Use TUI to select packages, or will use bundled defaults")
-        }
-        let selectedKeys = Set(selectedURLs.compactMap(Diagnostics.Probes.ownerRepoKey(forGitHubURL:)))
-
-        // Check downloaded READMEs and identify true orphans (downloaded
-        // owner/repo no longer in selections) and true gaps (selected but
-        // not yet downloaded).
-        if FileManager.default.fileExists(atPath: packagesDir.path) {
-            let readmeKeys = Diagnostics.Probes.packageREADMEKeys(in: packagesDir)
-            if readmeKeys.isEmpty {
-                Logging.Log.output("   ⚠  Package docs: directory exists but no package files")
-            } else {
-                Logging.Log.output("   ✓ Downloaded READMEs: \(readmeKeys.count) packages")
-                Logging.Log.output("     \(packagesDir.path)")
-
-                if !selectedKeys.isEmpty {
-                    let orphans = readmeKeys.subtracting(selectedKeys)
-                    let missing = selectedKeys.subtracting(readmeKeys)
-                    if !orphans.isEmpty {
-                        Logging.Log.output("   ⚠  Orphaned READMEs: \(orphans.count) (downloaded but no longer selected)")
-                    }
-                    if !missing.isEmpty {
-                        Logging.Log.output("   ⚠  Missing READMEs: \(missing.count) (selected but not yet downloaded)")
-                        Logging.Log.output("     → Run: cupertino fetch --type packages")
-                    }
+            for entry in entries {
+                if FileManager.default.fileExists(atPath: entry.url.path) {
+                    let count = Diagnostics.Probes.countCorpusFiles(in: entry.url)
+                    Logging.Log.output("   ✓ \(entry.label): \(entry.url.path) (\(count) \(entry.suffix))")
+                } else {
+                    Logging.Log.output("   ⚠  \(entry.label): \(entry.url.path) (not found)")
+                    Logging.Log.output("     → Run: cupertino fetch --type \(entry.fetchType)  (only needed to rebuild from scratch)")
                 }
             }
-        } else {
-            Logging.Log.output("   ⚠  Package docs: not downloaded")
+
+            Logging.Log.output("")
+            // Filesystem state is informational. The hard fail is whether
+            // search.db has indexed data, which `checkSearchDatabase` enforces.
+            return true
         }
 
-        // Show priority packages source
-        let allPackages = await PriorityPackagesCatalog.allPackages
-        let appleCount = await PriorityPackagesCatalog.applePackages.count
-        let ecosystemCount = await PriorityPackagesCatalog.ecosystemPackages.count
-        Logging.Log.output("   ℹ  Priority packages: \(allPackages.count) total")
-        Logging.Log.output("     Apple: \(appleCount), Ecosystem: \(ecosystemCount)")
+        private func checkSearchDatabase() async -> Bool {
+            let searchDBURL = URL(fileURLWithPath: searchDB).expandingTildeInPath
 
-        Logging.Log.output("")
-    }
+            Logging.Log.output("🔍 Search Index")
 
-    private func checkResourceProviders() -> Bool {
-        Logging.Log.output("🔧 Providers")
-        Logging.Log.output("   ✓ DocsResourceProvider: available")
-        Logging.Log.output("   ✓ SearchToolProvider: available")
-        Logging.Log.output("")
-        return true
+            guard FileManager.default.fileExists(atPath: searchDBURL.path) else {
+                Logging.Log.output("   ✗ Database: \(searchDBURL.path) (not found)")
+                Logging.Log.output("     → Run: cupertino setup  (or `cupertino save` if building locally)")
+                Logging.Log.output("")
+                return false
+            }
+
+            let fileSize = (try? FileManager.default.attributesOfItem(atPath: searchDBURL.path)[.size] as? UInt64) ?? 0
+            Logging.Log.output("   ✓ Database: \(searchDBURL.path)")
+            Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
+
+            if !reportSchemaVersion(at: searchDBURL) {
+                return false
+            }
+
+            do {
+                let searchIndex = try await SearchModule.Index(dbPath: searchDBURL)
+                let frameworks = try await searchIndex.listFrameworks()
+                Logging.Log.output("   ✓ Frameworks: \(frameworks.count)")
+                await searchIndex.disconnect()
+                return reportIndexedSources(at: searchDBURL)
+            } catch {
+                Logging.Log.output("   ✗ Database error: \(error)")
+                Logging.Log.output("     → rm \(searchDBURL.path) && cupertino save")
+                Logging.Log.output("")
+                return false
+            }
+        }
+
+        /// Read `PRAGMA user_version` and compare against the binary's expected
+        /// schema. Returns false on mismatch (with a precise rebuild hint), true
+        /// on match or unreadable. Read BEFORE opening via `SearchModule.Index` because
+        /// migrating from an incompatible version throws during init, and the
+        /// user wants to know which version they're stuck on.
+        private func reportSchemaVersion(at searchDBURL: URL) -> Bool {
+            let onDiskVersion = Diagnostics.Probes.userVersion(at: searchDBURL)
+            let expected = SearchModule.Index.schemaVersion
+            guard let onDiskVersion else {
+                Logging.Log.output("   ⚠  Schema version: could not read PRAGMA user_version")
+                return true
+            }
+            if onDiskVersion == expected {
+                Logging.Log.output("   ✓ Schema version: \(onDiskVersion) (matches installed binary)")
+                return true
+            }
+            if onDiskVersion < expected {
+                Logging.Log.output("   ✗ Schema version: \(onDiskVersion) (binary expects \(expected), rebuild required)")
+                Logging.Log.output("     → rm \(searchDBURL.path) && cupertino save")
+            } else {
+                Logging.Log.output("   ✗ Schema version: \(onDiskVersion) (newer than binary — expected \(expected))")
+                Logging.Log.output("     → Upgrade cupertino: brew upgrade cupertino")
+            }
+            Logging.Log.output("")
+            return false
+        }
+
+        /// Per-source indexed counts via direct sqlite read. This is the truth
+        /// for "can my MCP answer queries about source X?". Hard-fails if the DB
+        /// opens but has zero indexed rows (silent-empty MCP otherwise).
+        private func reportIndexedSources(at searchDBURL: URL) -> Bool {
+            let perSource = Diagnostics.Probes.perSourceCounts(at: searchDBURL)
+            if !perSource.isEmpty {
+                Logging.Log.output("   📚 Indexed sources:")
+                for (source, count) in perSource {
+                    Logging.Log.output("     ✓ \(source): \(count) entries")
+                }
+            }
+            Logging.Log.output("")
+            let totalIndexed = perSource.reduce(0) { $0 + $1.count }
+            if totalIndexed == 0 {
+                Logging.Log.output("   ✗ Search index is empty (0 rows in docs_metadata)")
+                Logging.Log.output("     → Rebuild: rm \(searchDBURL.path) && cupertino setup")
+                Logging.Log.output("")
+                return false
+            }
+            return true
+        }
+
+        /// Report `samples.db` presence, size, and row counts (sample projects +
+        /// indexed source files). Built by `cupertino save --samples` after sample-code
+        /// download + cleanup. Missing is a warning (server runs without it; the
+        /// sample-code search just isn't available).
+        private func checkSamplesDatabase() {
+            let samplesDBURL = SampleIndex.defaultDatabasePath
+
+            Logging.Log.output("🧪 Sample Code Index (samples.db)")
+
+            guard FileManager.default.fileExists(atPath: samplesDBURL.path) else {
+                Logging.Log.output("   ⚠  Database: \(samplesDBURL.path) (not found)")
+                Logging.Log.output("     → Run: cupertino fetch --type samples && cupertino cleanup && cupertino save --samples")
+                Logging.Log.output("")
+                return
+            }
+
+            let fileSize = (try? FileManager.default.attributesOfItem(atPath: samplesDBURL.path)[.size] as? UInt64) ?? 0
+            Logging.Log.output("   ✓ Database: \(samplesDBURL.path)")
+            Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
+
+            let projectCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM projects;")
+            let fileCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM files;")
+            let symbolCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM file_symbols;")
+            if let projectCount { Logging.Log.output("   ✓ Projects: \(projectCount)") }
+            if let fileCount { Logging.Log.output("   ✓ Indexed files: \(fileCount)") }
+            if let symbolCount { Logging.Log.output("   ✓ Indexed symbols: \(symbolCount)") }
+            Logging.Log.output("")
+        }
+
+        /// #192 F1. Report `packages.db` presence, size, and row counts (packages,
+        /// files). Schema version tracked via the bundle-wide
+        /// `Shared.Constants.App.databaseVersion` constant rather than a PRAGMA
+        /// (packages.db is downloaded as part of the v1.0+ bundle, not migrated).
+        private func checkPackagesDatabase() -> Bool {
+            let packagesDBURL = Shared.Constants.defaultPackagesDatabase
+
+            Logging.Log.output("📦 Packages Index (packages.db)")
+
+            guard FileManager.default.fileExists(atPath: packagesDBURL.path) else {
+                Logging.Log.output("   ⚠  Database: \(packagesDBURL.path) (not found)")
+                Logging.Log.output("     → Run: cupertino setup  (downloads the pre-built packages index)")
+                Logging.Log.output("     Expected version: \(Shared.Constants.App.databaseVersion)")
+                Logging.Log.output("")
+                // Missing packages.db is a warning, not a failure — server still
+                // runs, just without the packages tool. Doctor summary stays green.
+                return true
+            }
+
+            let fileSize = (try? FileManager.default.attributesOfItem(atPath: packagesDBURL.path)[.size] as? UInt64) ?? 0
+            Logging.Log.output("   ✓ Database: \(packagesDBURL.path)")
+            Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
+
+            let packageCount = Diagnostics.Probes.rowCount(at: packagesDBURL, sql: "SELECT COUNT(*) FROM packages;")
+            let fileCount = Diagnostics.Probes.rowCount(at: packagesDBURL, sql: "SELECT COUNT(*) FROM package_files;")
+            if let packageCount { Logging.Log.output("   ✓ Packages: \(packageCount)") }
+            if let fileCount { Logging.Log.output("   ✓ Indexed files: \(fileCount)") }
+            Logging.Log.output("   ℹ  Bundled version: \(Shared.Constants.App.databaseVersion)")
+            Logging.Log.output("")
+            return true
+        }
+
+        private func checkPackages() async {
+            let packagesDir = Shared.Constants.defaultPackagesDirectory
+            let userSelectionsURL = Shared.Constants.defaultBaseDirectory
+                .appendingPathComponent(Shared.Constants.FileName.selectedPackages)
+
+            Logging.Log.output("📦 Swift Packages")
+
+            // Load selected URLs once and derive the canonical "owner/repo" key
+            // set so we can compare against on-disk READMEs by NAME, not by count.
+            let selectedURLs: Set<String>
+            if FileManager.default.fileExists(atPath: userSelectionsURL.path) {
+                selectedURLs = Diagnostics.Probes.userSelectedPackageURLs(from: userSelectionsURL)
+                Logging.Log.output("   ✓ User selections: \(userSelectionsURL.path)")
+                Logging.Log.output("     \(selectedURLs.count) packages selected")
+            } else {
+                selectedURLs = []
+                Logging.Log.output("   ⚠  User selections: not configured")
+                Logging.Log.output("     → Use TUI to select packages, or will use bundled defaults")
+            }
+            let selectedKeys = Set(selectedURLs.compactMap(Diagnostics.Probes.ownerRepoKey(forGitHubURL:)))
+
+            // Check downloaded READMEs and identify true orphans (downloaded
+            // owner/repo no longer in selections) and true gaps (selected but
+            // not yet downloaded).
+            if FileManager.default.fileExists(atPath: packagesDir.path) {
+                let readmeKeys = Diagnostics.Probes.packageREADMEKeys(in: packagesDir)
+                if readmeKeys.isEmpty {
+                    Logging.Log.output("   ⚠  Package docs: directory exists but no package files")
+                } else {
+                    Logging.Log.output("   ✓ Downloaded READMEs: \(readmeKeys.count) packages")
+                    Logging.Log.output("     \(packagesDir.path)")
+
+                    if !selectedKeys.isEmpty {
+                        let orphans = readmeKeys.subtracting(selectedKeys)
+                        let missing = selectedKeys.subtracting(readmeKeys)
+                        if !orphans.isEmpty {
+                            Logging.Log.output("   ⚠  Orphaned READMEs: \(orphans.count) (downloaded but no longer selected)")
+                        }
+                        if !missing.isEmpty {
+                            Logging.Log.output("   ⚠  Missing READMEs: \(missing.count) (selected but not yet downloaded)")
+                            Logging.Log.output("     → Run: cupertino fetch --type packages")
+                        }
+                    }
+                }
+            } else {
+                Logging.Log.output("   ⚠  Package docs: not downloaded")
+            }
+
+            // Show priority packages source
+            let allPackages = await PriorityPackagesCatalog.allPackages
+            let appleCount = await PriorityPackagesCatalog.applePackages.count
+            let ecosystemCount = await PriorityPackagesCatalog.ecosystemPackages.count
+            Logging.Log.output("   ℹ  Priority packages: \(allPackages.count) total")
+            Logging.Log.output("     Apple: \(appleCount), Ecosystem: \(ecosystemCount)")
+
+            Logging.Log.output("")
+        }
+
+        private func checkResourceProviders() -> Bool {
+            Logging.Log.output("🔧 Providers")
+            Logging.Log.output("   ✓ DocsResourceProvider: available")
+            Logging.Log.output("   ✓ SearchToolProvider: available")
+            Logging.Log.output("")
+            return true
+        }
     }
 }

--- a/Packages/Sources/CLI/Commands/FetchCommand.swift
+++ b/Packages/Sources/CLI/Commands/FetchCommand.swift
@@ -21,1006 +21,1008 @@ extension Shared.DiscoveryMode: ExpressibleByArgument {}
 // MARK: - Fetch Command
 
 // swiftlint:disable type_body_length file_length function_body_length
-// Justification: FetchCommand handles 10+ different fetch types (docs, evolution, packages, code, etc.)
+// Justification: Command.Fetch handles 10+ different fetch types (docs, evolution, packages, code, etc.)
 // Each type has distinct configuration, progress reporting, and error handling.
 // Splitting into separate commands would duplicate shared options and break the unified fetch interface.
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-struct FetchCommand: AsyncParsableCommand {
-    typealias FetchType = Cupertino.FetchType
+extension Command {
+    struct Fetch: AsyncParsableCommand {
+        typealias FetchType = Cupertino.FetchType
 
-    static let configuration = CommandConfiguration(
-        commandName: "fetch",
-        abstract: "Fetch documentation and resources"
-    )
+        static let configuration = CommandConfiguration(
+            commandName: "fetch",
+            abstract: "Fetch documentation and resources"
+        )
 
-    @Option(
-        name: .long,
-        help: """
-        Type of documentation to fetch: docs (Apple), swift (Swift.org), \
-        evolution (Swift Evolution), \
-        packages (Swift package metadata + archives — see --skip-metadata / --skip-archives), \
-        code (Sample code from Apple), \
-        samples (Sample code from GitHub - recommended), \
-        archive (Apple Archive guides), hig (Human Interface Guidelines), \
-        availability (API version info for existing docs), \
-        all (all types in parallel)
-        """
-    )
-    var type: FetchType = .docs
+        @Option(
+            name: .long,
+            help: """
+            Type of documentation to fetch: docs (Apple), swift (Swift.org), \
+            evolution (Swift Evolution), \
+            packages (Swift package metadata + archives — see --skip-metadata / --skip-archives), \
+            code (Sample code from Apple), \
+            samples (Sample code from GitHub - recommended), \
+            archive (Apple Archive guides), hig (Human Interface Guidelines), \
+            availability (API version info for existing docs), \
+            all (all types in parallel)
+            """
+        )
+        var type: FetchType = .docs
 
-    @Option(name: .long, help: "Start URL to crawl from (overrides --type default)")
-    var startURL: String?
+        @Option(name: .long, help: "Start URL to crawl from (overrides --type default)")
+        var startURL: String?
 
-    @Option(name: .long, help: "Maximum number of pages to crawl")
-    var maxPages: Int = Shared.Constants.Limit.defaultMaxPages
+        @Option(name: .long, help: "Maximum number of pages to crawl")
+        var maxPages: Int = Shared.Constants.Limit.defaultMaxPages
 
-    @Option(name: .long, help: "Maximum depth to crawl")
-    var maxDepth: Int = 15
+        @Option(name: .long, help: "Maximum depth to crawl")
+        var maxDepth: Int = 15
 
-    @Option(name: .long, help: "Output directory for documentation")
-    var outputDir: String?
+        @Option(name: .long, help: "Output directory for documentation")
+        var outputDir: String?
 
-    @Option(
-        name: .long,
-        help: """
-        Allowed URL prefixes (comma-separated). \
-        If not specified, auto-detects based on start URL
-        """
-    )
-    var allowedPrefixes: String?
+        @Option(
+            name: .long,
+            help: """
+            Allowed URL prefixes (comma-separated). \
+            If not specified, auto-detects based on start URL
+            """
+        )
+        var allowedPrefixes: String?
 
-    @Flag(name: .long, help: "Force recrawl of all pages (re-fetch even unchanged content)")
-    var force: Bool = false
+        @Flag(name: .long, help: "Force recrawl of all pages (re-fetch even unchanged content)")
+        var force: Bool = false
 
-    @Flag(name: .long, help: "Ignore any saved session and start fresh from the seed URL")
-    var startClean: Bool = false
+        @Flag(name: .long, help: "Ignore any saved session and start fresh from the seed URL")
+        var startClean: Bool = false
 
-    @Flag(
-        name: .long,
-        help: """
-        Re-queue URLs that errored before save (visited but missing from \
-        the pages dict). Use after a filename or save bug is fixed to \
-        retry the affected pages without re-crawling the whole corpus.
-        """
-    )
-    var retryErrors: Bool = false
+        @Flag(
+            name: .long,
+            help: """
+            Re-queue URLs that errored before save (visited but missing from \
+            the pages dict). Use after a filename or save bug is fixed to \
+            retry the affected pages without re-crawling the whole corpus.
+            """
+        )
+        var retryErrors: Bool = false
 
-    @Option(
-        name: .long,
-        help: """
-        Path to a known-good baseline corpus directory (e.g. a prior \
-        cupertino-docs/docs snapshot). On startup, URLs present in the \
-        baseline but not in the current crawl's known set (queue / visited \
-        / pages) are prepended to the queue so the resumed crawl recovers \
-        gaps without re-crawling the whole corpus. Comparison is \
-        case-insensitive on the path.
-        """
-    )
-    var baseline: String?
+        @Option(
+            name: .long,
+            help: """
+            Path to a known-good baseline corpus directory (e.g. a prior \
+            cupertino-docs/docs snapshot). On startup, URLs present in the \
+            baseline but not in the current crawl's known set (queue / visited \
+            / pages) are prepended to the queue so the resumed crawl recovers \
+            gaps without re-crawling the whole corpus. Comparison is \
+            case-insensitive on the path.
+            """
+        )
+        var baseline: String?
 
-    @Option(
-        name: .long,
-        help: """
-        Path to a text file containing one URL per line. Each URL is \
-        enqueued at depth 0; the crawler follows links from each up to \
-        --max-depth, so set --max-depth 0 to fetch only the listed URLs \
-        with no descent, --max-depth 3 to follow 3 levels of children, etc. \
-        Useful for fetching a fixed list — e.g. URLs another corpus has \
-        but this one is missing — without re-spidering everything. Lines \
-        starting with '#' and blank lines are ignored. (#210)
-        """
-    )
-    var urls: String?
+        @Option(
+            name: .long,
+            help: """
+            Path to a text file containing one URL per line. Each URL is \
+            enqueued at depth 0; the crawler follows links from each up to \
+            --max-depth, so set --max-depth 0 to fetch only the listed URLs \
+            with no descent, --max-depth 3 to follow 3 levels of children, etc. \
+            Useful for fetching a fixed list — e.g. URLs another corpus has \
+            but this one is missing — without re-spidering everything. Lines \
+            starting with '#' and blank lines are ignored. (#210)
+            """
+        )
+        var urls: String?
 
-    @Option(
-        name: .long,
-        help: """
-        Discovery mode: \
-        auto (default — JSON API primary, WKWebView fallback when JSON 404s), \
-        json-only (JSON only, no WKWebView fallback — fastest, narrowest), \
-        webview-only (WKWebView for everything — slowest, broadest discovery, \
-        matches pre-2025-11-30 behavior).
-        """
-    )
-    var discoveryMode: Shared.DiscoveryMode = .auto
+        @Option(
+            name: .long,
+            help: """
+            Discovery mode: \
+            auto (default — JSON API primary, WKWebView fallback when JSON 404s), \
+            json-only (JSON only, no WKWebView fallback — fastest, narrowest), \
+            webview-only (WKWebView for everything — slowest, broadest discovery, \
+            matches pre-2025-11-30 behavior).
+            """
+        )
+        var discoveryMode: Shared.DiscoveryMode = .auto
 
-    @Flag(name: .long, inversion: .prefixedNo, help: "Only download accepted/implemented proposals (evolution type only)")
-    var onlyAccepted: Bool = true
+        @Flag(name: .long, inversion: .prefixedNo, help: "Only download accepted/implemented proposals (evolution type only)")
+        var onlyAccepted: Bool = true
 
-    @Option(name: .long, help: "Maximum number of items to fetch (packages/code types only)")
-    var limit: Int?
+        @Option(name: .long, help: "Maximum number of items to fetch (packages/code types only)")
+        var limit: Int?
 
-    @Flag(name: .long, help: "Use fast mode (higher concurrency, shorter timeout) for availability fetch")
-    var fast: Bool = false
+        @Flag(name: .long, help: "Use fast mode (higher concurrency, shorter timeout) for availability fetch")
+        var fast: Bool = false
 
-    @Flag(
-        name: .long,
-        inversion: .prefixedNo,
-        help: .hidden
-    )
-    var recurse: Bool = true
+        @Flag(
+            name: .long,
+            inversion: .prefixedNo,
+            help: .hidden
+        )
+        var recurse: Bool = true
 
-    @Flag(
-        name: .long,
-        help: .hidden
-    )
-    var refresh: Bool = false
+        @Flag(
+            name: .long,
+            help: .hidden
+        )
+        var refresh: Bool = false
 
-    @Flag(
-        name: .long,
-        help: """
-        Skip the Swift Package Index metadata refresh stage of \
-        `--type packages` (run only the archive download). #217
-        """
-    )
-    var skipMetadata: Bool = false
+        @Flag(
+            name: .long,
+            help: """
+            Skip the Swift Package Index metadata refresh stage of \
+            `--type packages` (run only the archive download). #217
+            """
+        )
+        var skipMetadata: Bool = false
 
-    @Flag(
-        name: .long,
-        help: """
-        Skip the GitHub archive download stage of `--type packages` \
-        (run only the metadata refresh). #217
-        """
-    )
-    var skipArchives: Bool = false
+        @Flag(
+            name: .long,
+            help: """
+            Skip the GitHub archive download stage of `--type packages` \
+            (run only the metadata refresh). #217
+            """
+        )
+        var skipArchives: Bool = false
 
-    @Flag(
-        name: .long,
-        help: """
-        After `--type packages` stage 2, walk the on-disk corpus and \
-        write a per-package `availability.json` recording \
-        `Package.swift` deployment targets and every `@available(...)` \
-        attribute occurrence in `Sources/` and `Tests/` (#219). Pure \
-        on-disk pass — no network. Idempotent.
-        """
-    )
-    var annotateAvailability: Bool = false
+        @Flag(
+            name: .long,
+            help: """
+            After `--type packages` stage 2, walk the on-disk corpus and \
+            write a per-package `availability.json` recording \
+            `Package.swift` deployment targets and every `@available(...)` \
+            attribute occurrence in `Sources/` and `Tests/` (#219). Pure \
+            on-disk pass — no network. Idempotent.
+            """
+        )
+        var annotateAvailability: Bool = false
 
-    mutating func run() async throws {
-        logStartMessage()
+        mutating func run() async throws {
+            logStartMessage()
 
-        if type == .all {
-            try await runAllFetches()
-            return
+            if type == .all {
+                try await runAllFetches()
+                return
+            }
+
+            // Direct fetch types (packages, code)
+            if type == .packages {
+                try await runPackageFetch()
+                return
+            }
+
+            if type == .code {
+                try await runCodeFetch()
+                return
+            }
+
+            if type == .samples {
+                try await runSamplesFetch()
+                return
+            }
+
+            if type == .archive {
+                try await runArchiveCrawl()
+                return
+            }
+
+            if type == .hig {
+                try await runHIGCrawl()
+                return
+            }
+
+            if type == .availability {
+                try await runAvailabilityFetch()
+                return
+            }
+
+            // Web crawl types (docs, swift, evolution)
+            if type == .evolution {
+                try await runEvolutionCrawl()
+                return
+            }
+
+            try await runStandardCrawl()
         }
 
-        // Direct fetch types (packages, code)
-        if type == .packages {
-            try await runPackageFetch()
-            return
+        private func logStartMessage() {
+            // The Crawler auto-resumes whenever metadata.json's crawlState is active
+            // and matches the start URL — no flag needed. We log "Fetching" here
+            // unconditionally; the Crawler itself prints "🔄 Found resumable session"
+            // when it actually loads saved state.
+            Logging.ConsoleLogger.info("🚀 Cupertino - Fetching \(type.displayName)")
+            // Print the resolved output directory at startup so #212-style
+            // BinaryConfig misrouting is immediately visible.
+            let resolvedOutputDir = outputDir.flatMap { URL(fileURLWithPath: $0).expandingTildeInPath.path }
+                ?? type.defaultOutputDir
+            Logging.ConsoleLogger.info("   Output: \(resolvedOutputDir)\n")
         }
 
-        if type == .code {
-            try await runCodeFetch()
-            return
+        private mutating func runAllFetches() async throws {
+            Logging.ConsoleLogger.info("📚 Fetching all documentation types in parallel:\n")
+            let baseCommand = self
+
+            try await withThrowingTaskGroup(of: (FetchType, Result<Void, Error>).self) { group in
+                for fetchType in FetchType.allTypes {
+                    group.addTask {
+                        await Self.fetchSingleType(fetchType, baseCommand: baseCommand)
+                    }
+                }
+
+                let results = try await collectFetchResults(from: &group)
+                try validateFetchResults(results)
+            }
         }
 
-        if type == .samples {
-            try await runSamplesFetch()
-            return
+        private static func fetchSingleType(
+            _ fetchType: FetchType,
+            baseCommand: Command.Fetch
+        ) async -> (FetchType, Result<Void, Error>) {
+            Logging.ConsoleLogger.info("🚀 Starting \(fetchType.displayName)...")
+            var fetchCommand = baseCommand
+            fetchCommand.type = fetchType
+            fetchCommand.outputDir = fetchType.defaultOutputDir
+
+            do {
+                try await fetchCommand.run()
+                return (fetchType, .success(()))
+            } catch {
+                return (fetchType, .failure(error))
+            }
         }
 
-        if type == .archive {
-            try await runArchiveCrawl()
-            return
+        private func collectFetchResults(
+            from group: inout ThrowingTaskGroup<(FetchType, Result<Void, Error>), Error>
+        ) async throws -> [(FetchType, Result<Void, Error>)] {
+            var results: [(FetchType, Result<Void, Error>)] = []
+            for try await result in group {
+                results.append(result)
+                let (fetchType, outcome) = result
+                switch outcome {
+                case .success:
+                    Logging.ConsoleLogger.info("✅ Completed \(fetchType.displayName)")
+                case .failure(let error):
+                    Logging.ConsoleLogger.error("❌ Failed \(fetchType.displayName): \(error)")
+                }
+            }
+            return results
         }
 
-        if type == .hig {
-            try await runHIGCrawl()
-            return
+        private func validateFetchResults(_ results: [(FetchType, Result<Void, Error>)]) throws {
+            let failures = results.filter {
+                if case .failure = $0.1 { return true }
+                return false
+            }
+
+            if failures.isEmpty {
+                Logging.ConsoleLogger.info("\n✅ All documentation types fetched successfully!")
+            } else {
+                Logging.ConsoleLogger.info("\n⚠️  Completed with \(failures.count) failure(s)")
+                throw ExitCode.failure
+            }
         }
 
-        if type == .availability {
-            try await runAvailabilityFetch()
-            return
+        private mutating func runStandardCrawl() async throws {
+            let url = try validateStartURL()
+            let outputDirectory = try await determineOutputDirectory(for: url)
+            if startClean {
+                try Ingest.Session.clearSavedSession(at: outputDirectory)
+            }
+            if retryErrors {
+                try Ingest.Session.requeueErroredURLs(at: outputDirectory, maxDepth: maxDepth)
+            }
+            if let baselinePath = baseline {
+                let baselineURL = URL(fileURLWithPath: baselinePath).expandingTildeInPath
+                try Ingest.Session.requeueFromBaseline(at: outputDirectory, baselineDir: baselineURL, maxDepth: maxDepth)
+            }
+            if let urlsPath = urls {
+                let urlsURL = URL(fileURLWithPath: urlsPath).expandingTildeInPath
+                try Ingest.Session.enqueueURLsFromFile(
+                    at: outputDirectory,
+                    urlsFile: urlsURL,
+                    maxDepth: maxDepth,
+                    startURL: url
+                )
+            }
+            let config = createConfiguration(url: url, outputDirectory: outputDirectory)
+            try await executeCrawl(with: config)
         }
 
-        // Web crawl types (docs, swift, evolution)
-        if type == .evolution {
-            try await runEvolutionCrawl()
-            return
+        // clearSavedSession lifted to Ingest.Session.clearSavedSession (#247)
+
+        // requeueErroredURLs lifted to Ingest.Session.requeueErroredURLs (#247)
+
+        // Inject URLs from a known-good baseline corpus that aren't in the
+        // current crawl's known set (queue ∪ visited ∪ pages keys). Comparison
+        // is case-insensitive on the URL path so the broken-extractor's
+        // case-mixed output still matches the baseline's casing.
+        //
+        // `baselineDir` should point at the `docs/` subtree of a prior corpus
+        // (e.g. `~/Developer/.../cupertino-docs/docs`). Each file's `.url` field
+        // is read; URLs not in the current set are prepended to the queue at
+        // `maxDepth` so the resumed crawl doesn't re-discover their children
+        // (which the baseline already crawled).
+        //
+        // requeueFromBaseline lifted to Ingest.Session.requeueFromBaseline (#247)
+
+        // Enqueue every URL listed in `urlsFile` (one URL per line) at
+        // depth 0. The crawler then follows each URL's outgoing links up
+        // to `maxDepth`, so the caller can use `--max-depth` to control
+        // how deep the descent tree goes (`--max-depth 0` = no descent,
+        // just fetch the listed URLs themselves). Lines starting with `#`
+        // and blank lines are ignored. Initialises `crawlState` if missing
+        // so the helper works against a fresh corpus too. (#210)
+        //
+        // enqueueURLsFromFile + collectBaselineURLs + lowercaseDocPath all lifted
+        // to Ingest.Session in #247.
+
+        private func validateStartURL() throws -> URL {
+            let urlString = startURL ?? type.defaultURL
+            guard let url = URL(string: urlString) else {
+                throw ValidationError("Invalid start URL: \(urlString)")
+            }
+            return url
         }
 
-        try await runStandardCrawl()
-    }
+        private func determineOutputDirectory(for url: URL) async throws -> URL {
+            if let outputDir {
+                return URL(fileURLWithPath: outputDir).expandingTildeInPath
+            }
+            return try await findExistingSession(for: url)
+                ?? URL(fileURLWithPath: type.defaultOutputDir).expandingTildeInPath
+        }
 
-    private func logStartMessage() {
-        // The Crawler auto-resumes whenever metadata.json's crawlState is active
-        // and matches the start URL — no flag needed. We log "Fetching" here
-        // unconditionally; the Crawler itself prints "🔄 Found resumable session"
-        // when it actually loads saved state.
-        Logging.ConsoleLogger.info("🚀 Cupertino - Fetching \(type.displayName)")
-        // Print the resolved output directory at startup so #212-style
-        // BinaryConfig misrouting is immediately visible.
-        let resolvedOutputDir = outputDir.flatMap { URL(fileURLWithPath: $0).expandingTildeInPath.path }
-            ?? type.defaultOutputDir
-        Logging.ConsoleLogger.info("   Output: \(resolvedOutputDir)\n")
-    }
+        private func findExistingSession(for url: URL) async throws -> URL? {
+            let candidates = [
+                Shared.Constants.defaultDocsDirectory,
+                Shared.Constants.defaultSwiftOrgDirectory,
+                Shared.Constants.defaultSwiftBookDirectory,
+            ]
 
-    private mutating func runAllFetches() async throws {
-        Logging.ConsoleLogger.info("📚 Fetching all documentation types in parallel:\n")
-        let baseCommand = self
-
-        try await withThrowingTaskGroup(of: (FetchType, Result<Void, Error>).self) { group in
-            for fetchType in FetchType.allTypes {
-                group.addTask {
-                    await Self.fetchSingleType(fetchType, baseCommand: baseCommand)
+            for candidate in candidates {
+                if let sessionDir = Ingest.Session.checkForSession(at: candidate, matching: url) {
+                    return sessionDir
                 }
             }
 
-            let results = try await collectFetchResults(from: &group)
-            try validateFetchResults(results)
+            return try await scanCupertinoDirectory(for: url)
         }
-    }
 
-    private static func fetchSingleType(
-        _ fetchType: FetchType,
-        baseCommand: FetchCommand
-    ) async -> (FetchType, Result<Void, Error>) {
-        Logging.ConsoleLogger.info("🚀 Starting \(fetchType.displayName)...")
-        var fetchCommand = baseCommand
-        fetchCommand.type = fetchType
-        fetchCommand.outputDir = fetchType.defaultOutputDir
+        // checkForSession lifted to Ingest.Session.checkForSession (#247)
 
-        do {
-            try await fetchCommand.run()
-            return (fetchType, .success(()))
-        } catch {
-            return (fetchType, .failure(error))
-        }
-    }
+        private func scanCupertinoDirectory(for url: URL) async throws -> URL? {
+            let cupertinoDir = Shared.Constants.defaultBaseDirectory
 
-    private func collectFetchResults(
-        from group: inout ThrowingTaskGroup<(FetchType, Result<Void, Error>), Error>
-    ) async throws -> [(FetchType, Result<Void, Error>)] {
-        var results: [(FetchType, Result<Void, Error>)] = []
-        for try await result in group {
-            results.append(result)
-            let (fetchType, outcome) = result
-            switch outcome {
-            case .success:
-                Logging.ConsoleLogger.info("✅ Completed \(fetchType.displayName)")
-            case .failure(let error):
-                Logging.ConsoleLogger.error("❌ Failed \(fetchType.displayName): \(error)")
+            guard let contents = try? FileManager.default.contentsOfDirectory(
+                at: cupertinoDir,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                return nil
             }
-        }
-        return results
-    }
 
-    private func validateFetchResults(_ results: [(FetchType, Result<Void, Error>)]) throws {
-        let failures = results.filter {
-            if case .failure = $0.1 { return true }
-            return false
-        }
-
-        if failures.isEmpty {
-            Logging.ConsoleLogger.info("\n✅ All documentation types fetched successfully!")
-        } else {
-            Logging.ConsoleLogger.info("\n⚠️  Completed with \(failures.count) failure(s)")
-            throw ExitCode.failure
-        }
-    }
-
-    private mutating func runStandardCrawl() async throws {
-        let url = try validateStartURL()
-        let outputDirectory = try await determineOutputDirectory(for: url)
-        if startClean {
-            try Ingest.Session.clearSavedSession(at: outputDirectory)
-        }
-        if retryErrors {
-            try Ingest.Session.requeueErroredURLs(at: outputDirectory, maxDepth: maxDepth)
-        }
-        if let baselinePath = baseline {
-            let baselineURL = URL(fileURLWithPath: baselinePath).expandingTildeInPath
-            try Ingest.Session.requeueFromBaseline(at: outputDirectory, baselineDir: baselineURL, maxDepth: maxDepth)
-        }
-        if let urlsPath = urls {
-            let urlsURL = URL(fileURLWithPath: urlsPath).expandingTildeInPath
-            try Ingest.Session.enqueueURLsFromFile(
-                at: outputDirectory,
-                urlsFile: urlsURL,
-                maxDepth: maxDepth,
-                startURL: url
-            )
-        }
-        let config = createConfiguration(url: url, outputDirectory: outputDirectory)
-        try await executeCrawl(with: config)
-    }
-
-    // clearSavedSession lifted to Ingest.Session.clearSavedSession (#247)
-
-    // requeueErroredURLs lifted to Ingest.Session.requeueErroredURLs (#247)
-
-    // Inject URLs from a known-good baseline corpus that aren't in the
-    // current crawl's known set (queue ∪ visited ∪ pages keys). Comparison
-    // is case-insensitive on the URL path so the broken-extractor's
-    // case-mixed output still matches the baseline's casing.
-    //
-    // `baselineDir` should point at the `docs/` subtree of a prior corpus
-    // (e.g. `~/Developer/.../cupertino-docs/docs`). Each file's `.url` field
-    // is read; URLs not in the current set are prepended to the queue at
-    // `maxDepth` so the resumed crawl doesn't re-discover their children
-    // (which the baseline already crawled).
-    //
-    // requeueFromBaseline lifted to Ingest.Session.requeueFromBaseline (#247)
-
-    // Enqueue every URL listed in `urlsFile` (one URL per line) at
-    // depth 0. The crawler then follows each URL's outgoing links up
-    // to `maxDepth`, so the caller can use `--max-depth` to control
-    // how deep the descent tree goes (`--max-depth 0` = no descent,
-    // just fetch the listed URLs themselves). Lines starting with `#`
-    // and blank lines are ignored. Initialises `crawlState` if missing
-    // so the helper works against a fresh corpus too. (#210)
-    //
-    // enqueueURLsFromFile + collectBaselineURLs + lowercaseDocPath all lifted
-    // to Ingest.Session in #247.
-
-    private func validateStartURL() throws -> URL {
-        let urlString = startURL ?? type.defaultURL
-        guard let url = URL(string: urlString) else {
-            throw ValidationError("Invalid start URL: \(urlString)")
-        }
-        return url
-    }
-
-    private func determineOutputDirectory(for url: URL) async throws -> URL {
-        if let outputDir {
-            return URL(fileURLWithPath: outputDir).expandingTildeInPath
-        }
-        return try await findExistingSession(for: url)
-            ?? URL(fileURLWithPath: type.defaultOutputDir).expandingTildeInPath
-    }
-
-    private func findExistingSession(for url: URL) async throws -> URL? {
-        let candidates = [
-            Shared.Constants.defaultDocsDirectory,
-            Shared.Constants.defaultSwiftOrgDirectory,
-            Shared.Constants.defaultSwiftBookDirectory,
-        ]
-
-        for candidate in candidates {
-            if let sessionDir = Ingest.Session.checkForSession(at: candidate, matching: url) {
-                return sessionDir
+            for dir in contents {
+                let isDirectory = (try? dir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory
+                guard isDirectory == true else {
+                    continue
+                }
+                if let sessionDir = Ingest.Session.checkForSession(at: dir, matching: url) {
+                    return sessionDir
+                }
             }
-        }
 
-        return try await scanCupertinoDirectory(for: url)
-    }
-
-    // checkForSession lifted to Ingest.Session.checkForSession (#247)
-
-    private func scanCupertinoDirectory(for url: URL) async throws -> URL? {
-        let cupertinoDir = Shared.Constants.defaultBaseDirectory
-
-        guard let contents = try? FileManager.default.contentsOfDirectory(
-            at: cupertinoDir,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ) else {
             return nil
         }
 
-        for dir in contents {
-            let isDirectory = (try? dir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory
-            guard isDirectory == true else {
-                continue
-            }
-            if let sessionDir = Ingest.Session.checkForSession(at: dir, matching: url) {
-                return sessionDir
-            }
-        }
+        private func createConfiguration(
+            url: URL,
+            outputDirectory: URL
+        ) -> Shared.Configuration {
+            // Use user-provided prefixes, or fall back to type defaults
+            let prefixes: [String]? = allowedPrefixes?
+                .split(separator: ",")
+                .map { String($0.trimmingCharacters(in: .whitespaces)) }
+                ?? type.defaultAllowedPrefixes
 
-        return nil
-    }
-
-    private func createConfiguration(
-        url: URL,
-        outputDirectory: URL
-    ) -> Shared.Configuration {
-        // Use user-provided prefixes, or fall back to type defaults
-        let prefixes: [String]? = allowedPrefixes?
-            .split(separator: ",")
-            .map { String($0.trimmingCharacters(in: .whitespaces)) }
-            ?? type.defaultAllowedPrefixes
-
-        return Shared.Configuration(
-            crawler: Shared.CrawlerConfiguration(
-                startURL: url,
-                allowedPrefixes: prefixes,
-                maxPages: maxPages,
-                maxDepth: maxDepth,
-                outputDirectory: outputDirectory,
-                discoveryMode: discoveryMode
-            ),
-            changeDetection: Shared.ChangeDetectionConfiguration(
-                forceRecrawl: force,
-                outputDirectory: outputDirectory
-            ),
-            output: Shared.OutputConfiguration(format: .markdown)
-        )
-    }
-
-    private func executeCrawl(with config: Shared.Configuration) async throws {
-        let crawler = await Core.Crawler(configuration: config)
-        let stats = try await crawler.crawl { progress in
-            let percentage = String(format: "%.1f", progress.percentage)
-            let urlComponent = progress.currentURL.lastPathComponent
-            Logging.ConsoleLogger.output("   Progress: \(percentage)% - \(urlComponent)")
-        }
-
-        logCrawlCompletion(stats)
-    }
-
-    private func logCrawlCompletion(_ stats: Shared.Models.CrawlStatistics) {
-        Logging.ConsoleLogger.output("")
-        Logging.ConsoleLogger.info("✅ Crawl completed!")
-        Logging.ConsoleLogger.info("   Total: \(stats.totalPages) pages")
-        Logging.ConsoleLogger.info("   New: \(stats.newPages)")
-        Logging.ConsoleLogger.info("   Updated: \(stats.updatedPages)")
-        Logging.ConsoleLogger.info("   Skipped: \(stats.skippedPages)")
-        if let duration = stats.duration {
-            Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
-        }
-    }
-
-    private func runEvolutionCrawl() async throws {
-        let defaultPath = Shared.Constants.defaultSwiftEvolutionDirectory.path
-        let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
-
-        let crawler = await Core.EvolutionCrawler(
-            outputDirectory: outputURL,
-            onlyAccepted: onlyAccepted
-        )
-
-        let stats = try await crawler.crawl { progress in
-            let percentage = String(format: "%.1f", progress.percentage)
-            Logging.ConsoleLogger.output("   Progress: \(percentage)% - \(progress.proposalID)")
-        }
-
-        Logging.ConsoleLogger.output("")
-        Logging.ConsoleLogger.info("✅ Download completed!")
-        Logging.ConsoleLogger.info("   Total: \(stats.totalProposals) proposals")
-        Logging.ConsoleLogger.info("   New: \(stats.newProposals)")
-        Logging.ConsoleLogger.info("   Updated: \(stats.updatedProposals)")
-        Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
-        if let duration = stats.duration {
-            Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
-        }
-    }
-
-    /// `--type packages` — runs metadata refresh then archive download in
-    /// sequence. Either stage can be skipped via `--skip-metadata` /
-    /// `--skip-archives`. The two were separate fetch types until #217;
-    /// merged because they always ran back-to-back, shared the output dir,
-    /// and the `package-docs` name was misleading (it fetches whole archives,
-    /// not READMEs). Stage 2 reads `PriorityPackagesCatalog`, not the
-    /// metadata catalog, so the stages are independent.
-    private func runPackageFetch() async throws {
-        let defaultPath = Shared.Constants.defaultPackagesDirectory.path
-        let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
-
-        try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
-
-        if skipMetadata, skipArchives, !annotateAvailability {
-            Logging.ConsoleLogger.error(
-                "❌ Both --skip-metadata and --skip-archives passed without --annotate-availability — nothing to do."
+            return Shared.Configuration(
+                crawler: Shared.CrawlerConfiguration(
+                    startURL: url,
+                    allowedPrefixes: prefixes,
+                    maxPages: maxPages,
+                    maxDepth: maxDepth,
+                    outputDirectory: outputDirectory,
+                    discoveryMode: discoveryMode
+                ),
+                changeDetection: Shared.ChangeDetectionConfiguration(
+                    forceRecrawl: force,
+                    outputDirectory: outputDirectory
+                ),
+                output: Shared.OutputConfiguration(format: .markdown)
             )
-            throw ExitCode.failure
         }
 
-        if ProcessInfo.processInfo.environment[Shared.Constants.EnvVar.githubToken] == nil {
-            Logging.ConsoleLogger.info(Shared.Constants.Message.gitHubTokenTip)
-            Logging.ConsoleLogger.info("   \(Shared.Constants.Message.rateLimitWithoutToken)")
-            Logging.ConsoleLogger.info("   \(Shared.Constants.Message.rateLimitWithToken)")
-            Logging.ConsoleLogger.info("   \(Shared.Constants.Message.exportGitHubToken)\n")
+        private func executeCrawl(with config: Shared.Configuration) async throws {
+            let crawler = await Core.Crawler(configuration: config)
+            let stats = try await crawler.crawl { progress in
+                let percentage = String(format: "%.1f", progress.percentage)
+                let urlComponent = progress.currentURL.lastPathComponent
+                Logging.ConsoleLogger.output("   Progress: \(percentage)% - \(urlComponent)")
+            }
+
+            logCrawlCompletion(stats)
         }
 
-        if !skipMetadata {
-            try await runPackageMetadataStage(outputURL: outputURL)
-        } else {
-            Logging.ConsoleLogger.info("⏭  --skip-metadata: skipping Swift Package Index metadata refresh")
+        private func logCrawlCompletion(_ stats: Shared.Models.CrawlStatistics) {
+            Logging.ConsoleLogger.output("")
+            Logging.ConsoleLogger.info("✅ Crawl completed!")
+            Logging.ConsoleLogger.info("   Total: \(stats.totalPages) pages")
+            Logging.ConsoleLogger.info("   New: \(stats.newPages)")
+            Logging.ConsoleLogger.info("   Updated: \(stats.updatedPages)")
+            Logging.ConsoleLogger.info("   Skipped: \(stats.skippedPages)")
+            if let duration = stats.duration {
+                Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
+            }
         }
 
-        if !skipArchives {
-            try await runPackageArchivesStage(outputURL: outputURL)
-        } else {
-            Logging.ConsoleLogger.info("⏭  --skip-archives: skipping GitHub archive download")
-        }
+        private func runEvolutionCrawl() async throws {
+            let defaultPath = Shared.Constants.defaultSwiftEvolutionDirectory.path
+            let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
 
-        if annotateAvailability {
-            try await runPackageAnnotationStage(outputURL: outputURL)
-        }
-    }
-
-    /// Stage 3 (#219): walk every `<owner>/<repo>/` subdir under `outputURL`
-    /// and write `availability.json` capturing `Package.swift` deployment
-    /// targets and every `@available(...)` attribute occurrence in the
-    /// `Sources/` and `Tests/` trees. Pure on-disk pass — runs whether or
-    /// not stage 2 just downloaded fresh archives. Idempotent.
-    private func runPackageAnnotationStage(outputURL: URL) async throws {
-        Logging.ConsoleLogger.info("🏷  Stage 3 — Annotating availability metadata (#219)")
-
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: outputURL.path) else {
-            Logging.ConsoleLogger.error(
-                "❌ Packages directory \(outputURL.path) doesn't exist — run with stage 2 first."
+            let crawler = await Core.EvolutionCrawler(
+                outputDirectory: outputURL,
+                onlyAccepted: onlyAccepted
             )
-            throw ExitCode.failure
+
+            let stats = try await crawler.crawl { progress in
+                let percentage = String(format: "%.1f", progress.percentage)
+                Logging.ConsoleLogger.output("   Progress: \(percentage)% - \(progress.proposalID)")
+            }
+
+            Logging.ConsoleLogger.output("")
+            Logging.ConsoleLogger.info("✅ Download completed!")
+            Logging.ConsoleLogger.info("   Total: \(stats.totalProposals) proposals")
+            Logging.ConsoleLogger.info("   New: \(stats.newProposals)")
+            Logging.ConsoleLogger.info("   Updated: \(stats.updatedProposals)")
+            Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
+            if let duration = stats.duration {
+                Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
+            }
         }
 
-        let owners = (try? fm.contentsOfDirectory(at: outputURL, includingPropertiesForKeys: nil))?
-            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
-            .filter { !$0.lastPathComponent.hasPrefix(".") }
-            ?? []
+        /// `--type packages` — runs metadata refresh then archive download in
+        /// sequence. Either stage can be skipped via `--skip-metadata` /
+        /// `--skip-archives`. The two were separate fetch types until #217;
+        /// merged because they always ran back-to-back, shared the output dir,
+        /// and the `package-docs` name was misleading (it fetches whole archives,
+        /// not READMEs). Stage 2 reads `PriorityPackagesCatalog`, not the
+        /// metadata catalog, so the stages are independent.
+        private func runPackageFetch() async throws {
+            let defaultPath = Shared.Constants.defaultPackagesDirectory.path
+            let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
 
-        let annotator = Core.PackageAvailabilityAnnotator()
-        var packagesAnnotated = 0
-        var totalAttrs = 0
-        let startedAt = Date()
+            try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
 
-        for ownerURL in owners.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
-            let repos = (try? fm.contentsOfDirectory(at: ownerURL, includingPropertiesForKeys: nil))?
+            if skipMetadata, skipArchives, !annotateAvailability {
+                Logging.ConsoleLogger.error(
+                    "❌ Both --skip-metadata and --skip-archives passed without --annotate-availability — nothing to do."
+                )
+                throw ExitCode.failure
+            }
+
+            if ProcessInfo.processInfo.environment[Shared.Constants.EnvVar.githubToken] == nil {
+                Logging.ConsoleLogger.info(Shared.Constants.Message.gitHubTokenTip)
+                Logging.ConsoleLogger.info("   \(Shared.Constants.Message.rateLimitWithoutToken)")
+                Logging.ConsoleLogger.info("   \(Shared.Constants.Message.rateLimitWithToken)")
+                Logging.ConsoleLogger.info("   \(Shared.Constants.Message.exportGitHubToken)\n")
+            }
+
+            if !skipMetadata {
+                try await runPackageMetadataStage(outputURL: outputURL)
+            } else {
+                Logging.ConsoleLogger.info("⏭  --skip-metadata: skipping Swift Package Index metadata refresh")
+            }
+
+            if !skipArchives {
+                try await runPackageArchivesStage(outputURL: outputURL)
+            } else {
+                Logging.ConsoleLogger.info("⏭  --skip-archives: skipping GitHub archive download")
+            }
+
+            if annotateAvailability {
+                try await runPackageAnnotationStage(outputURL: outputURL)
+            }
+        }
+
+        /// Stage 3 (#219): walk every `<owner>/<repo>/` subdir under `outputURL`
+        /// and write `availability.json` capturing `Package.swift` deployment
+        /// targets and every `@available(...)` attribute occurrence in the
+        /// `Sources/` and `Tests/` trees. Pure on-disk pass — runs whether or
+        /// not stage 2 just downloaded fresh archives. Idempotent.
+        private func runPackageAnnotationStage(outputURL: URL) async throws {
+            Logging.ConsoleLogger.info("🏷  Stage 3 — Annotating availability metadata (#219)")
+
+            let fm = FileManager.default
+            guard fm.fileExists(atPath: outputURL.path) else {
+                Logging.ConsoleLogger.error(
+                    "❌ Packages directory \(outputURL.path) doesn't exist — run with stage 2 first."
+                )
+                throw ExitCode.failure
+            }
+
+            let owners = (try? fm.contentsOfDirectory(at: outputURL, includingPropertiesForKeys: nil))?
                 .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
                 .filter { !$0.lastPathComponent.hasPrefix(".") }
                 ?? []
 
-            for repoURL in repos.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
-                let label = "\(ownerURL.lastPathComponent)/\(repoURL.lastPathComponent)"
-                do {
-                    let result = try await annotator.annotate(packageDirectory: repoURL)
-                    packagesAnnotated += 1
-                    totalAttrs += result.stats.totalAttributes
-                    Logging.ConsoleLogger.info(
-                        "  ✅ \(label) — \(result.stats.totalAttributes) @available attrs across "
-                            + "\(result.stats.filesWithAvailability)/\(result.stats.filesScanned) files"
-                    )
-                } catch {
-                    Logging.ConsoleLogger.error("  ✗ \(label) — \(error.localizedDescription)")
-                }
-            }
-        }
+            let annotator = Core.PackageAvailabilityAnnotator()
+            var packagesAnnotated = 0
+            var totalAttrs = 0
+            let startedAt = Date()
 
-        let duration = Int(Date().timeIntervalSince(startedAt))
-        Logging.ConsoleLogger.output("")
-        Logging.ConsoleLogger.info("✅ Annotation completed")
-        Logging.ConsoleLogger.info("   Packages annotated: \(packagesAnnotated)")
-        Logging.ConsoleLogger.info("   Total @available attrs: \(totalAttrs)")
-        Logging.ConsoleLogger.info("   Duration: \(duration)s")
-    }
+            for ownerURL in owners.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+                let repos = (try? fm.contentsOfDirectory(at: ownerURL, includingPropertiesForKeys: nil))?
+                    .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+                    .filter { !$0.lastPathComponent.hasPrefix(".") }
+                    ?? []
 
-    private func runPackageMetadataStage(outputURL: URL) async throws {
-        Logging.ConsoleLogger.info("📇 Stage 1/2 — Refreshing Swift Package Index metadata")
-
-        let fetcher = Core.PackageFetcher(
-            outputDirectory: outputURL,
-            limit: limit,
-            resume: !startClean
-        )
-
-        let stats = try await fetcher.fetch { progress in
-            let percent = String(format: "%.1f", progress.percentage)
-            Logging.ConsoleLogger.output("   Progress: \(percent)% - \(progress.packageName)")
-        }
-
-        Logging.ConsoleLogger.output("")
-        Logging.ConsoleLogger.info("✅ Metadata refresh completed")
-        Logging.ConsoleLogger.info("   Total packages: \(stats.totalPackages)")
-        Logging.ConsoleLogger.info("   Successful: \(stats.successfulFetches)")
-        Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
-        if let duration = stats.duration {
-            Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
-        }
-        Logging.ConsoleLogger.info("   📁 \(outputURL.path)/\(Shared.Constants.FileName.packagesWithStars)\n")
-    }
-
-    private func runPackageArchivesStage(outputURL: URL) async throws {
-        Logging.ConsoleLogger.info("📦 Stage 2/2 — Downloading priority package archives")
-
-        // Load priority packages
-        let priorityPackages = await PriorityPackagesCatalog.allPackages
-
-        guard !priorityPackages.isEmpty else {
-            let priorityPackagesPath = Shared.Constants.defaultPackagesDirectory
-                .appendingPathComponent(Shared.Constants.FileName.priorityPackages)
-                .path
-            Logging.ConsoleLogger.error("❌ Error: No priority packages found")
-            Logging.ConsoleLogger.error("   Searched:")
-            Logging.ConsoleLogger.error("   - \(priorityPackagesPath)")
-            Logging.ConsoleLogger.error("   - Shared.Constants.CriticalApplePackages")
-            Logging.ConsoleLogger.error("   - Shared.Constants.KnownEcosystemPackages")
-            Logging.ConsoleLogger.error("\n   Please ensure at least one package source is configured.")
-            throw ExitCode.failure
-        }
-
-        // Convert to PackageReference format
-        let seedRefs = priorityPackages.compactMap { pkg -> Shared.Models.PackageReference? in
-            // Extract owner from URL if not provided
-            let owner: String
-            if let explicitOwner = pkg.owner, !explicitOwner.isEmpty {
-                owner = explicitOwner
-            } else {
-                // Parse from GitHub URL: https://github.com/owner/repo
-                guard let url = URL(string: pkg.url) else {
-                    return nil
-                }
-                let pathComponents = Array(url.pathComponents.dropFirst())
-                guard pathComponents.count >= 2 else {
-                    return nil
-                }
-                owner = pathComponents[0]
-            }
-
-            let isApple = owner == Shared.Constants.GitHubOrg.apple
-                || owner == Shared.Constants.GitHubOrg.swiftlang
-                || owner == Shared.Constants.GitHubOrg.swiftServer
-            return Shared.Models.PackageReference(
-                owner: owner,
-                repo: pkg.repo,
-                url: pkg.url,
-                priority: isApple ? .appleOfficial : .ecosystem
-            )
-        }
-
-        let exclusions = Core.ExclusionList.load()
-        let seedChecksum = Core.ResolvedPackagesStore.checksum(seeds: seedRefs, exclusions: exclusions)
-        let resolvedStoreURL = Shared.Constants.defaultBaseDirectory
-            .appendingPathComponent(Shared.Constants.FileName.resolvedPackages)
-        let canonicalCacheURL = Shared.Constants.defaultBaseDirectory
-            .appendingPathComponent(".cache")
-            .appendingPathComponent(Shared.Constants.FileName.canonicalOwnersCache)
-
-        let resolvedPackages: [Core.ResolvedPackage]
-        if recurse {
-            if !refresh,
-               let cached = Core.ResolvedPackagesStore.load(from: resolvedStoreURL),
-               cached.seedChecksum == seedChecksum {
-                Logging.ConsoleLogger.info("🔗 Using cached closure from resolved-packages.json (\(cached.packages.count) packages, generated \(cached.generatedAt))")
-                resolvedPackages = cached.packages
-            } else {
-                if refresh {
-                    Logging.ConsoleLogger.info("🔗 --refresh: discarding cached closure, re-walking dependency graphs...")
-                } else {
-                    Logging.ConsoleLogger.info("🔗 Resolving transitive dependencies for \(seedRefs.count) seed packages...")
-                }
-                if !exclusions.isEmpty {
-                    Logging.ConsoleLogger.info("   Exclusion list in effect: \(exclusions.count) entries")
-                }
-                let canonicalizer = Core.GitHubCanonicalizer(cacheURL: canonicalCacheURL)
-                let manifestCache = Core.ManifestCache(
-                    rootDirectory: Shared.Constants.defaultBaseDirectory
-                        .appendingPathComponent(".cache")
-                        .appendingPathComponent("manifests")
-                )
-                let resolver = Core.PackageDependencyResolver(
-                    canonicalizer: canonicalizer,
-                    exclusions: exclusions,
-                    manifestCache: manifestCache
-                )
-                let (resolved, resolverStats) = await resolver.resolve(seeds: seedRefs) { name, done, total in
-                    if done == 1 || done % 10 == 0 || done == total {
-                        Logging.ConsoleLogger.output("   Resolving: \(done)/\(total) (\(name))")
+                for repoURL in repos.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+                    let label = "\(ownerURL.lastPathComponent)/\(repoURL.lastPathComponent)"
+                    do {
+                        let result = try await annotator.annotate(packageDirectory: repoURL)
+                        packagesAnnotated += 1
+                        totalAttrs += result.stats.totalAttributes
+                        Logging.ConsoleLogger.info(
+                            "  ✅ \(label) — \(result.stats.totalAttributes) @available attrs across "
+                                + "\(result.stats.filesWithAvailability)/\(result.stats.filesScanned) files"
+                        )
+                    } catch {
+                        Logging.ConsoleLogger.error("  ✗ \(label) — \(error.localizedDescription)")
                     }
                 }
-                resolvedPackages = resolved
-                Logging.ConsoleLogger.info("   Seeds: \(resolverStats.seedCount)")
-                Logging.ConsoleLogger.info("   Discovered via dependencies: \(resolverStats.discoveredCount)")
-                Logging.ConsoleLogger.info("   Excluded: \(resolverStats.excludedCount)")
-                Logging.ConsoleLogger.info("   Skipped (non-GitHub): \(resolverStats.skippedNonGitHub)")
-                Logging.ConsoleLogger.info("   Skipped (SPM registry id): \(resolverStats.skippedRegistry)")
-                Logging.ConsoleLogger.info("   Missing manifest: \(resolverStats.missingManifest)")
-                Logging.ConsoleLogger.info("   Malformed manifest: \(resolverStats.malformedManifest)")
-                Logging.ConsoleLogger.info("   Resolver duration: \(Int(resolverStats.duration))s")
+            }
 
-                let store = Core.ResolvedPackagesStore(
-                    cupertinoVersion: Shared.Constants.App.version,
-                    seedChecksum: seedChecksum,
-                    packages: resolved
+            let duration = Int(Date().timeIntervalSince(startedAt))
+            Logging.ConsoleLogger.output("")
+            Logging.ConsoleLogger.info("✅ Annotation completed")
+            Logging.ConsoleLogger.info("   Packages annotated: \(packagesAnnotated)")
+            Logging.ConsoleLogger.info("   Total @available attrs: \(totalAttrs)")
+            Logging.ConsoleLogger.info("   Duration: \(duration)s")
+        }
+
+        private func runPackageMetadataStage(outputURL: URL) async throws {
+            Logging.ConsoleLogger.info("📇 Stage 1/2 — Refreshing Swift Package Index metadata")
+
+            let fetcher = Core.PackageFetcher(
+                outputDirectory: outputURL,
+                limit: limit,
+                resume: !startClean
+            )
+
+            let stats = try await fetcher.fetch { progress in
+                let percent = String(format: "%.1f", progress.percentage)
+                Logging.ConsoleLogger.output("   Progress: \(percent)% - \(progress.packageName)")
+            }
+
+            Logging.ConsoleLogger.output("")
+            Logging.ConsoleLogger.info("✅ Metadata refresh completed")
+            Logging.ConsoleLogger.info("   Total packages: \(stats.totalPackages)")
+            Logging.ConsoleLogger.info("   Successful: \(stats.successfulFetches)")
+            Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
+            if let duration = stats.duration {
+                Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
+            }
+            Logging.ConsoleLogger.info("   📁 \(outputURL.path)/\(Shared.Constants.FileName.packagesWithStars)\n")
+        }
+
+        private func runPackageArchivesStage(outputURL: URL) async throws {
+            Logging.ConsoleLogger.info("📦 Stage 2/2 — Downloading priority package archives")
+
+            // Load priority packages
+            let priorityPackages = await PriorityPackagesCatalog.allPackages
+
+            guard !priorityPackages.isEmpty else {
+                let priorityPackagesPath = Shared.Constants.defaultPackagesDirectory
+                    .appendingPathComponent(Shared.Constants.FileName.priorityPackages)
+                    .path
+                Logging.ConsoleLogger.error("❌ Error: No priority packages found")
+                Logging.ConsoleLogger.error("   Searched:")
+                Logging.ConsoleLogger.error("   - \(priorityPackagesPath)")
+                Logging.ConsoleLogger.error("   - Shared.Constants.CriticalApplePackages")
+                Logging.ConsoleLogger.error("   - Shared.Constants.KnownEcosystemPackages")
+                Logging.ConsoleLogger.error("\n   Please ensure at least one package source is configured.")
+                throw ExitCode.failure
+            }
+
+            // Convert to PackageReference format
+            let seedRefs = priorityPackages.compactMap { pkg -> Shared.Models.PackageReference? in
+                // Extract owner from URL if not provided
+                let owner: String
+                if let explicitOwner = pkg.owner, !explicitOwner.isEmpty {
+                    owner = explicitOwner
+                } else {
+                    // Parse from GitHub URL: https://github.com/owner/repo
+                    guard let url = URL(string: pkg.url) else {
+                        return nil
+                    }
+                    let pathComponents = Array(url.pathComponents.dropFirst())
+                    guard pathComponents.count >= 2 else {
+                        return nil
+                    }
+                    owner = pathComponents[0]
+                }
+
+                let isApple = owner == Shared.Constants.GitHubOrg.apple
+                    || owner == Shared.Constants.GitHubOrg.swiftlang
+                    || owner == Shared.Constants.GitHubOrg.swiftServer
+                return Shared.Models.PackageReference(
+                    owner: owner,
+                    repo: pkg.repo,
+                    url: pkg.url,
+                    priority: isApple ? .appleOfficial : .ecosystem
                 )
-                do {
-                    try store.write(to: resolvedStoreURL)
-                    Logging.ConsoleLogger.info("   Saved closure to \(resolvedStoreURL.path)")
-                } catch {
-                    Logging.ConsoleLogger.error("   ⚠️  Could not persist resolved-packages.json: \(error)")
+            }
+
+            let exclusions = Core.ExclusionList.load()
+            let seedChecksum = Core.ResolvedPackagesStore.checksum(seeds: seedRefs, exclusions: exclusions)
+            let resolvedStoreURL = Shared.Constants.defaultBaseDirectory
+                .appendingPathComponent(Shared.Constants.FileName.resolvedPackages)
+            let canonicalCacheURL = Shared.Constants.defaultBaseDirectory
+                .appendingPathComponent(".cache")
+                .appendingPathComponent(Shared.Constants.FileName.canonicalOwnersCache)
+
+            let resolvedPackages: [Core.ResolvedPackage]
+            if recurse {
+                if !refresh,
+                   let cached = Core.ResolvedPackagesStore.load(from: resolvedStoreURL),
+                   cached.seedChecksum == seedChecksum {
+                    Logging.ConsoleLogger.info("🔗 Using cached closure from resolved-packages.json (\(cached.packages.count) packages, generated \(cached.generatedAt))")
+                    resolvedPackages = cached.packages
+                } else {
+                    if refresh {
+                        Logging.ConsoleLogger.info("🔗 --refresh: discarding cached closure, re-walking dependency graphs...")
+                    } else {
+                        Logging.ConsoleLogger.info("🔗 Resolving transitive dependencies for \(seedRefs.count) seed packages...")
+                    }
+                    if !exclusions.isEmpty {
+                        Logging.ConsoleLogger.info("   Exclusion list in effect: \(exclusions.count) entries")
+                    }
+                    let canonicalizer = Core.GitHubCanonicalizer(cacheURL: canonicalCacheURL)
+                    let manifestCache = Core.ManifestCache(
+                        rootDirectory: Shared.Constants.defaultBaseDirectory
+                            .appendingPathComponent(".cache")
+                            .appendingPathComponent("manifests")
+                    )
+                    let resolver = Core.PackageDependencyResolver(
+                        canonicalizer: canonicalizer,
+                        exclusions: exclusions,
+                        manifestCache: manifestCache
+                    )
+                    let (resolved, resolverStats) = await resolver.resolve(seeds: seedRefs) { name, done, total in
+                        if done == 1 || done % 10 == 0 || done == total {
+                            Logging.ConsoleLogger.output("   Resolving: \(done)/\(total) (\(name))")
+                        }
+                    }
+                    resolvedPackages = resolved
+                    Logging.ConsoleLogger.info("   Seeds: \(resolverStats.seedCount)")
+                    Logging.ConsoleLogger.info("   Discovered via dependencies: \(resolverStats.discoveredCount)")
+                    Logging.ConsoleLogger.info("   Excluded: \(resolverStats.excludedCount)")
+                    Logging.ConsoleLogger.info("   Skipped (non-GitHub): \(resolverStats.skippedNonGitHub)")
+                    Logging.ConsoleLogger.info("   Skipped (SPM registry id): \(resolverStats.skippedRegistry)")
+                    Logging.ConsoleLogger.info("   Missing manifest: \(resolverStats.missingManifest)")
+                    Logging.ConsoleLogger.info("   Malformed manifest: \(resolverStats.malformedManifest)")
+                    Logging.ConsoleLogger.info("   Resolver duration: \(Int(resolverStats.duration))s")
+
+                    let store = Core.ResolvedPackagesStore(
+                        cupertinoVersion: Shared.Constants.App.version,
+                        seedChecksum: seedChecksum,
+                        packages: resolved
+                    )
+                    do {
+                        try store.write(to: resolvedStoreURL)
+                        Logging.ConsoleLogger.info("   Saved closure to \(resolvedStoreURL.path)")
+                    } catch {
+                        Logging.ConsoleLogger.error("   ⚠️  Could not persist resolved-packages.json: \(error)")
+                    }
+                }
+            } else {
+                resolvedPackages = seedRefs.map { ref in
+                    Core.ResolvedPackage(
+                        owner: ref.owner,
+                        repo: ref.repo,
+                        url: ref.url,
+                        priority: ref.priority,
+                        parents: ["\(ref.owner.lowercased())/\(ref.repo.lowercased())"]
+                    )
+                }
+                Logging.ConsoleLogger.info("🔗 Skipping dependency resolution (--no-recurse)")
+                if !exclusions.isEmpty {
+                    Logging.ConsoleLogger.info("   Exclusion list ignored while --no-recurse is set")
                 }
             }
-        } else {
-            resolvedPackages = seedRefs.map { ref in
-                Core.ResolvedPackage(
-                    owner: ref.owner,
-                    repo: ref.repo,
-                    url: ref.url,
-                    priority: ref.priority,
-                    parents: ["\(ref.owner.lowercased())/\(ref.repo.lowercased())"]
-                )
+
+            Logging.ConsoleLogger.info("📦 Fetching \(resolvedPackages.count) archives into \(outputURL.path)...")
+
+            let extractor = Core.PackageArchiveExtractor()
+            let startedAt = Date()
+            var stats = Shared.Models.PackageDownloadStatistics(
+                totalPackages: resolvedPackages.count,
+                startTime: startedAt
+            )
+            for (idx, pkg) in resolvedPackages.enumerated() {
+                let label = "\(pkg.owner)/\(pkg.repo)"
+                let pkgDir = outputURL
+                    .appendingPathComponent(pkg.owner)
+                    .appendingPathComponent(pkg.repo)
+                do {
+                    let extraction = try await extractor.fetchAndExtract(
+                        owner: pkg.owner,
+                        repo: pkg.repo,
+                        destination: pkgDir
+                    )
+                    try writePackageManifest(
+                        resolved: pkg,
+                        extraction: extraction,
+                        destination: pkgDir
+                    )
+                    stats.newPackages += 1
+                    stats.totalFilesSaved += extraction.files.count
+                    stats.totalBytesSaved += extraction.totalBytes
+                    let kb = extraction.totalBytes / 1024
+                    Logging.ConsoleLogger.info("  ✅ \(label) — \(extraction.files.count) files, \(kb) KB")
+                } catch Core.PackageArchiveExtractor.ExtractError.tarballNotFound {
+                    stats.errors += 1
+                    Logging.ConsoleLogger.error("  ✗ \(label) — archive not found on any ref")
+                } catch Core.PackageArchiveExtractor.ExtractError.tarballTooLarge(let bytes) {
+                    stats.errors += 1
+                    Logging.ConsoleLogger.error("  ✗ \(label) — archive too large (\(bytes / 1024 / 1024) MB)")
+                } catch {
+                    stats.errors += 1
+                    Logging.ConsoleLogger.error("  ✗ \(label) — \(error.localizedDescription)")
+                }
+
+                if (idx + 1) % Shared.Constants.Interval.progressLogEvery == 0 || idx + 1 == resolvedPackages.count {
+                    let percent = Double(idx + 1) / Double(resolvedPackages.count) * 100
+                    Logging.ConsoleLogger.output(
+                        String(format: "📊 Progress: %.1f%% (%d/%d)", percent, idx + 1, resolvedPackages.count)
+                    )
+                }
             }
-            Logging.ConsoleLogger.info("🔗 Skipping dependency resolution (--no-recurse)")
-            if !exclusions.isEmpty {
-                Logging.ConsoleLogger.info("   Exclusion list ignored while --no-recurse is set")
+            stats.endTime = Date()
+
+            Logging.ConsoleLogger.output("")
+            Logging.ConsoleLogger.info("✅ Archive download completed")
+            Logging.ConsoleLogger.info("   New packages: \(stats.newPackages)")
+            Logging.ConsoleLogger.info("   Files saved: \(stats.totalFilesSaved)")
+            Logging.ConsoleLogger.info("   Bytes saved: \(stats.totalBytesSaved / 1024) KB")
+            Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
+            if let duration = stats.duration {
+                Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
+            }
+            Logging.ConsoleLogger.info("   📁 \(outputURL.path)")
+            Logging.ConsoleLogger.info("   Next: index them into \(Shared.Constants.defaultPackagesDatabase.path) via `save --packages`")
+        }
+
+        private func writePackageManifest(
+            resolved: Core.ResolvedPackage,
+            extraction: Core.PackageArchiveExtractor.Result,
+            destination: URL
+        ) throws {
+            struct Manifest: Encodable {
+                let owner: String
+                let repo: String
+                let url: String
+                let fetchedAt: Date
+                let cupertinoVersion: String
+                let branch: String
+                let parents: [String]
+                let savedFileCount: Int
+                let totalBytes: Int64
+                let tarballBytes: Int
+            }
+            let manifest = Manifest(
+                owner: resolved.owner,
+                repo: resolved.repo,
+                url: resolved.url,
+                fetchedAt: Date(),
+                cupertinoVersion: Shared.Constants.App.version,
+                branch: extraction.branch,
+                parents: resolved.parents,
+                savedFileCount: extraction.files.count,
+                totalBytes: extraction.totalBytes,
+                tarballBytes: extraction.tarballBytes
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(manifest)
+            try data.write(to: destination.appendingPathComponent("manifest.json"))
+        }
+
+        private func runCodeFetch() async throws {
+            let defaultPath = Shared.Constants.defaultSampleCodeDirectory.path
+            let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
+
+            try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
+
+            let crawler = await SampleCodeDownloader(
+                outputDirectory: outputURL,
+                maxSamples: limit,
+                forceDownload: force
+            )
+
+            let stats = try await crawler.download { progress in
+                let percent = String(format: "%.1f", progress.percentage)
+                Logging.ConsoleLogger.output("   Progress: \(percent)% - \(progress.sampleName)")
+            }
+
+            Logging.ConsoleLogger.output("")
+            Logging.ConsoleLogger.info("✅ Download completed!")
+            Logging.ConsoleLogger.info("   Total: \(stats.totalSamples) samples")
+            Logging.ConsoleLogger.info("   Downloaded: \(stats.downloadedSamples)")
+            Logging.ConsoleLogger.info("   Skipped: \(stats.skippedSamples)")
+            Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
+            if let duration = stats.duration {
+                Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
             }
         }
 
-        Logging.ConsoleLogger.info("📦 Fetching \(resolvedPackages.count) archives into \(outputURL.path)...")
+        private func runSamplesFetch() async throws {
+            let defaultPath = Shared.Constants.defaultSampleCodeDirectory.path
+            let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
 
-        let extractor = Core.PackageArchiveExtractor()
-        let startedAt = Date()
-        var stats = Shared.Models.PackageDownloadStatistics(
-            totalPackages: resolvedPackages.count,
-            startTime: startedAt
-        )
-        for (idx, pkg) in resolvedPackages.enumerated() {
-            let label = "\(pkg.owner)/\(pkg.repo)"
-            let pkgDir = outputURL
-                .appendingPathComponent(pkg.owner)
-                .appendingPathComponent(pkg.repo)
-            do {
-                let extraction = try await extractor.fetchAndExtract(
-                    owner: pkg.owner,
-                    repo: pkg.repo,
-                    destination: pkgDir
-                )
-                try writePackageManifest(
-                    resolved: pkg,
-                    extraction: extraction,
-                    destination: pkgDir
-                )
-                stats.newPackages += 1
-                stats.totalFilesSaved += extraction.files.count
-                stats.totalBytesSaved += extraction.totalBytes
-                let kb = extraction.totalBytes / 1024
-                Logging.ConsoleLogger.info("  ✅ \(label) — \(extraction.files.count) files, \(kb) KB")
-            } catch Core.PackageArchiveExtractor.ExtractError.tarballNotFound {
-                stats.errors += 1
-                Logging.ConsoleLogger.error("  ✗ \(label) — archive not found on any ref")
-            } catch Core.PackageArchiveExtractor.ExtractError.tarballTooLarge(let bytes) {
-                stats.errors += 1
-                Logging.ConsoleLogger.error("  ✗ \(label) — archive too large (\(bytes / 1024 / 1024) MB)")
-            } catch {
-                stats.errors += 1
-                Logging.ConsoleLogger.error("  ✗ \(label) — \(error.localizedDescription)")
+            let fetcher = GitHubSampleCodeFetcher(outputDirectory: outputURL)
+
+            let stats = try await fetcher.fetch { progress in
+                Logging.ConsoleLogger.output("   \(progress.message)")
             }
 
-            if (idx + 1) % Shared.Constants.Interval.progressLogEvery == 0 || idx + 1 == resolvedPackages.count {
-                let percent = Double(idx + 1) / Double(resolvedPackages.count) * 100
+            Logging.ConsoleLogger.output("")
+            Logging.ConsoleLogger.info("✅ Fetch completed!")
+            Logging.ConsoleLogger.info("   Action: \(stats.action.description)")
+            Logging.ConsoleLogger.info("   Projects: \(stats.projectCount)")
+            if let duration = stats.duration {
+                Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
+            }
+            Logging.ConsoleLogger.info("\n📁 Output: \(outputURL.path)/cupertino-sample-code")
+        }
+
+        private func runArchiveCrawl() async throws {
+            let defaultPath = Shared.Constants.defaultArchiveDirectory.path
+            let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
+
+            try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
+
+            // Load guides from bundled manifest or command line
+            let guides = try await loadArchiveGuides()
+
+            guard !guides.isEmpty else {
+                Logging.ConsoleLogger.error("❌ No archive guides configured")
+                Logging.ConsoleLogger.info("   Use --start-url to specify guide URLs or configure the manifest")
+                throw ExitCode.failure
+            }
+
+            Logging.ConsoleLogger.info("📚 Crawling \(guides.count) Apple Archive guides...")
+            Logging.ConsoleLogger.info("   Output: \(outputURL.path)\n")
+
+            let crawler = await Core.AppleArchiveCrawler(
+                outputDirectory: outputURL,
+                guides: guides,
+                forceRecrawl: force
+            )
+
+            let stats = try await crawler.crawl { progress in
+                let percent = String(format: "%.1f", progress.percentage)
+                Logging.ConsoleLogger.output("   Progress: \(percent)% - \(progress.currentItem)")
+            }
+
+            Logging.ConsoleLogger.output("")
+            Logging.ConsoleLogger.info("✅ Crawl completed!")
+            Logging.ConsoleLogger.info("   Total guides: \(stats.totalGuides)")
+            Logging.ConsoleLogger.info("   Total pages: \(stats.totalPages)")
+            Logging.ConsoleLogger.info("   New: \(stats.newPages)")
+            Logging.ConsoleLogger.info("   Updated: \(stats.updatedPages)")
+            Logging.ConsoleLogger.info("   Skipped: \(stats.skippedPages)")
+            Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
+            if let duration = stats.duration {
+                Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
+            }
+            Logging.ConsoleLogger.info("\n📁 Output: \(outputURL.path)/")
+        }
+
+        private func runHIGCrawl() async throws {
+            let defaultPath = Shared.Constants.defaultHIGDirectory.path
+            let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
+
+            try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
+
+            Logging.ConsoleLogger.info("📖 Crawling Human Interface Guidelines...")
+            Logging.ConsoleLogger.info("   Output: \(outputURL.path)\n")
+
+            let crawler = await Core.HIGCrawler(
+                outputDirectory: outputURL,
+                forceRecrawl: force
+            )
+
+            let stats = try await crawler.crawl { progress in
+                let percent = String(format: "%.1f", progress.percentage)
+                Logging.ConsoleLogger.output("   Progress: \(percent)% - \(progress.currentItem)")
+            }
+
+            Logging.ConsoleLogger.output("")
+            Logging.ConsoleLogger.info("✅ Crawl completed!")
+            Logging.ConsoleLogger.info("   Total pages: \(stats.totalPages)")
+            Logging.ConsoleLogger.info("   New: \(stats.newPages)")
+            Logging.ConsoleLogger.info("   Updated: \(stats.updatedPages)")
+            Logging.ConsoleLogger.info("   Skipped: \(stats.skippedPages)")
+            Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
+            if let duration = stats.duration {
+                Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
+            }
+            Logging.ConsoleLogger.info("\n📁 Output: \(outputURL.path)/")
+        }
+
+        private func loadArchiveGuides() async throws -> [ArchiveGuideInfo] {
+            // If start URL is provided, use it (no framework info available)
+            if let startURL, let url = URL(string: startURL) {
+                return [ArchiveGuideInfo(url: url, framework: "")]
+            }
+
+            // Otherwise use the curated list of essential archive guides with framework info
+            return ArchiveGuideCatalog.essentialGuidesWithInfo
+        }
+
+        private func runAvailabilityFetch() async throws {
+            let docsDir = outputDir.map { URL(fileURLWithPath: $0) }
+                ?? Shared.Constants.defaultDocsDirectory
+
+            guard FileManager.default.fileExists(atPath: docsDir.path) else {
+                Logging.ConsoleLogger.error("❌ Documentation directory not found: \(docsDir.path)")
+                Logging.ConsoleLogger.info("   Run 'cupertino fetch --type docs' first to download documentation.")
+                throw ExitCode.failure
+            }
+
+            Logging.ConsoleLogger.info("📊 Fetching API availability data...")
+            Logging.ConsoleLogger.info("   Source: \(docsDir.path)")
+            Logging.ConsoleLogger.info("   API: developer.apple.com/tutorials/data/documentation\n")
+
+            let configuration: Availability.Fetcher.Configuration
+            if fast {
+                configuration = .fast
+            } else {
+                configuration = Availability.Fetcher.Configuration(
+                    concurrency: 50,
+                    timeout: 1.0,
+                    skipExisting: !force
+                )
+            }
+
+            let fetcher = Availability.Fetcher(
+                docsDirectory: docsDir,
+                configuration: configuration
+            )
+
+            let stats = try await fetcher.fetch { progress in
+                let percent = String(format: "%.1f", progress.percentage)
+                let successRate = progress.completed > 0
+                    ? String(format: "%.0f", Double(progress.successful) / Double(progress.completed) * 100)
+                    : "0"
                 Logging.ConsoleLogger.output(
-                    String(format: "📊 Progress: %.1f%% (%d/%d)", percent, idx + 1, resolvedPackages.count)
+                    "   Progress: \(percent)% [\(progress.currentFramework)] \(successRate)% success"
                 )
             }
-        }
-        stats.endTime = Date()
 
-        Logging.ConsoleLogger.output("")
-        Logging.ConsoleLogger.info("✅ Archive download completed")
-        Logging.ConsoleLogger.info("   New packages: \(stats.newPackages)")
-        Logging.ConsoleLogger.info("   Files saved: \(stats.totalFilesSaved)")
-        Logging.ConsoleLogger.info("   Bytes saved: \(stats.totalBytesSaved / 1024) KB")
-        Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
-        if let duration = stats.duration {
-            Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
-        }
-        Logging.ConsoleLogger.info("   📁 \(outputURL.path)")
-        Logging.ConsoleLogger.info("   Next: index them into \(Shared.Constants.defaultPackagesDatabase.path) via `save --packages`")
-    }
-
-    private func writePackageManifest(
-        resolved: Core.ResolvedPackage,
-        extraction: Core.PackageArchiveExtractor.Result,
-        destination: URL
-    ) throws {
-        struct Manifest: Encodable {
-            let owner: String
-            let repo: String
-            let url: String
-            let fetchedAt: Date
-            let cupertinoVersion: String
-            let branch: String
-            let parents: [String]
-            let savedFileCount: Int
-            let totalBytes: Int64
-            let tarballBytes: Int
-        }
-        let manifest = Manifest(
-            owner: resolved.owner,
-            repo: resolved.repo,
-            url: resolved.url,
-            fetchedAt: Date(),
-            cupertinoVersion: Shared.Constants.App.version,
-            branch: extraction.branch,
-            parents: resolved.parents,
-            savedFileCount: extraction.files.count,
-            totalBytes: extraction.totalBytes,
-            tarballBytes: extraction.tarballBytes
-        )
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        let data = try encoder.encode(manifest)
-        try data.write(to: destination.appendingPathComponent("manifest.json"))
-    }
-
-    private func runCodeFetch() async throws {
-        let defaultPath = Shared.Constants.defaultSampleCodeDirectory.path
-        let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
-
-        try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
-
-        let crawler = await SampleCodeDownloader(
-            outputDirectory: outputURL,
-            maxSamples: limit,
-            forceDownload: force
-        )
-
-        let stats = try await crawler.download { progress in
-            let percent = String(format: "%.1f", progress.percentage)
-            Logging.ConsoleLogger.output("   Progress: \(percent)% - \(progress.sampleName)")
-        }
-
-        Logging.ConsoleLogger.output("")
-        Logging.ConsoleLogger.info("✅ Download completed!")
-        Logging.ConsoleLogger.info("   Total: \(stats.totalSamples) samples")
-        Logging.ConsoleLogger.info("   Downloaded: \(stats.downloadedSamples)")
-        Logging.ConsoleLogger.info("   Skipped: \(stats.skippedSamples)")
-        Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
-        if let duration = stats.duration {
-            Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
-        }
-    }
-
-    private func runSamplesFetch() async throws {
-        let defaultPath = Shared.Constants.defaultSampleCodeDirectory.path
-        let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
-
-        let fetcher = GitHubSampleCodeFetcher(outputDirectory: outputURL)
-
-        let stats = try await fetcher.fetch { progress in
-            Logging.ConsoleLogger.output("   \(progress.message)")
-        }
-
-        Logging.ConsoleLogger.output("")
-        Logging.ConsoleLogger.info("✅ Fetch completed!")
-        Logging.ConsoleLogger.info("   Action: \(stats.action.description)")
-        Logging.ConsoleLogger.info("   Projects: \(stats.projectCount)")
-        if let duration = stats.duration {
-            Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
-        }
-        Logging.ConsoleLogger.info("\n📁 Output: \(outputURL.path)/cupertino-sample-code")
-    }
-
-    private func runArchiveCrawl() async throws {
-        let defaultPath = Shared.Constants.defaultArchiveDirectory.path
-        let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
-
-        try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
-
-        // Load guides from bundled manifest or command line
-        let guides = try await loadArchiveGuides()
-
-        guard !guides.isEmpty else {
-            Logging.ConsoleLogger.error("❌ No archive guides configured")
-            Logging.ConsoleLogger.info("   Use --start-url to specify guide URLs or configure the manifest")
-            throw ExitCode.failure
-        }
-
-        Logging.ConsoleLogger.info("📚 Crawling \(guides.count) Apple Archive guides...")
-        Logging.ConsoleLogger.info("   Output: \(outputURL.path)\n")
-
-        let crawler = await Core.AppleArchiveCrawler(
-            outputDirectory: outputURL,
-            guides: guides,
-            forceRecrawl: force
-        )
-
-        let stats = try await crawler.crawl { progress in
-            let percent = String(format: "%.1f", progress.percentage)
-            Logging.ConsoleLogger.output("   Progress: \(percent)% - \(progress.currentItem)")
-        }
-
-        Logging.ConsoleLogger.output("")
-        Logging.ConsoleLogger.info("✅ Crawl completed!")
-        Logging.ConsoleLogger.info("   Total guides: \(stats.totalGuides)")
-        Logging.ConsoleLogger.info("   Total pages: \(stats.totalPages)")
-        Logging.ConsoleLogger.info("   New: \(stats.newPages)")
-        Logging.ConsoleLogger.info("   Updated: \(stats.updatedPages)")
-        Logging.ConsoleLogger.info("   Skipped: \(stats.skippedPages)")
-        Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
-        if let duration = stats.duration {
-            Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
-        }
-        Logging.ConsoleLogger.info("\n📁 Output: \(outputURL.path)/")
-    }
-
-    private func runHIGCrawl() async throws {
-        let defaultPath = Shared.Constants.defaultHIGDirectory.path
-        let outputURL = URL(fileURLWithPath: outputDir ?? defaultPath).expandingTildeInPath
-
-        try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
-
-        Logging.ConsoleLogger.info("📖 Crawling Human Interface Guidelines...")
-        Logging.ConsoleLogger.info("   Output: \(outputURL.path)\n")
-
-        let crawler = await Core.HIGCrawler(
-            outputDirectory: outputURL,
-            forceRecrawl: force
-        )
-
-        let stats = try await crawler.crawl { progress in
-            let percent = String(format: "%.1f", progress.percentage)
-            Logging.ConsoleLogger.output("   Progress: \(percent)% - \(progress.currentItem)")
-        }
-
-        Logging.ConsoleLogger.output("")
-        Logging.ConsoleLogger.info("✅ Crawl completed!")
-        Logging.ConsoleLogger.info("   Total pages: \(stats.totalPages)")
-        Logging.ConsoleLogger.info("   New: \(stats.newPages)")
-        Logging.ConsoleLogger.info("   Updated: \(stats.updatedPages)")
-        Logging.ConsoleLogger.info("   Skipped: \(stats.skippedPages)")
-        Logging.ConsoleLogger.info("   Errors: \(stats.errors)")
-        if let duration = stats.duration {
-            Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
-        }
-        Logging.ConsoleLogger.info("\n📁 Output: \(outputURL.path)/")
-    }
-
-    private func loadArchiveGuides() async throws -> [ArchiveGuideInfo] {
-        // If start URL is provided, use it (no framework info available)
-        if let startURL, let url = URL(string: startURL) {
-            return [ArchiveGuideInfo(url: url, framework: "")]
-        }
-
-        // Otherwise use the curated list of essential archive guides with framework info
-        return ArchiveGuideCatalog.essentialGuidesWithInfo
-    }
-
-    private func runAvailabilityFetch() async throws {
-        let docsDir = outputDir.map { URL(fileURLWithPath: $0) }
-            ?? Shared.Constants.defaultDocsDirectory
-
-        guard FileManager.default.fileExists(atPath: docsDir.path) else {
-            Logging.ConsoleLogger.error("❌ Documentation directory not found: \(docsDir.path)")
-            Logging.ConsoleLogger.info("   Run 'cupertino fetch --type docs' first to download documentation.")
-            throw ExitCode.failure
-        }
-
-        Logging.ConsoleLogger.info("📊 Fetching API availability data...")
-        Logging.ConsoleLogger.info("   Source: \(docsDir.path)")
-        Logging.ConsoleLogger.info("   API: developer.apple.com/tutorials/data/documentation\n")
-
-        let configuration: Availability.Fetcher.Configuration
-        if fast {
-            configuration = .fast
-        } else {
-            configuration = Availability.Fetcher.Configuration(
-                concurrency: 50,
-                timeout: 1.0,
-                skipExisting: !force
-            )
-        }
-
-        let fetcher = Availability.Fetcher(
-            docsDirectory: docsDir,
-            configuration: configuration
-        )
-
-        let stats = try await fetcher.fetch { progress in
-            let percent = String(format: "%.1f", progress.percentage)
-            let successRate = progress.completed > 0
-                ? String(format: "%.0f", Double(progress.successful) / Double(progress.completed) * 100)
-                : "0"
-            Logging.ConsoleLogger.output(
-                "   Progress: \(percent)% [\(progress.currentFramework)] \(successRate)% success"
-            )
-        }
-
-        Logging.ConsoleLogger.output("")
-        Logging.ConsoleLogger.info("✅ Availability fetch completed!")
-        Logging.ConsoleLogger.info("   Documents scanned: \(stats.totalDocuments)")
-        Logging.ConsoleLogger.info("   Updated: \(stats.updatedDocuments)")
-        Logging.ConsoleLogger.info("   Skipped: \(stats.skippedDocuments)")
-        Logging.ConsoleLogger.info("   Failed: \(stats.failedFetches)")
-        Logging.ConsoleLogger.info("   Frameworks: \(stats.frameworksProcessed)")
-        Logging.ConsoleLogger.info("   Success rate: \(String(format: "%.1f", stats.successRate))%")
-        if let duration = stats.duration {
-            Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
+            Logging.ConsoleLogger.output("")
+            Logging.ConsoleLogger.info("✅ Availability fetch completed!")
+            Logging.ConsoleLogger.info("   Documents scanned: \(stats.totalDocuments)")
+            Logging.ConsoleLogger.info("   Updated: \(stats.updatedDocuments)")
+            Logging.ConsoleLogger.info("   Skipped: \(stats.skippedDocuments)")
+            Logging.ConsoleLogger.info("   Failed: \(stats.failedFetches)")
+            Logging.ConsoleLogger.info("   Frameworks: \(stats.frameworksProcessed)")
+            Logging.ConsoleLogger.info("   Success rate: \(String(format: "%.1f", stats.successRate))%")
+            if let duration = stats.duration {
+                Logging.ConsoleLogger.info("   Duration: \(Int(duration))s")
+            }
         }
     }
 }

--- a/Packages/Sources/CLI/Commands/ListFrameworksCommand.swift
+++ b/Packages/Sources/CLI/Commands/ListFrameworksCommand.swift
@@ -8,50 +8,52 @@ import SharedCore
 
 /// CLI command for listing available frameworks - mirrors MCP tool functionality.
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-struct ListFrameworksCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "list-frameworks",
-        abstract: "List available frameworks with document counts"
-    )
+extension Command {
+    struct ListFrameworks: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list-frameworks",
+            abstract: "List available frameworks with document counts"
+        )
 
-    @Option(
-        name: .long,
-        help: "Output format: text (default), json, markdown"
-    )
-    var format: OutputFormat = .text
+        @Option(
+            name: .long,
+            help: "Output format: text (default), json, markdown"
+        )
+        var format: OutputFormat = .text
 
-    @Option(
-        name: .long,
-        help: "Path to search database"
-    )
-    var searchDb: String?
+        @Option(
+            name: .long,
+            help: "Path to search database"
+        )
+        var searchDb: String?
 
-    mutating func run() async throws {
-        // Use ServiceContainer for managed lifecycle
-        let (frameworks, totalDocs) = try await ServiceContainer.withDocsService(dbPath: searchDb) { service in
-            let frameworks = try await service.listFrameworks()
-            let totalDocs = try await service.documentCount()
-            return (frameworks, totalDocs)
-        }
+        mutating func run() async throws {
+            // Use ServiceContainer for managed lifecycle
+            let (frameworks, totalDocs) = try await ServiceContainer.withDocsService(dbPath: searchDb) { service in
+                let frameworks = try await service.listFrameworks()
+                let totalDocs = try await service.documentCount()
+                return (frameworks, totalDocs)
+            }
 
-        // Output results using formatters
-        switch format {
-        case .text:
-            let formatter = FrameworksTextFormatter(totalDocs: totalDocs)
-            Logging.Log.output(formatter.format(frameworks))
-        case .json:
-            let formatter = FrameworksJSONFormatter()
-            Logging.Log.output(formatter.format(frameworks))
-        case .markdown:
-            let formatter = FrameworksMarkdownFormatter(totalDocs: totalDocs)
-            Logging.Log.output(formatter.format(frameworks))
+            // Output results using formatters
+            switch format {
+            case .text:
+                let formatter = FrameworksTextFormatter(totalDocs: totalDocs)
+                Logging.Log.output(formatter.format(frameworks))
+            case .json:
+                let formatter = FrameworksJSONFormatter()
+                Logging.Log.output(formatter.format(frameworks))
+            case .markdown:
+                let formatter = FrameworksMarkdownFormatter(totalDocs: totalDocs)
+                Logging.Log.output(formatter.format(frameworks))
+            }
         }
     }
 }
 
 // MARK: - Output Format
 
-extension ListFrameworksCommand {
+extension Command.ListFrameworks {
     enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
         case text
         case json

--- a/Packages/Sources/CLI/Commands/ListSamplesCommand.swift
+++ b/Packages/Sources/CLI/Commands/ListSamplesCommand.swift
@@ -10,164 +10,166 @@ import SharedUtils
 
 /// CLI command for listing sample code projects - mirrors MCP tool functionality.
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-struct ListSamplesCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "list-samples",
-        abstract: "List indexed Apple sample code projects"
-    )
-
-    @Option(
-        name: .shortAndLong,
-        help: "Filter by framework (e.g., swiftui, uikit, appkit)"
-    )
-    var framework: String?
-
-    @Option(
-        name: .long,
-        help: "Maximum number of results to return"
-    )
-    var limit: Int = 50
-
-    @Option(
-        name: .long,
-        help: "Output format: text (default), json, markdown"
-    )
-    var format: OutputFormat = .text
-
-    @Option(
-        name: .long,
-        help: "Path to sample index database"
-    )
-    var sampleDb: String?
-
-    mutating func run() async throws {
-        // Resolve database path
-        let dbPath = resolveSampleDbPath()
-
-        // Use ServiceContainer for managed lifecycle
-        let (projects, totalProjects, totalFiles) = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
-            let projects = try await service.listProjects(framework: framework, limit: limit)
-            let totalProjects = try await service.projectCount()
-            let totalFiles = try await service.fileCount()
-            return (projects, totalProjects, totalFiles)
-        }
-
-        // Output results
-        switch format {
-        case .text:
-            outputText(projects, totalProjects: totalProjects, totalFiles: totalFiles)
-        case .json:
-            outputJSON(projects, totalProjects: totalProjects, totalFiles: totalFiles)
-        case .markdown:
-            outputMarkdown(projects, totalProjects: totalProjects, totalFiles: totalFiles)
-        }
-    }
-
-    // MARK: - Path Resolution
-
-    private func resolveSampleDbPath() -> URL {
-        if let sampleDb {
-            return URL(fileURLWithPath: sampleDb).expandingTildeInPath
-        }
-        return SampleIndex.defaultDatabasePath
-    }
-
-    // MARK: - Output Formatting
-
-    private func outputText(_ projects: [SampleIndex.Project], totalProjects: Int, totalFiles: Int) {
-        Logging.Log.output("Sample Code Projects")
-        Logging.Log.output("Total: \(totalProjects) projects, \(totalFiles) files")
-
-        if let framework {
-            Logging.Log.output("Filtered by: \(framework)")
-        }
-
-        Logging.Log.output("")
-
-        if projects.isEmpty {
-            Logging.Log.output("No projects found. Run 'cupertino save --samples' to index sample code.")
-            return
-        }
-
-        for (index, project) in projects.enumerated() {
-            Logging.Log.output("[\(index + 1)] \(project.title)")
-            Logging.Log.output("    ID: \(project.id)")
-            Logging.Log.output("    Frameworks: \(project.frameworks.joined(separator: ", "))")
-            Logging.Log.output("    Files: \(project.fileCount)")
-            Logging.Log.output("")
-        }
-    }
-
-    private func outputJSON(_ projects: [SampleIndex.Project], totalProjects: Int, totalFiles: Int) {
-        struct Output: Encodable {
-            let totalProjects: Int
-            let totalFiles: Int
-            let framework: String?
-            let projects: [ProjectOutput]
-        }
-
-        struct ProjectOutput: Encodable {
-            let id: String
-            let title: String
-            let description: String
-            let frameworks: [String]
-            let fileCount: Int
-        }
-
-        let output = Output(
-            totalProjects: totalProjects,
-            totalFiles: totalFiles,
-            framework: framework,
-            projects: projects.map {
-                ProjectOutput(
-                    id: $0.id,
-                    title: $0.title,
-                    description: $0.description,
-                    frameworks: $0.frameworks,
-                    fileCount: $0.fileCount
-                )
-            }
+extension Command {
+    struct ListSamples: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list-samples",
+            abstract: "List indexed Apple sample code projects"
         )
 
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        @Option(
+            name: .shortAndLong,
+            help: "Filter by framework (e.g., swiftui, uikit, appkit)"
+        )
+        var framework: String?
 
-        do {
-            let data = try encoder.encode(output)
-            if let jsonString = String(data: data, encoding: .utf8) {
-                Logging.Log.output(jsonString)
+        @Option(
+            name: .long,
+            help: "Maximum number of results to return"
+        )
+        var limit: Int = 50
+
+        @Option(
+            name: .long,
+            help: "Output format: text (default), json, markdown"
+        )
+        var format: OutputFormat = .text
+
+        @Option(
+            name: .long,
+            help: "Path to sample index database"
+        )
+        var sampleDb: String?
+
+        mutating func run() async throws {
+            // Resolve database path
+            let dbPath = resolveSampleDbPath()
+
+            // Use ServiceContainer for managed lifecycle
+            let (projects, totalProjects, totalFiles) = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
+                let projects = try await service.listProjects(framework: framework, limit: limit)
+                let totalProjects = try await service.projectCount()
+                let totalFiles = try await service.fileCount()
+                return (projects, totalProjects, totalFiles)
             }
-        } catch {
-            Logging.Log.error("Error encoding JSON: \(error)")
-        }
-    }
 
-    private func outputMarkdown(_ projects: [SampleIndex.Project], totalProjects: Int, totalFiles: Int) {
-        Logging.Log.output("# Sample Code Projects\n")
-        Logging.Log.output("Total: **\(totalProjects)** projects, **\(totalFiles)** files\n")
-
-        if let framework {
-            Logging.Log.output("_Filtered to framework: **\(framework)**_\n")
-        }
-
-        if projects.isEmpty {
-            Logging.Log.output("_No projects found. Run `cupertino save --samples` to index sample code._")
-            return
+            // Output results
+            switch format {
+            case .text:
+                outputText(projects, totalProjects: totalProjects, totalFiles: totalFiles)
+            case .json:
+                outputJSON(projects, totalProjects: totalProjects, totalFiles: totalFiles)
+            case .markdown:
+                outputMarkdown(projects, totalProjects: totalProjects, totalFiles: totalFiles)
+            }
         }
 
-        Logging.Log.output("| Project | Frameworks | Files |")
-        Logging.Log.output("|---------|-----------|------:|")
+        // MARK: - Path Resolution
 
-        for project in projects {
-            let frameworks = project.frameworks.joined(separator: ", ")
-            Logging.Log.output("| `\(project.id)` | \(frameworks) | \(project.fileCount) |")
+        private func resolveSampleDbPath() -> URL {
+            if let sampleDb {
+                return URL(fileURLWithPath: sampleDb).expandingTildeInPath
+            }
+            return SampleIndex.defaultDatabasePath
+        }
+
+        // MARK: - Output Formatting
+
+        private func outputText(_ projects: [SampleIndex.Project], totalProjects: Int, totalFiles: Int) {
+            Logging.Log.output("Sample Code Projects")
+            Logging.Log.output("Total: \(totalProjects) projects, \(totalFiles) files")
+
+            if let framework {
+                Logging.Log.output("Filtered by: \(framework)")
+            }
+
+            Logging.Log.output("")
+
+            if projects.isEmpty {
+                Logging.Log.output("No projects found. Run 'cupertino save --samples' to index sample code.")
+                return
+            }
+
+            for (index, project) in projects.enumerated() {
+                Logging.Log.output("[\(index + 1)] \(project.title)")
+                Logging.Log.output("    ID: \(project.id)")
+                Logging.Log.output("    Frameworks: \(project.frameworks.joined(separator: ", "))")
+                Logging.Log.output("    Files: \(project.fileCount)")
+                Logging.Log.output("")
+            }
+        }
+
+        private func outputJSON(_ projects: [SampleIndex.Project], totalProjects: Int, totalFiles: Int) {
+            struct Output: Encodable {
+                let totalProjects: Int
+                let totalFiles: Int
+                let framework: String?
+                let projects: [ProjectOutput]
+            }
+
+            struct ProjectOutput: Encodable {
+                let id: String
+                let title: String
+                let description: String
+                let frameworks: [String]
+                let fileCount: Int
+            }
+
+            let output = Output(
+                totalProjects: totalProjects,
+                totalFiles: totalFiles,
+                framework: framework,
+                projects: projects.map {
+                    ProjectOutput(
+                        id: $0.id,
+                        title: $0.title,
+                        description: $0.description,
+                        frameworks: $0.frameworks,
+                        fileCount: $0.fileCount
+                    )
+                }
+            )
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+            do {
+                let data = try encoder.encode(output)
+                if let jsonString = String(data: data, encoding: .utf8) {
+                    Logging.Log.output(jsonString)
+                }
+            } catch {
+                Logging.Log.error("Error encoding JSON: \(error)")
+            }
+        }
+
+        private func outputMarkdown(_ projects: [SampleIndex.Project], totalProjects: Int, totalFiles: Int) {
+            Logging.Log.output("# Sample Code Projects\n")
+            Logging.Log.output("Total: **\(totalProjects)** projects, **\(totalFiles)** files\n")
+
+            if let framework {
+                Logging.Log.output("_Filtered to framework: **\(framework)**_\n")
+            }
+
+            if projects.isEmpty {
+                Logging.Log.output("_No projects found. Run `cupertino save --samples` to index sample code._")
+                return
+            }
+
+            Logging.Log.output("| Project | Frameworks | Files |")
+            Logging.Log.output("|---------|-----------|------:|")
+
+            for project in projects {
+                let frameworks = project.frameworks.joined(separator: ", ")
+                Logging.Log.output("| `\(project.id)` | \(frameworks) | \(project.fileCount) |")
+            }
         }
     }
 }
 
 // MARK: - Output Format
 
-extension ListSamplesCommand {
+extension Command.ListSamples {
     enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
         case text
         case json

--- a/Packages/Sources/CLI/Commands/PackageSearchCommand.swift
+++ b/Packages/Sources/CLI/Commands/PackageSearchCommand.swift
@@ -11,115 +11,117 @@ import SharedUtils
 /// Hidden packages-only smart query. Invoked as:
 ///     cupertino package-search "how do I write a log handler in swift-log"
 ///
-/// Thin wrapper over `Search.SmartQuery` configured with a single
+/// Thin wrapper over `SearchModule.SmartQuery` configured with a single
 /// `PackageFTSCandidateFetcher` (#192 E6). Output format is identical to
 /// `cupertino search` (default fan-out mode, #239), so a user already
 /// fluent with `search` can substitute `package-search` whenever they
 /// specifically want packages-only results without typing `--skip-docs
 /// --skip-samples`.
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-struct PackageSearchCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "package-search",
-        abstract: "Smart query over the packages index (packages source only)",
-        shouldDisplay: false
-    )
-
-    @Argument(help: "Plain-text question")
-    var question: String
-
-    @Option(name: .long, help: "Max number of chunks to return")
-    var limit: Int = 3
-
-    @Option(name: .long, help: "Override packages.db path")
-    var db: String?
-
-    @Option(
-        name: .long,
-        help: """
-        Restrict results to packages whose declared deployment target is \
-        compatible with the named platform (#220). Values: iOS, macOS, \
-        tvOS, watchOS, visionOS (case-insensitive). Requires \
-        --min-version. Packages with no annotation source are dropped.
-        """
-    )
-    var platform: String?
-
-    @Option(
-        name: .long,
-        help: """
-        Minimum version for --platform, e.g. 16.0 / 13.0 / 10.15. \
-        Lexicographic compare in SQL — works correctly for current Apple \
-        platform versions (iOS 13+, macOS 11+ etc.). #220
-        """
-    )
-    var minVersion: String?
-
-    mutating func run() async throws {
-        let dbURL = db.map { URL(fileURLWithPath: $0).expandingTildeInPath }
-            ?? Shared.Constants.defaultPackagesDatabase
-
-        guard FileManager.default.fileExists(atPath: dbURL.path) else {
-            Logging.ConsoleLogger.error("❌ packages.db not found at \(dbURL.path)")
-            Logging.ConsoleLogger.error("   Run `cupertino fetch --type packages` then `cupertino save --packages` first.")
-            throw ExitCode.failure
-        }
-
-        let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            Logging.ConsoleLogger.error("❌ Question cannot be empty.")
-            throw ExitCode.failure
-        }
-
-        // E6: single-fetcher SmartQuery. RRF over one input degenerates to
-        // "preserve the fetcher's own ordering", so behaviour is equivalent
-        // to calling `PackageQuery.answer` directly — but it goes through the
-        // exact same code path as `cupertino ask`, which means future ranking
-        // tweaks land in one place.
-        let availabilityFilter: Search.PackageQuery.AvailabilityFilter?
-        switch (platform, minVersion) {
-        case let (platform?, minVersion?):
-            availabilityFilter = Search.PackageQuery.AvailabilityFilter(
-                platform: platform,
-                minVersion: minVersion
-            )
-        case (.some, nil), (nil, .some):
-            Logging.ConsoleLogger.error(
-                "❌ --platform and --min-version must be used together (#220)."
-            )
-            throw ExitCode.failure
-        case (nil, nil):
-            availabilityFilter = nil
-        }
-        let fetcher = Search.PackageFTSCandidateFetcher(
-            dbPath: dbURL,
-            availability: availabilityFilter
+extension Command {
+    struct PackageSearch: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "package-search",
+            abstract: "Smart query over the packages index (packages source only)",
+            shouldDisplay: false
         )
-        let smart = Search.SmartQuery(fetchers: [fetcher])
-        let result = await smart.answer(question: trimmed, limit: limit, perFetcherLimit: max(20, limit))
 
-        if result.candidates.isEmpty {
-            Logging.ConsoleLogger.info("No matches for: \(trimmed)")
-            return
-        }
+        @Argument(help: "Plain-text question")
+        var question: String
 
-        for (idx, fused) in result.candidates.enumerated() {
-            let cand = fused.candidate
-            let owner = cand.metadata["owner"] ?? ""
-            let repo = cand.metadata["repo"] ?? ""
-            let relpath = cand.metadata["relpath"] ?? cand.identifier
-            let module = cand.metadata["module"] ?? ""
-            print("══════════════════════════════════════════════════════════════════════")
-            print("[\(idx + 1)] \(owner)/\(repo) — \(relpath)")
-            let kindLabel = cand.kind ?? "?"
-            if !module.isEmpty {
-                print("    module: \(module)  •  kind: \(kindLabel)  •  score: \(String(format: "%.4f", fused.score))")
-            } else {
-                print("    kind: \(kindLabel)  •  score: \(String(format: "%.4f", fused.score))")
+        @Option(name: .long, help: "Max number of chunks to return")
+        var limit: Int = 3
+
+        @Option(name: .long, help: "Override packages.db path")
+        var db: String?
+
+        @Option(
+            name: .long,
+            help: """
+            Restrict results to packages whose declared deployment target is \
+            compatible with the named platform (#220). Values: iOS, macOS, \
+            tvOS, watchOS, visionOS (case-insensitive). Requires \
+            --min-version. Packages with no annotation source are dropped.
+            """
+        )
+        var platform: String?
+
+        @Option(
+            name: .long,
+            help: """
+            Minimum version for --platform, e.g. 16.0 / 13.0 / 10.15. \
+            Lexicographic compare in SQL — works correctly for current Apple \
+            platform versions (iOS 13+, macOS 11+ etc.). #220
+            """
+        )
+        var minVersion: String?
+
+        mutating func run() async throws {
+            let dbURL = db.map { URL(fileURLWithPath: $0).expandingTildeInPath }
+                ?? Shared.Constants.defaultPackagesDatabase
+
+            guard FileManager.default.fileExists(atPath: dbURL.path) else {
+                Logging.ConsoleLogger.error("❌ packages.db not found at \(dbURL.path)")
+                Logging.ConsoleLogger.error("   Run `cupertino fetch --type packages` then `cupertino save --packages` first.")
+                throw ExitCode.failure
             }
-            print("──────────────────────────────────────────────────────────────────────")
-            print(cand.chunk)
-            print("")
+
+            let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                Logging.ConsoleLogger.error("❌ Question cannot be empty.")
+                throw ExitCode.failure
+            }
+
+            // E6: single-fetcher SmartQuery. RRF over one input degenerates to
+            // "preserve the fetcher's own ordering", so behaviour is equivalent
+            // to calling `PackageQuery.answer` directly — but it goes through the
+            // exact same code path as `cupertino ask`, which means future ranking
+            // tweaks land in one place.
+            let availabilityFilter: SearchModule.PackageQuery.AvailabilityFilter?
+            switch (platform, minVersion) {
+            case let (platform?, minVersion?):
+                availabilityFilter = SearchModule.PackageQuery.AvailabilityFilter(
+                    platform: platform,
+                    minVersion: minVersion
+                )
+            case (.some, nil), (nil, .some):
+                Logging.ConsoleLogger.error(
+                    "❌ --platform and --min-version must be used together (#220)."
+                )
+                throw ExitCode.failure
+            case (nil, nil):
+                availabilityFilter = nil
+            }
+            let fetcher = SearchModule.PackageFTSCandidateFetcher(
+                dbPath: dbURL,
+                availability: availabilityFilter
+            )
+            let smart = SearchModule.SmartQuery(fetchers: [fetcher])
+            let result = await smart.answer(question: trimmed, limit: limit, perFetcherLimit: max(20, limit))
+
+            if result.candidates.isEmpty {
+                Logging.ConsoleLogger.info("No matches for: \(trimmed)")
+                return
+            }
+
+            for (idx, fused) in result.candidates.enumerated() {
+                let cand = fused.candidate
+                let owner = cand.metadata["owner"] ?? ""
+                let repo = cand.metadata["repo"] ?? ""
+                let relpath = cand.metadata["relpath"] ?? cand.identifier
+                let module = cand.metadata["module"] ?? ""
+                print("══════════════════════════════════════════════════════════════════════")
+                print("[\(idx + 1)] \(owner)/\(repo) — \(relpath)")
+                let kindLabel = cand.kind ?? "?"
+                if !module.isEmpty {
+                    print("    module: \(module)  •  kind: \(kindLabel)  •  score: \(String(format: "%.4f", fused.score))")
+                } else {
+                    print("    kind: \(kindLabel)  •  score: \(String(format: "%.4f", fused.score))")
+                }
+                print("──────────────────────────────────────────────────────────────────────")
+                print(cand.chunk)
+                print("")
+            }
         }
     }
 }

--- a/Packages/Sources/CLI/Commands/ReadCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadCommand.swift
@@ -13,109 +13,111 @@ import SharedUtils
 /// reads live there so the MCP layer (and any future agent-shell adapter)
 /// can share one implementation.
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-struct ReadCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "read",
-        abstract: "Read a document from any indexed source (docs, samples, packages)"
-    )
+extension Command {
+    struct Read: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "read",
+            abstract: "Read a document from any indexed source (docs, samples, packages)"
+        )
 
-    @Argument(
-        help: """
-        Identifier. Docs URIs (\"apple-docs://swiftui/...\") look up search.db; \
-        sample IDs and `<projectId>/<path>` look up samples.db; \
-        `<owner>/<repo>/<path>` is read from the on-disk packages tree.
-        """
-    )
-    var identifier: String
+        @Argument(
+            help: """
+            Identifier. Docs URIs (\"apple-docs://swiftui/...\") look up search.db; \
+            sample IDs and `<projectId>/<path>` look up samples.db; \
+            `<owner>/<repo>/<path>` is read from the on-disk packages tree.
+            """
+        )
+        var identifier: String
 
-    @Option(
-        name: .long,
-        help: """
-        Disambiguator for non-URI identifiers: apple-docs, apple-archive, hig, \
-        swift-evolution, swift-org, swift-book, samples, packages. \
-        Auto-detected when omitted.
-        """
-    )
-    var source: String?
+        @Option(
+            name: .long,
+            help: """
+            Disambiguator for non-URI identifiers: apple-docs, apple-archive, hig, \
+            swift-evolution, swift-org, swift-book, samples, packages. \
+            Auto-detected when omitted.
+            """
+        )
+        var source: String?
 
-    @Option(
-        name: .long,
-        help: "Output format: json (default), markdown"
-    )
-    var format: OutputFormat = .json
+        @Option(
+            name: .long,
+            help: "Output format: json (default), markdown"
+        )
+        var format: OutputFormat = .json
 
-    @Option(
-        name: .long,
-        help: "Path to search database (search.db)"
-    )
-    var searchDb: String?
+        @Option(
+            name: .long,
+            help: "Path to search database (search.db)"
+        )
+        var searchDb: String?
 
-    @Option(
-        name: .long,
-        help: "Path to sample index database (samples.db)"
-    )
-    var sampleDb: String?
+        @Option(
+            name: .long,
+            help: "Path to sample index database (samples.db)"
+        )
+        var sampleDb: String?
 
-    @Option(
-        name: .long,
-        help: "Path to packages database (packages.db)"
-    )
-    var packagesDb: String?
+        @Option(
+            name: .long,
+            help: "Path to packages database (packages.db)"
+        )
+        var packagesDb: String?
 
-    mutating func run() async throws {
-        let documentFormat: Search.Index.DocumentFormat = format == .markdown
-            ? .markdown
-            : .json
+        mutating func run() async throws {
+            let documentFormat: SearchModule.Index.DocumentFormat = format == .markdown
+                ? .markdown
+                : .json
 
-        let explicit: Services.ReadService.Source?
-        do {
-            explicit = try Services.ReadService.resolveSource(source)
-        } catch Services.ReadService.ReadError.unknownSource(let raw) {
-            Logging.Log.error("Unknown --source value: \(raw). See `cupertino read --help`.")
-            throw ExitCode.failure
+            let explicit: Services.ReadService.Source?
+            do {
+                explicit = try Services.ReadService.resolveSource(source)
+            } catch Services.ReadService.ReadError.unknownSource(let raw) {
+                Logging.Log.error("Unknown --source value: \(raw). See `cupertino read --help`.")
+                throw ExitCode.failure
+            }
+
+            let result: Services.ReadService.Result
+            do {
+                result = try await Services.ReadService.read(
+                    identifier: identifier,
+                    explicit: explicit,
+                    format: documentFormat,
+                    searchDB: searchDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
+                    samplesDB: sampleDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
+                    packagesDB: packagesDb.map { URL(fileURLWithPath: $0).expandingTildeInPath }
+                )
+            } catch Services.ReadService.ReadError.docsNotFound(let id) {
+                Logging.Log.error("Document not found in search.db: \(id)")
+                throw ExitCode.failure
+            } catch Services.ReadService.ReadError.samplesNotFound(let id) {
+                Logging.Log.error("Not found in samples.db: \(id)")
+                throw ExitCode.failure
+            } catch Services.ReadService.ReadError.packagesNotFound(let id) {
+                Logging.Log.error("Not found in packages.db: \(id)")
+                throw ExitCode.failure
+            } catch Services.ReadService.ReadError.packagesIdentifierInvalid(let id) {
+                Logging.Log.error(
+                    "Invalid package identifier: \(id) — expected `<owner>/<repo>/<relpath>`."
+                )
+                throw ExitCode.failure
+            } catch Services.ReadService.ReadError.backendFailed(let msg) {
+                Logging.Log.error("Read failed: \(msg)")
+                throw ExitCode.failure
+            } catch Services.ReadService.ReadError.notFoundAnywhere(let id) {
+                Logging.Log.error(
+                    "Tried docs, samples, and packages — no source matched. Identifier: \(id)"
+                )
+                throw ExitCode.failure
+            }
+
+            Logging.Log.output(result.content)
         }
-
-        let result: Services.ReadService.Result
-        do {
-            result = try await Services.ReadService.read(
-                identifier: identifier,
-                explicit: explicit,
-                format: documentFormat,
-                searchDB: searchDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
-                samplesDB: sampleDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
-                packagesDB: packagesDb.map { URL(fileURLWithPath: $0).expandingTildeInPath }
-            )
-        } catch Services.ReadService.ReadError.docsNotFound(let id) {
-            Logging.Log.error("Document not found in search.db: \(id)")
-            throw ExitCode.failure
-        } catch Services.ReadService.ReadError.samplesNotFound(let id) {
-            Logging.Log.error("Not found in samples.db: \(id)")
-            throw ExitCode.failure
-        } catch Services.ReadService.ReadError.packagesNotFound(let id) {
-            Logging.Log.error("Not found in packages.db: \(id)")
-            throw ExitCode.failure
-        } catch Services.ReadService.ReadError.packagesIdentifierInvalid(let id) {
-            Logging.Log.error(
-                "Invalid package identifier: \(id) — expected `<owner>/<repo>/<relpath>`."
-            )
-            throw ExitCode.failure
-        } catch Services.ReadService.ReadError.backendFailed(let msg) {
-            Logging.Log.error("Read failed: \(msg)")
-            throw ExitCode.failure
-        } catch Services.ReadService.ReadError.notFoundAnywhere(let id) {
-            Logging.Log.error(
-                "Tried docs, samples, and packages — no source matched. Identifier: \(id)"
-            )
-            throw ExitCode.failure
-        }
-
-        Logging.Log.output(result.content)
     }
 }
 
 // MARK: - Output Format
 
-extension ReadCommand {
+extension Command.Read {
     enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
         case json
         case markdown

--- a/Packages/Sources/CLI/Commands/ReadSampleCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadSampleCommand.swift
@@ -11,177 +11,179 @@ import SharedUtils
 
 /// CLI command for reading a sample project's README - mirrors MCP tool functionality.
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-struct ReadSampleCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "read-sample",
-        abstract: "Read a sample project's README and metadata"
-    )
-
-    @Argument(help: "Project ID (e.g., building-a-document-based-app-with-swiftui)")
-    var projectId: String
-
-    @Option(
-        name: .long,
-        help: "Output format: text (default), json, markdown"
-    )
-    var format: OutputFormat = .text
-
-    @Option(
-        name: .long,
-        help: "Path to sample index database"
-    )
-    var sampleDb: String?
-
-    mutating func run() async throws {
-        // Resolve database path
-        let dbPath = resolveSampleDbPath()
-
-        // Use ServiceContainer for managed lifecycle
-        let (project, files) = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
-            guard let project = try await service.getProject(id: projectId) else {
-                Logging.Log.error("Project not found: \(projectId)")
-                Logging.Log.output("Use 'cupertino list-samples' or 'cupertino search --source samples' to find valid project IDs.")
-                throw ExitCode.failure
-            }
-
-            let files = try await service.listFiles(projectId: projectId)
-            return (project, files)
-        }
-
-        // Output results
-        switch format {
-        case .text:
-            outputText(project, files: files)
-        case .json:
-            outputJSON(project, files: files)
-        case .markdown:
-            outputMarkdown(project, files: files)
-        }
-    }
-
-    // MARK: - Path Resolution
-
-    private func resolveSampleDbPath() -> URL {
-        if let sampleDb {
-            return URL(fileURLWithPath: sampleDb).expandingTildeInPath
-        }
-        return SampleIndex.defaultDatabasePath
-    }
-
-    // MARK: - Output Formatting
-
-    private func outputText(_ project: SampleIndex.Project, files: [SampleIndex.File]) {
-        Logging.Log.output(project.title)
-        Logging.Log.output(String(repeating: "=", count: project.title.count))
-        Logging.Log.output("")
-        Logging.Log.output("Project ID: \(project.id)")
-        Logging.Log.output("Frameworks: \(project.frameworks.joined(separator: ", "))")
-        Logging.Log.output("Files: \(project.fileCount)")
-        Logging.Log.output("Size: \(Shared.Utils.Formatting.formatBytes(project.totalSize))")
-
-        if !project.webURL.isEmpty {
-            Logging.Log.output("Apple Developer: \(project.webURL)")
-        }
-
-        Logging.Log.output("")
-
-        if !project.description.isEmpty {
-            Logging.Log.output("Description:")
-            Logging.Log.output(project.description)
-            Logging.Log.output("")
-        }
-
-        if let readme = project.readme, !readme.isEmpty {
-            Logging.Log.output("README:")
-            Logging.Log.output(readme)
-            Logging.Log.output("")
-        }
-
-        if !files.isEmpty {
-            Logging.Log.output("Files (\(files.count) total):")
-            for file in files.prefix(30) {
-                Logging.Log.output("  - \(file.path)")
-            }
-            if files.count > 30 {
-                Logging.Log.output("  ... and \(files.count - 30) more files")
-            }
-        }
-
-        Logging.Log.output("")
-        Logging.Log.output("Tip: Use 'cupertino read-sample-file \(project.id) <path>' to view source code")
-    }
-
-    private func outputJSON(_ project: SampleIndex.Project, files: [SampleIndex.File]) {
-        struct Output: Encodable {
-            let id: String
-            let title: String
-            let description: String
-            let frameworks: [String]
-            let readme: String?
-            let webURL: String
-            let fileCount: Int
-            let totalSize: Int
-            let files: [String]
-        }
-
-        let output = Output(
-            id: project.id,
-            title: project.title,
-            description: project.description,
-            frameworks: project.frameworks,
-            readme: project.readme,
-            webURL: project.webURL,
-            fileCount: project.fileCount,
-            totalSize: project.totalSize,
-            files: files.map(\.path)
+extension Command {
+    struct ReadSample: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "read-sample",
+            abstract: "Read a sample project's README and metadata"
         )
 
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        @Argument(help: "Project ID (e.g., building-a-document-based-app-with-swiftui)")
+        var projectId: String
 
-        do {
-            let data = try encoder.encode(output)
-            if let jsonString = String(data: data, encoding: .utf8) {
-                Logging.Log.output(jsonString)
+        @Option(
+            name: .long,
+            help: "Output format: text (default), json, markdown"
+        )
+        var format: OutputFormat = .text
+
+        @Option(
+            name: .long,
+            help: "Path to sample index database"
+        )
+        var sampleDb: String?
+
+        mutating func run() async throws {
+            // Resolve database path
+            let dbPath = resolveSampleDbPath()
+
+            // Use ServiceContainer for managed lifecycle
+            let (project, files) = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
+                guard let project = try await service.getProject(id: projectId) else {
+                    Logging.Log.error("Project not found: \(projectId)")
+                    Logging.Log.output("Use 'cupertino list-samples' or 'cupertino search --source samples' to find valid project IDs.")
+                    throw ExitCode.failure
+                }
+
+                let files = try await service.listFiles(projectId: projectId)
+                return (project, files)
             }
-        } catch {
-            Logging.Log.error("Error encoding JSON: \(error)")
-        }
-    }
 
-    private func outputMarkdown(_ project: SampleIndex.Project, files: [SampleIndex.File]) {
-        Logging.Log.output("# \(project.title)\n")
-        Logging.Log.output("**Project ID:** `\(project.id)`\n")
-
-        if !project.description.isEmpty {
-            Logging.Log.output("## Description\n")
-            Logging.Log.output("\(project.description)\n")
+            // Output results
+            switch format {
+            case .text:
+                outputText(project, files: files)
+            case .json:
+                outputJSON(project, files: files)
+            case .markdown:
+                outputMarkdown(project, files: files)
+            }
         }
 
-        Logging.Log.output("## Metadata\n")
-        Logging.Log.output("- **Frameworks:** \(project.frameworks.joined(separator: ", "))")
-        Logging.Log.output("- **Files:** \(project.fileCount)")
-        Logging.Log.output("- **Size:** \(Shared.Utils.Formatting.formatBytes(project.totalSize))")
+        // MARK: - Path Resolution
 
-        if !project.webURL.isEmpty {
-            Logging.Log.output("- **Apple Developer:** \(project.webURL)")
+        private func resolveSampleDbPath() -> URL {
+            if let sampleDb {
+                return URL(fileURLWithPath: sampleDb).expandingTildeInPath
+            }
+            return SampleIndex.defaultDatabasePath
         }
 
-        Logging.Log.output("")
+        // MARK: - Output Formatting
 
-        if let readme = project.readme, !readme.isEmpty {
-            Logging.Log.output("## README\n")
-            Logging.Log.output(readme)
+        private func outputText(_ project: SampleIndex.Project, files: [SampleIndex.File]) {
+            Logging.Log.output(project.title)
+            Logging.Log.output(String(repeating: "=", count: project.title.count))
             Logging.Log.output("")
+            Logging.Log.output("Project ID: \(project.id)")
+            Logging.Log.output("Frameworks: \(project.frameworks.joined(separator: ", "))")
+            Logging.Log.output("Files: \(project.fileCount)")
+            Logging.Log.output("Size: \(Shared.Utils.Formatting.formatBytes(project.totalSize))")
+
+            if !project.webURL.isEmpty {
+                Logging.Log.output("Apple Developer: \(project.webURL)")
+            }
+
+            Logging.Log.output("")
+
+            if !project.description.isEmpty {
+                Logging.Log.output("Description:")
+                Logging.Log.output(project.description)
+                Logging.Log.output("")
+            }
+
+            if let readme = project.readme, !readme.isEmpty {
+                Logging.Log.output("README:")
+                Logging.Log.output(readme)
+                Logging.Log.output("")
+            }
+
+            if !files.isEmpty {
+                Logging.Log.output("Files (\(files.count) total):")
+                for file in files.prefix(30) {
+                    Logging.Log.output("  - \(file.path)")
+                }
+                if files.count > 30 {
+                    Logging.Log.output("  ... and \(files.count - 30) more files")
+                }
+            }
+
+            Logging.Log.output("")
+            Logging.Log.output("Tip: Use 'cupertino read-sample-file \(project.id) <path>' to view source code")
         }
 
-        if !files.isEmpty {
-            Logging.Log.output("## Files (\(files.count) total)\n")
-            for file in files.prefix(30) {
-                Logging.Log.output("- `\(file.path)`")
+        private func outputJSON(_ project: SampleIndex.Project, files: [SampleIndex.File]) {
+            struct Output: Encodable {
+                let id: String
+                let title: String
+                let description: String
+                let frameworks: [String]
+                let readme: String?
+                let webURL: String
+                let fileCount: Int
+                let totalSize: Int
+                let files: [String]
             }
-            if files.count > 30 {
-                Logging.Log.output("- _... and \(files.count - 30) more files_")
+
+            let output = Output(
+                id: project.id,
+                title: project.title,
+                description: project.description,
+                frameworks: project.frameworks,
+                readme: project.readme,
+                webURL: project.webURL,
+                fileCount: project.fileCount,
+                totalSize: project.totalSize,
+                files: files.map(\.path)
+            )
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+            do {
+                let data = try encoder.encode(output)
+                if let jsonString = String(data: data, encoding: .utf8) {
+                    Logging.Log.output(jsonString)
+                }
+            } catch {
+                Logging.Log.error("Error encoding JSON: \(error)")
+            }
+        }
+
+        private func outputMarkdown(_ project: SampleIndex.Project, files: [SampleIndex.File]) {
+            Logging.Log.output("# \(project.title)\n")
+            Logging.Log.output("**Project ID:** `\(project.id)`\n")
+
+            if !project.description.isEmpty {
+                Logging.Log.output("## Description\n")
+                Logging.Log.output("\(project.description)\n")
+            }
+
+            Logging.Log.output("## Metadata\n")
+            Logging.Log.output("- **Frameworks:** \(project.frameworks.joined(separator: ", "))")
+            Logging.Log.output("- **Files:** \(project.fileCount)")
+            Logging.Log.output("- **Size:** \(Shared.Utils.Formatting.formatBytes(project.totalSize))")
+
+            if !project.webURL.isEmpty {
+                Logging.Log.output("- **Apple Developer:** \(project.webURL)")
+            }
+
+            Logging.Log.output("")
+
+            if let readme = project.readme, !readme.isEmpty {
+                Logging.Log.output("## README\n")
+                Logging.Log.output(readme)
+                Logging.Log.output("")
+            }
+
+            if !files.isEmpty {
+                Logging.Log.output("## Files (\(files.count) total)\n")
+                for file in files.prefix(30) {
+                    Logging.Log.output("- `\(file.path)`")
+                }
+                if files.count > 30 {
+                    Logging.Log.output("- _... and \(files.count - 30) more files_")
+                }
             }
         }
     }
@@ -189,7 +191,7 @@ struct ReadSampleCommand: AsyncParsableCommand {
 
 // MARK: - Output Format
 
-extension ReadSampleCommand {
+extension Command.ReadSample {
     enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
         case text
         case json

--- a/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
@@ -11,80 +11,82 @@ import SharedUtils
 
 /// CLI command for reading a specific file from a sample project - mirrors MCP tool functionality.
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-struct ReadSampleFileCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "read-sample-file",
-        abstract: "Read a source file from a sample project"
-    )
+extension Command {
+    struct ReadSampleFile: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "read-sample-file",
+            abstract: "Read a source file from a sample project"
+        )
 
-    @Argument(help: "Project ID (e.g., building-a-document-based-app-with-swiftui)")
-    var projectId: String
+        @Argument(help: "Project ID (e.g., building-a-document-based-app-with-swiftui)")
+        var projectId: String
 
-    @Argument(help: "File path within the project (e.g., ContentView.swift)")
-    var filePath: String
+        @Argument(help: "File path within the project (e.g., ContentView.swift)")
+        var filePath: String
 
-    @Option(
-        name: .long,
-        help: "Output format: text (default), json, markdown"
-    )
-    var format: OutputFormat = .text
+        @Option(
+            name: .long,
+            help: "Output format: text (default), json, markdown"
+        )
+        var format: OutputFormat = .text
 
-    @Option(
-        name: .long,
-        help: "Path to sample index database"
-    )
-    var sampleDb: String?
+        @Option(
+            name: .long,
+            help: "Path to sample index database"
+        )
+        var sampleDb: String?
 
-    mutating func run() async throws {
-        // Resolve database path
-        let dbPath = resolveSampleDbPath()
+        mutating func run() async throws {
+            // Resolve database path
+            let dbPath = resolveSampleDbPath()
 
-        // Use ServiceContainer for managed lifecycle
-        let file = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
-            guard let file = try await service.getFile(projectId: projectId, path: filePath) else {
-                Logging.Log.error("File not found: \(filePath) in project \(projectId)")
-                Logging.Log.output("Use 'cupertino read-sample \(projectId)' to list available files.")
-                throw ExitCode.failure
+            // Use ServiceContainer for managed lifecycle
+            let file = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
+                guard let file = try await service.getFile(projectId: projectId, path: filePath) else {
+                    Logging.Log.error("File not found: \(filePath) in project \(projectId)")
+                    Logging.Log.output("Use 'cupertino read-sample \(projectId)' to list available files.")
+                    throw ExitCode.failure
+                }
+                return file
             }
-            return file
+
+            // Output results using formatters
+            switch format {
+            case .text:
+                outputText(file)
+            case .json:
+                let formatter = SampleFileJSONFormatter()
+                Logging.Log.output(formatter.format(file))
+            case .markdown:
+                let formatter = SampleFileMarkdownFormatter()
+                Logging.Log.output(formatter.format(file))
+            }
         }
 
-        // Output results using formatters
-        switch format {
-        case .text:
-            outputText(file)
-        case .json:
-            let formatter = SampleFileJSONFormatter()
-            Logging.Log.output(formatter.format(file))
-        case .markdown:
-            let formatter = SampleFileMarkdownFormatter()
-            Logging.Log.output(formatter.format(file))
+        // MARK: - Path Resolution
+
+        private func resolveSampleDbPath() -> URL {
+            if let sampleDb {
+                return URL(fileURLWithPath: sampleDb).expandingTildeInPath
+            }
+            return SampleIndex.defaultDatabasePath
         }
-    }
 
-    // MARK: - Path Resolution
+        // MARK: - Output Formatting
 
-    private func resolveSampleDbPath() -> URL {
-        if let sampleDb {
-            return URL(fileURLWithPath: sampleDb).expandingTildeInPath
+        private func outputText(_ file: SampleIndex.File) {
+            Logging.Log.output("// File: \(file.path)")
+            Logging.Log.output("// Project: \(file.projectId)")
+            Logging.Log.output("// Size: \(Shared.Utils.Formatting.formatBytes(file.size))")
+            Logging.Log.output("")
+            Logging.Log.output(file.content)
         }
-        return SampleIndex.defaultDatabasePath
-    }
-
-    // MARK: - Output Formatting
-
-    private func outputText(_ file: SampleIndex.File) {
-        Logging.Log.output("// File: \(file.path)")
-        Logging.Log.output("// Project: \(file.projectId)")
-        Logging.Log.output("// Size: \(Shared.Utils.Formatting.formatBytes(file.size))")
-        Logging.Log.output("")
-        Logging.Log.output(file.content)
     }
 }
 
 // MARK: - Output Format
 
-extension ReadSampleFileCommand {
+extension Command.ReadSampleFile {
     enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
         case text
         case json

--- a/Packages/Sources/CLI/Commands/ResolveRefsCommand.swift
+++ b/Packages/Sources/CLI/Commands/ResolveRefsCommand.swift
@@ -16,138 +16,140 @@ import WebKit
 
 // MARK: - Resolve-Refs Command
 
-struct ResolveRefsCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "resolve-refs",
-        abstract: "Rewrite unresolved doc:// markers in saved page rawMarkdown",
-        discussion: """
-        Walks a directory of saved StructuredDocumentationPage JSON files
-        (typically from a `--discovery-mode json-only` crawl), harvests a
-        global identifier→title map from each page's sections[].items[],
-        and rewrites every `doc://com.apple.<bundle>/...` marker in
-        rawMarkdown to the readable title.
+extension Command {
+    struct ResolveRefs: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "resolve-refs",
+            abstract: "Rewrite unresolved doc:// markers in saved page rawMarkdown",
+            discussion: """
+            Walks a directory of saved StructuredDocumentationPage JSON files
+            (typically from a `--discovery-mode json-only` crawl), harvests a
+            global identifier→title map from each page's sections[].items[],
+            and rewrites every `doc://com.apple.<bundle>/...` marker in
+            rawMarkdown to the readable title.
 
-        This is a pure post-process pass: no network calls, no recrawl.
-        Markers pointing to pages no other page references will be left
-        intact and reported in the unresolved-markers report.
+            This is a pure post-process pass: no network calls, no recrawl.
+            Markers pointing to pages no other page references will be left
+            intact and reported in the unresolved-markers report.
 
-        See https://github.com/mihaelamj/cupertino/issues/208
-        """
-    )
-
-    @Option(
-        name: .long,
-        help: "Directory of saved page JSONs (e.g. ~/.cupertino/_docs)"
-    )
-    var input: String
-
-    @Flag(
-        name: .long,
-        help: "After harvest+rewrite, fetch titles for the still-unresolved markers via Apple's JSON API."
-    )
-    var useNetwork: Bool = false
-
-    @Flag(
-        name: .long,
-        help: "When --use-network is set, also fall back to WKWebView for markers that the JSON API can't serve. Slow; macOS only."
-    )
-    var useWebview: Bool = false
-
-    @Flag(
-        name: .long,
-        help: "Print unresolved doc:// markers (sorted, deduped) to stdout."
-    )
-    var printUnresolved: Bool = false
-
-    mutating func run() async throws {
-        let dir = URL(fileURLWithPath: input).expandingTildeInPath
-        guard FileManager.default.fileExists(atPath: dir.path) else {
-            Logging.Log.error("Directory does not exist: \(dir.path)")
-            throw ExitCode.failure
-        }
-
-        Logging.Log.info("Resolving doc:// markers in \(dir.path)")
-        let resolver = RefResolver(inputDirectory: dir)
-
-        let fetcher = try await makeFetcher()
-        let (stats, unresolved): (RefResolver.Stats, Set<String>)
-        if let fetcher {
-            (stats, unresolved) = try await resolver.runWithFetcher(fetcher) { done, total in
-                if done % 50 == 0 || done == total {
-                    Logging.Log.info("  network resolve: \(done)/\(total)")
-                }
-            }
-        } else {
-            (stats, unresolved) = try resolver.run()
-        }
-
-        Logging.Log.info("Pages scanned:                  \(stats.pagesScanned)")
-        Logging.Log.info("Refs harvested:                 \(stats.refsHarvested)")
-        Logging.Log.info("Pages rewritten:                \(stats.pagesRewritten)")
-        Logging.Log.info("doc:// markers found:           \(stats.markersFound)")
-        Logging.Log.info("Resolved from harvest:          \(stats.markersResolvedFromHarvest)")
-        Logging.Log.info("Resolved from network:          \(stats.markersResolvedFromNetwork)")
-        Logging.Log.info("Unresolved (unique):            \(unresolved.count)")
-
-        // Persist a report next to the corpus.
-        let report = ResolveReport(
-            generatedAt: Date(),
-            inputDirectory: dir.path,
-            stats: stats,
-            unresolvedMarkers: unresolved.sorted()
+            See https://github.com/mihaelamj/cupertino/issues/208
+            """
         )
-        let reportURL = dir.appendingPathComponent("resolve-refs-report.json")
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        try encoder.encode(report).write(to: reportURL)
-        Logging.Log.info("Report: \(reportURL.path)")
 
-        if printUnresolved {
-            for marker in report.unresolvedMarkers {
-                print(marker)
-            }
-        }
-    }
+        @Option(
+            name: .long,
+            help: "Directory of saved page JSONs (e.g. ~/.cupertino/_docs)"
+        )
+        var input: String
 
-    private struct ResolveReport: Codable {
-        let generatedAt: Date
-        let inputDirectory: String
-        let stats: RefResolver.Stats
-        let unresolvedMarkers: [String]
-    }
+        @Flag(
+            name: .long,
+            help: "After harvest+rewrite, fetch titles for the still-unresolved markers via Apple's JSON API."
+        )
+        var useNetwork: Bool = false
 
-    /// Build the title-fetcher chain based on `--use-network` /
-    /// `--use-webview` flags. Returns nil when no network resolution
-    /// should happen (default behaviour).
-    private func makeFetcher() async throws -> (any RefResolver.TitleFetcher)? {
-        guard useNetwork else {
-            if useWebview {
-                Logging.Log.error("--use-webview requires --use-network")
+        @Flag(
+            name: .long,
+            help: "When --use-network is set, also fall back to WKWebView for markers that the JSON API can't serve. Slow; macOS only."
+        )
+        var useWebview: Bool = false
+
+        @Flag(
+            name: .long,
+            help: "Print unresolved doc:// markers (sorted, deduped) to stdout."
+        )
+        var printUnresolved: Bool = false
+
+        mutating func run() async throws {
+            let dir = URL(fileURLWithPath: input).expandingTildeInPath
+            guard FileManager.default.fileExists(atPath: dir.path) else {
+                Logging.Log.error("Directory does not exist: \(dir.path)")
                 throw ExitCode.failure
             }
-            return nil
+
+            Logging.Log.info("Resolving doc:// markers in \(dir.path)")
+            let resolver = RefResolver(inputDirectory: dir)
+
+            let fetcher = try await makeFetcher()
+            let (stats, unresolved): (RefResolver.Stats, Set<String>)
+            if let fetcher {
+                (stats, unresolved) = try await resolver.runWithFetcher(fetcher) { done, total in
+                    if done % 50 == 0 || done == total {
+                        Logging.Log.info("  network resolve: \(done)/\(total)")
+                    }
+                }
+            } else {
+                (stats, unresolved) = try resolver.run()
+            }
+
+            Logging.Log.info("Pages scanned:                  \(stats.pagesScanned)")
+            Logging.Log.info("Refs harvested:                 \(stats.refsHarvested)")
+            Logging.Log.info("Pages rewritten:                \(stats.pagesRewritten)")
+            Logging.Log.info("doc:// markers found:           \(stats.markersFound)")
+            Logging.Log.info("Resolved from harvest:          \(stats.markersResolvedFromHarvest)")
+            Logging.Log.info("Resolved from network:          \(stats.markersResolvedFromNetwork)")
+            Logging.Log.info("Unresolved (unique):            \(unresolved.count)")
+
+            // Persist a report next to the corpus.
+            let report = ResolveReport(
+                generatedAt: Date(),
+                inputDirectory: dir.path,
+                stats: stats,
+                unresolvedMarkers: unresolved.sorted()
+            )
+            let reportURL = dir.appendingPathComponent("resolve-refs-report.json")
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            try encoder.encode(report).write(to: reportURL)
+            Logging.Log.info("Report: \(reportURL.path)")
+
+            if printUnresolved {
+                for marker in report.unresolvedMarkers {
+                    print(marker)
+                }
+            }
         }
 
-        let json = AppleJSONAPITitleFetcher()
-        guard useWebview else {
-            return json
+        private struct ResolveReport: Codable {
+            let generatedAt: Date
+            let inputDirectory: String
+            let stats: RefResolver.Stats
+            let unresolvedMarkers: [String]
         }
 
-        #if canImport(AppKit) && canImport(WebKit)
-        // WKWebView needs the AppKit runloop attached (otherwise its
-        // navigation observer never fires). The same bootstrap the auth
-        // flow in SampleCodeDownloader uses, but headless — we don't
-        // surface a Dock icon for a background resolve pass.
-        let webView = await MainActor.run { () -> any RefResolver.TitleFetcher in
-            NSApplication.shared.setActivationPolicy(.prohibited)
-            NSApplication.shared.finishLaunching()
-            return WKWebViewTitleFetcher()
+        /// Build the title-fetcher chain based on `--use-network` /
+        /// `--use-webview` flags. Returns nil when no network resolution
+        /// should happen (default behaviour).
+        private func makeFetcher() async throws -> (any RefResolver.TitleFetcher)? {
+            guard useNetwork else {
+                if useWebview {
+                    Logging.Log.error("--use-webview requires --use-network")
+                    throw ExitCode.failure
+                }
+                return nil
+            }
+
+            let json = AppleJSONAPITitleFetcher()
+            guard useWebview else {
+                return json
+            }
+
+            #if canImport(AppKit) && canImport(WebKit)
+            // WKWebView needs the AppKit runloop attached (otherwise its
+            // navigation observer never fires). The same bootstrap the auth
+            // flow in SampleCodeDownloader uses, but headless — we don't
+            // surface a Dock icon for a background resolve pass.
+            let webView = await MainActor.run { () -> any RefResolver.TitleFetcher in
+                NSApplication.shared.setActivationPolicy(.prohibited)
+                NSApplication.shared.finishLaunching()
+                return WKWebViewTitleFetcher()
+            }
+            return CompositeTitleFetcher(primary: json, fallback: webView)
+            #else
+            Logging.Log.error("--use-webview is only supported on macOS")
+            throw ExitCode.failure
+            #endif
         }
-        return CompositeTitleFetcher(primary: json, fallback: webView)
-        #else
-        Logging.Log.error("--use-webview is only supported on macOS")
-        throw ExitCode.failure
-        #endif
     }
 }

--- a/Packages/Sources/CLI/Commands/SaveCommand+Indexers.swift
+++ b/Packages/Sources/CLI/Commands/SaveCommand+Indexers.swift
@@ -8,12 +8,12 @@ import SharedUtils
 
 // MARK: - Indexer dispatch + progress rendering (#244)
 
-/// Per-source indexer dispatchers split out of `SaveCommand.swift` so the
+/// Per-source indexer dispatchers split out of `Command.Save.swift` so the
 /// struct body stays under SwiftLint's `type_body_length` 300-line
 /// ceiling. Each dispatcher converts CLI flags into an
 /// `Indexer.<X>Service.Request`, runs the service, renders progress
 /// events to the terminal, and prints a final summary.
-extension SaveCommand {
+extension Command.Save {
     // MARK: - Docs
 
     func runDocsIndexer(effectiveBase: URL) async throws {
@@ -71,7 +71,7 @@ extension SaveCommand {
         Logging.ConsoleLogger.info("   Total documents: \(outcome.documentCount)")
         Logging.ConsoleLogger.info("   Frameworks: \(outcome.frameworkCount)")
         Logging.ConsoleLogger.info("   Database: \(outcome.searchDBPath.path)")
-        Logging.ConsoleLogger.info("   Size: \(SaveCommand.formatFileSize(outcome.searchDBPath))")
+        Logging.ConsoleLogger.info("   Size: \(Command.Save.formatFileSize(outcome.searchDBPath))")
         Logging.ConsoleLogger.info(
             "\n💡 Tip: Start the MCP server with '\(Shared.Constants.App.commandName) serve' to enable search"
         )
@@ -220,7 +220,7 @@ extension SaveCommand {
         Logging.Log.output("   Symbols extracted: \(outcome.symbolsTotal)")
         Logging.Log.output("   Imports captured: \(outcome.importsTotal)")
         Logging.Log.output("   Duration: \(Int(outcome.durationSeconds))s")
-        Logging.Log.output("   Database: \(SaveCommand.formatFileSize(outcome.samplesDBPath))")
+        Logging.Log.output("   Database: \(Command.Save.formatFileSize(outcome.samplesDBPath))")
     }
 
     /// Class wrapper so `@Sendable` callbacks can mutate `lastPercent`.

--- a/Packages/Sources/CLI/Commands/SaveCommand.swift
+++ b/Packages/Sources/CLI/Commands/SaveCommand.swift
@@ -17,172 +17,174 @@ import SharedUtils
 /// command parses flags, runs the preflight prompt, dispatches to the
 /// requested scope, and renders progress.
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-struct SaveCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "save",
-        abstract: "Save documentation to database and build search indexes"
-    )
-
-    @Option(name: .long, help: "Base directory (auto-fills all directories from standard structure)")
-    var baseDir: String?
-
-    @Option(name: .long, help: "Directory containing crawled documentation")
-    var docsDir: String?
-
-    @Option(name: .long, help: "Directory containing Swift Evolution proposals")
-    var evolutionDir: String?
-
-    @Option(name: .long, help: "Directory containing Swift.org documentation")
-    var swiftOrgDir: String?
-
-    @Option(name: .long, help: "Directory containing package READMEs")
-    var packagesDir: String?
-
-    @Option(name: .long, help: "Directory containing Apple Archive documentation")
-    var archiveDir: String?
-
-    @Option(name: .long, help: "Metadata file path")
-    var metadataFile: String?
-
-    @Option(name: .long, help: "Search database path")
-    var searchDB: String?
-
-    @Flag(name: .long, help: "Clear existing index before building")
-    var clear: Bool = false
-
-    @Flag(name: .long, help: "Stream documentation from GitHub (instant setup, no local files needed)")
-    var remote: Bool = false
-
-    @Flag(
-        name: .long,
-        help: """
-        Build search.db (Apple docs + Swift Evolution + HIG + Archive + \
-        Swift.org + Swift Book). Defaults to ON when no scope flag is \
-        passed. (#231)
-        """
-    )
-    var docs: Bool = false
-
-    @Flag(
-        name: .long,
-        help: """
-        Build packages.db from extracted package archives at \
-        `~/.cupertino/packages/<owner>/<repo>/`. (#231)
-        """
-    )
-    var packages: Bool = false
-
-    @Flag(
-        name: .long,
-        help: """
-        Build samples.db from extracted sample-code zips at \
-        `~/.cupertino/sample-code/`. Replaces the removed `cupertino \
-        index` command. (#231)
-        """
-    )
-    var samples: Bool = false
-
-    @Option(name: .long, help: "Sample-code directory for `--samples` (#231).")
-    var samplesDir: String?
-
-    @Option(name: .long, help: "samples.db path override for `--samples` (#231).")
-    var samplesDB: String?
-
-    @Flag(
-        name: .long,
-        help: "Force re-index of every sample under `--samples` (existing rows wiped)."
-    )
-    var force: Bool = false
-
-    @Flag(
-        name: [.short, .long],
-        help: "Skip the preflight summary + confirmation prompt (#232). Auto-skipped when stdin isn't a TTY."
-    )
-    var yes: Bool = false
-
-    mutating func run() async throws {
-        if remote {
-            try await runRemote()
-            return
-        }
-
-        let scopeFlagsSet = docs || packages || samples
-        let buildDocs = !scopeFlagsSet || docs
-        let buildPackages = !scopeFlagsSet || packages
-        let buildSamples = !scopeFlagsSet || samples
-
-        if !runPreflightAndConfirm(
-            buildDocs: buildDocs,
-            buildPackages: buildPackages,
-            buildSamples: buildSamples
-        ) {
-            Logging.ConsoleLogger.info("Aborted by user.")
-            return
-        }
-
-        let effectiveBase = baseDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
-            ?? Shared.Constants.defaultBaseDirectory
-
-        if buildDocs {
-            try await runDocsIndexer(effectiveBase: effectiveBase)
-        }
-        if buildPackages {
-            try await runPackagesIndexerSafely(effectiveBase: effectiveBase)
-        }
-        if buildSamples {
-            try await runSamplesIndexerSafely()
-        }
-    }
-
-    // MARK: - Indexer dispatchers moved to SaveCommand+Indexers.swift (#244)
-
-    // MARK: - Preflight
-
-    private func runPreflightAndConfirm(
-        buildDocs: Bool,
-        buildPackages: Bool,
-        buildSamples: Bool
-    ) -> Bool {
-        let lines = Indexer.Preflight.preflightLines(
-            buildDocs: buildDocs,
-            buildPackages: buildPackages,
-            buildSamples: buildSamples,
-            baseDir: baseDir,
-            docsDir: docsDir,
-            samplesDir: samplesDir
+extension Command {
+    struct Save: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "save",
+            abstract: "Save documentation to database and build search indexes"
         )
-        Logging.ConsoleLogger.info("🔍 Preflight check for `cupertino save`\n")
-        for line in lines {
-            Logging.ConsoleLogger.info(line)
-        }
-        Logging.ConsoleLogger.info("")
 
-        if yes {
-            Logging.ConsoleLogger.info("--yes: skipping confirmation, continuing.\n")
-            return true
-        }
-        guard isatty(fileno(stdin)) != 0 else {
-            return true
+        @Option(name: .long, help: "Base directory (auto-fills all directories from standard structure)")
+        var baseDir: String?
+
+        @Option(name: .long, help: "Directory containing crawled documentation")
+        var docsDir: String?
+
+        @Option(name: .long, help: "Directory containing Swift Evolution proposals")
+        var evolutionDir: String?
+
+        @Option(name: .long, help: "Directory containing Swift.org documentation")
+        var swiftOrgDir: String?
+
+        @Option(name: .long, help: "Directory containing package READMEs")
+        var packagesDir: String?
+
+        @Option(name: .long, help: "Directory containing Apple Archive documentation")
+        var archiveDir: String?
+
+        @Option(name: .long, help: "Metadata file path")
+        var metadataFile: String?
+
+        @Option(name: .long, help: "Search database path")
+        var searchDB: String?
+
+        @Flag(name: .long, help: "Clear existing index before building")
+        var clear: Bool = false
+
+        @Flag(name: .long, help: "Stream documentation from GitHub (instant setup, no local files needed)")
+        var remote: Bool = false
+
+        @Flag(
+            name: .long,
+            help: """
+            Build search.db (Apple docs + Swift Evolution + HIG + Archive + \
+            Swift.org + Swift Book). Defaults to ON when no scope flag is \
+            passed. (#231)
+            """
+        )
+        var docs: Bool = false
+
+        @Flag(
+            name: .long,
+            help: """
+            Build packages.db from extracted package archives at \
+            `~/.cupertino/packages/<owner>/<repo>/`. (#231)
+            """
+        )
+        var packages: Bool = false
+
+        @Flag(
+            name: .long,
+            help: """
+            Build samples.db from extracted sample-code zips at \
+            `~/.cupertino/sample-code/`. Replaces the removed `cupertino \
+            index` command. (#231)
+            """
+        )
+        var samples: Bool = false
+
+        @Option(name: .long, help: "Sample-code directory for `--samples` (#231).")
+        var samplesDir: String?
+
+        @Option(name: .long, help: "samples.db path override for `--samples` (#231).")
+        var samplesDB: String?
+
+        @Flag(
+            name: .long,
+            help: "Force re-index of every sample under `--samples` (existing rows wiped)."
+        )
+        var force: Bool = false
+
+        @Flag(
+            name: [.short, .long],
+            help: "Skip the preflight summary + confirmation prompt (#232). Auto-skipped when stdin isn't a TTY."
+        )
+        var yes: Bool = false
+
+        mutating func run() async throws {
+            if remote {
+                try await runRemote()
+                return
+            }
+
+            let scopeFlagsSet = docs || packages || samples
+            let buildDocs = !scopeFlagsSet || docs
+            let buildPackages = !scopeFlagsSet || packages
+            let buildSamples = !scopeFlagsSet || samples
+
+            if !runPreflightAndConfirm(
+                buildDocs: buildDocs,
+                buildPackages: buildPackages,
+                buildSamples: buildSamples
+            ) {
+                Logging.ConsoleLogger.info("Aborted by user.")
+                return
+            }
+
+            let effectiveBase = baseDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
+                ?? Shared.Constants.defaultBaseDirectory
+
+            if buildDocs {
+                try await runDocsIndexer(effectiveBase: effectiveBase)
+            }
+            if buildPackages {
+                try await runPackagesIndexerSafely(effectiveBase: effectiveBase)
+            }
+            if buildSamples {
+                try await runSamplesIndexerSafely()
+            }
         }
 
-        Logging.ConsoleLogger.info("Continue? [Y/n] ")
-        guard let response = readLine() else { return true }
-        let normalized = response.trimmingCharacters(in: .whitespaces).lowercased()
-        return normalized.isEmpty || normalized == "y" || normalized == "yes"
-    }
+        // MARK: - Indexer dispatchers moved to Command.Save+Indexers.swift (#244)
 
-    // MARK: - Helpers
+        // MARK: - Preflight
 
-    static func formatFileSize(_ url: URL) -> String {
-        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
-              let size = attrs[.size] as? Int64
-        else {
-            return "unknown"
+        private func runPreflightAndConfirm(
+            buildDocs: Bool,
+            buildPackages: Bool,
+            buildSamples: Bool
+        ) -> Bool {
+            let lines = Indexer.Preflight.preflightLines(
+                buildDocs: buildDocs,
+                buildPackages: buildPackages,
+                buildSamples: buildSamples,
+                baseDir: baseDir,
+                docsDir: docsDir,
+                samplesDir: samplesDir
+            )
+            Logging.ConsoleLogger.info("🔍 Preflight check for `cupertino save`\n")
+            for line in lines {
+                Logging.ConsoleLogger.info(line)
+            }
+            Logging.ConsoleLogger.info("")
+
+            if yes {
+                Logging.ConsoleLogger.info("--yes: skipping confirmation, continuing.\n")
+                return true
+            }
+            guard isatty(fileno(stdin)) != 0 else {
+                return true
+            }
+
+            Logging.ConsoleLogger.info("Continue? [Y/n] ")
+            guard let response = readLine() else { return true }
+            let normalized = response.trimmingCharacters(in: .whitespaces).lowercased()
+            return normalized.isEmpty || normalized == "y" || normalized == "yes"
         }
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = [.useKB, .useMB, .useGB]
-        formatter.countStyle = .file
-        return formatter.string(fromByteCount: size)
+
+        // MARK: - Helpers
+
+        static func formatFileSize(_ url: URL) -> String {
+            guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+                  let size = attrs[.size] as? Int64
+            else {
+                return "unknown"
+            }
+            let formatter = ByteCountFormatter()
+            formatter.allowedUnits = [.useKB, .useMB, .useGB]
+            formatter.countStyle = .file
+            return formatter.string(fromByteCount: size)
+        }
     }
 }
 
@@ -193,7 +195,7 @@ struct SaveCommand: AsyncParsableCommand {
 /// `RemoteIndexer` interface is heavily UI-coupled (animated progress
 /// bar, framework-by-framework status). Stays here until that pipeline
 /// gets a callback-based shape.
-extension SaveCommand {
+extension Command.Save {
     private func runRemote() async throws {
         Logging.ConsoleLogger.info("🚀 Building Search Index from Remote\n")
 
@@ -221,7 +223,7 @@ extension SaveCommand {
         }
 
         Logging.ConsoleLogger.info("🗄️  Initializing search database...")
-        let searchIndex = try await Search.Index(dbPath: searchDBURL)
+        let searchIndex = try await SearchModule.Index(dbPath: searchDBURL)
 
         let progressDisplay = AnimatedProgress(barWidth: 20, useEmoji: true)
         let reporter = ProgressReporter(display: progressDisplay)

--- a/Packages/Sources/CLI/Commands/SearchCommand+SmartReport.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand+SmartReport.swift
@@ -10,19 +10,19 @@ import SharedUtils
 
 // MARK: - SmartQuery fan-out helpers (#239)
 
-/// Helpers for `SearchCommand`'s default (no `--source`) path: building the
+/// Helpers for `Command.Search`'s default (no `--source`) path: building the
 /// per-DB `CandidateFetcher` list, then printing the fused result in
-/// text / markdown / json. Lifted out of `SearchCommand.swift` so the
+/// text / markdown / json. Lifted out of `Command.Search.swift` so the
 /// struct body stays under SwiftLint's `type_body_length` ceiling and so
 /// the printers don't need access to instance-level CLI options.
-extension SearchCommand {
+extension Command.Search {
     /// Bundle returned by `buildFetchers`. The `searchIndex` and
     /// `sampleService` references are kept so the caller can disconnect
     /// them once the SmartQuery has run — the fetchers don't own those
     /// connections.
     struct FetcherPlan {
         let fetchers: [any Search.CandidateFetcher]
-        let searchIndex: Search.Index?
+        let searchIndex: SearchModule.Index?
         let sampleService: Services.SampleSearchService?
     }
 
@@ -50,10 +50,10 @@ extension SearchCommand {
     /// Validate the `--platform` / `--min-version` pair into an
     /// `AvailabilityFilter`. Either both flags or neither — anything else
     /// errors out with `ExitCode.failure` so the user sees a clean message.
-    func resolveAvailabilityFilter() throws -> Search.PackageQuery.AvailabilityFilter? {
+    func resolveAvailabilityFilter() throws -> SearchModule.PackageQuery.AvailabilityFilter? {
         switch (platform, minVersion) {
         case let (platform?, minVersion?):
-            return Search.PackageQuery.AvailabilityFilter(
+            return SearchModule.PackageQuery.AvailabilityFilter(
                 platform: platform,
                 minVersion: minVersion
             )
@@ -71,7 +71,7 @@ extension SearchCommand {
     /// or unopenable DBs log a one-line info note and are silently dropped
     /// from the fan-out (mirrors the resilience that `cupertino ask` had).
     func buildFetchers(
-        availabilityFilter: Search.PackageQuery.AvailabilityFilter?
+        availabilityFilter: SearchModule.PackageQuery.AvailabilityFilter?
     ) async -> FetcherPlan {
         var fetchers: [any Search.CandidateFetcher] = []
 
@@ -106,9 +106,9 @@ extension SearchCommand {
     private static func openDocsFetchers(
         override: String?,
         skip: Bool,
-        availability: Search.PackageQuery.AvailabilityFilter?,
+        availability: SearchModule.PackageQuery.AvailabilityFilter?,
         into fetchers: inout [any Search.CandidateFetcher]
-    ) async -> Search.Index? {
+    ) async -> SearchModule.Index? {
         guard !skip else { return nil }
         let url = override.map { URL(fileURLWithPath: $0).expandingTildeInPath }
             ?? Shared.Constants.defaultSearchDatabase
@@ -119,7 +119,7 @@ extension SearchCommand {
             return nil
         }
         do {
-            let index = try await Search.Index(dbPath: url)
+            let index = try await SearchModule.Index(dbPath: url)
             for source in docsSources {
                 fetchers.append(Search.DocsSourceCandidateFetcher(
                     searchIndex: index,
@@ -140,7 +140,7 @@ extension SearchCommand {
     private static func openPackagesFetcher(
         override: String?,
         skip: Bool,
-        availability: Search.PackageQuery.AvailabilityFilter?,
+        availability: SearchModule.PackageQuery.AvailabilityFilter?,
         into fetchers: inout [any Search.CandidateFetcher]
     ) {
         guard !skip else { return }
@@ -152,7 +152,7 @@ extension SearchCommand {
             )
             return
         }
-        fetchers.append(Search.PackageFTSCandidateFetcher(
+        fetchers.append(SearchModule.PackageFTSCandidateFetcher(
             dbPath: url,
             availability: availability
         ))
@@ -161,7 +161,7 @@ extension SearchCommand {
     private static func openSamplesFetcher(
         override: String?,
         skip: Bool,
-        availability: Search.PackageQuery.AvailabilityFilter?,
+        availability: SearchModule.PackageQuery.AvailabilityFilter?,
         into fetchers: inout [any Search.CandidateFetcher]
     ) async -> Services.SampleSearchService? {
         guard !skip else { return nil }

--- a/Packages/Sources/CLI/Commands/SearchCommand+SourceRunners.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand+SourceRunners.swift
@@ -9,11 +9,11 @@ import SharedUtils
 
 // MARK: - Per-source runners
 
-/// `--source <name>` paths split out of `SearchCommand` so the struct body
+/// `--source <name>` paths split out of `Command.Search` so the struct body
 /// stays under SwiftLint's `type_body_length` ceiling. The default
 /// (no `--source`) fan-out + chunked report lives in
-/// `SearchCommand+SmartReport.swift` (#239).
-extension SearchCommand {
+/// `Command.Search+SmartReport.swift` (#239).
+extension Command.Search {
     func runDocsSearch() async throws {
         let results = try await ServiceContainer.withDocsService(dbPath: searchDb) { service in
             try await service.search(SearchQuery(
@@ -150,11 +150,11 @@ extension SearchCommand {
         }
 
         let availabilityFilter = try resolveAvailabilityFilter()
-        let fetcher = Search.PackageFTSCandidateFetcher(
+        let fetcher = SearchModule.PackageFTSCandidateFetcher(
             dbPath: dbURL,
             availability: availabilityFilter
         )
-        let smartQuery = Search.SmartQuery(fetchers: [fetcher])
+        let smartQuery = SearchModule.SmartQuery(fetchers: [fetcher])
         let result = await smartQuery.answer(
             question: trimmed,
             limit: limit,

--- a/Packages/Sources/CLI/Commands/SearchCommand.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand.swift
@@ -13,279 +13,281 @@ import SharedUtils
 /// CLI command for unified search across all documentation sources.
 /// Mirrors MCP `search` tool functionality with `--source` parameter routing.
 ///
-/// After #239 the default (no `--source`) path runs `Search.SmartQuery` —
+/// After #239 the default (no `--source`) path runs `SearchModule.SmartQuery` —
 /// a fan-out across every available DB with reciprocal-rank-fusion ranking
 /// and chunked output, replacing what `cupertino ask` used to do. The
 /// single-source `--source <name>` path still runs the source-specific
 /// list-style formatters.
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-struct SearchCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "search",
-        abstract: "Search Apple documentation, samples, HIG, and more",
-        discussion: """
-        Unified search across all documentation sources. By default, searches ALL sources
-        in parallel and returns chunked excerpts ranked by reciprocal-rank fusion (#239:
-        absorbed from the removed `cupertino ask`). Use --source to narrow to one source
-        and get the source-specific list view instead.
+extension Command {
+    struct Search: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "search",
+            abstract: "Search Apple documentation, samples, HIG, and more",
+            discussion: """
+            Unified search across all documentation sources. By default, searches ALL sources
+            in parallel and returns chunked excerpts ranked by reciprocal-rank fusion (#239:
+            absorbed from the removed `cupertino ask`). Use --source to narrow to one source
+            and get the source-specific list view instead.
 
-        SOURCES:
-          (default)       Fan out across every available DB (chunked, RRF-fused)
-          apple-docs      Modern Apple API documentation only
-          samples         Sample code projects with working examples
-          hig             Human Interface Guidelines
-          apple-archive   Legacy guides (Core Animation, Quartz 2D, KVO/KVC)
-          swift-evolution Swift Evolution proposals
-          swift-org       Swift.org documentation
-          swift-book      The Swift Programming Language book
-          packages        Swift package documentation
+            SOURCES:
+              (default)       Fan out across every available DB (chunked, RRF-fused)
+              apple-docs      Modern Apple API documentation only
+              samples         Sample code projects with working examples
+              hig             Human Interface Guidelines
+              apple-archive   Legacy guides (Core Animation, Quartz 2D, KVO/KVC)
+              swift-evolution Swift Evolution proposals
+              swift-org       Swift.org documentation
+              swift-book      The Swift Programming Language book
+              packages        Swift package documentation
 
-        SEMANTIC SEARCH:
-          Search includes AST-extracted symbols from Swift source code.
-          Find @Observable classes, async functions, View conformances, etc.
-          Works across both documentation and sample code.
+            SEMANTIC SEARCH:
+              Search includes AST-extracted symbols from Swift source code.
+              Find @Observable classes, async functions, View conformances, etc.
+              Works across both documentation and sample code.
 
-        EXAMPLES:
-          cupertino search "how do I make a SwiftUI view observable"
-          cupertino search "@Observable" --source samples
-          cupertino search "Core Animation" --source apple-archive
-          cupertino search "button styles" --source samples
-          cupertino search "async throws" --source apple-docs
-          cupertino search "actor reentrancy" --skip-docs
-        """
-    )
+            EXAMPLES:
+              cupertino search "how do I make a SwiftUI view observable"
+              cupertino search "@Observable" --source samples
+              cupertino search "Core Animation" --source apple-archive
+              cupertino search "button styles" --source samples
+              cupertino search "async throws" --source apple-docs
+              cupertino search "actor reentrancy" --skip-docs
+            """
+        )
 
-    @Argument(help: "Search query")
-    var query: String
+        @Argument(help: "Search query")
+        var query: String
 
-    @Option(
-        name: .shortAndLong,
-        help: """
-        Filter by source: apple-docs, samples, hig, apple-archive, swift-evolution, swift-org, swift-book, packages, all
-        """
-    )
-    var source: String?
+        @Option(
+            name: .shortAndLong,
+            help: """
+            Filter by source: apple-docs, samples, hig, apple-archive, swift-evolution, swift-org, swift-book, packages, all
+            """
+        )
+        var source: String?
 
-    @Flag(
-        name: .long,
-        help: "Include Apple Archive documentation in results (excluded by default)"
-    )
-    var includeArchive: Bool = false
+        @Flag(
+            name: .long,
+            help: "Include Apple Archive documentation in results (excluded by default)"
+        )
+        var includeArchive: Bool = false
 
-    @Option(
-        name: .shortAndLong,
-        help: "Filter by framework (e.g., swiftui, foundation, uikit)"
-    )
-    var framework: String?
+        @Option(
+            name: .shortAndLong,
+            help: "Filter by framework (e.g., swiftui, foundation, uikit)"
+        )
+        var framework: String?
 
-    @Option(
-        name: .shortAndLong,
-        help: "Filter by programming language: swift, objc"
-    )
-    var language: String?
+        @Option(
+            name: .shortAndLong,
+            help: "Filter by programming language: swift, objc"
+        )
+        var language: String?
 
-    @Option(
-        name: .long,
-        help: "Maximum number of results to return"
-    )
-    var limit: Int = Shared.Constants.Limit.defaultSearchLimit
+        @Option(
+            name: .long,
+            help: "Maximum number of results to return"
+        )
+        var limit: Int = Shared.Constants.Limit.defaultSearchLimit
 
-    @Option(
-        name: .long,
-        help: "Filter to APIs available on iOS version (e.g., 13.0, 15.0)"
-    )
-    var minIos: String?
+        @Option(
+            name: .long,
+            help: "Filter to APIs available on iOS version (e.g., 13.0, 15.0)"
+        )
+        var minIos: String?
 
-    @Option(
-        name: .long,
-        help: "Filter to APIs available on macOS version (e.g., 10.15, 12.0)"
-    )
-    var minMacos: String?
+        @Option(
+            name: .long,
+            help: "Filter to APIs available on macOS version (e.g., 10.15, 12.0)"
+        )
+        var minMacos: String?
 
-    @Option(
-        name: .long,
-        help: "Filter to APIs available on tvOS version (e.g., 13.0, 15.0)"
-    )
-    var minTvos: String?
+        @Option(
+            name: .long,
+            help: "Filter to APIs available on tvOS version (e.g., 13.0, 15.0)"
+        )
+        var minTvos: String?
 
-    @Option(
-        name: .long,
-        help: "Filter to APIs available on watchOS version (e.g., 6.0, 8.0)"
-    )
-    var minWatchos: String?
+        @Option(
+            name: .long,
+            help: "Filter to APIs available on watchOS version (e.g., 6.0, 8.0)"
+        )
+        var minWatchos: String?
 
-    @Option(
-        name: .long,
-        help: "Filter to APIs available on visionOS version (e.g., 1.0, 2.0)"
-    )
-    var minVisionos: String?
+        @Option(
+            name: .long,
+            help: "Filter to APIs available on visionOS version (e.g., 1.0, 2.0)"
+        )
+        var minVisionos: String?
 
-    @Option(
-        name: .long,
-        help: "Path to search database (search.db)"
-    )
-    var searchDb: String?
+        @Option(
+            name: .long,
+            help: "Path to search database (search.db)"
+        )
+        var searchDb: String?
 
-    @Option(
-        name: .long,
-        help: "Path to packages database (packages.db). Used in fan-out mode and `--source packages`."
-    )
-    var packagesDb: String?
+        @Option(
+            name: .long,
+            help: "Path to packages database (packages.db). Used in fan-out mode and `--source packages`."
+        )
+        var packagesDb: String?
 
-    @Option(
-        name: .long,
-        help: "Path to sample index database (samples.db)"
-    )
-    var sampleDb: String?
+        @Option(
+            name: .long,
+            help: "Path to sample index database (samples.db)"
+        )
+        var sampleDb: String?
 
-    @Option(
-        name: .long,
-        help: """
-        Per-source candidate cap before reciprocal-rank fusion. \
-        Only applies in fan-out mode (no --source). Default 10. (#239)
-        """
-    )
-    var perSource: Int = 10
+        @Option(
+            name: .long,
+            help: """
+            Per-source candidate cap before reciprocal-rank fusion. \
+            Only applies in fan-out mode (no --source). Default 10. (#239)
+            """
+        )
+        var perSource: Int = 10
 
-    @Flag(
-        name: .long,
-        help: "Skip every apple-docs-backed source. Fan-out mode only. (#239)"
-    )
-    var skipDocs: Bool = false
+        @Flag(
+            name: .long,
+            help: "Skip every apple-docs-backed source. Fan-out mode only. (#239)"
+        )
+        var skipDocs: Bool = false
 
-    @Flag(
-        name: .long,
-        help: "Skip the packages source. Fan-out mode only. (#239)"
-    )
-    var skipPackages: Bool = false
+        @Flag(
+            name: .long,
+            help: "Skip the packages source. Fan-out mode only. (#239)"
+        )
+        var skipPackages: Bool = false
 
-    @Flag(
-        name: .long,
-        help: "Skip the samples source. Fan-out mode only. (#239)"
-    )
-    var skipSamples: Bool = false
+        @Flag(
+            name: .long,
+            help: "Skip the samples source. Fan-out mode only. (#239)"
+        )
+        var skipSamples: Bool = false
 
-    @Flag(
-        name: .long,
-        help: """
-        Trim each result's excerpt to its first few lines for quick triage. \
-        Read-full link, tips, and see-also still print. Fan-out mode + \
-        text/markdown only — JSON keeps full chunks for programmatic \
-        consumers. (#239)
-        """
-    )
-    var brief: Bool = false
+        @Flag(
+            name: .long,
+            help: """
+            Trim each result's excerpt to its first few lines for quick triage. \
+            Read-full link, tips, and see-also still print. Fan-out mode + \
+            text/markdown only — JSON keeps full chunks for programmatic \
+            consumers. (#239)
+            """
+        )
+        var brief: Bool = false
 
-    @Option(
-        name: .long,
-        help: """
-        Restrict packages + samples + apple-docs results to the named platform's \
-        deployment target (#220, #233). Values: iOS, macOS, tvOS, watchOS, visionOS \
-        (case-insensitive). Requires --min-version. Fan-out mode only.
-        """
-    )
-    var platform: String?
+        @Option(
+            name: .long,
+            help: """
+            Restrict packages + samples + apple-docs results to the named platform's \
+            deployment target (#220, #233). Values: iOS, macOS, tvOS, watchOS, visionOS \
+            (case-insensitive). Requires --min-version. Fan-out mode only.
+            """
+        )
+        var platform: String?
 
-    @Option(
-        name: .long,
-        help: """
-        Minimum version for --platform, e.g. 16.0 / 13.0 / 10.15. Lex compare \
-        in SQL; correct for current Apple platforms. (#220)
-        """
-    )
-    var minVersion: String?
+        @Option(
+            name: .long,
+            help: """
+            Minimum version for --platform, e.g. 16.0 / 13.0 / 10.15. Lex compare \
+            in SQL; correct for current Apple platforms. (#220)
+            """
+        )
+        var minVersion: String?
 
-    @Option(
-        name: .long,
-        help: "Output format: text (default), json, markdown"
-    )
-    var format: OutputFormat = .text
+        @Option(
+            name: .long,
+            help: "Output format: text (default), json, markdown"
+        )
+        var format: OutputFormat = .text
 
-    mutating func run() async throws {
-        switch source {
-        case Shared.Constants.SourcePrefix.samples, Shared.Constants.SourcePrefix.appleSampleCode:
-            try await runSampleSearch()
-        case Shared.Constants.SourcePrefix.hig:
-            try await runHIGSearch()
-        case Shared.Constants.SourcePrefix.packages:
-            // packages live in their own DB (packages.db), not search.db.
-            // The docs runner queries search.db only and would silently
-            // return [] here. Use the dedicated single-fetcher SmartQuery
-            // path instead so packages.db is actually consulted (#261).
-            try await runPackageSearch()
-        case Shared.Constants.SourcePrefix.appleDocs,
-             Shared.Constants.SourcePrefix.appleArchive,
-             Shared.Constants.SourcePrefix.swiftEvolution,
-             Shared.Constants.SourcePrefix.swiftOrg,
-             Shared.Constants.SourcePrefix.swiftBook:
-            try await runDocsSearch()
-        default:
-            // Default (nil or "all") triggers the SmartQuery fan-out.
-            try await runUnifiedSearch()
-        }
-    }
-
-    // MARK: - Per-source runners moved to SearchCommand+SourceRunners.swift
-
-    // MARK: - Unified Search (All Sources, fan-out + RRF) (#239)
-
-    /// Replaces the previous `UnifiedSearchService` path with the SmartQuery
-    /// fan-out absorbed from `cupertino ask`. Default behaviour when no
-    /// `--source` is passed.
-    private func runUnifiedSearch() async throws {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            Logging.ConsoleLogger.error("❌ Query cannot be empty.")
-            throw ExitCode.failure
+        mutating func run() async throws {
+            switch source {
+            case Shared.Constants.SourcePrefix.samples, Shared.Constants.SourcePrefix.appleSampleCode:
+                try await runSampleSearch()
+            case Shared.Constants.SourcePrefix.hig:
+                try await runHIGSearch()
+            case Shared.Constants.SourcePrefix.packages:
+                // packages live in their own DB (packages.db), not search.db.
+                // The docs runner queries search.db only and would silently
+                // return [] here. Use the dedicated single-fetcher SmartQuery
+                // path instead so packages.db is actually consulted (#261).
+                try await runPackageSearch()
+            case Shared.Constants.SourcePrefix.appleDocs,
+                 Shared.Constants.SourcePrefix.appleArchive,
+                 Shared.Constants.SourcePrefix.swiftEvolution,
+                 Shared.Constants.SourcePrefix.swiftOrg,
+                 Shared.Constants.SourcePrefix.swiftBook:
+                try await runDocsSearch()
+            default:
+                // Default (nil or "all") triggers the SmartQuery fan-out.
+                try await runUnifiedSearch()
+            }
         }
 
-        let availabilityFilter = try resolveAvailabilityFilter()
-        let plan = await buildFetchers(availabilityFilter: availabilityFilter)
-        guard !plan.fetchers.isEmpty else {
-            Logging.ConsoleLogger.error(
-                "❌ No data sources available. Run `cupertino setup` to populate them."
+        // MARK: - Per-source runners moved to Command.Search+SourceRunners.swift
+
+        // MARK: - Unified Search (All Sources, fan-out + RRF) (#239)
+
+        /// Replaces the previous `UnifiedSearchService` path with the SmartQuery
+        /// fan-out absorbed from `cupertino ask`. Default behaviour when no
+        /// `--source` is passed.
+        private func runUnifiedSearch() async throws {
+            let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                Logging.ConsoleLogger.error("❌ Query cannot be empty.")
+                throw ExitCode.failure
+            }
+
+            let availabilityFilter = try resolveAvailabilityFilter()
+            let plan = await buildFetchers(availabilityFilter: availabilityFilter)
+            guard !plan.fetchers.isEmpty else {
+                Logging.ConsoleLogger.error(
+                    "❌ No data sources available. Run `cupertino setup` to populate them."
+                )
+                throw ExitCode.failure
+            }
+
+            let smartQuery = SearchModule.SmartQuery(fetchers: plan.fetchers)
+            let result = await smartQuery.answer(
+                question: trimmed,
+                limit: limit,
+                perFetcherLimit: perSource
             )
-            throw ExitCode.failure
+
+            if let index = plan.searchIndex {
+                await index.disconnect()
+            }
+            if let service = plan.sampleService {
+                await service.disconnect()
+            }
+
+            Self.printSmartReport(
+                result: result,
+                question: trimmed,
+                availabilityFilterActive: availabilityFilter != nil,
+                platform: platform,
+                minVersion: minVersion,
+                format: format,
+                brief: brief
+            )
         }
 
-        let smartQuery = Search.SmartQuery(fetchers: plan.fetchers)
-        let result = await smartQuery.answer(
-            question: trimmed,
-            limit: limit,
-            perFetcherLimit: perSource
-        )
+        // MARK: - Path Resolution
 
-        if let index = plan.searchIndex {
-            await index.disconnect()
+        func resolveSampleDbPath() -> URL {
+            if let sampleDb {
+                return URL(fileURLWithPath: sampleDb).expandingTildeInPath
+            }
+            return SampleIndex.defaultDatabasePath
         }
-        if let service = plan.sampleService {
-            await service.disconnect()
-        }
-
-        Self.printSmartReport(
-            result: result,
-            question: trimmed,
-            availabilityFilterActive: availabilityFilter != nil,
-            platform: platform,
-            minVersion: minVersion,
-            format: format,
-            brief: brief
-        )
-    }
-
-    // MARK: - Path Resolution
-
-    func resolveSampleDbPath() -> URL {
-        if let sampleDb {
-            return URL(fileURLWithPath: sampleDb).expandingTildeInPath
-        }
-        return SampleIndex.defaultDatabasePath
     }
 }
 
 // MARK: - Output Format
 
-extension SearchCommand {
+extension Command.Search {
     enum OutputFormat: String, ExpressibleByArgument, CaseIterable {
         case text
         case json

--- a/Packages/Sources/CLI/Commands/ServeCommand.swift
+++ b/Packages/Sources/CLI/Commands/ServeCommand.swift
@@ -15,266 +15,268 @@ import SharedCore
 
 // MARK: - Serve Command
 
-struct ServeCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "serve",
-        abstract: "Start MCP server for documentation access",
-        discussion: """
-        Starts the Model Context Protocol (MCP) server that provides documentation
-        search and access capabilities for AI assistants.
+extension Command {
+    struct Serve: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "serve",
+            abstract: "Start MCP server for documentation access",
+            discussion: """
+            Starts the Model Context Protocol (MCP) server that provides documentation
+            search and access capabilities for AI assistants.
 
-        The server communicates via stdio using JSON-RPC and provides:
+            The server communicates via stdio using JSON-RPC and provides:
 
-        Unified Search (requires 'cupertino save' or 'cupertino save --samples'):
-        • search - Smart query fanned out across every available source
-                   (apple-docs, samples, swift-evolution, swift-org, swift-book,
-                   packages, hig, apple-archive), reciprocal-rank fused. Replaces
-                   the pre-#239 per-source search_docs / search_samples tools.
+            Unified Search (requires 'cupertino save' or 'cupertino save --samples'):
+            • search - Smart query fanned out across every available source
+                       (apple-docs, samples, swift-evolution, swift-org, swift-book,
+                       packages, hig, apple-archive), reciprocal-rank fused. Replaces
+                       the pre-#239 per-source search_docs / search_samples tools.
 
-        Documentation Tools (requires 'cupertino save'):
-        • list_frameworks - List available frameworks with document counts
-        • read_document   - Read full document content by URI
+            Documentation Tools (requires 'cupertino save'):
+            • list_frameworks - List available frameworks with document counts
+            • read_document   - Read full document content by URI
 
-        Sample Code Tools (requires 'cupertino save --samples'):
-        • list_samples     - List all indexed sample projects
-        • read_sample      - Read sample project README and metadata
-        • read_sample_file - Read a specific source file from a sample
+            Sample Code Tools (requires 'cupertino save --samples'):
+            • list_samples     - List all indexed sample projects
+            • read_sample      - Read sample project README and metadata
+            • read_sample_file - Read a specific source file from a sample
 
-        Semantic Search Tools (requires 'cupertino save', AST-indexed, #81):
-        • search_symbols          - Find Swift symbols by name + kind
-        • search_property_wrappers - Find @PropertyWrapper usage in indexed sources
-        • search_concurrency       - Find concurrency patterns (@MainActor, async, …)
-        • search_conformances      - Find protocol conformances by protocol name
+            Semantic Search Tools (requires 'cupertino save', AST-indexed, #81):
+            • search_symbols          - Find Swift symbols by name + kind
+            • search_property_wrappers - Find @PropertyWrapper usage in indexed sources
+            • search_concurrency       - Find concurrency patterns (@MainActor, async, …)
+            • search_conformances      - Find protocol conformances by protocol name
 
-        The server runs indefinitely until terminated.
-        """
-    )
+            The server runs indefinitely until terminated.
+            """
+        )
 
-    mutating func run() async throws {
-        // Reap any sibling `cupertino serve` processes of the same binary
-        // before we bind stdio. MCP host config reloads (Claude Desktop,
-        // Cursor, etc.) leave orphan servers behind otherwise — they pin
-        // SQLite read locks and stack RAM usage. (#242)
-        ServeReaper.reapSiblings()
+        mutating func run() async throws {
+            // Reap any sibling `cupertino serve` processes of the same binary
+            // before we bind stdio. MCP host config reloads (Claude Desktop,
+            // Cursor, etc.) leave orphan servers behind otherwise — they pin
+            // SQLite read locks and stack RAM usage. (#242)
+            ServeReaper.reapSiblings()
 
-        if isatty(STDOUT_FILENO) == 0 {
-            Logging.Log.disableConsole()
-        }
+            if isatty(STDOUT_FILENO) == 0 {
+                Logging.Log.disableConsole()
+            }
 
-        let config = Shared.Configuration(
-            crawler: Shared.CrawlerConfiguration(
-                outputDirectory: Shared.Constants.defaultDocsDirectory
+            let config = Shared.Configuration(
+                crawler: Shared.CrawlerConfiguration(
+                    outputDirectory: Shared.Constants.defaultDocsDirectory
+                )
             )
-        )
 
-        let evolutionURL = Shared.Constants.defaultSwiftEvolutionDirectory
-        let searchDBURL = Shared.Constants.defaultSearchDatabase
+            let evolutionURL = Shared.Constants.defaultSwiftEvolutionDirectory
+            let searchDBURL = Shared.Constants.defaultSearchDatabase
 
-        // Check if there's anything to serve
-        let hasData = checkForData(
-            docsDir: config.crawler.outputDirectory,
-            evolutionDir: evolutionURL,
-            searchDB: searchDBURL
-        )
+            // Check if there's anything to serve
+            let hasData = checkForData(
+                docsDir: config.crawler.outputDirectory,
+                evolutionDir: evolutionURL,
+                searchDB: searchDBURL
+            )
 
-        if !hasData {
-            printGettingStartedGuide()
-            throw ExitCode.failure
+            if !hasData {
+                printGettingStartedGuide()
+                throw ExitCode.failure
+            }
+
+            // Advertise the embedded cupertino icon to MCP clients that speak
+            // the 2025-11-25 protocol. Older clients ignore the field.
+            let icon = MCP.Core.Protocols.Icon(
+                src: MCP.Core.Protocols.CupertinoIcon.dataURI,
+                mimeType: "image/png",
+                sizes: ["64x64"]
+            )
+            let server = MCP.Core.Server(
+                name: Shared.Constants.App.mcpServerName,
+                version: Shared.Constants.App.version,
+                icons: [icon]
+            )
+
+            await registerProviders(
+                server: server,
+                config: config,
+                evolutionURL: evolutionURL,
+                searchDBURL: searchDBURL
+            )
+
+            printStartupMessages(config: config, evolutionURL: evolutionURL, searchDBURL: searchDBURL)
+
+            let transport = MCP.Core.Transport.Stdio()
+            try await server.connect(transport)
+
+            // Keep running indefinitely
+            while true {
+                try await Task.sleep(for: .seconds(60))
+            }
         }
 
-        // Advertise the embedded cupertino icon to MCP clients that speak
-        // the 2025-11-25 protocol. Older clients ignore the field.
-        let icon = MCP.Core.Protocols.Icon(
-            src: MCP.Core.Protocols.CupertinoIcon.dataURI,
-            mimeType: "image/png",
-            sizes: ["64x64"]
-        )
-        let server = MCP.Core.Server(
-            name: Shared.Constants.App.mcpServerName,
-            version: Shared.Constants.App.version,
-            icons: [icon]
-        )
+        private func registerProviders(
+            server: MCP.Core.Server,
+            config: Shared.Configuration,
+            evolutionURL: URL,
+            searchDBURL: URL
+        ) async {
+            // Initialize search index if available
+            let searchIndex: SearchModule.Index? = await loadSearchIndex(searchDBURL: searchDBURL)
 
-        await registerProviders(
-            server: server,
-            config: config,
-            evolutionURL: evolutionURL,
-            searchDBURL: searchDBURL
-        )
+            // Register resource provider with optional search index
+            let resourceProvider = DocsResourceProvider(
+                configuration: config,
+                evolutionDirectory: evolutionURL,
+                searchIndex: searchIndex
+            )
+            await server.registerResourceProvider(resourceProvider)
 
-        printStartupMessages(config: config, evolutionURL: evolutionURL, searchDBURL: searchDBURL)
+            // Initialize sample code index if available
+            let sampleIndex = await loadSampleIndex()
 
-        let transport = MCP.Core.Transport.Stdio()
-        try await server.connect(transport)
+            // Register composite tool provider with both indexes
+            let toolProvider = CompositeToolProvider(searchIndex: searchIndex, sampleDatabase: sampleIndex)
+            await server.registerToolProvider(toolProvider)
 
-        // Keep running indefinitely
-        while true {
-            try await Task.sleep(for: .seconds(60))
-        }
-    }
-
-    private func registerProviders(
-        server: MCP.Core.Server,
-        config: Shared.Configuration,
-        evolutionURL: URL,
-        searchDBURL: URL
-    ) async {
-        // Initialize search index if available
-        let searchIndex: Search.Index? = await loadSearchIndex(searchDBURL: searchDBURL)
-
-        // Register resource provider with optional search index
-        let resourceProvider = DocsResourceProvider(
-            configuration: config,
-            evolutionDirectory: evolutionURL,
-            searchIndex: searchIndex
-        )
-        await server.registerResourceProvider(resourceProvider)
-
-        // Initialize sample code index if available
-        let sampleIndex = await loadSampleIndex()
-
-        // Register composite tool provider with both indexes
-        let toolProvider = CompositeToolProvider(searchIndex: searchIndex, sampleDatabase: sampleIndex)
-        await server.registerToolProvider(toolProvider)
-
-        // Log availability of each index
-        if searchIndex != nil {
-            let message = "✅ Documentation search enabled (index found)"
-            Logging.Log.info(message, category: .mcp)
-        }
-        if sampleIndex != nil {
-            let message = "✅ Sample code search enabled (index found)"
-            Logging.Log.info(message, category: .mcp)
-        }
-    }
-
-    private func loadSampleIndex() async -> SampleIndex.Database? {
-        let sampleDBURL = SampleIndex.defaultDatabasePath
-        guard FileManager.default.fileExists(atPath: sampleDBURL.path) else {
-            let infoMsg = "ℹ️  Sample code index not found at: \(sampleDBURL.path)"
-            let cmd = "\(Shared.Constants.App.commandName) index"
-            let hintMsg = "   Sample tools will not be available. Run '\(cmd)' to enable."
-            Logging.Log.info("\(infoMsg) \(hintMsg)", category: .mcp)
-            return nil
+            // Log availability of each index
+            if searchIndex != nil {
+                let message = "✅ Documentation search enabled (index found)"
+                Logging.Log.info(message, category: .mcp)
+            }
+            if sampleIndex != nil {
+                let message = "✅ Sample code search enabled (index found)"
+                Logging.Log.info(message, category: .mcp)
+            }
         }
 
-        do {
-            return try await SampleIndex.Database(dbPath: sampleDBURL)
-        } catch {
-            let errorMsg = "⚠️  Failed to load sample index: \(error)"
-            let cmd = "\(Shared.Constants.App.commandName) index"
-            let hintMsg = "   Sample tools will not be available. Run '\(cmd)' to create the index."
-            Logging.Log.warning("\(errorMsg) \(hintMsg)", category: .mcp)
-            return nil
-        }
-    }
+        private func loadSampleIndex() async -> SampleIndex.Database? {
+            let sampleDBURL = SampleIndex.defaultDatabasePath
+            guard FileManager.default.fileExists(atPath: sampleDBURL.path) else {
+                let infoMsg = "ℹ️  Sample code index not found at: \(sampleDBURL.path)"
+                let cmd = "\(Shared.Constants.App.commandName) index"
+                let hintMsg = "   Sample tools will not be available. Run '\(cmd)' to enable."
+                Logging.Log.info("\(infoMsg) \(hintMsg)", category: .mcp)
+                return nil
+            }
 
-    private func loadSearchIndex(searchDBURL: URL) async -> Search.Index? {
-        guard FileManager.default.fileExists(atPath: searchDBURL.path) else {
-            let infoMsg = "ℹ️  Search index not found at: \(searchDBURL.path)"
-            let cmd = "\(Shared.Constants.App.commandName) save"
-            let hintMsg = "   Tools will not be available. Run '\(cmd)' to enable search."
-            Logging.Log.info("\(infoMsg) \(hintMsg)", category: .mcp)
-            return nil
-        }
-
-        do {
-            return try await Search.Index(dbPath: searchDBURL)
-        } catch {
-            let errorMsg = "⚠️  Failed to load search index: \(error)"
-            let cmd = "\(Shared.Constants.App.commandName) save"
-            let hintMsg = "   Tools will not be available. Run '\(cmd)' to create the index."
-            Logging.Log.warning("\(errorMsg) \(hintMsg)", category: .mcp)
-            return nil
-        }
-    }
-
-    private func printStartupMessages(config _: Shared.Configuration, evolutionURL _: URL, searchDBURL: URL) {
-        var messages = ["🚀 Cupertino MCP Server starting..."]
-
-        // Add search DB path if it exists
-        if FileManager.default.fileExists(atPath: searchDBURL.path) {
-            messages.append("   Search DB: \(searchDBURL.path)")
+            do {
+                return try await SampleIndex.Database(dbPath: sampleDBURL)
+            } catch {
+                let errorMsg = "⚠️  Failed to load sample index: \(error)"
+                let cmd = "\(Shared.Constants.App.commandName) index"
+                let hintMsg = "   Sample tools will not be available. Run '\(cmd)' to create the index."
+                Logging.Log.warning("\(errorMsg) \(hintMsg)", category: .mcp)
+                return nil
+            }
         }
 
-        // Add samples DB path if it exists
-        let sampleDBURL = SampleIndex.defaultDatabasePath
-        if FileManager.default.fileExists(atPath: sampleDBURL.path) {
-            messages.append("   Samples DB: \(sampleDBURL.path)")
+        private func loadSearchIndex(searchDBURL: URL) async -> SearchModule.Index? {
+            guard FileManager.default.fileExists(atPath: searchDBURL.path) else {
+                let infoMsg = "ℹ️  Search index not found at: \(searchDBURL.path)"
+                let cmd = "\(Shared.Constants.App.commandName) save"
+                let hintMsg = "   Tools will not be available. Run '\(cmd)' to enable search."
+                Logging.Log.info("\(infoMsg) \(hintMsg)", category: .mcp)
+                return nil
+            }
+
+            do {
+                return try await SearchModule.Index(dbPath: searchDBURL)
+            } catch {
+                let errorMsg = "⚠️  Failed to load search index: \(error)"
+                let cmd = "\(Shared.Constants.App.commandName) save"
+                let hintMsg = "   Tools will not be available. Run '\(cmd)' to create the index."
+                Logging.Log.warning("\(errorMsg) \(hintMsg)", category: .mcp)
+                return nil
+            }
         }
 
-        messages.append("   Waiting for client connection...")
+        private func printStartupMessages(config _: Shared.Configuration, evolutionURL _: URL, searchDBURL: URL) {
+            var messages = ["🚀 Cupertino MCP Server starting..."]
 
-        for message in messages {
-            Logging.Log.info(message, category: .mcp)
+            // Add search DB path if it exists
+            if FileManager.default.fileExists(atPath: searchDBURL.path) {
+                messages.append("   Search DB: \(searchDBURL.path)")
+            }
+
+            // Add samples DB path if it exists
+            let sampleDBURL = SampleIndex.defaultDatabasePath
+            if FileManager.default.fileExists(atPath: sampleDBURL.path) {
+                messages.append("   Samples DB: \(sampleDBURL.path)")
+            }
+
+            messages.append("   Waiting for client connection...")
+
+            for message in messages {
+                Logging.Log.info(message, category: .mcp)
+            }
         }
-    }
 
-    private func checkForData(docsDir _: URL, evolutionDir _: URL, searchDB: URL) -> Bool {
-        let fileManager = FileManager.default
+        private func checkForData(docsDir _: URL, evolutionDir _: URL, searchDB: URL) -> Bool {
+            let fileManager = FileManager.default
 
-        // Check if either database exists
-        let hasSearchDB = fileManager.fileExists(atPath: searchDB.path)
-        let hasSamplesDB = fileManager.fileExists(atPath: SampleIndex.defaultDatabasePath.path)
+            // Check if either database exists
+            let hasSearchDB = fileManager.fileExists(atPath: searchDB.path)
+            let hasSamplesDB = fileManager.fileExists(atPath: SampleIndex.defaultDatabasePath.path)
 
-        return hasSearchDB || hasSamplesDB
-    }
+            return hasSearchDB || hasSamplesDB
+        }
 
-    private func printGettingStartedGuide() {
-        let cmd = Shared.Constants.App.commandName
-        let guide = """
+        private func printGettingStartedGuide() {
+            let cmd = Shared.Constants.App.commandName
+            let guide = """
 
-        ╭─────────────────────────────────────────────────────────────────────────╮
-        │                                                                         │
-        │  👋 Welcome to Cupertino MCP Server!                                    │
-        │                                                                         │
-        │  No documentation found to serve. Let's get you started!                │
-        │                                                                         │
-        ╰─────────────────────────────────────────────────────────────────────────╯
+            ╭─────────────────────────────────────────────────────────────────────────╮
+            │                                                                         │
+            │  👋 Welcome to Cupertino MCP Server!                                    │
+            │                                                                         │
+            │  No documentation found to serve. Let's get you started!                │
+            │                                                                         │
+            ╰─────────────────────────────────────────────────────────────────────────╯
 
-        📚 STEP 1: Crawl Documentation
-        ───────────────────────────────────────────────────────────────────────────
-        First, download the documentation you want to serve:
+            📚 STEP 1: Crawl Documentation
+            ───────────────────────────────────────────────────────────────────────────
+            First, download the documentation you want to serve:
 
-        • Apple Developer Documentation (recommended):
-          $ \(cmd) crawl --type docs
+            • Apple Developer Documentation (recommended):
+              $ \(cmd) crawl --type docs
 
-        • Swift Evolution Proposals:
-          $ \(cmd) crawl --type evolution
+            • Swift Evolution Proposals:
+              $ \(cmd) crawl --type evolution
 
-        • Swift.org Documentation:
-          $ \(cmd) crawl --type swift
+            • Swift.org Documentation:
+              $ \(cmd) crawl --type swift
 
-        • Swift Packages (priority packages):
-          $ \(cmd) fetch --type packages
+            • Swift Packages (priority packages):
+              $ \(cmd) fetch --type packages
 
-        ⏱️  Crawling takes 10-30 minutes depending on content type.
-           If interrupted, just re-run the same command — fetch resumes by default.
+            ⏱️  Crawling takes 10-30 minutes depending on content type.
+               If interrupted, just re-run the same command — fetch resumes by default.
 
-        🔍 STEP 2: Build Search Index
-        ───────────────────────────────────────────────────────────────────────────
-        After crawling, create a search index for fast lookups:
+            🔍 STEP 2: Build Search Index
+            ───────────────────────────────────────────────────────────────────────────
+            After crawling, create a search index for fast lookups:
 
-          $ \(cmd) index
+              $ \(cmd) index
 
-        ⏱️  Indexing typically takes 2-5 minutes.
+            ⏱️  Indexing typically takes 2-5 minutes.
 
-        🚀 STEP 3: Start the Server
-        ───────────────────────────────────────────────────────────────────────────
-        Once you have data, start the MCP server:
+            🚀 STEP 3: Start the Server
+            ───────────────────────────────────────────────────────────────────────────
+            Once you have data, start the MCP server:
 
-          $ \(cmd)
+              $ \(cmd)
 
-        The server will provide documentation access to AI assistants like Claude.
+            The server will provide documentation access to AI assistants like Claude.
 
-        ───────────────────────────────────────────────────────────────────────────
-        💡 TIP: Run '\(cmd) doctor' to check your setup anytime.
+            ───────────────────────────────────────────────────────────────────────────
+            💡 TIP: Run '\(cmd) doctor' to check your setup anytime.
 
-        📖 For more information, see the README or run '\(cmd) --help'
+            📖 For more information, see the README or run '\(cmd) --help'
 
-        """
+            """
 
-        // Use stderr for getting started guide (stdout is for MCP protocol)
-        fputs(guide, stderr)
+            // Use stderr for getting started guide (stdout is for MCP protocol)
+            fputs(guide, stderr)
+        }
     }
 }

--- a/Packages/Sources/CLI/Commands/SetupCommand.swift
+++ b/Packages/Sources/CLI/Commands/SetupCommand.swift
@@ -13,38 +13,40 @@ import SharedUtils
 /// this command parses flags, subscribes to progress events, and renders
 /// the spinner + progress bar + final summary.
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-struct SetupCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "setup",
-        abstract: "Download every cupertino database (search.db, samples.db, packages.db) in one go"
-    )
-
-    @Option(name: .long, help: "Base directory for databases")
-    var baseDir: String?
-
-    @Flag(name: .long, help: "Skip the download and keep whatever databases are already installed")
-    var keepExisting: Bool = false
-
-    mutating func run() async throws {
-        Logging.ConsoleLogger.info("📦 Cupertino Setup\n")
-
-        let baseURL = baseDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
-            ?? Shared.Constants.defaultBaseDirectory
-
-        let renderer = SetupRenderer()
-        let request = Distribution.SetupService.Request(
-            baseDir: baseURL,
-            keepExisting: keepExisting
+extension Command {
+    struct Setup: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "setup",
+            abstract: "Download every cupertino database (search.db, samples.db, packages.db) in one go"
         )
 
-        do {
-            let outcome = try await Distribution.SetupService.run(request) { event in
-                renderer.handle(event)
+        @Option(name: .long, help: "Base directory for databases")
+        var baseDir: String?
+
+        @Flag(name: .long, help: "Skip the download and keep whatever databases are already installed")
+        var keepExisting: Bool = false
+
+        mutating func run() async throws {
+            Logging.ConsoleLogger.info("📦 Cupertino Setup\n")
+
+            let baseURL = baseDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
+                ?? Shared.Constants.defaultBaseDirectory
+
+            let renderer = SetupRenderer()
+            let request = Distribution.SetupService.Request(
+                baseDir: baseURL,
+                keepExisting: keepExisting
+            )
+
+            do {
+                let outcome = try await Distribution.SetupService.run(request) { event in
+                    renderer.handle(event)
+                }
+                renderer.printFinalSummary(outcome: outcome)
+            } catch {
+                Logging.ConsoleLogger.error("❌ Setup failed: \(error)")
+                throw ExitCode.failure
             }
-            renderer.printFinalSummary(outcome: outcome)
-        } catch {
-            Logging.ConsoleLogger.error("❌ Setup failed: \(error)")
-            throw ExitCode.failure
         }
     }
 }
@@ -53,7 +55,7 @@ struct SetupCommand: AsyncParsableCommand {
 
 /// Subscribes to `Distribution.SetupService.Event` and renders the
 /// terminal UI: download progress bar, extract spinner, version banner,
-/// final summary. Pulled into its own type so `SetupCommand.run` stays a
+/// final summary. Pulled into its own type so `Command.Setup.run` stays a
 /// flat orchestration body.
 private final class SetupRenderer: @unchecked Sendable {
     private let lock = NSLock()

--- a/Packages/Sources/CLI/Cupertino.swift
+++ b/Packages/Sources/CLI/Cupertino.swift
@@ -13,22 +13,22 @@ struct Cupertino: AsyncParsableCommand {
         abstract: "MCP Server for Apple Documentation, Swift Evolution, and Swift Packages",
         version: Shared.Constants.App.version,
         subcommands: [
-            SetupCommand.self,
-            FetchCommand.self,
-            SaveCommand.self,
-            ServeCommand.self,
-            SearchCommand.self,
-            ReadCommand.self,
-            ListFrameworksCommand.self,
-            ListSamplesCommand.self,
-            ReadSampleCommand.self,
-            ReadSampleFileCommand.self,
-            DoctorCommand.self,
-            CleanupCommand.self,
-            PackageSearchCommand.self,
-            ResolveRefsCommand.self,
+            Command.Setup.self,
+            Command.Fetch.self,
+            Command.Save.self,
+            Command.Serve.self,
+            Command.Search.self,
+            Command.Read.self,
+            Command.ListFrameworks.self,
+            Command.ListSamples.self,
+            Command.ReadSample.self,
+            Command.ReadSampleFile.self,
+            Command.Doctor.self,
+            Command.Cleanup.self,
+            Command.PackageSearch.self,
+            Command.ResolveRefs.self,
         ],
-        defaultSubcommand: ServeCommand.self
+        defaultSubcommand: Command.Serve.self
     )
 
     /// Force stdout to line-buffered mode before any subcommand runs. By

--- a/Packages/Sources/CLI/SearchModuleAlias.swift
+++ b/Packages/Sources/CLI/SearchModuleAlias.swift
@@ -1,0 +1,16 @@
+import Search
+
+// MARK: - Search Module Disambiguator
+
+// `Command.Search` (the subcommand struct under `Sources/CLI/Commands/`) and
+// the `Search` SPM target share a name. From inside any `extension Command`
+// scope, bare `Search.<Type>` resolves to the nested subcommand struct, not
+// the SPM target — Swift's name lookup checks enclosing types before
+// imported modules, so the local match wins.
+//
+// `SearchModule` pins the SPM target at module-internal scope so callers in
+// the CLI target can write `SearchModule.Index`, `SearchModule.SmartQuery`,
+// etc. and reach the actual module types. One declaration covers every file
+// in the CLI target.
+
+typealias SearchModule = Search

--- a/Packages/Tests/CLICommandTests/FetchTests/FetchTests.swift
+++ b/Packages/Tests/CLICommandTests/FetchTests/FetchTests.swift
@@ -48,21 +48,21 @@ struct FetchCommandTests {
 struct FetchPackagesMergeTests {
     @Test("--skip-metadata parses to true; archives flag defaults to false")
     func skipMetadataParses() throws {
-        let cmd = try FetchCommand.parse(["--type", "packages", "--skip-metadata"])
+        let cmd = try Command.Fetch.parse(["--type", "packages", "--skip-metadata"])
         #expect(cmd.skipMetadata == true)
         #expect(cmd.skipArchives == false)
     }
 
     @Test("--skip-archives parses to true; metadata flag defaults to false")
     func skipArchivesParses() throws {
-        let cmd = try FetchCommand.parse(["--type", "packages", "--skip-archives"])
+        let cmd = try Command.Fetch.parse(["--type", "packages", "--skip-archives"])
         #expect(cmd.skipMetadata == false)
         #expect(cmd.skipArchives == true)
     }
 
     @Test("Default --type packages invocation has both skip flags false")
     func defaultsAreFalse() throws {
-        let cmd = try FetchCommand.parse(["--type", "packages"])
+        let cmd = try Command.Fetch.parse(["--type", "packages"])
         #expect(cmd.skipMetadata == false)
         #expect(cmd.skipArchives == false)
     }
@@ -75,7 +75,7 @@ struct FetchPackagesMergeTests {
             .appendingPathComponent("cupertino-fetch-skipboth-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        var cmd = try FetchCommand.parse([
+        var cmd = try Command.Fetch.parse([
             "--type", "packages",
             "--skip-metadata",
             "--skip-archives",
@@ -91,7 +91,7 @@ struct FetchPackagesMergeTests {
     func packageDocsRejected() {
         // ArgumentParser surfaces invalid enum values as ValidationError.
         #expect(throws: (any Error).self) {
-            _ = try FetchCommand.parse(["--type", "package-docs"])
+            _ = try Command.Fetch.parse(["--type", "package-docs"])
         }
     }
 }

--- a/Packages/Tests/CLITests/CLITests.swift
+++ b/Packages/Tests/CLITests/CLITests.swift
@@ -22,26 +22,26 @@ struct CommandRegistrationTests {
         // into `search` in #239 (default fan-out path produces the same
         // chunked output as `ask` did).
         #expect(config.subcommands.count == 14)
-        #expect(config.subcommands.contains { $0 == SetupCommand.self })
-        #expect(config.subcommands.contains { $0 == FetchCommand.self })
-        #expect(config.subcommands.contains { $0 == SaveCommand.self })
-        #expect(config.subcommands.contains { $0 == ServeCommand.self })
-        #expect(config.subcommands.contains { $0 == SearchCommand.self })
-        #expect(config.subcommands.contains { $0 == ReadCommand.self })
-        #expect(config.subcommands.contains { $0 == ListFrameworksCommand.self })
-        #expect(config.subcommands.contains { $0 == ListSamplesCommand.self })
-        #expect(config.subcommands.contains { $0 == ReadSampleCommand.self })
-        #expect(config.subcommands.contains { $0 == ReadSampleFileCommand.self })
-        #expect(config.subcommands.contains { $0 == DoctorCommand.self })
-        #expect(config.subcommands.contains { $0 == CleanupCommand.self })
-        #expect(config.subcommands.contains { $0 == PackageSearchCommand.self })
-        #expect(config.subcommands.contains { $0 == ResolveRefsCommand.self })
+        #expect(config.subcommands.contains { $0 == Command.Setup.self })
+        #expect(config.subcommands.contains { $0 == Command.Fetch.self })
+        #expect(config.subcommands.contains { $0 == Command.Save.self })
+        #expect(config.subcommands.contains { $0 == Command.Serve.self })
+        #expect(config.subcommands.contains { $0 == Command.Search.self })
+        #expect(config.subcommands.contains { $0 == Command.Read.self })
+        #expect(config.subcommands.contains { $0 == Command.ListFrameworks.self })
+        #expect(config.subcommands.contains { $0 == Command.ListSamples.self })
+        #expect(config.subcommands.contains { $0 == Command.ReadSample.self })
+        #expect(config.subcommands.contains { $0 == Command.ReadSampleFile.self })
+        #expect(config.subcommands.contains { $0 == Command.Doctor.self })
+        #expect(config.subcommands.contains { $0 == Command.Cleanup.self })
+        #expect(config.subcommands.contains { $0 == Command.PackageSearch.self })
+        #expect(config.subcommands.contains { $0 == Command.ResolveRefs.self })
     }
 
-    @Test("Default subcommand is ServeCommand")
+    @Test("Default subcommand is Command.Serve")
     func defaultSubcommand() {
         let config = Cupertino.configuration
-        #expect(config.defaultSubcommand == ServeCommand.self)
+        #expect(config.defaultSubcommand == Command.Serve.self)
     }
 
     @Test("Command name is set correctly")

--- a/Packages/Tests/MockAIAgentTests/MCPIntegrationTests.swift
+++ b/Packages/Tests/MockAIAgentTests/MCPIntegrationTests.swift
@@ -345,7 +345,7 @@ struct TimeoutError: Error {}
 ///    config aside for the duration of the test so both processes agree
 ///    on `~/.cupertino/`.
 ///
-/// 2. `ServeCommand.checkForData` exits with the welcome-guide message
+/// 2. `Command.Serve.checkForData` exits with the welcome-guide message
 ///    if neither `~/.cupertino/samples.db` nor `~/.cupertino/search.db`
 ///    exists. Creating an empty samples.db (the same code path
 ///    `cupertino save --samples` uses) is enough to make
@@ -368,7 +368,7 @@ struct CupertinoServerFixture {
         }
 
         // Ensure samples.db exists at the production path so
-        // `ServeCommand.checkForData()` sees data. Empty schema is fine —
+        // `Command.Serve.checkForData()` sees data. Empty schema is fine —
         // these tests check MCP framing, not query results.
         let sampleDBPath = SampleIndex.defaultDatabasePath
         if !FileManager.default.fileExists(atPath: sampleDBPath.path) {

--- a/Packages/Tests/SearchTests/SmartQueryIntentRoutingTests.swift
+++ b/Packages/Tests/SearchTests/SmartQueryIntentRoutingTests.swift
@@ -145,7 +145,7 @@ struct SmartQueryIntentRoutingTests {
 
     @Test("Source-scoped fall-through: caller passes only apple-archive — symbol query still runs it")
     func sourceScopedFallThrough() async {
-        // PackageSearchCommand and `--source apple-archive` paths construct
+        // Command.PackageSearch and `--source apple-archive` paths construct
         // SmartQuery with a single fetcher of a non-allowlisted source.
         // Intent routing must not silence that fetcher; otherwise scoped
         // queries return zero results.

--- a/Packages/Tests/ServicesTests/ServicesTests.swift
+++ b/Packages/Tests/ServicesTests/ServicesTests.swift
@@ -226,7 +226,7 @@ struct TeaserResultsResilienceTests {
 
     @Test("Caller swallowing withTeaserService error → empty TeaserResults works")
     func callerCanFallBackOnEmpty() async {
-        // Replicates the resilience pattern in SearchCommand.runSampleSearch:
+        // Replicates the resilience pattern in Command.Search.runSampleSearch:
         // catch the throw, fall back to TeaserResults(). Verifies the
         // fallback contract (empty + iterable) so future changes don't
         // accidentally make the empty struct require parameters.


### PR DESCRIPTION
Every CLI subcommand is now a struct under a single `Command` namespace enum. The `Command` suffix drops on every type because the enclosing namespace already says it.

| Before | After |
|---|---|
| `CleanupCommand`        | `Command.Cleanup` |
| `DoctorCommand`         | `Command.Doctor` |
| `FetchCommand`          | `Command.Fetch` |
| `ListFrameworksCommand` | `Command.ListFrameworks` |
| `ListSamplesCommand`    | `Command.ListSamples` |
| `PackageSearchCommand`  | `Command.PackageSearch` |
| `ReadCommand`           | `Command.Read` |
| `ReadSampleCommand`     | `Command.ReadSample` |
| `ReadSampleFileCommand` | `Command.ReadSampleFile` |
| `ResolveRefsCommand`    | `Command.ResolveRefs` |
| `SaveCommand`           | `Command.Save` |
| `SearchCommand`         | `Command.Search` |
| `ServeCommand`          | `Command.Serve` |
| `SetupCommand`          | `Command.Setup` |

The root `Cupertino` (`AsyncParsableCommand`) stays at top level — it's the dispatcher, not a subcommand.

## Mechanics

- New `Sources/CLI/Commands/Command.swift` declares `enum Command {}`.
- Each `<Name>Command.swift` wraps its `struct <Name>Command: AsyncParsableCommand` in `extension Command { struct <Name>: AsyncParsableCommand { ... } }`.
- Companion files (`SearchCommand+SmartReport.swift`, `SaveCommand+Indexers.swift`, etc.) rewrite their `extension <Name>Command` blocks to `extension Command.<Name>`.
- `Cupertino.swift`'s `subcommands: [...]` list and `defaultSubcommand` retargeted.
- 14 commands × ~2 files each + cross-target tests (CLITests, CLICommandTests, ServicesTests, MockAIAgentTests, SearchTests) all swept.

## Search-module collision

`Command.Search` (the subcommand) shadows the `Search` SPM target inside any `extension Command { ... }` scope. Swift's name lookup checks enclosing types before imported modules, so bare `Search.Index` / `Search.SmartQuery` / `Search.PackageQuery` resolve to the nested subcommand and fail.

Fix: one module-internal typealias at `Sources/CLI/SearchModuleAlias.swift`:

```swift
typealias SearchModule = Search
```

Call sites in `CLI/Commands/` that need the Search SPM target now write `SearchModule.Index`, `SearchModule.SmartQuery`, `SearchModule.PackageQuery`, `SearchModule.PackageFTSCandidateFetcher`, etc. One declaration covers every consumer in the CLI target.

`swift-argument-parser` conformance is preserved on every struct; the namespace is purely organisational.

## File renames

This PR only does type-level renames. Filename renames (`SearchCommand.swift` → `Search.swift`, etc.) ship in a follow-up — easier to review the structural change first, then move files.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Previous: #348 Foundation, #350 MCP, #351 Shared.