### PR TITLE
refactor(Cleanup,Services): nest file-scope types under their module namespaces; sweep callers

### DIFF
--- a/Packages/Sources/CLI/CleanupModuleAlias.swift
+++ b/Packages/Sources/CLI/CleanupModuleAlias.swift
@@ -1,0 +1,15 @@
+import Cleanup
+
+// MARK: - Cleanup Module Disambiguator
+
+// `Command.Cleanup` (the subcommand struct under `Sources/CLI/Commands/`)
+// and the `Cleanup` SPM target share a name. From inside any
+// `extension Command` scope, bare `Cleanup.<Type>` resolves to the nested
+// subcommand struct, not the SPM target — Swift's name lookup checks
+// enclosing types before imported modules.
+//
+// `CleanupModule` pins the SPM target so callers in the CLI target can
+// write `CleanupModule.SampleCodeCleaner` and reach the actual module type.
+// One declaration covers every file in the CLI target.
+
+typealias CleanupModule = Cleanup

--- a/Packages/Sources/CLI/Commands/CleanupCommand.swift
+++ b/Packages/Sources/CLI/Commands/CleanupCommand.swift
@@ -79,7 +79,7 @@ extension Command {
                 Logging.Log.output("")
             }
 
-            let cleaner = SampleCodeCleaner(
+            let cleaner = CleanupModule.SampleCodeCleaner(
                 sampleCodeDirectory: directory,
                 dryRun: dryRun,
                 keepOriginals: keepOriginals

--- a/Packages/Sources/CLI/Commands/ListFrameworksCommand.swift
+++ b/Packages/Sources/CLI/Commands/ListFrameworksCommand.swift
@@ -28,8 +28,8 @@ extension Command {
         var searchDb: String?
 
         mutating func run() async throws {
-            // Use ServiceContainer for managed lifecycle
-            let (frameworks, totalDocs) = try await ServiceContainer.withDocsService(dbPath: searchDb) { service in
+            // Use Services.ServiceContainer for managed lifecycle
+            let (frameworks, totalDocs) = try await Services.ServiceContainer.withDocsService(dbPath: searchDb) { service in
                 let frameworks = try await service.listFrameworks()
                 let totalDocs = try await service.documentCount()
                 return (frameworks, totalDocs)

--- a/Packages/Sources/CLI/Commands/ListSamplesCommand.swift
+++ b/Packages/Sources/CLI/Commands/ListSamplesCommand.swift
@@ -45,8 +45,8 @@ extension Command {
             // Resolve database path
             let dbPath = resolveSampleDbPath()
 
-            // Use ServiceContainer for managed lifecycle
-            let (projects, totalProjects, totalFiles) = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
+            // Use Services.ServiceContainer for managed lifecycle
+            let (projects, totalProjects, totalFiles) = try await Services.ServiceContainer.withSampleService(dbPath: dbPath) { service in
                 let projects = try await service.listProjects(framework: framework, limit: limit)
                 let totalProjects = try await service.projectCount()
                 let totalFiles = try await service.fileCount()

--- a/Packages/Sources/CLI/Commands/ReadCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadCommand.swift
@@ -9,7 +9,7 @@ import SharedUtils
 
 // MARK: - Read Command (unified, #239 follow-up)
 
-/// Thin CLI wrapper around `Services.ReadService`. The dispatch + per-source
+/// Thin CLI wrapper around `ReadService`. The dispatch + per-source
 /// reads live there so the MCP layer (and any future agent-shell adapter)
 /// can share one implementation.
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
@@ -68,17 +68,17 @@ extension Command {
                 ? .markdown
                 : .json
 
-            let explicit: Services.ReadService.Source?
+            let explicit: ReadService.Source?
             do {
-                explicit = try Services.ReadService.resolveSource(source)
-            } catch Services.ReadService.ReadError.unknownSource(let raw) {
+                explicit = try ReadService.resolveSource(source)
+            } catch ReadService.ReadError.unknownSource(let raw) {
                 Logging.Log.error("Unknown --source value: \(raw). See `cupertino read --help`.")
                 throw ExitCode.failure
             }
 
-            let result: Services.ReadService.Result
+            let result: ReadService.Result
             do {
-                result = try await Services.ReadService.read(
+                result = try await ReadService.read(
                     identifier: identifier,
                     explicit: explicit,
                     format: documentFormat,
@@ -86,24 +86,24 @@ extension Command {
                     samplesDB: sampleDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
                     packagesDB: packagesDb.map { URL(fileURLWithPath: $0).expandingTildeInPath }
                 )
-            } catch Services.ReadService.ReadError.docsNotFound(let id) {
+            } catch ReadService.ReadError.docsNotFound(let id) {
                 Logging.Log.error("Document not found in search.db: \(id)")
                 throw ExitCode.failure
-            } catch Services.ReadService.ReadError.samplesNotFound(let id) {
+            } catch ReadService.ReadError.samplesNotFound(let id) {
                 Logging.Log.error("Not found in samples.db: \(id)")
                 throw ExitCode.failure
-            } catch Services.ReadService.ReadError.packagesNotFound(let id) {
+            } catch ReadService.ReadError.packagesNotFound(let id) {
                 Logging.Log.error("Not found in packages.db: \(id)")
                 throw ExitCode.failure
-            } catch Services.ReadService.ReadError.packagesIdentifierInvalid(let id) {
+            } catch ReadService.ReadError.packagesIdentifierInvalid(let id) {
                 Logging.Log.error(
                     "Invalid package identifier: \(id) — expected `<owner>/<repo>/<relpath>`."
                 )
                 throw ExitCode.failure
-            } catch Services.ReadService.ReadError.backendFailed(let msg) {
+            } catch ReadService.ReadError.backendFailed(let msg) {
                 Logging.Log.error("Read failed: \(msg)")
                 throw ExitCode.failure
-            } catch Services.ReadService.ReadError.notFoundAnywhere(let id) {
+            } catch ReadService.ReadError.notFoundAnywhere(let id) {
                 Logging.Log.error(
                     "Tried docs, samples, and packages — no source matched. Identifier: \(id)"
                 )

--- a/Packages/Sources/CLI/Commands/ReadSampleCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadSampleCommand.swift
@@ -37,8 +37,8 @@ extension Command {
             // Resolve database path
             let dbPath = resolveSampleDbPath()
 
-            // Use ServiceContainer for managed lifecycle
-            let (project, files) = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
+            // Use Services.ServiceContainer for managed lifecycle
+            let (project, files) = try await Services.ServiceContainer.withSampleService(dbPath: dbPath) { service in
                 guard let project = try await service.getProject(id: projectId) else {
                     Logging.Log.error("Project not found: \(projectId)")
                     Logging.Log.output("Use 'cupertino list-samples' or 'cupertino search --source samples' to find valid project IDs.")

--- a/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
@@ -40,8 +40,8 @@ extension Command {
             // Resolve database path
             let dbPath = resolveSampleDbPath()
 
-            // Use ServiceContainer for managed lifecycle
-            let file = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
+            // Use Services.ServiceContainer for managed lifecycle
+            let file = try await Services.ServiceContainer.withSampleService(dbPath: dbPath) { service in
                 guard let file = try await service.getFile(projectId: projectId, path: filePath) else {
                     Logging.Log.error("File not found: \(filePath) in project \(projectId)")
                     Logging.Log.output("Use 'cupertino read-sample \(projectId)' to list available files.")

--- a/Packages/Sources/CLI/Commands/SearchCommand+SmartReport.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand+SmartReport.swift
@@ -23,7 +23,7 @@ extension Command.Search {
     struct FetcherPlan {
         let fetchers: [any Search.CandidateFetcher]
         let searchIndex: SearchModule.Index?
-        let sampleService: Services.SampleSearchService?
+        let sampleService: SampleSearchService?
     }
 
     /// Docs-backed sources in a consistent order. `apple-archive` is included
@@ -163,7 +163,7 @@ extension Command.Search {
         skip: Bool,
         availability: SearchModule.PackageQuery.AvailabilityFilter?,
         into fetchers: inout [any Search.CandidateFetcher]
-    ) async -> Services.SampleSearchService? {
+    ) async -> SampleSearchService? {
         guard !skip else { return nil }
         let url = override.map { URL(fileURLWithPath: $0).expandingTildeInPath }
             ?? SampleIndex.defaultDatabasePath
@@ -174,7 +174,7 @@ extension Command.Search {
             return nil
         }
         do {
-            let service = try await Services.SampleSearchService(dbPath: url)
+            let service = try await SampleSearchService(dbPath: url)
             fetchers.append(Services.SampleCandidateFetcher(
                 service: service,
                 availability: availability

--- a/Packages/Sources/CLI/Commands/SearchCommand+SourceRunners.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand+SourceRunners.swift
@@ -15,8 +15,8 @@ import SharedUtils
 /// `Command.Search+SmartReport.swift` (#239).
 extension Command.Search {
     func runDocsSearch() async throws {
-        let results = try await ServiceContainer.withDocsService(dbPath: searchDb) { service in
-            try await service.search(SearchQuery(
+        let results = try await Services.ServiceContainer.withDocsService(dbPath: searchDb) { service in
+            try await service.search(Services.SearchQuery(
                 text: query,
                 source: source,
                 framework: framework,
@@ -31,7 +31,7 @@ extension Command.Search {
             ))
         }
 
-        let teasers = try await ServiceContainer.withTeaserService(
+        let teasers = try await Services.ServiceContainer.withTeaserService(
             searchDbPath: searchDb,
             sampleDbPath: resolveSampleDbPath()
         ) { service in
@@ -57,7 +57,7 @@ extension Command.Search {
         case .markdown:
             let formatter = MarkdownSearchResultFormatter(
                 query: query,
-                filters: SearchFilters(
+                filters: Services.SearchFilters(
                     source: source,
                     framework: framework,
                     language: language,
@@ -77,7 +77,7 @@ extension Command.Search {
     func runSampleSearch() async throws {
         let dbPath = resolveSampleDbPath()
 
-        let result = try await ServiceContainer.withSampleService(dbPath: dbPath) { service in
+        let result = try await Services.ServiceContainer.withSampleService(dbPath: dbPath) { service in
             try await service.search(SampleQuery(
                 text: query,
                 framework: framework,
@@ -92,7 +92,7 @@ extension Command.Search {
         // query (#237).
         let teasers: TeaserResults
         do {
-            teasers = try await ServiceContainer.withTeaserService(
+            teasers = try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: searchDb,
                 sampleDbPath: resolveSampleDbPath()
             ) { service in
@@ -173,8 +173,8 @@ extension Command.Search {
     }
 
     func runHIGSearch() async throws {
-        let results = try await ServiceContainer.withDocsService(dbPath: searchDb) { service in
-            try await service.search(SearchQuery(
+        let results = try await Services.ServiceContainer.withDocsService(dbPath: searchDb) { service in
+            try await service.search(Services.SearchQuery(
                 text: query,
                 source: Shared.Constants.SourcePrefix.hig,
                 framework: nil,
@@ -184,7 +184,7 @@ extension Command.Search {
             ))
         }
 
-        let teasers = try await ServiceContainer.withTeaserService(
+        let teasers = try await Services.ServiceContainer.withTeaserService(
             searchDbPath: searchDb,
             sampleDbPath: resolveSampleDbPath()
         ) { service in

--- a/Packages/Sources/Cleanup/Cleanup.swift
+++ b/Packages/Sources/Cleanup/Cleanup.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+// MARK: - Cleanup Namespace
+
+/// Namespace for sample-code post-fetch cleanup operations. Holds
+/// `Cleanup.SampleCodeCleaner` (the actor that prunes orphaned sample
+/// archives + manifests after a fetch run) and any related types added
+/// later.
+public enum Cleanup {}

--- a/Packages/Sources/Cleanup/SampleCodeCleaner.swift
+++ b/Packages/Sources/Cleanup/SampleCodeCleaner.swift
@@ -6,385 +6,387 @@ import SharedModels
 
 // MARK: - Sample Code Cleaner
 
-/// Actor for cleaning sample code archives by removing unnecessary files
-/// such as .git folders, .DS_Store, build artifacts, etc.
-public actor SampleCodeCleaner {
-    private let sampleCodeDirectory: URL
-    private let dryRun: Bool
-    private let keepOriginals: Bool
+extension Cleanup {
+    /// Actor for cleaning sample code archives by removing unnecessary files
+    /// such as .git folders, .DS_Store, build artifacts, etc.
+    public actor SampleCodeCleaner {
+        private let sampleCodeDirectory: URL
+        private let dryRun: Bool
+        private let keepOriginals: Bool
 
-    /// Patterns of files/folders to remove from archives
-    /// Standard gitignore patterns - safe to remove (build artifacts, not source code)
-    private static let cleanupPatterns: [String] = [
-        ".git",
-        ".DS_Store",
-        "DerivedData",
-        "build",
-        ".build",
-        "xcuserdata",
-        "*.xcuserstate",
-    ]
+        /// Patterns of files/folders to remove from archives
+        /// Standard gitignore patterns - safe to remove (build artifacts, not source code)
+        private static let cleanupPatterns: [String] = [
+            ".git",
+            ".DS_Store",
+            "DerivedData",
+            "build",
+            ".build",
+            "xcuserdata",
+            "*.xcuserstate",
+        ]
 
-    public init(
-        sampleCodeDirectory: URL = Shared.Constants.defaultSampleCodeDirectory,
-        dryRun: Bool = false,
-        keepOriginals: Bool = false
-    ) {
-        self.sampleCodeDirectory = sampleCodeDirectory
-        self.dryRun = dryRun
-        self.keepOriginals = keepOriginals
-    }
+        public init(
+            sampleCodeDirectory: URL = Shared.Constants.defaultSampleCodeDirectory,
+            dryRun: Bool = false,
+            keepOriginals: Bool = false
+        ) {
+            self.sampleCodeDirectory = sampleCodeDirectory
+            self.dryRun = dryRun
+            self.keepOriginals = keepOriginals
+        }
 
-    // MARK: - Public Methods
+        // MARK: - Public Methods
 
-    /// Clean all ZIP archives in the sample code directory
-    public func cleanup(
-        onProgress: (@Sendable (Shared.Models.CleanupProgress) -> Void)? = nil
-    ) async throws -> Shared.Models.CleanupStatistics {
-        let startTime = Date()
+        /// Clean all ZIP archives in the sample code directory
+        public func cleanup(
+            onProgress: (@Sendable (Shared.Models.CleanupProgress) -> Void)? = nil
+        ) async throws -> Shared.Models.CleanupStatistics {
+            let startTime = Date()
 
-        // Find all ZIP files
-        let zipFiles = try findZipFiles()
+            // Find all ZIP files
+            let zipFiles = try findZipFiles()
 
-        guard !zipFiles.isEmpty else {
-            Logging.Log.info("No ZIP files found in \(sampleCodeDirectory.path)", category: .samples)
+            guard !zipFiles.isEmpty else {
+                Logging.Log.info("No ZIP files found in \(sampleCodeDirectory.path)", category: .samples)
+                return Shared.Models.CleanupStatistics(
+                    totalArchives: 0,
+                    cleanedArchives: 0,
+                    skippedArchives: 0,
+                    errors: 0,
+                    originalTotalSize: 0,
+                    cleanedTotalSize: 0,
+                    duration: Date().timeIntervalSince(startTime)
+                )
+            }
+
+            Logging.Log.info("Found \(zipFiles.count) ZIP archives to process", category: .samples)
+
+            var cleanedArchives = 0
+            var skippedArchives = 0
+            var errors = 0
+            var originalTotalSize: Int64 = 0
+            var cleanedTotalSize: Int64 = 0
+            var totalItemsRemoved = 0
+
+            for (index, zipFile) in zipFiles.enumerated() {
+                let result = await cleanArchive(at: zipFile)
+
+                originalTotalSize += result.originalSize
+                cleanedTotalSize += result.cleanedSize
+                totalItemsRemoved += result.itemsRemoved
+
+                if result.success {
+                    if result.itemsRemoved > 0 {
+                        cleanedArchives += 1
+                    } else {
+                        skippedArchives += 1
+                    }
+                } else {
+                    errors += 1
+                    if let error = result.errorMessage {
+                        Logging.Log.error("Failed to clean \(zipFile.lastPathComponent): \(error)", category: .samples)
+                    }
+                }
+
+                onProgress?(Shared.Models.CleanupProgress(
+                    current: index + 1,
+                    total: zipFiles.count,
+                    currentFile: zipFile.lastPathComponent,
+                    originalSize: originalTotalSize,
+                    cleanedSize: cleanedTotalSize
+                ))
+            }
+
             return Shared.Models.CleanupStatistics(
-                totalArchives: 0,
-                cleanedArchives: 0,
-                skippedArchives: 0,
-                errors: 0,
-                originalTotalSize: 0,
-                cleanedTotalSize: 0,
+                totalArchives: zipFiles.count,
+                cleanedArchives: cleanedArchives,
+                skippedArchives: skippedArchives,
+                errors: errors,
+                originalTotalSize: originalTotalSize,
+                cleanedTotalSize: cleanedTotalSize,
+                totalItemsRemoved: totalItemsRemoved,
                 duration: Date().timeIntervalSince(startTime)
             )
         }
 
-        Logging.Log.info("Found \(zipFiles.count) ZIP archives to process", category: .samples)
+        // MARK: - Private Methods
 
-        var cleanedArchives = 0
-        var skippedArchives = 0
-        var errors = 0
-        var originalTotalSize: Int64 = 0
-        var cleanedTotalSize: Int64 = 0
-        var totalItemsRemoved = 0
-
-        for (index, zipFile) in zipFiles.enumerated() {
-            let result = await cleanArchive(at: zipFile)
-
-            originalTotalSize += result.originalSize
-            cleanedTotalSize += result.cleanedSize
-            totalItemsRemoved += result.itemsRemoved
-
-            if result.success {
-                if result.itemsRemoved > 0 {
-                    cleanedArchives += 1
-                } else {
-                    skippedArchives += 1
-                }
-            } else {
-                errors += 1
-                if let error = result.errorMessage {
-                    Logging.Log.error("Failed to clean \(zipFile.lastPathComponent): \(error)", category: .samples)
-                }
-            }
-
-            onProgress?(Shared.Models.CleanupProgress(
-                current: index + 1,
-                total: zipFiles.count,
-                currentFile: zipFile.lastPathComponent,
-                originalSize: originalTotalSize,
-                cleanedSize: cleanedTotalSize
-            ))
-        }
-
-        return Shared.Models.CleanupStatistics(
-            totalArchives: zipFiles.count,
-            cleanedArchives: cleanedArchives,
-            skippedArchives: skippedArchives,
-            errors: errors,
-            originalTotalSize: originalTotalSize,
-            cleanedTotalSize: cleanedTotalSize,
-            totalItemsRemoved: totalItemsRemoved,
-            duration: Date().timeIntervalSince(startTime)
-        )
-    }
-
-    // MARK: - Private Methods
-
-    /// Find all ZIP files in the sample code directory
-    private func findZipFiles() throws -> [URL] {
-        let contents = try FileManager.default.contentsOfDirectory(
-            at: sampleCodeDirectory,
-            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        )
-
-        return contents.filter { $0.pathExtension.lowercased() == "zip" }
-            .sorted { $0.lastPathComponent < $1.lastPathComponent }
-    }
-
-    /// Clean a single archive
-    private func cleanArchive(at zipURL: URL) async -> Shared.Models.CleanupResult {
-        let filename = zipURL.lastPathComponent
-
-        // Get original size
-        let originalSize: Int64
-        do {
-            let attributes = try FileManager.default.attributesOfItem(atPath: zipURL.path)
-            originalSize = (attributes[.size] as? Int64) ?? 0
-        } catch {
-            return Shared.Models.CleanupResult(
-                filename: filename,
-                originalSize: 0,
-                cleanedSize: 0,
-                itemsRemoved: 0,
-                success: false,
-                errorMessage: "Failed to get file size: \(error.localizedDescription)"
-            )
-        }
-
-        // Dry run - just report what would be cleaned
-        if dryRun {
-            let itemsToRemove = await countItemsToRemove(in: zipURL)
-            return Shared.Models.CleanupResult(
-                filename: filename,
-                originalSize: originalSize,
-                cleanedSize: originalSize,
-                itemsRemoved: itemsToRemove,
-                success: true
-            )
-        }
-
-        // Create temporary directory for extraction
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
-        do {
-            // Create temp directory
-            try FileManager.default.createDirectory(
-                at: tempDir,
-                withIntermediateDirectories: true
+        /// Find all ZIP files in the sample code directory
+        private func findZipFiles() throws -> [URL] {
+            let contents = try FileManager.default.contentsOfDirectory(
+                at: sampleCodeDirectory,
+                includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
+                options: [.skipsHiddenFiles]
             )
 
-            // Extract ZIP
-            let extractResult = try await extractZip(zipURL, to: tempDir)
-            guard extractResult else {
+            return contents.filter { $0.pathExtension.lowercased() == "zip" }
+                .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        }
+
+        /// Clean a single archive
+        private func cleanArchive(at zipURL: URL) async -> Shared.Models.CleanupResult {
+            let filename = zipURL.lastPathComponent
+
+            // Get original size
+            let originalSize: Int64
+            do {
+                let attributes = try FileManager.default.attributesOfItem(atPath: zipURL.path)
+                originalSize = (attributes[.size] as? Int64) ?? 0
+            } catch {
                 return Shared.Models.CleanupResult(
                     filename: filename,
-                    originalSize: originalSize,
-                    cleanedSize: originalSize,
+                    originalSize: 0,
+                    cleanedSize: 0,
                     itemsRemoved: 0,
                     success: false,
-                    errorMessage: "Failed to extract archive"
+                    errorMessage: "Failed to get file size: \(error.localizedDescription)"
                 )
             }
 
-            // Remove unwanted files/folders
-            let itemsRemoved = try removeUnwantedItems(in: tempDir)
-
-            // Skip recompression if nothing was removed
-            if itemsRemoved == 0 {
+            // Dry run - just report what would be cleaned
+            if dryRun {
+                let itemsToRemove = await countItemsToRemove(in: zipURL)
                 return Shared.Models.CleanupResult(
                     filename: filename,
                     originalSize: originalSize,
                     cleanedSize: originalSize,
-                    itemsRemoved: 0,
+                    itemsRemoved: itemsToRemove,
                     success: true
                 )
             }
 
-            // Recompress
-            let cleanedZipURL: URL
-            if keepOriginals {
-                cleanedZipURL = zipURL.deletingPathExtension()
-                    .appendingPathExtension("cleaned.zip")
-            } else {
-                cleanedZipURL = zipURL
+            // Create temporary directory for extraction
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+
+            defer {
+                try? FileManager.default.removeItem(at: tempDir)
             }
 
-            // Remove original if replacing
-            if !keepOriginals {
-                try FileManager.default.removeItem(at: zipURL)
-            }
+            do {
+                // Create temp directory
+                try FileManager.default.createDirectory(
+                    at: tempDir,
+                    withIntermediateDirectories: true
+                )
 
-            let compressResult = try await compressDirectory(tempDir, to: cleanedZipURL)
-            guard compressResult else {
+                // Extract ZIP
+                let extractResult = try await extractZip(zipURL, to: tempDir)
+                guard extractResult else {
+                    return Shared.Models.CleanupResult(
+                        filename: filename,
+                        originalSize: originalSize,
+                        cleanedSize: originalSize,
+                        itemsRemoved: 0,
+                        success: false,
+                        errorMessage: "Failed to extract archive"
+                    )
+                }
+
+                // Remove unwanted files/folders
+                let itemsRemoved = try removeUnwantedItems(in: tempDir)
+
+                // Skip recompression if nothing was removed
+                if itemsRemoved == 0 {
+                    return Shared.Models.CleanupResult(
+                        filename: filename,
+                        originalSize: originalSize,
+                        cleanedSize: originalSize,
+                        itemsRemoved: 0,
+                        success: true
+                    )
+                }
+
+                // Recompress
+                let cleanedZipURL: URL
+                if keepOriginals {
+                    cleanedZipURL = zipURL.deletingPathExtension()
+                        .appendingPathExtension("cleaned.zip")
+                } else {
+                    cleanedZipURL = zipURL
+                }
+
+                // Remove original if replacing
+                if !keepOriginals {
+                    try FileManager.default.removeItem(at: zipURL)
+                }
+
+                let compressResult = try await compressDirectory(tempDir, to: cleanedZipURL)
+                guard compressResult else {
+                    return Shared.Models.CleanupResult(
+                        filename: filename,
+                        originalSize: originalSize,
+                        cleanedSize: originalSize,
+                        itemsRemoved: itemsRemoved,
+                        success: false,
+                        errorMessage: "Failed to recompress archive"
+                    )
+                }
+
+                // Get new size
+                let newAttributes = try FileManager.default.attributesOfItem(atPath: cleanedZipURL.path)
+                let cleanedSize = (newAttributes[.size] as? Int64) ?? 0
+
+                return Shared.Models.CleanupResult(
+                    filename: filename,
+                    originalSize: originalSize,
+                    cleanedSize: cleanedSize,
+                    itemsRemoved: itemsRemoved,
+                    success: true
+                )
+
+            } catch {
                 return Shared.Models.CleanupResult(
                     filename: filename,
                     originalSize: originalSize,
                     cleanedSize: originalSize,
-                    itemsRemoved: itemsRemoved,
+                    itemsRemoved: 0,
                     success: false,
-                    errorMessage: "Failed to recompress archive"
+                    errorMessage: error.localizedDescription
                 )
             }
-
-            // Get new size
-            let newAttributes = try FileManager.default.attributesOfItem(atPath: cleanedZipURL.path)
-            let cleanedSize = (newAttributes[.size] as? Int64) ?? 0
-
-            return Shared.Models.CleanupResult(
-                filename: filename,
-                originalSize: originalSize,
-                cleanedSize: cleanedSize,
-                itemsRemoved: itemsRemoved,
-                success: true
-            )
-
-        } catch {
-            return Shared.Models.CleanupResult(
-                filename: filename,
-                originalSize: originalSize,
-                cleanedSize: originalSize,
-                itemsRemoved: 0,
-                success: false,
-                errorMessage: error.localizedDescription
-            )
-        }
-    }
-
-    /// Extract ZIP archive using ditto (preserves permissions and attributes)
-    private func extractZip(_ zipURL: URL, to destination: URL) async throws -> Bool {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
-        process.arguments = ["-xk", zipURL.path, destination.path]
-
-        try process.run()
-        process.waitUntilExit()
-
-        return process.terminationStatus == 0
-    }
-
-    /// Compress directory to ZIP using ditto
-    private func compressDirectory(_ directory: URL, to zipURL: URL) async throws -> Bool {
-        // Sample code ZIPs extract flat (no wrapper directory)
-        // All files (.git, source dirs, xcodeproj, etc.) are at temp directory root
-        // We need to compress ALL contents together, not pick a single directory
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
-
-        // Compress the directory itself (which contains all the extracted files)
-        // This recreates the flat structure in the ZIP
-        process.arguments = ["-ck", directory.path, zipURL.path]
-
-        try process.run()
-        process.waitUntilExit()
-
-        return process.terminationStatus == 0
-    }
-
-    /// Remove unwanted items from extracted directory
-    private func removeUnwantedItems(in directory: URL) throws -> Int {
-        var itemsRemoved = 0
-
-        guard let enumerator = FileManager.default.enumerator(
-            at: directory,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: []
-        ) else {
-            return 0
         }
 
-        var itemsToRemove: [URL] = []
+        /// Extract ZIP archive using ditto (preserves permissions and attributes)
+        private func extractZip(_ zipURL: URL, to destination: URL) async throws -> Bool {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+            process.arguments = ["-xk", zipURL.path, destination.path]
 
-        for case let fileURL as URL in enumerator {
-            let name = fileURL.lastPathComponent
-
-            if shouldRemove(name: name, url: fileURL) {
-                itemsToRemove.append(fileURL)
-
-                // Skip enumeration inside directories we're removing
-                let resourceValues = try? fileURL.resourceValues(forKeys: [.isDirectoryKey])
-                if resourceValues?.isDirectory == true {
-                    enumerator.skipDescendants()
-                }
-            }
-        }
-
-        // Sort by path length (longest first) to remove nested items before parents
-        itemsToRemove.sort { $0.path.count > $1.path.count }
-
-        for itemURL in itemsToRemove {
-            do {
-                try FileManager.default.removeItem(at: itemURL)
-                itemsRemoved += 1
-                Logging.Log.debug("Removed: \(itemURL.path)", category: .samples)
-            } catch {
-                Logging.Log.warning("Failed to remove \(itemURL.path): \(error)", category: .samples)
-            }
-        }
-
-        return itemsRemoved
-    }
-
-    /// Check if a file/folder should be removed
-    private func shouldRemove(name: String, url: URL) -> Bool {
-        for pattern in Self.cleanupPatterns {
-            if pattern.contains("*") {
-                // Wildcard pattern
-                let regex = pattern
-                    .replacingOccurrences(of: ".", with: "\\.")
-                    .replacingOccurrences(of: "*", with: ".*")
-                if name.range(of: "^\(regex)$", options: .regularExpression) != nil {
-                    return true
-                }
-            } else {
-                // Exact match
-                if name == pattern {
-                    return true
-                }
-            }
-        }
-        return false
-    }
-
-    /// Count items that would be removed (for dry run)
-    private func countItemsToRemove(in zipURL: URL) async -> Int {
-        // For dry run, we use zipinfo to inspect without extracting
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/zipinfo")
-        process.arguments = ["-1", zipURL.path]
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-
-        do {
             try process.run()
             process.waitUntilExit()
 
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            guard let output = String(data: data, encoding: .utf8) else {
+            return process.terminationStatus == 0
+        }
+
+        /// Compress directory to ZIP using ditto
+        private func compressDirectory(_ directory: URL, to zipURL: URL) async throws -> Bool {
+            // Sample code ZIPs extract flat (no wrapper directory)
+            // All files (.git, source dirs, xcodeproj, etc.) are at temp directory root
+            // We need to compress ALL contents together, not pick a single directory
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+
+            // Compress the directory itself (which contains all the extracted files)
+            // This recreates the flat structure in the ZIP
+            process.arguments = ["-ck", directory.path, zipURL.path]
+
+            try process.run()
+            process.waitUntilExit()
+
+            return process.terminationStatus == 0
+        }
+
+        /// Remove unwanted items from extracted directory
+        private func removeUnwantedItems(in directory: URL) throws -> Int {
+            var itemsRemoved = 0
+
+            guard let enumerator = FileManager.default.enumerator(
+                at: directory,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: []
+            ) else {
                 return 0
             }
 
-            let files = output.components(separatedBy: "\n")
-            var count = 0
+            var itemsToRemove: [URL] = []
 
-            for file in files where !file.isEmpty {
-                if shouldRemovePath(file) {
-                    count += 1
+            for case let fileURL as URL in enumerator {
+                let name = fileURL.lastPathComponent
+
+                if shouldRemove(name: name, url: fileURL) {
+                    itemsToRemove.append(fileURL)
+
+                    // Skip enumeration inside directories we're removing
+                    let resourceValues = try? fileURL.resourceValues(forKeys: [.isDirectoryKey])
+                    if resourceValues?.isDirectory == true {
+                        enumerator.skipDescendants()
+                    }
                 }
             }
 
-            return count
-        } catch {
-            return 0
-        }
-    }
+            // Sort by path length (longest first) to remove nested items before parents
+            itemsToRemove.sort { $0.path.count > $1.path.count }
 
-    /// Check if a path should be removed (checks all path components)
-    private func shouldRemovePath(_ path: String) -> Bool {
-        let components = path.components(separatedBy: "/")
-        for component in components {
-            if shouldRemove(name: component, url: URL(fileURLWithPath: path)) {
-                return true
+            for itemURL in itemsToRemove {
+                do {
+                    try FileManager.default.removeItem(at: itemURL)
+                    itemsRemoved += 1
+                    Logging.Log.debug("Removed: \(itemURL.path)", category: .samples)
+                } catch {
+                    Logging.Log.warning("Failed to remove \(itemURL.path): \(error)", category: .samples)
+                }
+            }
+
+            return itemsRemoved
+        }
+
+        /// Check if a file/folder should be removed
+        private func shouldRemove(name: String, url: URL) -> Bool {
+            for pattern in Self.cleanupPatterns {
+                if pattern.contains("*") {
+                    // Wildcard pattern
+                    let regex = pattern
+                        .replacingOccurrences(of: ".", with: "\\.")
+                        .replacingOccurrences(of: "*", with: ".*")
+                    if name.range(of: "^\(regex)$", options: .regularExpression) != nil {
+                        return true
+                    }
+                } else {
+                    // Exact match
+                    if name == pattern {
+                        return true
+                    }
+                }
+            }
+            return false
+        }
+
+        /// Count items that would be removed (for dry run)
+        private func countItemsToRemove(in zipURL: URL) async -> Int {
+            // For dry run, we use zipinfo to inspect without extracting
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/zipinfo")
+            process.arguments = ["-1", zipURL.path]
+
+            let pipe = Pipe()
+            process.standardOutput = pipe
+
+            do {
+                try process.run()
+                process.waitUntilExit()
+
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                guard let output = String(data: data, encoding: .utf8) else {
+                    return 0
+                }
+
+                let files = output.components(separatedBy: "\n")
+                var count = 0
+
+                for file in files where !file.isEmpty {
+                    if shouldRemovePath(file) {
+                        count += 1
+                    }
+                }
+
+                return count
+            } catch {
+                return 0
             }
         }
-        return false
+
+        /// Check if a path should be removed (checks all path components)
+        private func shouldRemovePath(_ path: String) -> Bool {
+            let components = path.components(separatedBy: "/")
+            for component in components {
+                if shouldRemove(name: component, url: URL(fileURLWithPath: path)) {
+                    return true
+                }
+            }
+            return false
+        }
     }
 }

--- a/Packages/Sources/Search/PackageQuery.swift
+++ b/Packages/Sources/Search/PackageQuery.swift
@@ -54,7 +54,7 @@ extension Search {
         }
 
         /// Read a single package file's stored content out of
-        /// `package_files_fts`. Used by `Services.ReadService` for the
+        /// `package_files_fts`. Used by `ReadService` for the
         /// `cupertino read <owner>/<repo>/<relpath> --source packages`
         /// path so the read source matches what was indexed (no need
         /// to keep the on-disk packages tree around when consumers

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -421,7 +421,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         }
 
         // Use service layer (same as CLI)
-        let results = try await docsService.search(SearchQuery(
+        let results = try await docsService.search(Services.SearchQuery(
             text: query,
             source: source,
             framework: framework,
@@ -444,7 +444,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         )
 
         // Use shared formatter
-        let filters = SearchFilters(
+        let filters = Services.SearchFilters(
             source: source,
             framework: framework,
             language: language,
@@ -489,7 +489,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         framework: String?,
         currentSource: String?,
         includeArchive: Bool
-    ) async -> Services.TeaserResults {
+    ) async -> TeaserResults {
         let teaserService = TeaserService(searchIndex: searchIndex, sampleDatabase: sampleDatabase)
         return await teaserService.fetchAllTeasers(
             query: query,
@@ -545,7 +545,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         }
 
         // Use service layer (same as CLI)
-        let results = try await docsService.search(SearchQuery(
+        let results = try await docsService.search(Services.SearchQuery(
             text: query,
             source: Shared.Constants.SourcePrefix.hig,
             framework: framework,

--- a/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
@@ -9,14 +9,14 @@ import SharedCore
 /// Formats search results as markdown for MCP tools and CLI --format markdown
 public struct MarkdownSearchResultFormatter: ResultFormatter {
     private let query: String
-    private let filters: SearchFilters?
+    private let filters: Services.SearchFilters?
     private let config: SearchResultFormatConfig
     private let teasers: TeaserResults?
     private let showPlatformTip: Bool
 
     public init(
         query: String,
-        filters: SearchFilters? = nil,
+        filters: Services.SearchFilters? = nil,
         config: SearchResultFormatConfig = .mcpDefault,
         teasers: TeaserResults? = nil,
         showPlatformTip: Bool = true

--- a/Packages/Sources/Services/ReadCommands/DocsSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/DocsSearchService.swift
@@ -7,7 +7,7 @@ import SharedCore
 
 /// Service for searching Apple documentation, Swift Evolution, and other indexed sources.
 /// Wraps Search.Index with a clean interface for both CLI and MCP consumers.
-public actor DocsSearchService: SearchService {
+public actor DocsSearchService: Services.SearchService {
     private let index: Search.Index
 
     /// Initialize with an existing search index
@@ -20,9 +20,9 @@ public actor DocsSearchService: SearchService {
         index = try await Search.Index(dbPath: dbPath)
     }
 
-    // MARK: - SearchService Protocol
+    // MARK: - Services.SearchService Protocol
 
-    public func search(_ query: SearchQuery) async throws -> [Search.Result] {
+    public func search(_ query: Services.SearchQuery) async throws -> [Search.Result] {
         // Platform version filtering is now done at SQL level for better performance
         try await index.search(
             query: query.text,
@@ -59,16 +59,16 @@ public actor DocsSearchService: SearchService {
 
     /// Search with a simple text query using defaults
     public func search(text: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> [Search.Result] {
-        try await search(SearchQuery(text: text, limit: limit))
+        try await search(Services.SearchQuery(text: text, limit: limit))
     }
 
     /// Search within a specific framework
     public func search(text: String, framework: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> [Search.Result] {
-        try await search(SearchQuery(text: text, framework: framework, limit: limit))
+        try await search(Services.SearchQuery(text: text, framework: framework, limit: limit))
     }
 
     /// Search within a specific source (apple-docs, swift-evolution, etc.)
     public func search(text: String, source: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> [Search.Result] {
-        try await search(SearchQuery(text: text, source: source, limit: limit))
+        try await search(Services.SearchQuery(text: text, source: source, limit: limit))
     }
 }

--- a/Packages/Sources/Services/ReadCommands/HIGSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/HIGSearchService.swift
@@ -61,7 +61,7 @@ public actor HIGSearchService {
             effectiveText += " \(category)"
         }
 
-        let searchQuery = SearchQuery(
+        let searchQuery = Services.SearchQuery(
             text: effectiveText,
             source: Shared.Constants.SourcePrefix.hig,
             limit: query.limit,

--- a/Packages/Sources/Services/ReadCommands/ReadService.swift
+++ b/Packages/Sources/Services/ReadCommands/ReadService.swift
@@ -168,7 +168,7 @@ public enum ReadService {
         format: Search.Index.DocumentFormat,
         searchDB: URL?
     ) async throws -> Result {
-        let content = try await ServiceContainer.withDocsService(
+        let content = try await Services.ServiceContainer.withDocsService(
             dbPath: searchDB?.path
         ) { service in
             try await service.read(uri: identifier, format: format)
@@ -199,14 +199,14 @@ public enum ReadService {
         if let slashIdx = identifier.firstIndex(of: "/") {
             let projectId = String(identifier[..<slashIdx])
             let path = String(identifier[identifier.index(after: slashIdx)...])
-            let file = try await ServiceContainer.withSampleService(dbPath: dbURL) { service in
+            let file = try await Services.ServiceContainer.withSampleService(dbPath: dbURL) { service in
                 try await service.getFile(projectId: projectId, path: path)
             }
             if let file {
                 return Result(content: file.content, resolvedSource: .samples)
             }
         } else {
-            let project = try await ServiceContainer.withSampleService(dbPath: dbURL) { service in
+            let project = try await Services.ServiceContainer.withSampleService(dbPath: dbURL) { service in
                 try await service.getProject(id: identifier)
             }
             if let project {

--- a/Packages/Sources/Services/ReadCommands/TeaserService.swift
+++ b/Packages/Sources/Services/ReadCommands/TeaserService.swift
@@ -154,9 +154,9 @@ public actor TeaserService {
     }
 }
 
-// MARK: - ServiceContainer Extension
+// MARK: - Services.ServiceContainer Extension
 
-extension ServiceContainer {
+extension Services.ServiceContainer {
     /// Execute an operation with a teaser service
     public static func withTeaserService<T: Sendable>(
         searchDbPath: String? = nil,

--- a/Packages/Sources/Services/ReadCommands/UnifiedSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/UnifiedSearchService.swift
@@ -165,9 +165,9 @@ public actor UnifiedSearchService {
     }
 }
 
-// MARK: - ServiceContainer Extension
+// MARK: - Services.ServiceContainer Extension
 
-extension ServiceContainer {
+extension Services.ServiceContainer {
     /// Execute an operation with a unified search service
     public static func withUnifiedSearchService<T: Sendable>(
         searchDbPath: String? = nil,

--- a/Packages/Sources/Services/SampleCandidateFetcher.swift
+++ b/Packages/Sources/Services/SampleCandidateFetcher.swift
@@ -20,83 +20,85 @@ import SharedCore
 /// `Search` would force a hard dep on `SampleIndex` for every consumer
 /// that just wants the docs corpus. `Services` already imports both
 /// `SampleIndex` and `Search`, so the fetcher slots in cleanly.
-public struct SampleCandidateFetcher: Search.CandidateFetcher {
-    public let sourceName: String = Shared.Constants.SourcePrefix.samples
+extension Services {
+    public struct SampleCandidateFetcher: Search.CandidateFetcher {
+        public let sourceName: String = Shared.Constants.SourcePrefix.samples
 
-    private let service: SampleSearchService
-    private let availability: Search.PackageQuery.AvailabilityFilter?
+        private let service: SampleSearchService
+        private let availability: Search.PackageQuery.AvailabilityFilter?
 
-    public init(
-        service: SampleSearchService,
-        availability: Search.PackageQuery.AvailabilityFilter? = nil
-    ) {
-        self.service = service
-        self.availability = availability
-    }
-
-    public func fetch(question: String, limit: Int) async throws -> [Search.SmartCandidate] {
-        let query = SampleQuery(
-            text: question,
-            limit: limit,
-            platform: availability?.platform,
-            minVersion: availability?.minVersion
-        )
-        let result = try await service.search(query)
-
-        var candidates: [Search.SmartCandidate] = []
-
-        // #238 follow-up: include project-level matches too. A natural-
-        // language query like "swiftui list animation" frequently scores
-        // a project's title/description/README without lighting up any
-        // single file's content via FTS5. Emitting only file matches
-        // dropped those projects entirely. Now both flow into RRF;
-        // SmartResult dedupe still collapses obvious duplicates.
-        for (idx, project) in result.projects.enumerated() {
-            // Project rows lack their own bm25 score; rank by ordinal
-            // (sample of arrival from the FTS query, best-first).
-            let pseudoScore = 1.0 / Double(idx + 1)
-            let chunk = project.readme.flatMap { readme -> String? in
-                let lines = readme.split(separator: "\n", omittingEmptySubsequences: false).prefix(20)
-                return lines.isEmpty ? nil : lines.joined(separator: "\n")
-            } ?? project.description
-            candidates.append(Search.SmartCandidate(
-                source: sourceName,
-                identifier: project.id,
-                title: project.title,
-                chunk: chunk,
-                rawScore: pseudoScore,
-                kind: "sampleProject",
-                metadata: [
-                    "projectId": project.id,
-                    "frameworks": project.frameworks.joined(separator: ","),
-                    "rank": String(idx + 1),
-                ]
-            ))
+        public init(
+            service: SampleSearchService,
+            availability: Search.PackageQuery.AvailabilityFilter? = nil
+        ) {
+            self.service = service
+            self.availability = availability
         }
 
-        // File-level matches — same shape as before.
-        for (idx, file) in result.files.enumerated() {
-            // Higher rawScore = better. samples.db FTS5 returns its
-            // native BM25 score (lower = better). Invert sign to match
-            // the convention used by every other fetcher in the
-            // SmartQuery fan-out so reciprocal-rank-fusion sees
-            // comparable scales.
-            let rawScore = -file.rank
-            candidates.append(Search.SmartCandidate(
-                source: sourceName,
-                identifier: "\(file.projectId)/\(file.path)",
-                title: file.filename.isEmpty ? file.path : file.filename,
-                chunk: file.snippet,
-                rawScore: rawScore,
-                kind: nil,
-                metadata: [
-                    "projectId": file.projectId,
-                    "path": file.path,
-                    "rank": String(idx + 1),
-                ]
-            ))
-        }
+        public func fetch(question: String, limit: Int) async throws -> [Search.SmartCandidate] {
+            let query = SampleQuery(
+                text: question,
+                limit: limit,
+                platform: availability?.platform,
+                minVersion: availability?.minVersion
+            )
+            let result = try await service.search(query)
 
-        return candidates
+            var candidates: [Search.SmartCandidate] = []
+
+            // #238 follow-up: include project-level matches too. A natural-
+            // language query like "swiftui list animation" frequently scores
+            // a project's title/description/README without lighting up any
+            // single file's content via FTS5. Emitting only file matches
+            // dropped those projects entirely. Now both flow into RRF;
+            // SmartResult dedupe still collapses obvious duplicates.
+            for (idx, project) in result.projects.enumerated() {
+                // Project rows lack their own bm25 score; rank by ordinal
+                // (sample of arrival from the FTS query, best-first).
+                let pseudoScore = 1.0 / Double(idx + 1)
+                let chunk = project.readme.flatMap { readme -> String? in
+                    let lines = readme.split(separator: "\n", omittingEmptySubsequences: false).prefix(20)
+                    return lines.isEmpty ? nil : lines.joined(separator: "\n")
+                } ?? project.description
+                candidates.append(Search.SmartCandidate(
+                    source: sourceName,
+                    identifier: project.id,
+                    title: project.title,
+                    chunk: chunk,
+                    rawScore: pseudoScore,
+                    kind: "sampleProject",
+                    metadata: [
+                        "projectId": project.id,
+                        "frameworks": project.frameworks.joined(separator: ","),
+                        "rank": String(idx + 1),
+                    ]
+                ))
+            }
+
+            // File-level matches — same shape as before.
+            for (idx, file) in result.files.enumerated() {
+                // Higher rawScore = better. samples.db FTS5 returns its
+                // native BM25 score (lower = better). Invert sign to match
+                // the convention used by every other fetcher in the
+                // SmartQuery fan-out so reciprocal-rank-fusion sees
+                // comparable scales.
+                let rawScore = -file.rank
+                candidates.append(Search.SmartCandidate(
+                    source: sourceName,
+                    identifier: "\(file.projectId)/\(file.path)",
+                    title: file.filename.isEmpty ? file.path : file.filename,
+                    chunk: file.snippet,
+                    rawScore: rawScore,
+                    kind: nil,
+                    metadata: [
+                        "projectId": file.projectId,
+                        "path": file.path,
+                        "rank": String(idx + 1),
+                    ]
+                ))
+            }
+
+            return candidates
+        }
     }
 }

--- a/Packages/Sources/Services/SearchService.swift
+++ b/Packages/Sources/Services/SearchService.swift
@@ -7,103 +7,109 @@ import SharedCore
 
 /// Protocol for search operations across different documentation sources.
 /// Provides a unified interface for CLI commands and MCP tool providers.
-public protocol SearchService: Actor {
-    /// Search for documents matching the query
-    func search(_ query: SearchQuery) async throws -> [Search.Result]
+extension Services {
+    public protocol SearchService: Actor {
+        /// Search for documents matching the query
+        func search(_ query: SearchQuery) async throws -> [Search.Result]
 
-    /// Get document content by URI
-    func read(uri: String, format: Search.Index.DocumentFormat) async throws -> String?
+        /// Get document content by URI
+        func read(uri: String, format: Search.Index.DocumentFormat) async throws -> String?
 
-    /// List all available frameworks with document counts
-    func listFrameworks() async throws -> [String: Int]
+        /// List all available frameworks with document counts
+        func listFrameworks() async throws -> [String: Int]
 
-    /// Get total document count
-    func documentCount() async throws -> Int
+        /// Get total document count
+        func documentCount() async throws -> Int
 
-    /// Disconnect from the underlying database
-    func disconnect() async
+        /// Disconnect from the underlying database
+        func disconnect() async
+    }
 }
 
 // MARK: - Search Query
 
 /// Common search query parameters for all search operations
-public struct SearchQuery: Sendable {
-    public let text: String
-    public let source: String?
-    public let framework: String?
-    public let language: String?
-    public let limit: Int
-    public let includeArchive: Bool
-    public let minimumiOS: String?
-    public let minimumMacOS: String?
-    public let minimumTvOS: String?
-    public let minimumWatchOS: String?
-    public let minimumVisionOS: String?
+extension Services {
+    public struct SearchQuery: Sendable {
+        public let text: String
+        public let source: String?
+        public let framework: String?
+        public let language: String?
+        public let limit: Int
+        public let includeArchive: Bool
+        public let minimumiOS: String?
+        public let minimumMacOS: String?
+        public let minimumTvOS: String?
+        public let minimumWatchOS: String?
+        public let minimumVisionOS: String?
 
-    public init(
-        text: String,
-        source: String? = nil,
-        framework: String? = nil,
-        language: String? = nil,
-        limit: Int = Shared.Constants.Limit.defaultSearchLimit,
-        includeArchive: Bool = false,
-        minimumiOS: String? = nil,
-        minimumMacOS: String? = nil,
-        minimumTvOS: String? = nil,
-        minimumWatchOS: String? = nil,
-        minimumVisionOS: String? = nil
-    ) {
-        self.text = text
-        self.source = source
-        self.framework = framework
-        self.language = language
-        self.limit = min(limit, Shared.Constants.Limit.maxSearchLimit)
-        self.includeArchive = includeArchive
-        self.minimumiOS = minimumiOS
-        self.minimumMacOS = minimumMacOS
-        self.minimumTvOS = minimumTvOS
-        self.minimumWatchOS = minimumWatchOS
-        self.minimumVisionOS = minimumVisionOS
+        public init(
+            text: String,
+            source: String? = nil,
+            framework: String? = nil,
+            language: String? = nil,
+            limit: Int = Shared.Constants.Limit.defaultSearchLimit,
+            includeArchive: Bool = false,
+            minimumiOS: String? = nil,
+            minimumMacOS: String? = nil,
+            minimumTvOS: String? = nil,
+            minimumWatchOS: String? = nil,
+            minimumVisionOS: String? = nil
+        ) {
+            self.text = text
+            self.source = source
+            self.framework = framework
+            self.language = language
+            self.limit = min(limit, Shared.Constants.Limit.maxSearchLimit)
+            self.includeArchive = includeArchive
+            self.minimumiOS = minimumiOS
+            self.minimumMacOS = minimumMacOS
+            self.minimumTvOS = minimumTvOS
+            self.minimumWatchOS = minimumWatchOS
+            self.minimumVisionOS = minimumVisionOS
+        }
     }
 }
 
 // MARK: - Search Filters
 
 /// Active filters for formatting search results
-public struct SearchFilters: Sendable {
-    public let source: String?
-    public let framework: String?
-    public let language: String?
-    public let minimumiOS: String?
-    public let minimumMacOS: String?
-    public let minimumTvOS: String?
-    public let minimumWatchOS: String?
-    public let minimumVisionOS: String?
+extension Services {
+    public struct SearchFilters: Sendable {
+        public let source: String?
+        public let framework: String?
+        public let language: String?
+        public let minimumiOS: String?
+        public let minimumMacOS: String?
+        public let minimumTvOS: String?
+        public let minimumWatchOS: String?
+        public let minimumVisionOS: String?
 
-    public init(
-        source: String? = nil,
-        framework: String? = nil,
-        language: String? = nil,
-        minimumiOS: String? = nil,
-        minimumMacOS: String? = nil,
-        minimumTvOS: String? = nil,
-        minimumWatchOS: String? = nil,
-        minimumVisionOS: String? = nil
-    ) {
-        self.source = source
-        self.framework = framework
-        self.language = language
-        self.minimumiOS = minimumiOS
-        self.minimumMacOS = minimumMacOS
-        self.minimumTvOS = minimumTvOS
-        self.minimumWatchOS = minimumWatchOS
-        self.minimumVisionOS = minimumVisionOS
-    }
+        public init(
+            source: String? = nil,
+            framework: String? = nil,
+            language: String? = nil,
+            minimumiOS: String? = nil,
+            minimumMacOS: String? = nil,
+            minimumTvOS: String? = nil,
+            minimumWatchOS: String? = nil,
+            minimumVisionOS: String? = nil
+        ) {
+            self.source = source
+            self.framework = framework
+            self.language = language
+            self.minimumiOS = minimumiOS
+            self.minimumMacOS = minimumMacOS
+            self.minimumTvOS = minimumTvOS
+            self.minimumWatchOS = minimumWatchOS
+            self.minimumVisionOS = minimumVisionOS
+        }
 
-    /// Check if any filters are active
-    public var hasActiveFilters: Bool {
-        source != nil || framework != nil || language != nil ||
-            minimumiOS != nil || minimumMacOS != nil || minimumTvOS != nil ||
-            minimumWatchOS != nil || minimumVisionOS != nil
+        /// Check if any filters are active
+        public var hasActiveFilters: Bool {
+            source != nil || framework != nil || language != nil ||
+                minimumiOS != nil || minimumMacOS != nil || minimumTvOS != nil ||
+                minimumWatchOS != nil || minimumVisionOS != nil
+        }
     }
 }

--- a/Packages/Sources/Services/ServiceContainer.swift
+++ b/Packages/Sources/Services/ServiceContainer.swift
@@ -9,140 +9,142 @@ import SharedUtils
 
 /// Container for managing service lifecycle and providing access to search services.
 /// Handles database connections and cleanup.
-public actor ServiceContainer {
-    private var docsService: DocsSearchService?
-    private var higService: HIGSearchService?
-    private var sampleService: SampleSearchService?
+extension Services {
+    public actor ServiceContainer {
+        private var docsService: DocsSearchService?
+        private var higService: HIGSearchService?
+        private var sampleService: SampleSearchService?
 
-    private let searchDbPath: URL
-    private let sampleDbPath: URL?
+        private let searchDbPath: URL
+        private let sampleDbPath: URL?
 
-    /// Initialize with database paths
-    public init(
-        searchDbPath: URL = Shared.Constants.defaultSearchDatabase,
-        sampleDbPath: URL? = nil
-    ) {
-        self.searchDbPath = searchDbPath
-        self.sampleDbPath = sampleDbPath
-    }
+        /// Initialize with database paths
+        public init(
+            searchDbPath: URL = Shared.Constants.defaultSearchDatabase,
+            sampleDbPath: URL? = nil
+        ) {
+            self.searchDbPath = searchDbPath
+            self.sampleDbPath = sampleDbPath
+        }
 
-    // MARK: - Service Access
+        // MARK: - Service Access
 
-    /// Get or create the documentation search service
-    public func getDocsService() async throws -> DocsSearchService {
-        if let service = docsService {
+        /// Get or create the documentation search service
+        public func getDocsService() async throws -> DocsSearchService {
+            if let service = docsService {
+                return service
+            }
+
+            let service = try await DocsSearchService(dbPath: searchDbPath)
+            docsService = service
             return service
         }
 
-        let service = try await DocsSearchService(dbPath: searchDbPath)
-        docsService = service
-        return service
-    }
+        /// Get or create the HIG search service
+        public func getHIGService() async throws -> HIGSearchService {
+            if let service = higService {
+                return service
+            }
 
-    /// Get or create the HIG search service
-    public func getHIGService() async throws -> HIGSearchService {
-        if let service = higService {
+            let docsService = try await getDocsService()
+            let service = HIGSearchService(docsService: docsService)
+            higService = service
             return service
         }
 
-        let docsService = try await getDocsService()
-        let service = HIGSearchService(docsService: docsService)
-        higService = service
-        return service
-    }
+        /// Get or create the sample search service
+        public func getSampleService() async throws -> SampleSearchService {
+            if let service = sampleService {
+                return service
+            }
 
-    /// Get or create the sample search service
-    public func getSampleService() async throws -> SampleSearchService {
-        if let service = sampleService {
+            guard let dbPath = sampleDbPath else {
+                throw ToolError.noData("Sample database path not configured")
+            }
+
+            let service = try await SampleSearchService(dbPath: dbPath)
+            sampleService = service
             return service
         }
 
-        guard let dbPath = sampleDbPath else {
-            throw ToolError.noData("Sample database path not configured")
-        }
+        // MARK: - Lifecycle
 
-        let service = try await SampleSearchService(dbPath: dbPath)
-        sampleService = service
-        return service
-    }
+        /// Disconnect all services
+        public func disconnectAll() async {
+            if let docs = docsService {
+                await docs.disconnect()
+                docsService = nil
+            }
 
-    // MARK: - Lifecycle
+            if let hig = higService {
+                await hig.disconnect()
+                higService = nil
+            }
 
-    /// Disconnect all services
-    public func disconnectAll() async {
-        if let docs = docsService {
-            await docs.disconnect()
-            docsService = nil
-        }
-
-        if let hig = higService {
-            await hig.disconnect()
-            higService = nil
-        }
-
-        if let sample = sampleService {
-            await sample.disconnect()
-            sampleService = nil
-        }
-    }
-
-    // MARK: - Convenience Factory Methods
-
-    /// Execute an operation with a docs service, handling lifecycle
-    public static func withDocsService<T>(
-        dbPath: String? = nil,
-        operation: (DocsSearchService) async throws -> T
-    ) async throws -> T {
-        let resolvedPath = Shared.Utils.PathResolver.searchDatabase(dbPath)
-
-        guard Shared.Utils.PathResolver.exists(resolvedPath) else {
-            throw ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
-        }
-
-        let service = try await DocsSearchService(dbPath: resolvedPath)
-        defer {
-            Task {
-                await service.disconnect()
+            if let sample = sampleService {
+                await sample.disconnect()
+                sampleService = nil
             }
         }
 
-        return try await operation(service)
-    }
+        // MARK: - Convenience Factory Methods
 
-    /// Execute an operation with a HIG service, handling lifecycle
-    public static func withHIGService<T>(
-        dbPath: String? = nil,
-        operation: (HIGSearchService) async throws -> T
-    ) async throws -> T {
-        let resolvedPath = Shared.Utils.PathResolver.searchDatabase(dbPath)
+        /// Execute an operation with a docs service, handling lifecycle
+        public static func withDocsService<T>(
+            dbPath: String? = nil,
+            operation: (DocsSearchService) async throws -> T
+        ) async throws -> T {
+            let resolvedPath = Shared.Utils.PathResolver.searchDatabase(dbPath)
 
-        guard Shared.Utils.PathResolver.exists(resolvedPath) else {
-            throw ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
-        }
-
-        let index = try await Search.Index(dbPath: resolvedPath)
-        let service = HIGSearchService(index: index)
-        defer {
-            Task {
-                await service.disconnect()
+            guard Shared.Utils.PathResolver.exists(resolvedPath) else {
+                throw ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
             }
+
+            let service = try await DocsSearchService(dbPath: resolvedPath)
+            defer {
+                Task {
+                    await service.disconnect()
+                }
+            }
+
+            return try await operation(service)
         }
 
-        return try await operation(service)
-    }
+        /// Execute an operation with a HIG service, handling lifecycle
+        public static func withHIGService<T>(
+            dbPath: String? = nil,
+            operation: (HIGSearchService) async throws -> T
+        ) async throws -> T {
+            let resolvedPath = Shared.Utils.PathResolver.searchDatabase(dbPath)
 
-    /// Execute an operation with a sample service, handling lifecycle
-    public static func withSampleService<T: Sendable>(
-        dbPath: URL,
-        operation: (SampleSearchService) async throws -> T
-    ) async throws -> T {
-        guard Shared.Utils.PathResolver.exists(dbPath) else {
-            throw ToolError.noData("Sample database not found at \(dbPath.path). Run 'cupertino save --samples' to build the index.")
+            guard Shared.Utils.PathResolver.exists(resolvedPath) else {
+                throw ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
+            }
+
+            let index = try await Search.Index(dbPath: resolvedPath)
+            let service = HIGSearchService(index: index)
+            defer {
+                Task {
+                    await service.disconnect()
+                }
+            }
+
+            return try await operation(service)
         }
 
-        let service = try await SampleSearchService(dbPath: dbPath)
-        let result = try await operation(service)
-        await service.disconnect()
-        return result
+        /// Execute an operation with a sample service, handling lifecycle
+        public static func withSampleService<T: Sendable>(
+            dbPath: URL,
+            operation: (SampleSearchService) async throws -> T
+        ) async throws -> T {
+            guard Shared.Utils.PathResolver.exists(dbPath) else {
+                throw ToolError.noData("Sample database not found at \(dbPath.path). Run 'cupertino save --samples' to build the index.")
+            }
+
+            let service = try await SampleSearchService(dbPath: dbPath)
+            let result = try await operation(service)
+            await service.disconnect()
+            return result
+        }
     }
 }

--- a/Packages/Sources/Services/Services.swift
+++ b/Packages/Sources/Services/Services.swift
@@ -2,24 +2,37 @@
 
 //
 // The Services module provides a unified service layer for search operations.
-// It abstracts database access and result formatting, allowing both CLI commands
-// and MCP tool providers to share the same business logic.
+// It abstracts database access and result formatting, allowing both CLI
+// commands and MCP tool providers to share the same business logic.
 //
 // Usage:
 //
 // ```swift
 // // Using ServiceContainer for managed lifecycle
-// try await ServiceContainer.withDocsService { service in
+// try await Services.ServiceContainer.withDocsService { service in
 //     let results = try await service.search(text: "View")
-//     let formatter = MarkdownSearchResultFormatter(query: "View")
+//     let formatter = Services.MarkdownSearchResultFormatter(query: "View")
 //     print(formatter.format(results))
 // }
 //
 // // Or create services directly
-// let service = try await DocsSearchService(dbPath: dbPath)
+// let service = try await Services.DocsSearchService(dbPath: dbPath)
 // defer { Task { await service.disconnect() } }
 //
-// let results = try await service.search(SearchQuery(text: "SwiftUI"))
+// let results = try await service.search(Services.SearchQuery(text: "SwiftUI"))
 // ```
 
 @_exported import Foundation
+
+// MARK: - Services Namespace
+
+/// Namespace for the service layer: a `ServiceContainer` that owns service
+/// lifecycle, the `SearchService` protocol + `SearchQuery` / `SearchFilters`
+/// inputs, and the concrete service actors that live in `Services/ReadCommands/`
+/// (`DocsSearchService`, `HIGSearchService`, `SampleSearchService`,
+/// `UnifiedSearchService`, `TeaserService`, `ReadService`).
+///
+/// Result formatters in `Services/Formatters/` also extend this same root
+/// (`Services.MarkdownSearchResultFormatter`, `Services.JSONSearchResultFormatter`,
+/// `Services.TextSearchResultFormatter`, etc.).
+public enum Services {}

--- a/Packages/Tests/CleanupTests/SampleCodeCleanerTests.swift
+++ b/Packages/Tests/CleanupTests/SampleCodeCleanerTests.swift
@@ -6,7 +6,7 @@ import SharedModels
 import Testing
 import TestSupport
 
-// MARK: - SampleCodeCleaner Tests
+// MARK: - Cleanup.SampleCodeCleaner Tests
 
 @Test("CleanupProgress percentage calculation")
 func cleanupProgressPercentage() {

--- a/Packages/Tests/ServicesTests/ServicesTests.swift
+++ b/Packages/Tests/ServicesTests/ServicesTests.swift
@@ -8,11 +8,11 @@ import Testing
 
 @Suite("Services Module Tests")
 struct ServicesTests {
-    // MARK: - SearchQuery Tests
+    // MARK: - Services.SearchQuery Tests
 
-    @Test("SearchQuery initializes with defaults")
+    @Test("Services.SearchQuery initializes with defaults")
     func searchQueryDefaults() {
-        let query = SearchQuery(text: "View")
+        let query = Services.SearchQuery(text: "View")
 
         #expect(query.text == "View")
         #expect(query.source == nil)
@@ -22,16 +22,16 @@ struct ServicesTests {
         #expect(query.includeArchive == false)
     }
 
-    @Test("SearchQuery clamps limit to max")
+    @Test("Services.SearchQuery clamps limit to max")
     func searchQueryClampsLimit() {
-        let query = SearchQuery(text: "View", limit: 1000)
+        let query = Services.SearchQuery(text: "View", limit: 1000)
 
         #expect(query.limit == Shared.Constants.Limit.maxSearchLimit)
     }
 
-    @Test("SearchQuery accepts all parameters")
+    @Test("Services.SearchQuery accepts all parameters")
     func searchQueryAllParams() {
-        let query = SearchQuery(
+        let query = Services.SearchQuery(
             text: "Button",
             source: "apple-docs",
             framework: "swiftui",
@@ -48,20 +48,20 @@ struct ServicesTests {
         #expect(query.includeArchive == true)
     }
 
-    // MARK: - SearchFilters Tests
+    // MARK: - Services.SearchFilters Tests
 
-    @Test("SearchFilters detects active filters")
+    @Test("Services.SearchFilters detects active filters")
     func searchFiltersActiveDetection() {
-        let noFilters = SearchFilters()
+        let noFilters = Services.SearchFilters()
         #expect(noFilters.hasActiveFilters == false)
 
-        let withSource = SearchFilters(source: "apple-docs")
+        let withSource = Services.SearchFilters(source: "apple-docs")
         #expect(withSource.hasActiveFilters == true)
 
-        let withFramework = SearchFilters(framework: "swiftui")
+        let withFramework = Services.SearchFilters(framework: "swiftui")
         #expect(withFramework.hasActiveFilters == true)
 
-        let withLanguage = SearchFilters(language: "swift")
+        let withLanguage = Services.SearchFilters(language: "swift")
         #expect(withLanguage.hasActiveFilters == true)
     }
 
@@ -143,9 +143,9 @@ struct FormatConfigTests {
     }
 }
 
-// MARK: - SampleCandidateFetcher (#230)
+// MARK: - Services.SampleCandidateFetcher (#230)
 
-@Suite("SampleCandidateFetcher (#230)")
+@Suite("Services.SampleCandidateFetcher (#230)")
 struct SampleCandidateFetcherTests {
     @Test("sourceName matches the canonical samples prefix")
     func sourceNameIsSamples() async throws {
@@ -156,7 +156,7 @@ struct SampleCandidateFetcherTests {
             .appendingPathComponent("samples-fetcher-test-\(UUID().uuidString).db")
         defer { try? FileManager.default.removeItem(at: tempDB) }
 
-        let service = try await Services.SampleSearchService(dbPath: tempDB)
+        let service = try await SampleSearchService(dbPath: tempDB)
         defer { Task { await service.disconnect() } }
 
         let fetcher = Services.SampleCandidateFetcher(service: service)
@@ -169,7 +169,7 @@ struct SampleCandidateFetcherTests {
             .appendingPathComponent("samples-fetcher-test-\(UUID().uuidString).db")
         defer { try? FileManager.default.removeItem(at: tempDB) }
 
-        let service = try await Services.SampleSearchService(dbPath: tempDB)
+        let service = try await SampleSearchService(dbPath: tempDB)
         defer { Task { await service.disconnect() } }
 
         let fetcher = Services.SampleCandidateFetcher(service: service)


### PR DESCRIPTION
Two small modules that were still using file-scope types after the earlier namespacing passes. Each module gets a `public enum <Name> {}` namespace declaration, and every file-scope public type moves inside.

## Cleanup

| Before | After |
|---|---|
| `SampleCodeCleaner` | `Cleanup.SampleCodeCleaner` |

- New `Sources/Cleanup/Cleanup.swift` declares the namespace enum.
- `SampleCodeCleaner.swift` wraps its actor in `extension Cleanup { ... }`.
- **CleanupModule typealias** at `Sources/CLI/CleanupModuleAlias.swift` (same pattern as `SearchModule` in #352): `Command.Cleanup` (the subcommand from #352) shadows the SPM target inside any `extension Command` scope. The module-internal typealias `CleanupModule = Cleanup` lets CLI call sites write `CleanupModule.SampleCodeCleaner`.

## Services

| Before | After |
|---|---|
| `SampleCandidateFetcher` | `Services.SampleCandidateFetcher` |
| `SearchService` (protocol) | `Services.SearchService` |
| `SearchQuery` | `Services.SearchQuery` |
| `SearchFilters` | `Services.SearchFilters` |
| `ServiceContainer` | `Services.ServiceContainer` |

- `Services.swift` now declares the namespace enum alongside the module docstring.
- The three root-level files (`SampleCandidateFetcher.swift`, `SearchService.swift`, `ServiceContainer.swift`) wrap their public types under `extension Services { ... }`.
- Internal files in `Services/Formatters/` and `Services/ReadCommands/` that reference the wrapped types (e.g. `DocsSearchService: SearchService` conformance) get their bare references qualified to `Services.SearchService`, `Services.SearchQuery`, etc.

## Scope deliberately NOT in this PR

`Services/Formatters/` (~30 types) and `Services/ReadCommands/` (~7 types) stay at file scope. They're still in the Services SPM target but aren't sub-namespaced as `Services.Formatters.*` / `Services.ReadCommands.*` — that's a separate slice because:
- The Formatters folder has multi-axis names (`MarkdownSearchResultFormatter`, `JSONSearchResultFormatter`, `HIGTextFormatter`, …) — deciding whether to drop the `Formatter` / `ResultFormatter` suffix once they're inside `Services.Formatters` is a real naming call.
- ReadCommands has actors with `Service` suffix — same question.

Defer for a focused follow-up.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Previous: #348 Foundation, #350 MCP, #351 Shared, #352 Command, #353 CoreProtocols.