### PR TITLE
refactor(CoreProtocols): nest every type under Core.Protocols.*; sweep callers

### DIFF
--- a/Packages/Sources/CLI/Commands/FetchCommand.swift
+++ b/Packages/Sources/CLI/Commands/FetchCommand.swift
@@ -663,7 +663,7 @@ extension Command {
                 )
             }
 
-            let exclusions = Core.ExclusionList.load()
+            let exclusions = Core.Protocols.ExclusionList.load()
             let seedChecksum = Core.ResolvedPackagesStore.checksum(seeds: seedRefs, exclusions: exclusions)
             let resolvedStoreURL = Shared.Constants.defaultBaseDirectory
                 .appendingPathComponent(Shared.Constants.FileName.resolvedPackages)
@@ -687,7 +687,7 @@ extension Command {
                     if !exclusions.isEmpty {
                         Logging.ConsoleLogger.info("   Exclusion list in effect: \(exclusions.count) entries")
                     }
-                    let canonicalizer = Core.GitHubCanonicalizer(cacheURL: canonicalCacheURL)
+                    let canonicalizer = Core.Protocols.GitHubCanonicalizer(cacheURL: canonicalCacheURL)
                     let manifestCache = Core.ManifestCache(
                         rootDirectory: Shared.Constants.defaultBaseDirectory
                             .appendingPathComponent(".cache")

--- a/Packages/Sources/Core/HTMLParser/HTMLToMarkdown.swift
+++ b/Packages/Sources/Core/HTMLParser/HTMLToMarkdown.swift
@@ -25,7 +25,7 @@ import WebKit
 
 extension Core.Parser {
     /// Converts HTML documentation to clean Markdown
-    public struct HTML: ContentTransformer, @unchecked Sendable {
+    public struct HTML: Core.Protocols.ContentTransformer, @unchecked Sendable {
         public typealias RawContent = String
 
         public init() {}

--- a/Packages/Sources/Core/HTMLParser/XMLTransformer.swift
+++ b/Packages/Sources/Core/HTMLParser/XMLTransformer.swift
@@ -6,7 +6,7 @@ import Foundation
 extension Core.Parser {
     /// Transforms XML content (like sitemaps or RSS feeds) into structured data
     /// Useful for parsing web crawled pages that return XML format
-    public struct XML: ContentTransformer, @unchecked Sendable {
+    public struct XML: Core.Protocols.ContentTransformer, @unchecked Sendable {
         public typealias RawContent = Data
 
         public init() {}

--- a/Packages/Sources/Core/JSONParser/AppleJSONCrawlerEngine.swift
+++ b/Packages/Sources/Core/JSONParser/AppleJSONCrawlerEngine.swift
@@ -7,14 +7,14 @@ import SharedCore
 /// Complete crawler engine for Apple documentation using JSON API
 /// Uses JSONContentFetcher for fetching and AppleJSONToMarkdown for transformation
 extension JSONCrawler {
-    public final class AppleJSONCrawlerEngine: CrawlerEngine, @unchecked Sendable {
+    public final class AppleJSONCrawlerEngine: Core.Protocols.CrawlerEngine, @unchecked Sendable {
         private let fetcher: JSONContentFetcher
 
         public init(timeout: TimeInterval = 30) {
             fetcher = JSONContentFetcher(timeout: timeout)
         }
 
-        public func crawl(url: URL) async throws -> TransformResult {
+        public func crawl(url: URL) async throws -> Core.Protocols.TransformResult {
             // Convert documentation URL to JSON API URL
             guard let jsonURL = apiURL(from: url) else {
                 throw JSONCrawlerError.invalidURL
@@ -41,7 +41,7 @@ extension JSONCrawler {
             // Extract metadata
             let metadata = extractMetadata(from: data)
 
-            return TransformResult(
+            return Core.Protocols.TransformResult(
                 markdown: markdown,
                 links: links,
                 metadata: metadata,
@@ -56,7 +56,7 @@ extension JSONCrawler {
 
         // MARK: - Private Helpers
 
-        private func extractMetadata(from data: Data) -> TransformMetadata? {
+        private func extractMetadata(from data: Data) -> Core.Protocols.TransformMetadata? {
             guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let metadata = json["metadata"] as? [String: Any]
             else {
@@ -81,7 +81,7 @@ extension JSONCrawler {
                 framework = firstModule["name"] as? String
             }
 
-            return TransformMetadata(
+            return Core.Protocols.TransformMetadata(
                 title: title,
                 description: role,
                 framework: framework,

--- a/Packages/Sources/Core/JSONParser/AppleJSONToMarkdown.swift
+++ b/Packages/Sources/Core/JSONParser/AppleJSONToMarkdown.swift
@@ -9,7 +9,7 @@ import SharedModels
 /// Converts Apple's documentation JSON API response to Markdown
 /// This is a lightweight alternative to WKWebView rendering that avoids memory issues
 /// with large index pages like lapack-functions (1600+ items)
-public struct AppleJSONToMarkdown: ContentTransformer, @unchecked Sendable {
+public struct AppleJSONToMarkdown: Core.Protocols.ContentTransformer, @unchecked Sendable {
     public typealias RawContent = Data
 
     public init() {}

--- a/Packages/Sources/Core/JSONParser/JSONContentFetcher.swift
+++ b/Packages/Sources/Core/JSONParser/JSONContentFetcher.swift
@@ -6,7 +6,7 @@ import Foundation
 /// Fetches JSON content from Apple's documentation API
 /// Uses URLSession for direct HTTP requests, avoiding WKWebView memory issues
 extension JSONCrawler {
-    public struct JSONContentFetcher: ContentFetcher, @unchecked Sendable {
+    public struct JSONContentFetcher: Core.Protocols.ContentFetcher, @unchecked Sendable {
         public typealias RawContent = Data
 
         private let session: URLSession
@@ -20,7 +20,7 @@ extension JSONCrawler {
             session = URLSession(configuration: config)
         }
 
-        public func fetch(url: URL) async throws -> FetchResult<Data> {
+        public func fetch(url: URL) async throws -> Core.Protocols.FetchResult<Data> {
             let (data, response) = try await session.data(from: url)
 
             guard let httpResponse = response as? HTTPURLResponse else {
@@ -32,7 +32,7 @@ extension JSONCrawler {
             }
 
             let finalURL = response.url ?? url
-            return FetchResult(content: data, url: finalURL)
+            return Core.Protocols.FetchResult(content: data, url: finalURL)
         }
     }
 }

--- a/Packages/Sources/Core/PackageIndexing/PackageDependencyResolver.swift
+++ b/Packages/Sources/Core/PackageIndexing/PackageDependencyResolver.swift
@@ -37,12 +37,12 @@ extension Core {
         private let requestDelay: TimeInterval
         private let concurrency: Int
         private let candidateBranches = ["HEAD", "main", "master"]
-        private let canonicalizer: GitHubCanonicalizer?
+        private let canonicalizer: Core.Protocols.GitHubCanonicalizer?
         private let exclusions: Set<String>
         private let manifestCache: ManifestCache?
 
         public init(
-            canonicalizer: GitHubCanonicalizer? = nil,
+            canonicalizer: Core.Protocols.GitHubCanonicalizer? = nil,
             exclusions: Set<String> = [],
             manifestCache: ManifestCache? = nil,
             concurrency: Int = 10,

--- a/Packages/Sources/Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift
+++ b/Packages/Sources/Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift
@@ -13,7 +13,7 @@ import WebKit
 extension WKWebCrawler {
     #if canImport(WebKit)
     @MainActor
-    public final class Engine: @preconcurrency CrawlerEngine {
+    public final class Engine: @preconcurrency Core.Protocols.CrawlerEngine {
         private let fetcher: WKWebCrawler.ContentFetcher
 
         public init(
@@ -26,7 +26,7 @@ extension WKWebCrawler {
             )
         }
 
-        public func crawl(url: URL) async throws -> TransformResult {
+        public func crawl(url: URL) async throws -> Core.Protocols.TransformResult {
             // Fetch HTML content via WKWebView; result.url is the post-redirect final URL
             let result = try await fetcher.fetch(url: url)
             let html = result.content
@@ -41,7 +41,7 @@ extension WKWebCrawler {
             // Extract metadata from HTML
             let metadata = extractMetadata(from: html)
 
-            return TransformResult(
+            return Core.Protocols.TransformResult(
                 markdown: markdown,
                 links: links,
                 metadata: metadata
@@ -80,7 +80,7 @@ extension WKWebCrawler {
             return links
         }
 
-        private func extractMetadata(from html: String) -> TransformMetadata? {
+        private func extractMetadata(from html: String) -> Core.Protocols.TransformMetadata? {
             var title: String?
             var description: String?
 
@@ -110,7 +110,7 @@ extension WKWebCrawler {
                 return nil
             }
 
-            return TransformMetadata(
+            return Core.Protocols.TransformMetadata(
                 title: title,
                 description: description
             )

--- a/Packages/Sources/Core/WKWebCrawler/Fetchers/WKWebContentFetcher.swift
+++ b/Packages/Sources/Core/WKWebCrawler/Fetchers/WKWebContentFetcher.swift
@@ -13,7 +13,7 @@ import WebKit
 extension WKWebCrawler {
     #if canImport(WebKit)
     @MainActor
-    public final class ContentFetcher: NSObject, @preconcurrency CoreProtocols.ContentFetcher {
+    public final class ContentFetcher: NSObject, @preconcurrency Core.Protocols.ContentFetcher {
         public typealias RawContent = String
 
         // `webView` is an IUO on purpose: `recycle()` (below) is called
@@ -47,7 +47,7 @@ extension WKWebCrawler {
         /// Fetch HTML content from a URL using WKWebView
         /// - Parameter url: The URL to fetch
         /// - Returns: A FetchResult containing the rendered HTML and the post-redirect final URL
-        public func fetch(url: URL) async throws -> FetchResult<String> {
+        public func fetch(url: URL) async throws -> Core.Protocols.FetchResult<String> {
             webView.load(URLRequest(url: url))
 
             let html = try await withThrowingTaskGroup(of: String?.self) { group in
@@ -74,7 +74,7 @@ extension WKWebCrawler {
             }
 
             let finalURL = webView.url ?? url
-            return FetchResult(content: html, url: finalURL)
+            return Core.Protocols.FetchResult(content: html, url: finalURL)
         }
 
         /// Recycle the WKWebView to free memory.

--- a/Packages/Sources/CoreProtocols/ContentFetcher.swift
+++ b/Packages/Sources/CoreProtocols/ContentFetcher.swift
@@ -4,27 +4,29 @@ import Foundation
 
 /// Protocol for fetching raw content from a URL
 /// Implementations include WKWebView (HTML), JSON API, URLSession (HTML), etc.
-public protocol ContentFetcher: Sendable {
-    /// The type of raw content this fetcher produces
-    associatedtype RawContent: Sendable
+extension Core.Protocols {
+    public protocol ContentFetcher: Sendable {
+        /// The type of raw content this fetcher produces
+        associatedtype RawContent: Sendable
 
-    /// Fetch raw content from the given URL
-    /// - Parameter url: The URL to fetch content from
-    /// - Returns: A FetchResult containing the raw content and the post-redirect final URL
-    func fetch(url: URL) async throws -> FetchResult<RawContent>
+        /// Fetch raw content from the given URL
+        /// - Parameter url: The URL to fetch content from
+        /// - Returns: A FetchResult containing the raw content and the post-redirect final URL
+        func fetch(url: URL) async throws -> FetchResult<RawContent>
 
-    /// Optional: Recycle resources to free memory
-    /// Default implementation does nothing
-    func recycle()
+        /// Optional: Recycle resources to free memory
+        /// Default implementation does nothing
+        func recycle()
 
-    /// Optional: Get current memory usage in MB
-    /// Default implementation returns 0
-    func getMemoryUsageMB() -> Double
+        /// Optional: Get current memory usage in MB
+        /// Default implementation returns 0
+        func getMemoryUsageMB() -> Double
+    }
 }
 
 // MARK: - Default Implementations
 
-public extension ContentFetcher {
+public extension Core.Protocols.ContentFetcher {
     func recycle() {
         // Default: no-op
     }
@@ -38,14 +40,16 @@ public extension ContentFetcher {
 // MARK: - Fetch Result
 
 /// Result of a content fetch operation
-public struct FetchResult<Content: Sendable>: Sendable {
-    public let content: Content
-    public let url: URL
-    public let responseHeaders: [String: String]?
+extension Core.Protocols {
+    public struct FetchResult<Content: Sendable>: Sendable {
+        public let content: Content
+        public let url: URL
+        public let responseHeaders: [String: String]?
 
-    public init(content: Content, url: URL, responseHeaders: [String: String]? = nil) {
-        self.content = content
-        self.url = url
-        self.responseHeaders = responseHeaders
+        public init(content: Content, url: URL, responseHeaders: [String: String]? = nil) {
+            self.content = content
+            self.url = url
+            self.responseHeaders = responseHeaders
+        }
     }
 }

--- a/Packages/Sources/CoreProtocols/ContentTransformer.swift
+++ b/Packages/Sources/CoreProtocols/ContentTransformer.swift
@@ -7,64 +7,70 @@ import SharedModels
 
 /// Protocol for transforming raw content into Markdown
 /// Implementations include HTML→Markdown, JSON→Markdown, XML→Markdown, etc.
-public protocol ContentTransformer: Sendable {
-    /// The type of raw content this transformer accepts
-    associatedtype RawContent: Sendable
+extension Core.Protocols {
+    public protocol ContentTransformer: Sendable {
+        /// The type of raw content this transformer accepts
+        associatedtype RawContent: Sendable
 
-    /// Transform raw content into Markdown
-    /// - Parameters:
-    ///   - content: The raw content to transform
-    ///   - url: The source URL (for resolving relative links)
-    /// - Returns: Markdown string, or nil if transformation failed
-    func transform(_ content: RawContent, url: URL) -> String?
+        /// Transform raw content into Markdown
+        /// - Parameters:
+        ///   - content: The raw content to transform
+        ///   - url: The source URL (for resolving relative links)
+        /// - Returns: Markdown string, or nil if transformation failed
+        func transform(_ content: RawContent, url: URL) -> String?
 
-    /// Extract links from the raw content
-    /// - Parameter content: The raw content to extract links from
-    /// - Returns: Array of discovered URLs
-    func extractLinks(from content: RawContent) -> [URL]
+        /// Extract links from the raw content
+        /// - Parameter content: The raw content to extract links from
+        /// - Returns: Array of discovered URLs
+        func extractLinks(from content: RawContent) -> [URL]
+    }
 }
 
 // MARK: - Transform Result
 
 /// Result of a content transformation
-public struct TransformResult: Sendable {
-    public let markdown: String
-    public let links: [URL]
-    public let metadata: TransformMetadata?
-    public let structuredPage: Shared.Models.StructuredDocumentationPage?
+extension Core.Protocols {
+    public struct TransformResult: Sendable {
+        public let markdown: String
+        public let links: [URL]
+        public let metadata: TransformMetadata?
+        public let structuredPage: Shared.Models.StructuredDocumentationPage?
 
-    public init(
-        markdown: String,
-        links: [URL],
-        metadata: TransformMetadata? = nil,
-        structuredPage: Shared.Models.StructuredDocumentationPage? = nil
-    ) {
-        self.markdown = markdown
-        self.links = links
-        self.metadata = metadata
-        self.structuredPage = structuredPage
+        public init(
+            markdown: String,
+            links: [URL],
+            metadata: TransformMetadata? = nil,
+            structuredPage: Shared.Models.StructuredDocumentationPage? = nil
+        ) {
+            self.markdown = markdown
+            self.links = links
+            self.metadata = metadata
+            self.structuredPage = structuredPage
+        }
     }
 }
 
 /// Metadata extracted during transformation
-public struct TransformMetadata: Sendable {
-    public let title: String?
-    public let description: String?
-    public let framework: String?
-    public let platforms: [String]?
-    public let isDeprecated: Bool
+extension Core.Protocols {
+    public struct TransformMetadata: Sendable {
+        public let title: String?
+        public let description: String?
+        public let framework: String?
+        public let platforms: [String]?
+        public let isDeprecated: Bool
 
-    public init(
-        title: String? = nil,
-        description: String? = nil,
-        framework: String? = nil,
-        platforms: [String]? = nil,
-        isDeprecated: Bool = false
-    ) {
-        self.title = title
-        self.description = description
-        self.framework = framework
-        self.platforms = platforms
-        self.isDeprecated = isDeprecated
+        public init(
+            title: String? = nil,
+            description: String? = nil,
+            framework: String? = nil,
+            platforms: [String]? = nil,
+            isDeprecated: Bool = false
+        ) {
+            self.title = title
+            self.description = description
+            self.framework = framework
+            self.platforms = platforms
+            self.isDeprecated = isDeprecated
+        }
     }
 }

--- a/Packages/Sources/CoreProtocols/Core.swift
+++ b/Packages/Sources/CoreProtocols/Core.swift
@@ -1,6 +1,25 @@
 import Foundation
 
-/// Namespace for core crawling functionality
+// MARK: - Core Namespace
+
+/// Namespace for the core crawling / fetching / transforming layer.
+///
+/// Layout:
+/// - `Core.Protocols.*` — protocols (`ContentFetcher`, `ContentTransformer`,
+///                       `CrawlerEngine`) and their companion result types
+///                       (`FetchResult`, `TransformResult`, `TransformMetadata`).
+///                       Also folds in the concrete utilities that ship in the
+///                       same SPM target (`Core.Protocols.ExclusionList`,
+///                       `Core.Protocols.GitHubCanonicalizer`,
+///                       `Core.Protocols.SwiftPackagesCatalog`,
+///                       `Core.Protocols.SwiftPackageEntry`) so the namespace
+///                       mirrors the folder on disk.
+/// - The rest of `Core.*` (`Core.Crawler`, `Core.Parser.*`, `Core.JSONParser.*`,
+///   `Core.PackageIndexing.*`, `Core.WKWebCrawler.*`, …) lives in sibling SPM
+///   targets and extends this same root from their own files.
 public enum Core {
-    // Namespace root - types defined in extensions
+    /// Folder-mirror sub-namespace for the `Sources/CoreProtocols/` SPM target:
+    /// protocols, their result-value companions, and the small utilities that
+    /// ship alongside them.
+    public enum Protocols {}
 }

--- a/Packages/Sources/CoreProtocols/CrawlerEngine.swift
+++ b/Packages/Sources/CoreProtocols/CrawlerEngine.swift
@@ -4,28 +4,30 @@ import Foundation
 
 /// Protocol combining content fetching and transformation
 /// This is the main interface for crawling implementations
-public protocol CrawlerEngine: Sendable {
-    /// Crawl a URL and return Markdown content with discovered links
-    /// - Parameter url: The URL to crawl
-    /// - Returns: Transform result containing markdown and links
-    func crawl(url: URL) async throws -> TransformResult
+extension Core.Protocols {
+    public protocol CrawlerEngine: Sendable {
+        /// Crawl a URL and return Markdown content with discovered links
+        /// - Parameter url: The URL to crawl
+        /// - Returns: Transform result containing markdown and links
+        func crawl(url: URL) async throws -> TransformResult
 
-    /// Get the API URL for a given documentation URL
-    /// Some engines (like JSON API) need to transform the URL before fetching
-    /// - Parameter documentationURL: The public documentation URL
-    /// - Returns: The URL to actually fetch from, or nil if not applicable
-    func apiURL(from documentationURL: URL) -> URL?
+        /// Get the API URL for a given documentation URL
+        /// Some engines (like JSON API) need to transform the URL before fetching
+        /// - Parameter documentationURL: The public documentation URL
+        /// - Returns: The URL to actually fetch from, or nil if not applicable
+        func apiURL(from documentationURL: URL) -> URL?
 
-    /// Recycle resources to free memory
-    func recycle()
+        /// Recycle resources to free memory
+        func recycle()
 
-    /// Get current memory usage in MB
-    func getMemoryUsageMB() -> Double
+        /// Get current memory usage in MB
+        func getMemoryUsageMB() -> Double
+    }
 }
 
 // MARK: - Default Implementations
 
-public extension CrawlerEngine {
+public extension Core.Protocols.CrawlerEngine {
     func apiURL(from documentationURL: URL) -> URL? {
         // Default: use the URL as-is
         documentationURL

--- a/Packages/Sources/CoreProtocols/ExclusionList.swift
+++ b/Packages/Sources/CoreProtocols/ExclusionList.swift
@@ -2,7 +2,7 @@ import Foundation
 import SharedConstants
 import SharedCore
 
-extension Core {
+extension Core.Protocols {
     /// User-maintained skip list at `~/.cupertino/excluded-packages.json`: a flat JSON
     /// array of `"owner/repo"` strings that the resolver must drop from its closure
     /// even when transitively discovered. Absent file = empty set.

--- a/Packages/Sources/CoreProtocols/GitHubCanonicalizer.swift
+++ b/Packages/Sources/CoreProtocols/GitHubCanonicalizer.swift
@@ -2,7 +2,7 @@ import Foundation
 import SharedConstants
 import SharedCore
 
-extension Core {
+extension Core.Protocols {
     /// Canonicalizes `(owner, repo)` pairs using `api.github.com/repos/<owner>/<repo>`,
     /// resolving GitHub's silent redirects (e.g. `apple/swift-docc` → `swiftlang/swift-docc`)
     /// so the resolver can dedupe aliases. Results are memoised in-process and persisted

--- a/Packages/Sources/CoreProtocols/SwiftPackagesCatalog.swift
+++ b/Packages/Sources/CoreProtocols/SwiftPackagesCatalog.swift
@@ -18,120 +18,124 @@ import Resources
 /// after the #161 slimming, most fields default since only the URL is
 /// compiled in. Consumers that still need the metadata should fetch from
 /// GitHub or read from `packages.db` (v1.0.0+).
-public struct SwiftPackageEntry: Codable, Sendable {
-    public let owner: String
-    public let repo: String
-    public let url: String
-    public let description: String?
-    public let stars: Int
-    public let language: String?
-    public let license: String?
-    public let fork: Bool
-    public let archived: Bool
-    public let updatedAt: String?
+extension Core.Protocols {
+    public struct SwiftPackageEntry: Codable, Sendable {
+        public let owner: String
+        public let repo: String
+        public let url: String
+        public let description: String?
+        public let stars: Int
+        public let language: String?
+        public let license: String?
+        public let fork: Bool
+        public let archived: Bool
+        public let updatedAt: String?
 
-    public init(
-        owner: String,
-        repo: String,
-        url: String,
-        description: String? = nil,
-        stars: Int = 0,
-        language: String? = nil,
-        license: String? = nil,
-        fork: Bool = false,
-        archived: Bool = false,
-        updatedAt: String? = nil
-    ) {
-        self.owner = owner
-        self.repo = repo
-        self.url = url
-        self.description = description
-        self.stars = stars
-        self.language = language
-        self.license = license
-        self.fork = fork
-        self.archived = archived
-        self.updatedAt = updatedAt
-    }
+        public init(
+            owner: String,
+            repo: String,
+            url: String,
+            description: String? = nil,
+            stars: Int = 0,
+            language: String? = nil,
+            license: String? = nil,
+            fork: Bool = false,
+            archived: Bool = false,
+            updatedAt: String? = nil
+        ) {
+            self.owner = owner
+            self.repo = repo
+            self.url = url
+            self.description = description
+            self.stars = stars
+            self.language = language
+            self.license = license
+            self.fork = fork
+            self.archived = archived
+            self.updatedAt = updatedAt
+        }
 
-    /// Parse a URL into an entry. Handles `https://github.com/<owner>/<repo>`
-    /// primarily; also tolerates `.git` suffixes and non-github hosts by
-    /// taking the last two path components as owner/repo.
-    static func fromURL(_ url: String) -> SwiftPackageEntry? {
-        guard let parsed = URL(string: url) else { return nil }
-        var path = parsed.path
-        if path.hasSuffix(".git") { path = String(path.dropLast(4)) }
-        let parts = path.split(separator: "/").map(String.init)
-        guard parts.count >= 2 else { return nil }
-        let owner = parts[parts.count - 2]
-        let repo = parts[parts.count - 1]
-        return SwiftPackageEntry(owner: owner, repo: repo, url: url)
+        /// Parse a URL into an entry. Handles `https://github.com/<owner>/<repo>`
+        /// primarily; also tolerates `.git` suffixes and non-github hosts by
+        /// taking the last two path components as owner/repo.
+        static func fromURL(_ url: String) -> SwiftPackageEntry? {
+            guard let parsed = URL(string: url) else { return nil }
+            var path = parsed.path
+            if path.hasSuffix(".git") { path = String(path.dropLast(4)) }
+            let parts = path.split(separator: "/").map(String.init)
+            guard parts.count >= 2 else { return nil }
+            let owner = parts[parts.count - 2]
+            let repo = parts[parts.count - 1]
+            return SwiftPackageEntry(owner: owner, repo: repo, url: url)
+        }
     }
 }
 
 /// Complete catalog of all Swift packages — URL list only post-#161.
 /// Keeps the async-actor-cached shape for API compatibility with existing
 /// consumers even though the data is now a compile-time constant.
-public enum SwiftPackagesCatalog {
-    private actor Cache {
-        var entries: [SwiftPackageEntry]?
+extension Core.Protocols {
+    public enum SwiftPackagesCatalog {
+        private actor Cache {
+            var entries: [SwiftPackageEntry]?
 
-        func get() -> [SwiftPackageEntry]? {
-            entries
+            func get() -> [SwiftPackageEntry]? {
+                entries
+            }
+
+            func set(_ newEntries: [SwiftPackageEntry]) {
+                entries = newEntries
+            }
         }
 
-        func set(_ newEntries: [SwiftPackageEntry]) {
-            entries = newEntries
+        private static let cache = Cache()
+
+        private static func loadEntries() async -> [SwiftPackageEntry] {
+            if let cached = await cache.get() { return cached }
+            let entries = Resources.Embedded.SwiftPackagesCatalog.urls.compactMap(SwiftPackageEntry.fromURL)
+            await cache.set(entries)
+            return entries
         }
+
+        /// Total number of Swift packages in the bundled URL list.
+        public static var count: Int {
+            get async { await loadEntries().count }
+        }
+
+        /// Last crawled date (stamped at catalog generation time).
+        public static var lastCrawled: String {
+            get async { Resources.Embedded.SwiftPackagesCatalog.lastCrawled }
+        }
+
+        /// Catalog version marker. Fixed string post-slim; bumped when the URL
+        /// schema changes, not on every content refresh.
+        public static var version: String {
+            get async { "url-only-1" }
+        }
+
+        /// Data source description.
+        public static var source: String {
+            get async { "Bundled URL seed list" }
+        }
+
+        /// All Swift package entries (URL-only; metadata fields default).
+        public static var allPackages: [SwiftPackageEntry] {
+            get async { await loadEntries() }
+        }
+
+        /// Packages whose owner matches (case-insensitive).
+        public static func packages(by owner: String) async -> [SwiftPackageEntry] {
+            await allPackages.filter { $0.owner.lowercased() == owner.lowercased() }
+        }
+
+        /// Search packages by repo name (description is nil post-slim).
+        public static func search(_ query: String) async -> [SwiftPackageEntry] {
+            let q = query.lowercased()
+            return await allPackages.filter { $0.repo.lowercased().contains(q) }
+        }
+
+        // Removed post-#161: packages(license:), activePackages(minStars:), topPackages(limit:)
+        // rely on metadata no longer in the bundled catalog. Use packages.db (v1.0.0+)
+        // for metadata-driven queries.
     }
-
-    private static let cache = Cache()
-
-    private static func loadEntries() async -> [SwiftPackageEntry] {
-        if let cached = await cache.get() { return cached }
-        let entries = Resources.Embedded.SwiftPackagesCatalog.urls.compactMap(SwiftPackageEntry.fromURL)
-        await cache.set(entries)
-        return entries
-    }
-
-    /// Total number of Swift packages in the bundled URL list.
-    public static var count: Int {
-        get async { await loadEntries().count }
-    }
-
-    /// Last crawled date (stamped at catalog generation time).
-    public static var lastCrawled: String {
-        get async { Resources.Embedded.SwiftPackagesCatalog.lastCrawled }
-    }
-
-    /// Catalog version marker. Fixed string post-slim; bumped when the URL
-    /// schema changes, not on every content refresh.
-    public static var version: String {
-        get async { "url-only-1" }
-    }
-
-    /// Data source description.
-    public static var source: String {
-        get async { "Bundled URL seed list" }
-    }
-
-    /// All Swift package entries (URL-only; metadata fields default).
-    public static var allPackages: [SwiftPackageEntry] {
-        get async { await loadEntries() }
-    }
-
-    /// Packages whose owner matches (case-insensitive).
-    public static func packages(by owner: String) async -> [SwiftPackageEntry] {
-        await allPackages.filter { $0.owner.lowercased() == owner.lowercased() }
-    }
-
-    /// Search packages by repo name (description is nil post-slim).
-    public static func search(_ query: String) async -> [SwiftPackageEntry] {
-        let q = query.lowercased()
-        return await allPackages.filter { $0.repo.lowercased().contains(q) }
-    }
-
-    // Removed post-#161: packages(license:), activePackages(minStars:), topPackages(limit:)
-    // rely on metadata no longer in the bundled catalog. Use packages.db (v1.0.0+)
-    // for metadata-driven queries.
 }

--- a/Packages/Sources/Search/SearchIndexBuilder.swift
+++ b/Packages/Sources/Search/SearchIndexBuilder.swift
@@ -1233,7 +1233,7 @@ extension Search {
         private func indexPackagesCatalog(onProgress: (@Sendable (Int, Int) -> Void)?) async throws {
             logInfo("📦 Indexing Swift packages catalog from bundled resources...")
 
-            let packages = await SwiftPackagesCatalog.allPackages
+            let packages = await Core.Protocols.SwiftPackagesCatalog.allPackages
 
             guard !packages.isEmpty else {
                 logInfo("⚠️  No packages found in catalog")

--- a/Packages/Sources/TUI/Helpers/PackageActions.swift
+++ b/Packages/Sources/TUI/Helpers/PackageActions.swift
@@ -130,7 +130,7 @@ private var userExclusionsURL: URL {
 /// Load excluded "owner/repo" entries from disk; empty set if absent/malformed.
 @MainActor
 func loadExcludedPackages() -> Set<String> {
-    Core.ExclusionList.load()
+    Core.Protocols.ExclusionList.load()
 }
 
 /// Load the resolved closure's non-seed entries so the TUI can flag them as

--- a/Packages/Sources/TUI/Models/PackageEntry.swift
+++ b/Packages/Sources/TUI/Models/PackageEntry.swift
@@ -3,7 +3,7 @@ import CoreProtocols
 import Foundation
 
 struct PackageEntry {
-    let package: SwiftPackageEntry
+    let package: Core.Protocols.SwiftPackageEntry
     var isSelected: Bool
     var isDownloaded: Bool = false
     /// True when the resolver pulled this package in via a seed's dependency graph

--- a/Packages/Sources/TUI/PackageCurator.swift
+++ b/Packages/Sources/TUI/PackageCurator.swift
@@ -23,7 +23,7 @@ struct PackageCuratorApp {
         }
 
         // Load packages
-        let packages = await SwiftPackagesCatalog.allPackages
+        let packages = await Core.Protocols.SwiftPackagesCatalog.allPackages
 
         // Load user selections first, fall back to bundled priority packages
         let userSelectedURLs = loadUserSelectedPackageURLs()

--- a/Packages/Tests/CoreTests/CupertinoCoreTests.swift
+++ b/Packages/Tests/CoreTests/CupertinoCoreTests.swift
@@ -36,7 +36,7 @@ import TestSupport
 
 @Test("SwiftPackagesCatalog loads from JSON resource")
 func swiftPackagesCatalogLoadsFromJSON() async {
-    let count = await SwiftPackagesCatalog.count
+    let count = await Core.Protocols.SwiftPackagesCatalog.count
     #expect(count > 9000, "Should have thousands of Swift packages")
     #expect(count < 15000, "Package count should be reasonable")
     print("   ✅ Loaded \(count) Swift packages")
@@ -44,9 +44,9 @@ func swiftPackagesCatalogLoadsFromJSON() async {
 
 @Test("SwiftPackagesCatalog has correct metadata")
 func swiftPackagesCatalogMetadata() async {
-    let version = await SwiftPackagesCatalog.version
-    let lastCrawled = await SwiftPackagesCatalog.lastCrawled
-    let source = await SwiftPackagesCatalog.source
+    let version = await Core.Protocols.SwiftPackagesCatalog.version
+    let lastCrawled = await Core.Protocols.SwiftPackagesCatalog.lastCrawled
+    let source = await Core.Protocols.SwiftPackagesCatalog.source
 
     #expect(!version.isEmpty, "Version should not be empty")
     #expect(!lastCrawled.isEmpty, "Last crawled date should not be empty")
@@ -57,7 +57,7 @@ func swiftPackagesCatalogMetadata() async {
 
 @Test("SwiftPackagesCatalog entries have required fields")
 func swiftPackagesCatalogEntriesValid() async {
-    let packages = await SwiftPackagesCatalog.allPackages
+    let packages = await Core.Protocols.SwiftPackagesCatalog.allPackages
     #expect(!packages.isEmpty, "Should have at least one package")
 
     // Verify first entry has all required fields
@@ -75,7 +75,7 @@ func swiftPackagesCatalogEntriesValid() async {
 
 @Test("SwiftPackagesCatalog search works")
 func swiftPackagesCatalogSearch() async {
-    let results = await SwiftPackagesCatalog.search("SwiftUI")
+    let results = await Core.Protocols.SwiftPackagesCatalog.search("SwiftUI")
     #expect(!results.isEmpty, "Search for 'SwiftUI' should return results")
 
     print("   ✅ Found \(results.count) results for 'SwiftUI'")

--- a/Packages/Tests/CoreTests/ResolverPipelineTests.swift
+++ b/Packages/Tests/CoreTests/ResolverPipelineTests.swift
@@ -134,7 +134,7 @@ func exclusionListAbsent() throws {
         .appendingPathComponent("cupertino-excl-test-\(UUID().uuidString)")
     try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: tempDir) }
-    #expect(Core.ExclusionList.load(from: tempDir).isEmpty)
+    #expect(Core.Protocols.ExclusionList.load(from: tempDir).isEmpty)
 }
 
 @Test("ExclusionList: loads and normalises entries")
@@ -146,7 +146,7 @@ func exclusionListLoads() throws {
     let fileURL = tempDir.appendingPathComponent(Shared.Constants.FileName.excludedPackages)
     let json = #"[" APPLE/Swift-NIO ", "vapor/vapor"]"#.data(using: .utf8)!
     try json.write(to: fileURL)
-    let excluded = Core.ExclusionList.load(from: tempDir)
+    let excluded = Core.Protocols.ExclusionList.load(from: tempDir)
     #expect(excluded.contains("apple/swift-nio"))
     #expect(excluded.contains("vapor/vapor"))
     #expect(excluded.count == 2)
@@ -161,7 +161,7 @@ func exclusionListMalformed() throws {
     let fileURL = tempDir.appendingPathComponent(Shared.Constants.FileName.excludedPackages)
     let badPayload = try #require("not a json array".data(using: .utf8))
     try badPayload.write(to: fileURL)
-    #expect(Core.ExclusionList.load(from: tempDir).isEmpty)
+    #expect(Core.Protocols.ExclusionList.load(from: tempDir).isEmpty)
 }
 
 // MARK: - Canonicalizer disk cache
@@ -179,7 +179,7 @@ func canonicalizerCacheHit() async throws {
     let data = try JSONEncoder().encode(seed)
     try data.write(to: cacheURL)
 
-    let canonicalizer = Core.GitHubCanonicalizer(cacheURL: cacheURL)
+    let canonicalizer = Core.Protocols.GitHubCanonicalizer(cacheURL: cacheURL)
     let canonical = await canonicalizer.canonicalize(owner: "apple", repo: "swift-docc")
     #expect(canonical.owner == "swiftlang")
     #expect(canonical.repo == "swift-docc")
@@ -193,7 +193,7 @@ func canonicalizerPersistRoundTrip() async throws {
     defer { try? FileManager.default.removeItem(at: tempDir) }
     let cacheURL = tempDir.appendingPathComponent("canonical-owners.json")
 
-    let c1 = Core.GitHubCanonicalizer(cacheURL: cacheURL)
+    let c1 = Core.Protocols.GitHubCanonicalizer(cacheURL: cacheURL)
     await c1.primeCache(
         inputOwner: "apple", inputRepo: "swift-docc",
         canonicalOwner: "swiftlang", canonicalRepo: "swift-docc"
@@ -201,7 +201,7 @@ func canonicalizerPersistRoundTrip() async throws {
     await c1.persist()
 
     // New canonicalizer reads the persisted cache from disk.
-    let c2 = Core.GitHubCanonicalizer(cacheURL: cacheURL)
+    let c2 = Core.Protocols.GitHubCanonicalizer(cacheURL: cacheURL)
     let canonical = await c2.canonicalize(owner: "apple", repo: "swift-docc")
     #expect(canonical.owner == "swiftlang")
     #expect(canonical.repo == "swift-docc")
@@ -219,7 +219,7 @@ func resolverSeedIsSelfParent() async throws {
     defer { try? FileManager.default.removeItem(at: tempDir) }
     let cacheURL = tempDir.appendingPathComponent("canonical-owners.json")
     // Prime the canonicalizer so we don't hit the network: canonical == input.
-    let canonicalizer = Core.GitHubCanonicalizer(cacheURL: cacheURL)
+    let canonicalizer = Core.Protocols.GitHubCanonicalizer(cacheURL: cacheURL)
     await canonicalizer.primeCache(
         inputOwner: "apple", inputRepo: "only-seed",
         canonicalOwner: "apple", canonicalRepo: "only-seed"
@@ -244,7 +244,7 @@ func resolverExcludesSeed() async throws {
     try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: tempDir) }
     let cacheURL = tempDir.appendingPathComponent("canonical-owners.json")
-    let canonicalizer = Core.GitHubCanonicalizer(cacheURL: cacheURL)
+    let canonicalizer = Core.Protocols.GitHubCanonicalizer(cacheURL: cacheURL)
     await canonicalizer.primeCache(
         inputOwner: "apple", inputRepo: "only-seed",
         canonicalOwner: "apple", canonicalRepo: "only-seed"
@@ -376,7 +376,7 @@ func manifestCacheMissSentinel() async throws {
 @Test("parseGitHubURL: plain github.com/owner/repo")
 func parseGitHubURLPlain() throws {
     let url = try #require(URL(string: "https://github.com/apple/swift-nio"))
-    let parsed = try #require(Core.GitHubCanonicalizer.parseGitHubURL(url))
+    let parsed = try #require(Core.Protocols.GitHubCanonicalizer.parseGitHubURL(url))
     #expect(parsed.owner == "apple")
     #expect(parsed.repo == "swift-nio")
 }
@@ -384,7 +384,7 @@ func parseGitHubURLPlain() throws {
 @Test("parseGitHubURL: strips trailing .git")
 func parseGitHubURLStripsGitSuffix() throws {
     let url = try #require(URL(string: "https://github.com/apple/swift-nio.git"))
-    let parsed = try #require(Core.GitHubCanonicalizer.parseGitHubURL(url))
+    let parsed = try #require(Core.Protocols.GitHubCanonicalizer.parseGitHubURL(url))
     #expect(parsed.owner == "apple")
     #expect(parsed.repo == "swift-nio")
 }
@@ -392,7 +392,7 @@ func parseGitHubURLStripsGitSuffix() throws {
 @Test("parseGitHubURL: strips tree/branch suffixes")
 func parseGitHubURLStripsExtraPath() throws {
     let url = try #require(URL(string: "https://github.com/apple/swift-nio/tree/main"))
-    let parsed = try #require(Core.GitHubCanonicalizer.parseGitHubURL(url))
+    let parsed = try #require(Core.Protocols.GitHubCanonicalizer.parseGitHubURL(url))
     #expect(parsed.owner == "apple")
     #expect(parsed.repo == "swift-nio")
 }
@@ -400,13 +400,13 @@ func parseGitHubURLStripsExtraPath() throws {
 @Test("parseGitHubURL: rejects non-github host")
 func parseGitHubURLRejectsOtherHosts() throws {
     let url = try #require(URL(string: "https://gitlab.com/apple/swift-nio"))
-    #expect(Core.GitHubCanonicalizer.parseGitHubURL(url) == nil)
+    #expect(Core.Protocols.GitHubCanonicalizer.parseGitHubURL(url) == nil)
 }
 
 @Test("parseGitHubURL: rejects path with only owner")
 func parseGitHubURLRejectsSingleComponent() throws {
     let url = try #require(URL(string: "https://github.com/apple"))
-    #expect(Core.GitHubCanonicalizer.parseGitHubURL(url) == nil)
+    #expect(Core.Protocols.GitHubCanonicalizer.parseGitHubURL(url) == nil)
 }
 
 // MARK: - Integration (network required)
@@ -425,7 +425,7 @@ struct ResolverNetworkIntegration {
         defer { try? FileManager.default.removeItem(at: tempDir) }
         let cacheURL = tempDir.appendingPathComponent("canonical-owners.json")
 
-        let canonicalizer = Core.GitHubCanonicalizer(cacheURL: cacheURL)
+        let canonicalizer = Core.Protocols.GitHubCanonicalizer(cacheURL: cacheURL)
         let canonical = await canonicalizer.canonicalize(owner: "apple", repo: "swift-docc")
         #expect(canonical.owner == "swiftlang")
         #expect(canonical.repo == "swift-docc")
@@ -442,7 +442,7 @@ struct ResolverNetworkIntegration {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let canonicalizer = Core.GitHubCanonicalizer(
+        let canonicalizer = Core.Protocols.GitHubCanonicalizer(
             cacheURL: tempDir.appendingPathComponent("canonical-owners.json")
         )
         let manifestCache = Core.ManifestCache(
@@ -486,7 +486,7 @@ struct ResolverNetworkIntegration {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let canonicalizer = Core.GitHubCanonicalizer(
+        let canonicalizer = Core.Protocols.GitHubCanonicalizer(
             cacheURL: tempDir.appendingPathComponent("canonical-owners.json")
         )
         let manifestCache = Core.ManifestCache(
@@ -531,7 +531,7 @@ func resolverCanonicalizeDedupes() async throws {
     try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: tempDir) }
     let cacheURL = tempDir.appendingPathComponent("canonical-owners.json")
-    let canonicalizer = Core.GitHubCanonicalizer(cacheURL: cacheURL)
+    let canonicalizer = Core.Protocols.GitHubCanonicalizer(cacheURL: cacheURL)
     // Use fake repos so no real Package.swift is fetched; both canonicalize to the
     // same fake canonical name to prove dedupe.
     await canonicalizer.primeCache(

--- a/Packages/Tests/TUITests/AppStateTests.swift
+++ b/Packages/Tests/TUITests/AppStateTests.swift
@@ -29,7 +29,7 @@ func appStateVisiblePackagesFilter() {
     let state = AppState()
 
     // Create test packages
-    let pkg1 = SwiftPackageEntry(
+    let pkg1 = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",
@@ -42,7 +42,7 @@ func appStateVisiblePackagesFilter() {
         updatedAt: "2025-11-19"
     )
 
-    let pkg2 = SwiftPackageEntry(
+    let pkg2 = Core.Protocols.SwiftPackageEntry(
         owner: "vapor",
         repo: "vapor",
         url: "https://github.com/vapor/vapor",
@@ -55,7 +55,7 @@ func appStateVisiblePackagesFilter() {
         updatedAt: "2025-11-18"
     )
 
-    let pkg3 = SwiftPackageEntry(
+    let pkg3 = Core.Protocols.SwiftPackageEntry(
         owner: "realm",
         repo: "SwiftLint",
         url: "https://github.com/realm/SwiftLint",
@@ -92,7 +92,7 @@ func appStateVisiblePackagesFilter() {
 func appStateSearchFilter() {
     let state = AppState()
 
-    let pkg1 = SwiftPackageEntry(
+    let pkg1 = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",
@@ -105,7 +105,7 @@ func appStateSearchFilter() {
         updatedAt: "2025-11-19"
     )
 
-    let pkg2 = SwiftPackageEntry(
+    let pkg2 = Core.Protocols.SwiftPackageEntry(
         owner: "vapor",
         repo: "vapor",
         url: "https://github.com/vapor/vapor",
@@ -151,7 +151,7 @@ func appStateSearchFilter() {
 func appStateSortModes() {
     let state = AppState()
 
-    let pkg1 = SwiftPackageEntry(
+    let pkg1 = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",
@@ -164,7 +164,7 @@ func appStateSortModes() {
         updatedAt: "2025-11-19"
     )
 
-    let pkg2 = SwiftPackageEntry(
+    let pkg2 = Core.Protocols.SwiftPackageEntry(
         owner: "vapor",
         repo: "vapor",
         url: "https://github.com/vapor/vapor",
@@ -177,7 +177,7 @@ func appStateSortModes() {
         updatedAt: "2025-11-20"
     )
 
-    let pkg3 = SwiftPackageEntry(
+    let pkg3 = Core.Protocols.SwiftPackageEntry(
         owner: "realm",
         repo: "SwiftLint",
         url: "https://github.com/realm/SwiftLint",
@@ -220,7 +220,7 @@ func appStateSortModes() {
 func appStateToggleCurrent() {
     let state = AppState()
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",
@@ -255,7 +255,7 @@ func appStateMoveCursor() {
 
     // Create 10 test packages
     for index in 0..<10 {
-        let pkg = SwiftPackageEntry(
+        let pkg = Core.Protocols.SwiftPackageEntry(
             owner: "owner\(index)",
             repo: "repo\(index)",
             url: "https://github.com/owner\(index)/repo\(index)",

--- a/Packages/Tests/TUITests/InputHandlerTests.swift
+++ b/Packages/Tests/TUITests/InputHandlerTests.swift
@@ -463,7 +463,7 @@ func inputHandlerToggleSelection() {
     let state = AppState()
     state.viewMode = .packages
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",
@@ -549,7 +549,7 @@ func inputHandlerPackageCursorMovement() {
     state.viewMode = .packages
     state.cursor = 5
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "test",
         repo: "test",
         url: "https://github.com/test/test",
@@ -599,7 +599,7 @@ func inputHandlerPageNavigation() {
     state.viewMode = .packages
     state.cursor = 0
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "test",
         repo: "test",
         url: "https://github.com/test/test",

--- a/Packages/Tests/TUITests/PackageEntryTests.swift
+++ b/Packages/Tests/TUITests/PackageEntryTests.swift
@@ -9,7 +9,7 @@ import TestSupport
 
 @Test("PackageEntry initializes with package data")
 func packageEntryInitialization() {
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",
@@ -32,7 +32,7 @@ func packageEntryInitialization() {
 
 @Test("PackageEntry isSelected can be toggled")
 func packageEntrySelection() {
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "vapor",
         repo: "vapor",
         url: "https://github.com/vapor/vapor",
@@ -58,7 +58,7 @@ func packageEntrySelection() {
 
 @Test("PackageEntry isDownloaded reflects local state")
 func packageEntryDownloadStatus() {
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "realm",
         repo: "SwiftLint",
         url: "https://github.com/realm/SwiftLint",
@@ -81,7 +81,7 @@ func packageEntryDownloadStatus() {
 @Test("PackageEntry works with different package data")
 func packageEntryVariousData() {
     // Test with minimal data
-    let minimalPkg = SwiftPackageEntry(
+    let minimalPkg = Core.Protocols.SwiftPackageEntry(
         owner: "user",
         repo: "repo",
         url: "https://github.com/user/repo",
@@ -101,7 +101,7 @@ func packageEntryVariousData() {
     #expect(minimalEntry.package.archived, "Should handle archived status")
 
     // Test with full data
-    let fullPkg = SwiftPackageEntry(
+    let fullPkg = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift-nio",
         url: "https://github.com/apple/swift-nio",

--- a/Packages/Tests/TUITests/ViewTests.swift
+++ b/Packages/Tests/TUITests/ViewTests.swift
@@ -172,7 +172,7 @@ func packageViewWithPackages() {
     let view = PackageView()
     let state = AppState()
 
-    let pkg1 = SwiftPackageEntry(
+    let pkg1 = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",
@@ -203,7 +203,7 @@ func packageViewSelectionIndicator() {
     let view = PackageView()
     let state = AppState()
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "test",
         repo: "package",
         url: "https://github.com/test/package",
@@ -231,7 +231,7 @@ func packageViewDownloadIndicator() {
     let view = PackageView()
     let state = AppState()
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "test",
         repo: "package",
         url: "https://github.com/test/package",
@@ -311,7 +311,7 @@ func packageViewLineWidth() {
 
     // Add packages with varying name lengths
     let packages = [
-        SwiftPackageEntry(
+        Core.Protocols.SwiftPackageEntry(
             owner: "a",
             repo: "b",
             url: "https://github.com/a/b",
@@ -323,7 +323,7 @@ func packageViewLineWidth() {
             archived: false,
             updatedAt: nil
         ),
-        SwiftPackageEntry(
+        Core.Protocols.SwiftPackageEntry(
             owner: "verylongowner",
             repo: "verylongrepo",
             url: "https://github.com/verylongowner/verylongrepo",
@@ -335,7 +335,7 @@ func packageViewLineWidth() {
             archived: false,
             updatedAt: nil
         ),
-        SwiftPackageEntry(
+        Core.Protocols.SwiftPackageEntry(
             owner: "apple",
             repo: "swift",
             url: "https://github.com/apple/swift",
@@ -382,7 +382,7 @@ func packageViewBorderAlignment() {
     let view = PackageView()
     let state = AppState()
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",
@@ -480,7 +480,7 @@ func packageViewSelectedState() {
     let state = AppState()
     let width = 100
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",
@@ -521,7 +521,7 @@ func packageViewDownloadedState() {
     let state = AppState()
     let width = 100
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",
@@ -562,7 +562,7 @@ func packageViewSearchHighlighting() {
     let state = AppState()
     let width = 100
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift-foundation",
         url: "https://github.com/apple/swift-foundation",
@@ -600,7 +600,7 @@ func packageViewSearchHighlightingOnSelected() {
     let state = AppState()
     let width = 100
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift-foundation",
         url: "https://github.com/apple/swift-foundation",
@@ -639,7 +639,7 @@ func packageViewLongNames() {
     let width = 100
 
     // Very long name that will definitely need truncation
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "verylongorganizationname",
         repo: "verylongrepositorynamethatshouldbetruncatedwithellipsis",
         url: "https://github.com/test/test",
@@ -679,7 +679,7 @@ func packageViewComponentWidths() {
     let state = AppState()
     let width = 100
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "test",
         repo: "pkg",
         url: "https://github.com/test/pkg",
@@ -723,7 +723,7 @@ func packageViewMinimumWidth() {
     let state = AppState()
     let width = 80 // Minimum guaranteed width
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "test",
         repo: "package",
         url: "https://github.com/test/package",
@@ -792,7 +792,7 @@ func packageViewBoxCharacters() {
     let view = PackageView()
     let state = AppState()
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "test",
         repo: "pkg",
         url: "https://github.com/test/pkg",
@@ -829,7 +829,7 @@ func packageViewLargeWidth() {
     let state = AppState()
     let width = 200 // Very wide terminal
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "test",
         repo: "package",
         url: "https://github.com/test/package",
@@ -860,7 +860,7 @@ func packageViewZeroStars() {
     let state = AppState()
     let width = 100
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "test",
         repo: "package",
         url: "https://github.com/test/package",
@@ -896,7 +896,7 @@ func packageViewCombinedStates() {
     let state = AppState()
     let width = 100
 
-    let pkg = SwiftPackageEntry(
+    let pkg = Core.Protocols.SwiftPackageEntry(
         owner: "apple",
         repo: "swift",
         url: "https://github.com/apple/swift",


### PR DESCRIPTION
The `CoreProtocols` SPM target now mirrors its folder name in the namespace: every public type lives at `Core.Protocols.X` rather than at the top level of the module.

## Renames

**Protocols and their result-value companions:**

| Before | After |
|---|---|
| `ContentFetcher`     | `Core.Protocols.ContentFetcher` |
| `ContentTransformer` | `Core.Protocols.ContentTransformer` |
| `CrawlerEngine`      | `Core.Protocols.CrawlerEngine` |
| `FetchResult<C>`     | `Core.Protocols.FetchResult<C>` |
| `TransformResult`    | `Core.Protocols.TransformResult` |
| `TransformMetadata`  | `Core.Protocols.TransformMetadata` |

**Utilities that already lived under `Core` via `extension Core { ... }` — relocated one level deeper to mirror the folder:**

| Before | After |
|---|---|
| `Core.ExclusionList`        | `Core.Protocols.ExclusionList` |
| `Core.GitHubCanonicalizer`  | `Core.Protocols.GitHubCanonicalizer` |

**File-scope concrete utilities in the same target:**

| Before | After |
|---|---|
| `SwiftPackageEntry`     | `Core.Protocols.SwiftPackageEntry` |
| `SwiftPackagesCatalog`  | `Core.Protocols.SwiftPackagesCatalog` |

## Mechanics

- `Sources/CoreProtocols/Core.swift` now declares `public enum Protocols {}` inside the existing `Core` namespace enum.
- Each file in the target wraps its public types via `extension Core.Protocols { ... }` around the individual declarations — file-scope helper extensions on system types stay put.
- `public extension ContentFetcher { ... }` default-impl blocks retarget to `public extension Core.Protocols.ContentFetcher { ... }`.
- 19 caller files swept across Core, Search, TUI, CLI, and tests. Sweep is string- and comment-aware. Bare references to the renamed names **and** module-qualified `CoreProtocols.<X>` references both get rewritten.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Previous: #348 Foundation, #350 MCP, #351 Shared (Constants/Utils/Models), #352 Command.

## Next slices

- Shared.Configuration + Shared.Core (needs aggregate-struct rename decision).
- MCPSharedTools → `MCP.SharedTools.*`, MCP.Client → `MCP.Client.*`, MCP.Support → `MCP.Support.*`.
- Diagnostics, Distribution, Indexer, Ingest, Cleanup, SampleIndex, SearchToolProvider, Services, RemoteSync residue.
- File renames (CLI commands, etc.).