### PR TITLE
refactor(MCP): nest Client, Support, SharedTools sub-targets under MCP namespace

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -141,7 +141,7 @@ let targets: [Target] = {
         path: "Sources/Shared/Configuration"
     )
 
-    // ---------- MCPSharedTools (v1.1 refactor 1.1: extracts ArgumentExtractor + MCP-protocol-output constants from Shared) ----------
+    // ---------- MCPSharedTools (v1.1 refactor 1.1: extracts MCP.SharedTools.ArgumentExtractor + MCP-protocol-output constants from Shared) ----------
     let mcpSharedToolsTarget = Target.target(
         name: "MCPSharedTools",
         dependencies: ["MCP", "SharedCore", "SharedConstants"],

--- a/Packages/Sources/CLI/Commands/DoctorCommand.swift
+++ b/Packages/Sources/CLI/Commands/DoctorCommand.swift
@@ -399,7 +399,7 @@ extension Command {
 
         private func checkResourceProviders() -> Bool {
             Logging.Log.output("🔧 Providers")
-            Logging.Log.output("   ✓ DocsResourceProvider: available")
+            Logging.Log.output("   ✓ MCP.Support.DocsResourceProvider: available")
             Logging.Log.output("   ✓ SearchToolProvider: available")
             Logging.Log.output("")
             return true

--- a/Packages/Sources/CLI/Commands/ServeCommand.swift
+++ b/Packages/Sources/CLI/Commands/ServeCommand.swift
@@ -124,7 +124,7 @@ extension Command {
             let searchIndex: SearchModule.Index? = await loadSearchIndex(searchDBURL: searchDBURL)
 
             // Register resource provider with optional search index
-            let resourceProvider = DocsResourceProvider(
+            let resourceProvider = MCP.Support.DocsResourceProvider(
                 configuration: config,
                 evolutionDirectory: evolutionURL,
                 searchIndex: searchIndex

--- a/Packages/Sources/Core/CrawlerState.swift
+++ b/Packages/Sources/Core/CrawlerState.swift
@@ -28,7 +28,7 @@ public actor CrawlerState {
                     // Cross-machine portability: PageMetadata.filePath is an
                     // absolute string captured on the writing host. After rsync
                     // to a machine with a different home dir, those strings
-                    // point at nothing — SearchIndexBuilder + DocsResourceProvider
+                    // point at nothing — SearchIndexBuilder + MCP.Support.DocsResourceProvider
                     // would silently fail to read each page, and our own
                     // validateMetadata would have already wiped crawlState.
                     // Rebase on load so all downstream consumers see paths

--- a/Packages/Sources/MCP/Client/MCPClient+Cupertino.swift
+++ b/Packages/Sources/MCP/Client/MCPClient+Cupertino.swift
@@ -3,12 +3,12 @@ import MCP
 
 // MARK: - Cupertino Convenience Methods
 
-extension MCPClient {
+extension MCP.Client {
     /// Create an MCP client configured for the cupertino server
     /// - Parameter executablePath: Path to cupertino executable (defaults to searching in common locations)
-    public static func cupertino(executablePath: String? = nil) -> MCPClient {
+    public static func cupertino(executablePath: String? = nil) -> MCP.Client {
         let path = executablePath ?? findCupertinoExecutable()
-        return MCPClient(serverCommand: path, serverArguments: ["serve"])
+        return MCP.Client(serverCommand: path, serverArguments: ["serve"])
     }
 
     /// Search Apple documentation

--- a/Packages/Sources/MCP/Client/MCPClient.swift
+++ b/Packages/Sources/MCP/Client/MCPClient.swift
@@ -3,311 +3,315 @@ import MCP
 
 // MARK: - MCP Client
 
-/// A reusable MCP client that connects to an MCP server via stdio.
-/// Can be used by CLI tools, SwiftUI apps, or any other Swift application.
-public actor MCPClient {
-    private var process: Process?
-    private var stdin: FileHandle?
-    private var stdout: FileHandle?
-    private var messageID = 0
-    private var responseBuffer = ""
-    private var pendingResponses: [CheckedContinuation<String, Error>] = []
+extension MCP {
+    /// A reusable MCP client that connects to an MCP server via stdio.
+    /// Can be used by CLI tools, SwiftUI apps, or any other Swift application.
+    public actor Client {
+        private var process: Process?
+        private var stdin: FileHandle?
+        private var stdout: FileHandle?
+        private var messageID = 0
+        private var responseBuffer = ""
+        private var pendingResponses: [CheckedContinuation<String, Error>] = []
 
-    private let serverCommand: [String]
-    private let serverArguments: [String]
+        private let serverCommand: [String]
+        private let serverArguments: [String]
 
-    /// Server information after initialization
-    public private(set) var serverInfo: MCP.Core.Protocols.Implementation?
-    public private(set) var serverCapabilities: MCP.Core.Protocols.ServerCapabilities?
-    public private(set) var protocolVersion: String?
+        /// Server information after initialization
+        public private(set) var serverInfo: MCP.Core.Protocols.Implementation?
+        public private(set) var serverCapabilities: MCP.Core.Protocols.ServerCapabilities?
+        public private(set) var protocolVersion: String?
 
-    /// Whether the client is connected to a server
-    public var isConnected: Bool {
-        process?.isRunning ?? false
-    }
-
-    // MARK: - Initialization
-
-    /// Create an MCP client that will connect to a server via stdio
-    /// - Parameters:
-    ///   - serverCommand: The executable to run (e.g., "cupertino" or "npx")
-    ///   - serverArguments: Arguments to pass (e.g., ["serve"] or ["-y", "@modelcontextprotocol/server-memory"])
-    public init(serverCommand: String, serverArguments: [String] = []) {
-        self.serverCommand = [serverCommand]
-        self.serverArguments = serverArguments
-    }
-
-    /// Create an MCP client with a full command array
-    /// - Parameter command: Full command array (e.g., ["npx", "-y", "@modelcontextprotocol/server-memory"])
-    public init(command: [String]) {
-        guard !command.isEmpty else {
-            serverCommand = []
-            serverArguments = []
-            return
-        }
-        serverCommand = [command[0]]
-        serverArguments = Array(command.dropFirst())
-    }
-
-    // MARK: - Connection Management
-
-    /// Start the MCP server and establish connection
-    public func connect() async throws {
-        guard !serverCommand.isEmpty else {
-            throw MCPClientError.invalidCommand
+        /// Whether the client is connected to a server
+        public var isConnected: Bool {
+            process?.isRunning ?? false
         }
 
-        process = Process()
+        // MARK: - Initialization
 
-        // Set up the executable
-        let executable = serverCommand[0]
-        if executable.hasPrefix("/") {
-            process?.executableURL = URL(fileURLWithPath: executable)
-            process?.arguments = serverArguments
-        } else {
-            // Use env to find the executable in PATH
-            process?.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process?.arguments = [executable] + serverArguments
+        /// Create an MCP client that will connect to a server via stdio
+        /// - Parameters:
+        ///   - serverCommand: The executable to run (e.g., "cupertino" or "npx")
+        ///   - serverArguments: Arguments to pass (e.g., ["serve"] or ["-y", "@modelcontextprotocol/server-memory"])
+        public init(serverCommand: String, serverArguments: [String] = []) {
+            self.serverCommand = [serverCommand]
+            self.serverArguments = serverArguments
         }
 
-        // Set up pipes for stdio
-        let stdinPipe = Pipe()
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
+        /// Create an MCP client with a full command array
+        /// - Parameter command: Full command array (e.g., ["npx", "-y", "@modelcontextprotocol/server-memory"])
+        public init(command: [String]) {
+            guard !command.isEmpty else {
+                serverCommand = []
+                serverArguments = []
+                return
+            }
+            serverCommand = [command[0]]
+            serverArguments = Array(command.dropFirst())
+        }
 
-        process?.standardInput = stdinPipe
-        process?.standardOutput = stdoutPipe
-        process?.standardError = stderrPipe
+        // MARK: - Connection Management
 
-        stdin = stdinPipe.fileHandleForWriting
-        stdout = stdoutPipe.fileHandleForReading
+        /// Start the MCP server and establish connection
+        public func connect() async throws {
+            guard !serverCommand.isEmpty else {
+                throw MCP.ClientError.invalidCommand
+            }
 
-        // Set up readability handler for stdout
-        stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            guard !data.isEmpty else { return }
-            if let text = String(data: data, encoding: .utf8) {
-                Task {
-                    await self?.handleIncomingData(text)
+            process = Process()
+
+            // Set up the executable
+            let executable = serverCommand[0]
+            if executable.hasPrefix("/") {
+                process?.executableURL = URL(fileURLWithPath: executable)
+                process?.arguments = serverArguments
+            } else {
+                // Use env to find the executable in PATH
+                process?.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+                process?.arguments = [executable] + serverArguments
+            }
+
+            // Set up pipes for stdio
+            let stdinPipe = Pipe()
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+
+            process?.standardInput = stdinPipe
+            process?.standardOutput = stdoutPipe
+            process?.standardError = stderrPipe
+
+            stdin = stdinPipe.fileHandleForWriting
+            stdout = stdoutPipe.fileHandleForReading
+
+            // Set up readability handler for stdout
+            stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+                let data = handle.availableData
+                guard !data.isEmpty else { return }
+                if let text = String(data: data, encoding: .utf8) {
+                    Task {
+                        await self?.handleIncomingData(text)
+                    }
                 }
             }
+
+            try process?.run()
+
+            // Give server time to start
+            try await Task.sleep(for: .seconds(0.5))
+
+            // Initialize the MCP connection
+            try await initialize()
         }
 
-        try process?.run()
+        /// Disconnect from the server
+        public func disconnect() {
+            stdin?.closeFile()
+            stdout?.closeFile()
+            process?.terminate()
+            process?.waitUntilExit()
 
-        // Give server time to start
-        try await Task.sleep(for: .seconds(0.5))
+            process = nil
+            stdin = nil
+            stdout = nil
+            serverInfo = nil
+            serverCapabilities = nil
+            protocolVersion = nil
+        }
 
-        // Initialize the MCP connection
-        try await initialize()
-    }
+        // MARK: - MCP Protocol Methods
 
-    /// Disconnect from the server
-    public func disconnect() {
-        stdin?.closeFile()
-        stdout?.closeFile()
-        process?.terminate()
-        process?.waitUntilExit()
+        /// Initialize the MCP connection
+        private func initialize() async throws {
+            let versions = preferredProtocolVersions()
+            var lastError: Error?
 
-        process = nil
-        stdin = nil
-        stdout = nil
-        serverInfo = nil
-        serverCapabilities = nil
-        protocolVersion = nil
-    }
+            for version in versions {
+                let request = MCP.Core.Protocols.Request(
+                    jsonrpc: "2.0",
+                    id: .int(nextMessageID()),
+                    method: "initialize",
+                    params: MCP.Core.Protocols.InitializeParams(
+                        protocolVersion: version,
+                        capabilities: MCP.Core.Protocols.ClientCapabilities(
+                            experimental: nil,
+                            sampling: nil,
+                            roots: MCP.Core.Protocols.RootsCapability(listChanged: true)
+                        ),
+                        clientInfo: MCP.Core.Protocols.Implementation(name: "MCPClient", version: "1.0.0")
+                    )
+                )
 
-    // MARK: - MCP Protocol Methods
+                do {
+                    let response: MCP.Core.Protocols.InitializeResult = try await sendRequest(request)
+                    serverInfo = response.serverInfo
+                    serverCapabilities = response.capabilities
+                    protocolVersion = response.protocolVersion
+                    return
+                } catch let error as MCP.ClientError {
+                    lastError = error
+                    if shouldRetryInitialize(error: error) {
+                        continue
+                    }
+                    throw error
+                } catch {
+                    throw error
+                }
+            }
 
-    /// Initialize the MCP connection
-    private func initialize() async throws {
-        let versions = preferredProtocolVersions()
-        var lastError: Error?
+            throw lastError ?? MCP.ClientError.serverError("Unsupported protocol version")
+        }
 
-        for version in versions {
+        private func preferredProtocolVersions() -> [String] {
+            var ordered = [MCPProtocolVersion]
+            for version in MCPProtocolVersionsSupported where !ordered.contains(version) {
+                ordered.append(version)
+            }
+            return ordered
+        }
+
+        private func shouldRetryInitialize(error: MCP.ClientError) -> Bool {
+            guard case let .serverError(message) = error else {
+                return false
+            }
+
+            let lower = message.lowercased()
+            return lower.contains("protocol") || lower.contains("version")
+        }
+
+        /// List available tools from the server
+        public func listTools() async throws -> [MCP.Core.Protocols.Tool] {
             let request = MCP.Core.Protocols.Request(
                 jsonrpc: "2.0",
                 id: .int(nextMessageID()),
-                method: "initialize",
-                params: MCP.Core.Protocols.InitializeParams(
-                    protocolVersion: version,
-                    capabilities: MCP.Core.Protocols.ClientCapabilities(
-                        experimental: nil,
-                        sampling: nil,
-                        roots: MCP.Core.Protocols.RootsCapability(listChanged: true)
-                    ),
-                    clientInfo: MCP.Core.Protocols.Implementation(name: "MCPClient", version: "1.0.0")
-                )
+                method: "tools/list",
+                params: EmptyParams()
             )
 
-            do {
-                let response: MCP.Core.Protocols.InitializeResult = try await sendRequest(request)
-                serverInfo = response.serverInfo
-                serverCapabilities = response.capabilities
-                protocolVersion = response.protocolVersion
-                return
-            } catch let error as MCPClientError {
-                lastError = error
-                if shouldRetryInitialize(error: error) {
+            let response: MCP.Core.Protocols.ListToolsResult = try await sendRequest(request)
+            return response.tools
+        }
+
+        /// Call a tool on the server
+        /// - Parameters:
+        ///   - name: Tool name
+        ///   - arguments: Tool arguments as a dictionary
+        /// - Returns: Tool call result with content blocks
+        public func callTool(name: String, arguments: [String: MCP.Core.Protocols.AnyCodable]? = nil) async throws -> MCP.Core.Protocols.CallToolResult {
+            let request = MCP.Core.Protocols.Request(
+                jsonrpc: "2.0",
+                id: .int(nextMessageID()),
+                method: "tools/call",
+                params: MCP.Core.Protocols.CallToolParams(name: name, arguments: arguments)
+            )
+
+            return try await sendRequest(request)
+        }
+
+        /// List available resources from the server
+        public func listResources() async throws -> [MCP.Core.Protocols.Resource] {
+            let request = MCP.Core.Protocols.Request(
+                jsonrpc: "2.0",
+                id: .int(nextMessageID()),
+                method: "resources/list",
+                params: EmptyParams()
+            )
+
+            let response: MCP.Core.Protocols.ListResourcesResult = try await sendRequest(request)
+            return response.resources
+        }
+
+        /// Read a resource from the server
+        /// - Parameter uri: Resource URI
+        /// - Returns: Resource contents
+        public func readResource(uri: String) async throws -> MCP.Core.Protocols.ReadResourceResult {
+            let request = MCP.Core.Protocols.Request(
+                jsonrpc: "2.0",
+                id: .int(nextMessageID()),
+                method: "resources/read",
+                params: MCP.Core.Protocols.ReadResourceParams(uri: uri)
+            )
+
+            return try await sendRequest(request)
+        }
+
+        // MARK: - Low-level Communication
+
+        private func sendRequest<R: Decodable>(_ request: MCP.Core.Protocols.Request<some Codable & Sendable>) async throws -> R {
+            guard let stdin, let stdout else {
+                throw MCP.ClientError.notConnected
+            }
+
+            // Encode compact JSON for the wire
+            let wireEncoder = JSONEncoder()
+            wireEncoder.outputFormatting = [.sortedKeys]
+            let wireData = try wireEncoder.encode(request)
+
+            guard var wireString = String(data: wireData, encoding: .utf8) else {
+                throw MCP.ClientError.encodingFailed
+            }
+
+            // MCP stdio: messages are newline-delimited
+            if wireString.contains("\n") {
+                wireString = wireString.replacingOccurrences(of: "\n", with: "")
+            }
+
+            let message = wireString + "\n"
+            let messageData = Data(message.utf8)
+
+            // Write the message
+            stdin.write(messageData)
+
+            // Wait for response
+            let responseLine = try await readLine(from: stdout)
+
+            // Decode response
+            let responseData = Data(responseLine.utf8)
+
+            // Check for error response
+            if let errorResponse = try? JSONDecoder().decode(MCP.Core.Protocols.JSONRPCError.self, from: responseData) {
+                throw MCP.ClientError.serverError(errorResponse.error.message)
+            }
+
+            // Decode success response
+            let response = try JSONDecoder().decode(MCP.Core.Protocols.JSONRPCResponse.self, from: responseData)
+
+            // Convert result to specific type
+            let resultData = try JSONEncoder().encode(response.result)
+            return try JSONDecoder().decode(R.self, from: resultData)
+        }
+
+        private func handleIncomingData(_ text: String) {
+            responseBuffer += text
+
+            while let newlineRange = responseBuffer.range(of: "\n") {
+                let line = String(responseBuffer[..<newlineRange.lowerBound])
+                responseBuffer.removeSubrange(...newlineRange.lowerBound)
+
+                if line.trimmingCharacters(in: .whitespaces).isEmpty {
                     continue
                 }
-                throw error
-            } catch {
-                throw error
+
+                if !pendingResponses.isEmpty {
+                    let continuation = pendingResponses.removeFirst()
+                    continuation.resume(returning: line)
+                }
             }
         }
 
-        throw lastError ?? MCPClientError.serverError("Unsupported protocol version")
-    }
-
-    private func preferredProtocolVersions() -> [String] {
-        var ordered = [MCPProtocolVersion]
-        for version in MCPProtocolVersionsSupported where !ordered.contains(version) {
-            ordered.append(version)
-        }
-        return ordered
-    }
-
-    private func shouldRetryInitialize(error: MCPClientError) -> Bool {
-        guard case let .serverError(message) = error else {
-            return false
-        }
-
-        let lower = message.lowercased()
-        return lower.contains("protocol") || lower.contains("version")
-    }
-
-    /// List available tools from the server
-    public func listTools() async throws -> [MCP.Core.Protocols.Tool] {
-        let request = MCP.Core.Protocols.Request(
-            jsonrpc: "2.0",
-            id: .int(nextMessageID()),
-            method: "tools/list",
-            params: EmptyParams()
-        )
-
-        let response: MCP.Core.Protocols.ListToolsResult = try await sendRequest(request)
-        return response.tools
-    }
-
-    /// Call a tool on the server
-    /// - Parameters:
-    ///   - name: Tool name
-    ///   - arguments: Tool arguments as a dictionary
-    /// - Returns: Tool call result with content blocks
-    public func callTool(name: String, arguments: [String: MCP.Core.Protocols.AnyCodable]? = nil) async throws -> MCP.Core.Protocols.CallToolResult {
-        let request = MCP.Core.Protocols.Request(
-            jsonrpc: "2.0",
-            id: .int(nextMessageID()),
-            method: "tools/call",
-            params: MCP.Core.Protocols.CallToolParams(name: name, arguments: arguments)
-        )
-
-        return try await sendRequest(request)
-    }
-
-    /// List available resources from the server
-    public func listResources() async throws -> [MCP.Core.Protocols.Resource] {
-        let request = MCP.Core.Protocols.Request(
-            jsonrpc: "2.0",
-            id: .int(nextMessageID()),
-            method: "resources/list",
-            params: EmptyParams()
-        )
-
-        let response: MCP.Core.Protocols.ListResourcesResult = try await sendRequest(request)
-        return response.resources
-    }
-
-    /// Read a resource from the server
-    /// - Parameter uri: Resource URI
-    /// - Returns: Resource contents
-    public func readResource(uri: String) async throws -> MCP.Core.Protocols.ReadResourceResult {
-        let request = MCP.Core.Protocols.Request(
-            jsonrpc: "2.0",
-            id: .int(nextMessageID()),
-            method: "resources/read",
-            params: MCP.Core.Protocols.ReadResourceParams(uri: uri)
-        )
-
-        return try await sendRequest(request)
-    }
-
-    // MARK: - Low-level Communication
-
-    private func sendRequest<R: Decodable>(_ request: MCP.Core.Protocols.Request<some Codable & Sendable>) async throws -> R {
-        guard let stdin, let stdout else {
-            throw MCPClientError.notConnected
-        }
-
-        // Encode compact JSON for the wire
-        let wireEncoder = JSONEncoder()
-        wireEncoder.outputFormatting = [.sortedKeys]
-        let wireData = try wireEncoder.encode(request)
-
-        guard var wireString = String(data: wireData, encoding: .utf8) else {
-            throw MCPClientError.encodingFailed
-        }
-
-        // MCP stdio: messages are newline-delimited
-        if wireString.contains("\n") {
-            wireString = wireString.replacingOccurrences(of: "\n", with: "")
-        }
-
-        let message = wireString + "\n"
-        let messageData = Data(message.utf8)
-
-        // Write the message
-        stdin.write(messageData)
-
-        // Wait for response
-        let responseLine = try await readLine(from: stdout)
-
-        // Decode response
-        let responseData = Data(responseLine.utf8)
-
-        // Check for error response
-        if let errorResponse = try? JSONDecoder().decode(MCP.Core.Protocols.JSONRPCError.self, from: responseData) {
-            throw MCPClientError.serverError(errorResponse.error.message)
-        }
-
-        // Decode success response
-        let response = try JSONDecoder().decode(MCP.Core.Protocols.JSONRPCResponse.self, from: responseData)
-
-        // Convert result to specific type
-        let resultData = try JSONEncoder().encode(response.result)
-        return try JSONDecoder().decode(R.self, from: resultData)
-    }
-
-    private func handleIncomingData(_ text: String) {
-        responseBuffer += text
-
-        while let newlineRange = responseBuffer.range(of: "\n") {
-            let line = String(responseBuffer[..<newlineRange.lowerBound])
-            responseBuffer.removeSubrange(...newlineRange.lowerBound)
-
-            if line.trimmingCharacters(in: .whitespaces).isEmpty {
-                continue
-            }
-
-            if !pendingResponses.isEmpty {
-                let continuation = pendingResponses.removeFirst()
-                continuation.resume(returning: line)
+        private func readLine(from fileHandle: FileHandle) async throws -> String {
+            try await withCheckedThrowingContinuation { continuation in
+                pendingResponses.append(continuation)
             }
         }
-    }
 
-    private func readLine(from fileHandle: FileHandle) async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
-            pendingResponses.append(continuation)
+        private func nextMessageID() -> Int {
+            messageID += 1
+            return messageID
         }
-    }
-
-    private func nextMessageID() -> Int {
-        messageID += 1
-        return messageID
     }
 }
+
+// closes extension MCP (Client)
 
 // MARK: - Helper Types
 
@@ -315,28 +319,30 @@ struct EmptyParams: Codable {}
 
 // MARK: - Errors
 
-public enum MCPClientError: Error, LocalizedError {
-    case invalidCommand
-    case notConnected
-    case encodingFailed
-    case decodingFailed
-    case noResponse
-    case serverError(String)
+extension MCP {
+    public enum ClientError: Error, LocalizedError {
+        case invalidCommand
+        case notConnected
+        case encodingFailed
+        case decodingFailed
+        case noResponse
+        case serverError(String)
 
-    public var errorDescription: String? {
-        switch self {
-        case .invalidCommand:
-            return "Invalid server command"
-        case .notConnected:
-            return "Not connected to MCP server"
-        case .encodingFailed:
-            return "Failed to encode request"
-        case .decodingFailed:
-            return "Failed to decode response"
-        case .noResponse:
-            return "No response from server"
-        case .serverError(let message):
-            return "Server error: \(message)"
+        public var errorDescription: String? {
+            switch self {
+            case .invalidCommand:
+                return "Invalid server command"
+            case .notConnected:
+                return "Not connected to MCP server"
+            case .encodingFailed:
+                return "Failed to encode request"
+            case .decodingFailed:
+                return "Failed to decode response"
+            case .noResponse:
+                return "No response from server"
+            case .serverError(let message):
+                return "Server error: \(message)"
+            }
         }
     }
 }

--- a/Packages/Sources/MCP/SharedTools/ArgumentExtractor.swift
+++ b/Packages/Sources/MCP/SharedTools/ArgumentExtractor.swift
@@ -5,134 +5,136 @@ import SharedCore
 
 // MARK: - Argument Extractor
 
-/// Helper for extracting and validating MCP tool arguments.
-/// Reduces boilerplate in tool providers by providing type-safe access to arguments.
-public struct ArgumentExtractor: Sendable {
-    private let arguments: [String: MCP.Core.Protocols.AnyCodable]?
+extension MCP.SharedTools {
+    /// Helper for extracting and validating MCP tool arguments.
+    /// Reduces boilerplate in tool providers by providing type-safe access to arguments.
+    public struct ArgumentExtractor: Sendable {
+        private let arguments: [String: MCP.Core.Protocols.AnyCodable]?
 
-    /// Initialize with MCP tool arguments
-    public init(_ arguments: [String: MCP.Core.Protocols.AnyCodable]?) {
-        self.arguments = arguments
-    }
-
-    // MARK: - Required Arguments
-
-    /// Extract a required string argument, throwing if missing
-    public func require(_ key: String) throws -> String {
-        guard let value = arguments?[key]?.value as? String else {
-            throw ToolError.missingArgument(key)
+        /// Initialize with MCP tool arguments
+        public init(_ arguments: [String: MCP.Core.Protocols.AnyCodable]?) {
+            self.arguments = arguments
         }
-        return value
-    }
 
-    /// Extract a required integer argument, throwing if missing
-    public func requireInt(_ key: String) throws -> Int {
-        guard let value = arguments?[key]?.value as? Int else {
-            throw ToolError.missingArgument(key)
+        // MARK: - Required Arguments
+
+        /// Extract a required string argument, throwing if missing
+        public func require(_ key: String) throws -> String {
+            guard let value = arguments?[key]?.value as? String else {
+                throw ToolError.missingArgument(key)
+            }
+            return value
         }
-        return value
-    }
 
-    /// Extract a required boolean argument, throwing if missing
-    public func requireBool(_ key: String) throws -> Bool {
-        guard let value = arguments?[key]?.value as? Bool else {
-            throw ToolError.missingArgument(key)
+        /// Extract a required integer argument, throwing if missing
+        public func requireInt(_ key: String) throws -> Int {
+            guard let value = arguments?[key]?.value as? Int else {
+                throw ToolError.missingArgument(key)
+            }
+            return value
         }
-        return value
-    }
 
-    // MARK: - Optional Arguments
+        /// Extract a required boolean argument, throwing if missing
+        public func requireBool(_ key: String) throws -> Bool {
+            guard let value = arguments?[key]?.value as? Bool else {
+                throw ToolError.missingArgument(key)
+            }
+            return value
+        }
 
-    /// Extract an optional string argument
-    public func optional(_ key: String) -> String? {
-        arguments?[key]?.value as? String
-    }
+        // MARK: - Optional Arguments
 
-    /// Extract an optional integer argument
-    public func optionalInt(_ key: String) -> Int? {
-        arguments?[key]?.value as? Int
-    }
+        /// Extract an optional string argument
+        public func optional(_ key: String) -> String? {
+            arguments?[key]?.value as? String
+        }
 
-    /// Extract an optional boolean argument
-    public func optionalBool(_ key: String) -> Bool? {
-        arguments?[key]?.value as? Bool
-    }
+        /// Extract an optional integer argument
+        public func optionalInt(_ key: String) -> Int? {
+            arguments?[key]?.value as? Int
+        }
 
-    // MARK: - Arguments with Defaults
+        /// Extract an optional boolean argument
+        public func optionalBool(_ key: String) -> Bool? {
+            arguments?[key]?.value as? Bool
+        }
 
-    /// Extract a string argument with a default value
-    public func optional(_ key: String, default defaultValue: String) -> String {
-        (arguments?[key]?.value as? String) ?? defaultValue
-    }
+        // MARK: - Arguments with Defaults
 
-    /// Extract an integer argument with a default value
-    public func optional(_ key: String, default defaultValue: Int) -> Int {
-        (arguments?[key]?.value as? Int) ?? defaultValue
-    }
+        /// Extract a string argument with a default value
+        public func optional(_ key: String, default defaultValue: String) -> String {
+            (arguments?[key]?.value as? String) ?? defaultValue
+        }
 
-    /// Extract a boolean argument with a default value
-    public func optional(_ key: String, default defaultValue: Bool) -> Bool {
-        (arguments?[key]?.value as? Bool) ?? defaultValue
-    }
+        /// Extract an integer argument with a default value
+        public func optional(_ key: String, default defaultValue: Int) -> Int {
+            (arguments?[key]?.value as? Int) ?? defaultValue
+        }
 
-    // MARK: - Specialized Extractors
+        /// Extract a boolean argument with a default value
+        public func optional(_ key: String, default defaultValue: Bool) -> Bool {
+            (arguments?[key]?.value as? Bool) ?? defaultValue
+        }
 
-    /// Extract a limit argument, clamped to the max search limit
-    public func limit(
-        key: String = Shared.Constants.Search.schemaParamLimit,
-        default defaultLimit: Int = Shared.Constants.Limit.defaultSearchLimit
-    ) -> Int {
-        let requested = optional(key, default: defaultLimit)
-        return min(requested, Shared.Constants.Limit.maxSearchLimit)
-    }
+        // MARK: - Specialized Extractors
 
-    /// Extract a format argument for document output
-    public func format(
-        key: String = Shared.Constants.Search.schemaParamFormat,
-        default defaultFormat: String = Shared.Constants.Search.formatValueJSON
-    ) -> String {
-        optional(key, default: defaultFormat)
-    }
+        /// Extract a limit argument, clamped to the max search limit
+        public func limit(
+            key: String = Shared.Constants.Search.schemaParamLimit,
+            default defaultLimit: Int = Shared.Constants.Limit.defaultSearchLimit
+        ) -> Int {
+            let requested = optional(key, default: defaultLimit)
+            return min(requested, Shared.Constants.Limit.maxSearchLimit)
+        }
 
-    /// Check if include_archive flag is set
-    public func includeArchive(
-        key: String = Shared.Constants.Search.schemaParamIncludeArchive
-    ) -> Bool {
-        optional(key, default: false)
-    }
+        /// Extract a format argument for document output
+        public func format(
+            key: String = Shared.Constants.Search.schemaParamFormat,
+            default defaultFormat: String = Shared.Constants.Search.formatValueJSON
+        ) -> String {
+            optional(key, default: defaultFormat)
+        }
 
-    /// Extract min_ios version filter
-    public func minIOS(
-        key: String = Shared.Constants.Search.schemaParamMinIOS
-    ) -> String? {
-        optional(key)
-    }
+        /// Check if include_archive flag is set
+        public func includeArchive(
+            key: String = Shared.Constants.Search.schemaParamIncludeArchive
+        ) -> Bool {
+            optional(key, default: false)
+        }
 
-    /// Extract min_macos version filter
-    public func minMacOS(
-        key: String = Shared.Constants.Search.schemaParamMinMacOS
-    ) -> String? {
-        optional(key)
-    }
+        /// Extract min_ios version filter
+        public func minIOS(
+            key: String = Shared.Constants.Search.schemaParamMinIOS
+        ) -> String? {
+            optional(key)
+        }
 
-    /// Extract min_tvos version filter
-    public func minTvOS(
-        key: String = Shared.Constants.Search.schemaParamMinTvOS
-    ) -> String? {
-        optional(key)
-    }
+        /// Extract min_macos version filter
+        public func minMacOS(
+            key: String = Shared.Constants.Search.schemaParamMinMacOS
+        ) -> String? {
+            optional(key)
+        }
 
-    /// Extract min_watchos version filter
-    public func minWatchOS(
-        key: String = Shared.Constants.Search.schemaParamMinWatchOS
-    ) -> String? {
-        optional(key)
-    }
+        /// Extract min_tvos version filter
+        public func minTvOS(
+            key: String = Shared.Constants.Search.schemaParamMinTvOS
+        ) -> String? {
+            optional(key)
+        }
 
-    /// Extract min_visionos version filter
-    public func minVisionOS(
-        key: String = Shared.Constants.Search.schemaParamMinVisionOS
-    ) -> String? {
-        optional(key)
+        /// Extract min_watchos version filter
+        public func minWatchOS(
+            key: String = Shared.Constants.Search.schemaParamMinWatchOS
+        ) -> String? {
+            optional(key)
+        }
+
+        /// Extract min_visionos version filter
+        public func minVisionOS(
+            key: String = Shared.Constants.Search.schemaParamMinVisionOS
+        ) -> String? {
+            optional(key)
+        }
     }
 }

--- a/Packages/Sources/MCP/SharedTools/MCPCopy.swift
+++ b/Packages/Sources/MCP/SharedTools/MCPCopy.swift
@@ -1,190 +1,193 @@
 import Foundation
+import MCP
 import SharedConstants
 
-// MARK: - MCPCopy
+// MARK: - MCP.SharedTools.Copy
 
-/// MCP-protocol output strings extracted from `Shared.Constants.Search`.
-///
-/// These are the values that `MCPSupport` and `SearchToolProvider` serialize
-/// back to MCP clients: tool descriptions, resource template URIs, resource
-/// descriptions, and MIME types. Anything that a non-MCP package would also
-/// need (URI schemes, tool/command names, JSON schema parameter names,
-/// format values, Swift Evolution prefixes, tips, messages) stays in
-/// `Shared.Constants.Search` so the formatters and CLI keep working without
-/// an MCP-adjacent dependency.
-public enum MCPCopy {
-    // MARK: Resource Template URIs
+extension MCP.SharedTools {
+    /// MCP-protocol output strings extracted from `Shared.Constants.Search`.
+    ///
+    /// These are the values that `MCP.Support` and `SearchToolProvider` serialize
+    /// back to MCP clients: tool descriptions, resource template URIs, resource
+    /// descriptions, and MIME types. Anything that a non-MCP package would also
+    /// need (URI schemes, tool/command names, JSON schema parameter names,
+    /// format values, Swift Evolution prefixes, tips, messages) stays in
+    /// `Shared.Constants.Search` so the formatters and CLI keep working without
+    /// an MCP-adjacent dependency.
+    public enum Copy {
+        // MARK: Resource Template URIs
 
-    /// Apple documentation resource template
-    public static let templateAppleDocs = "apple-docs://{framework}/{page}"
+        /// Apple documentation resource template
+        public static let templateAppleDocs = "apple-docs://{framework}/{page}"
 
-    /// Swift Evolution resource template
-    public static let templateSwiftEvolution = "swift-evolution://{proposalID}"
+        /// Swift Evolution resource template
+        public static let templateSwiftEvolution = "swift-evolution://{proposalID}"
 
-    // MARK: Resource Descriptions
+        // MARK: Resource Descriptions
 
-    /// Apple documentation resource description prefix
-    public static let appleDocsDescriptionPrefix = "Apple Documentation:"
+        /// Apple documentation resource description prefix
+        public static let appleDocsDescriptionPrefix = "Apple Documentation:"
 
-    /// Swift Evolution proposal resource description
-    public static let swiftEvolutionDescription = "Swift Evolution Proposal"
+        /// Swift Evolution proposal resource description
+        public static let swiftEvolutionDescription = "Swift Evolution Proposal"
 
-    /// Apple documentation template name
-    public static let appleDocsTemplateName = "Apple Documentation Page"
+        /// Apple documentation template name
+        public static let appleDocsTemplateName = "Apple Documentation Page"
 
-    /// Apple documentation template description
-    public static let appleDocsTemplateDescription = "Access Apple documentation by framework and page name"
+        /// Apple documentation template description
+        public static let appleDocsTemplateDescription = "Access Apple documentation by framework and page name"
 
-    /// Swift Evolution template description
-    public static let swiftEvolutionTemplateDescription =
-        "Access Swift Evolution proposals by ID (e.g., SE-0001 or ST-0001)"
+        /// Swift Evolution template description
+        public static let swiftEvolutionTemplateDescription =
+            "Access Swift Evolution proposals by ID (e.g., SE-0001 or ST-0001)"
 
-    // MARK: MIME Types
+        // MARK: MIME Types
 
-    /// Markdown MIME type
-    public static let mimeTypeMarkdown = "text/markdown"
+        /// Markdown MIME type
+        public static let mimeTypeMarkdown = "text/markdown"
 
-    // MARK: Tool Descriptions
+        // MARK: Tool Descriptions
 
-    /// Unified search tool description
-    public static let toolSearchDescription = """
-    Search Apple documentation and Swift Evolution proposals by keywords. \
-    Returns a ranked list of relevant documents with URIs that can be read using resources/read.
+        /// Unified search tool description
+        public static let toolSearchDescription = """
+        Search Apple documentation and Swift Evolution proposals by keywords. \
+        Returns a ranked list of relevant documents with URIs that can be read using resources/read.
 
-    **By default, searches ALL sources** (docs, samples, HIG, etc.) for comprehensive results. \
-    Use `source` parameter to narrow to a specific source.
+        **By default, searches ALL sources** (docs, samples, HIG, etc.) for comprehensive results. \
+        Use `source` parameter to narrow to a specific source.
 
-    **Semantic search:** Includes AST-extracted symbols from Swift source code. \
-    Find @Observable classes, async functions, View conformances, protocol conformances, etc. \
-    Works across both documentation and sample code.
+        **Semantic search:** Includes AST-extracted symbols from Swift source code. \
+        Find @Observable classes, async functions, View conformances, protocol conformances, etc. \
+        Works across both documentation and sample code.
 
-    **Source options** (use `source` parameter to narrow scope):
-    - (default): Search ALL sources at once
-    - apple-docs: Modern Apple API documentation only
-    - samples: Sample code projects with working examples
-    - hig: Human Interface Guidelines
-    - apple-archive: Legacy guides (Core Animation, Quartz 2D, KVO/KVC)
-    - swift-evolution: Swift Evolution proposals
-    - swift-org: Swift.org documentation
-    - swift-book: The Swift Programming Language book
-    - packages: Swift package documentation
+        **Source options** (use `source` parameter to narrow scope):
+        - (default): Search ALL sources at once
+        - apple-docs: Modern Apple API documentation only
+        - samples: Sample code projects with working examples
+        - hig: Human Interface Guidelines
+        - apple-archive: Legacy guides (Core Animation, Quartz 2D, KVO/KVC)
+        - swift-evolution: Swift Evolution proposals
+        - swift-org: Swift.org documentation
+        - swift-book: The Swift Programming Language book
+        - packages: Swift package documentation
 
-    **IMPORTANT:** For foundational topics (Core Animation, Quartz 2D, KVO/KVC, threading), \
-    use source=apple-archive. For working code examples, use source=samples.
+        **IMPORTANT:** For foundational topics (Core Animation, Quartz 2D, KVO/KVC, threading), \
+        use source=apple-archive. For working code examples, use source=samples.
 
-    **Optional parameters:**
-    - source: Filter by documentation source (see above)
-    - framework: Filter by framework (e.g. swiftui, foundation)
-    - include_archive: Include archive results when source is not specified
-    - min_ios/min_macos/min_tvos/min_watchos/min_visionos: Filter by API availability
-    - limit: Maximum results (default 20)
-    """
+        **Optional parameters:**
+        - source: Filter by documentation source (see above)
+        - framework: Filter by framework (e.g. swiftui, foundation)
+        - include_archive: Include archive results when source is not specified
+        - min_ios/min_macos/min_tvos/min_watchos/min_visionos: Filter by API availability
+        - limit: Maximum results (default 20)
+        """
 
-    /// List frameworks tool description
-    public static let toolListFrameworksDescription = """
-    List all available frameworks in the documentation index with document counts. \
-    Useful for discovering what documentation is available.
-    """
+        /// List frameworks tool description
+        public static let toolListFrameworksDescription = """
+        List all available frameworks in the documentation index with document counts. \
+        Useful for discovering what documentation is available.
+        """
 
-    /// Read document tool description
-    public static let toolReadDocumentDescription = """
-    Read a document by URI. Returns the full document content in the requested format. \
-    Use URIs from search_docs results. Format parameter: 'json' (default, structured) or 'markdown' (rendered).
-    """
+        /// Read document tool description
+        public static let toolReadDocumentDescription = """
+        Read a document by URI. Returns the full document content in the requested format. \
+        Use URIs from search_docs results. Format parameter: 'json' (default, structured) or 'markdown' (rendered).
+        """
 
-    // MARK: Sample Code Tool Descriptions
+        // MARK: Sample Code Tool Descriptions
 
-    /// List samples tool description
-    public static let toolListSamplesDescription = """
-    List all indexed Apple sample code projects with metadata. \
-    Useful for discovering available sample code before searching.
-    """
+        /// List samples tool description
+        public static let toolListSamplesDescription = """
+        List all indexed Apple sample code projects with metadata. \
+        Useful for discovering available sample code before searching.
+        """
 
-    /// Read sample tool description
-    public static let toolReadSampleDescription = """
-    Read a sample code project's README and metadata by project ID. \
-    Use project IDs from search_samples or list_samples results.
-    """
+        /// Read sample tool description
+        public static let toolReadSampleDescription = """
+        Read a sample code project's README and metadata by project ID. \
+        Use project IDs from search_samples or list_samples results.
+        """
 
-    /// Read sample file tool description
-    public static let toolReadSampleFileDescription = """
-    Read a specific source file from a sample code project. \
-    Requires project_id and file_path parameters. File paths are relative to project root.
-    """
+        /// Read sample file tool description
+        public static let toolReadSampleFileDescription = """
+        Read a specific source file from a sample code project. \
+        Requires project_id and file_path parameters. File paths are relative to project root.
+        """
 
-    // MARK: Semantic Search Tool Descriptions (#81)
+        // MARK: Semantic Search Tool Descriptions (#81)
 
-    /// Search symbols tool description
-    public static let toolSearchSymbolsDescription = """
-    Search Swift symbols by type and name pattern. Uses SwiftSyntax AST extraction. \
-    Find structs, classes, actors, protocols, functions, properties by kind and name.
+        /// Search symbols tool description
+        public static let toolSearchSymbolsDescription = """
+        Search Swift symbols by type and name pattern. Uses SwiftSyntax AST extraction. \
+        Find structs, classes, actors, protocols, functions, properties by kind and name.
 
-    **Symbol kinds:** struct, class, actor, enum, protocol, extension, function, property, typealias
+        **Symbol kinds:** struct, class, actor, enum, protocol, extension, function, property, typealias
 
-    **Parameters:**
-    - query: Symbol name pattern (partial match supported)
-    - kind: Filter by symbol kind (optional)
-    - is_async: Filter async functions only (optional)
-    - framework: Filter by framework (optional)
-    - limit: Maximum results (default 20)
+        **Parameters:**
+        - query: Symbol name pattern (partial match supported)
+        - kind: Filter by symbol kind (optional)
+        - is_async: Filter async functions only (optional)
+        - framework: Filter by framework (optional)
+        - limit: Maximum results (default 20)
 
-    **Examples:**
-    - Find all actors: kind=actor
-    - Find async functions: is_async=true
-    - Find View structs: query=View, kind=struct
-    """
+        **Examples:**
+        - Find all actors: kind=actor
+        - Find async functions: is_async=true
+        - Find View structs: query=View, kind=struct
+        """
 
-    /// Search property wrappers tool description
-    public static let toolSearchPropertyWrappersDescription = """
-    Find Swift property wrapper usage patterns across documentation and samples. \
-    Essential for discovering SwiftUI state management patterns.
+        /// Search property wrappers tool description
+        public static let toolSearchPropertyWrappersDescription = """
+        Find Swift property wrapper usage patterns across documentation and samples. \
+        Essential for discovering SwiftUI state management patterns.
 
-    **Common wrappers:** @State, @Binding, @StateObject, @ObservedObject, @Observable, \
-    @Environment, @EnvironmentObject, @Published, @AppStorage, @MainActor, @Sendable
+        **Common wrappers:** @State, @Binding, @StateObject, @ObservedObject, @Observable, \
+        @Environment, @EnvironmentObject, @Published, @AppStorage, @MainActor, @Sendable
 
-    **Parameters:**
-    - wrapper: Property wrapper name (with or without @)
-    - framework: Filter by framework (optional)
-    - limit: Maximum results (default 20)
+        **Parameters:**
+        - wrapper: Property wrapper name (with or without @)
+        - framework: Filter by framework (optional)
+        - limit: Maximum results (default 20)
 
-    **Examples:**
-    - Find @Observable usage: wrapper=Observable
-    - Find @MainActor usage: wrapper=MainActor
-    """
+        **Examples:**
+        - Find @Observable usage: wrapper=Observable
+        - Find @MainActor usage: wrapper=MainActor
+        """
 
-    /// Search concurrency patterns tool description
-    public static let toolSearchConcurrencyDescription = """
-    Find Swift concurrency patterns: async/await, actors, Sendable conformances. \
-    Discover real-world concurrency usage in Apple documentation and samples.
+        /// Search concurrency patterns tool description
+        public static let toolSearchConcurrencyDescription = """
+        Find Swift concurrency patterns: async/await, actors, Sendable conformances. \
+        Discover real-world concurrency usage in Apple documentation and samples.
 
-    **Pattern options:** async, actor, sendable, mainactor, task, asyncsequence
+        **Pattern options:** async, actor, sendable, mainactor, task, asyncsequence
 
-    **Parameters:**
-    - pattern: Concurrency pattern to search for
-    - framework: Filter by framework (optional)
-    - limit: Maximum results (default 20)
+        **Parameters:**
+        - pattern: Concurrency pattern to search for
+        - framework: Filter by framework (optional)
+        - limit: Maximum results (default 20)
 
-    **Examples:**
-    - Find async functions: pattern=async
-    - Find actor declarations: pattern=actor
-    - Find Sendable types: pattern=sendable
-    """
+        **Examples:**
+        - Find async functions: pattern=async
+        - Find actor declarations: pattern=actor
+        - Find Sendable types: pattern=sendable
+        """
 
-    /// Search conformances tool description
-    public static let toolSearchConformancesDescription = """
-    Find types by protocol conformance. Discover how protocols are implemented \
-    across Apple documentation and sample code.
+        /// Search conformances tool description
+        public static let toolSearchConformancesDescription = """
+        Find types by protocol conformance. Discover how protocols are implemented \
+        across Apple documentation and sample code.
 
-    **Common protocols:** View, Codable, Hashable, Equatable, Identifiable, \
-    ObservableObject, Sendable, AsyncSequence, Error
+        **Common protocols:** View, Codable, Hashable, Equatable, Identifiable, \
+        ObservableObject, Sendable, AsyncSequence, Error
 
-    **Parameters:**
-    - protocol: Protocol name to search for
-    - framework: Filter by framework (optional)
-    - limit: Maximum results (default 20)
+        **Parameters:**
+        - protocol: Protocol name to search for
+        - framework: Filter by framework (optional)
+        - limit: Maximum results (default 20)
 
-    **Examples:**
-    - Find View conformances: protocol=View
-    - Find Sendable types: protocol=Sendable
-    """
+        **Examples:**
+        - Find View conformances: protocol=View
+        - Find Sendable types: protocol=Sendable
+        """
+    }
 }

--- a/Packages/Sources/MCP/SharedTools/MCPSharedTools.swift
+++ b/Packages/Sources/MCP/SharedTools/MCPSharedTools.swift
@@ -1,0 +1,14 @@
+import Foundation
+import MCP
+
+// MARK: - MCP.SharedTools Namespace
+
+/// Sub-namespace under the MCP root for utilities shared between every MCP
+/// SPM target in the monorepo (MCP, MCP.Support, MCP.Client, plus the CLI's
+/// `SearchToolProvider` consumer). Holds `MCP.SharedTools.ArgumentExtractor`
+/// for type-safe MCP tool-argument extraction and `MCP.SharedTools.Copy`
+/// for MCP-protocol output strings (resource template URIs, MIME types,
+/// tool descriptions) that are emitted back to clients.
+extension MCP {
+    public enum SharedTools {}
+}

--- a/Packages/Sources/MCP/Support/DocsResourceProvider.swift
+++ b/Packages/Sources/MCP/Support/DocsResourceProvider.swift
@@ -11,351 +11,353 @@ import SharedUtils
 
 // MARK: - Documentation Resource Provider
 
-/// Provides crawled documentation as MCP resources
-public actor DocsResourceProvider: MCP.Core.ResourceProvider {
-    private let configuration: Shared.Configuration
-    private var metadata: Shared.Models.CrawlMetadata?
-    private let evolutionDirectory: URL
-    private let archiveDirectory: URL
-    private let searchIndex: Search.Index?
+extension MCP.Support {
+    /// Provides crawled documentation as MCP resources
+    public actor DocsResourceProvider: MCP.Core.ResourceProvider {
+        private let configuration: Shared.Configuration
+        private var metadata: Shared.Models.CrawlMetadata?
+        private let evolutionDirectory: URL
+        private let archiveDirectory: URL
+        private let searchIndex: Search.Index?
 
-    public init(
-        configuration: Shared.Configuration,
-        evolutionDirectory: URL? = nil,
-        archiveDirectory: URL? = nil,
-        searchIndex: Search.Index? = nil
-    ) {
-        self.configuration = configuration
-        self.evolutionDirectory = evolutionDirectory ?? Shared.Constants.defaultSwiftEvolutionDirectory
-        self.archiveDirectory = archiveDirectory ?? Shared.Constants.defaultArchiveDirectory
-        self.searchIndex = searchIndex
-        // Metadata will be loaded lazily on first access
-    }
-
-    // MARK: - ResourceProvider
-
-    public func listResources(cursor: String?) async throws -> MCP.Core.Protocols.ListResourcesResult {
-        var resources: [MCP.Core.Protocols.Resource] = []
-
-        // Add Apple Documentation resources
-        do {
-            let metadata = try await getMetadata()
-
-            for (url, pageMetadata) in metadata.pages {
-                // `url` comes from indexed page metadata; skip rows whose key
-                // doesn't parse rather than crashing the resource listing.
-                // The other two skip sites (SearchIndexBuilder,
-                // SampleCodeDownloader) log the skip; matching that here so
-                // a degraded listing doesn't go unnoticed.
-                guard let parsedURL = URL(string: url) else {
-                    Logging.Log.warning(
-                        "Skipping malformed URL key in CrawlMetadata.pages: '\(url)' "
-                            + "(framework: \(pageMetadata.framework))",
-                        category: .mcp
-                    )
-                    continue
-                }
-                let uri = "\(Shared.Constants.Search.appleDocsScheme)\(pageMetadata.framework)/"
-                    + "\(Shared.Models.URLUtilities.filename(from: parsedURL))"
-                let resource = MCP.Core.Protocols.Resource(
-                    uri: uri,
-                    name: extractTitle(from: url),
-                    description: "\(MCPSharedTools.MCPCopy.appleDocsDescriptionPrefix) \(pageMetadata.framework)",
-                    mimeType: MCPSharedTools.MCPCopy.mimeTypeMarkdown
-                )
-                resources.append(resource)
-            }
-        } catch {
-            // If Apple docs aren't available, that's OK - we might only have Evolution proposals
+        public init(
+            configuration: Shared.Configuration,
+            evolutionDirectory: URL? = nil,
+            archiveDirectory: URL? = nil,
+            searchIndex: Search.Index? = nil
+        ) {
+            self.configuration = configuration
+            self.evolutionDirectory = evolutionDirectory ?? Shared.Constants.defaultSwiftEvolutionDirectory
+            self.archiveDirectory = archiveDirectory ?? Shared.Constants.defaultArchiveDirectory
+            self.searchIndex = searchIndex
+            // Metadata will be loaded lazily on first access
         }
 
-        // Add Swift Evolution proposals
-        if FileManager.default.fileExists(atPath: evolutionDirectory.path) {
+        // MARK: - ResourceProvider
+
+        public func listResources(cursor: String?) async throws -> MCP.Core.Protocols.ListResourcesResult {
+            var resources: [MCP.Core.Protocols.Resource] = []
+
+            // Add Apple Documentation resources
             do {
+                let metadata = try await getMetadata()
+
+                for (url, pageMetadata) in metadata.pages {
+                    // `url` comes from indexed page metadata; skip rows whose key
+                    // doesn't parse rather than crashing the resource listing.
+                    // The other two skip sites (SearchIndexBuilder,
+                    // SampleCodeDownloader) log the skip; matching that here so
+                    // a degraded listing doesn't go unnoticed.
+                    guard let parsedURL = URL(string: url) else {
+                        Logging.Log.warning(
+                            "Skipping malformed URL key in CrawlMetadata.pages: '\(url)' "
+                                + "(framework: \(pageMetadata.framework))",
+                            category: .mcp
+                        )
+                        continue
+                    }
+                    let uri = "\(Shared.Constants.Search.appleDocsScheme)\(pageMetadata.framework)/"
+                        + "\(Shared.Models.URLUtilities.filename(from: parsedURL))"
+                    let resource = MCP.Core.Protocols.Resource(
+                        uri: uri,
+                        name: extractTitle(from: url),
+                        description: "\(MCP.SharedTools.Copy.appleDocsDescriptionPrefix) \(pageMetadata.framework)",
+                        mimeType: MCP.SharedTools.Copy.mimeTypeMarkdown
+                    )
+                    resources.append(resource)
+                }
+            } catch {
+                // If Apple docs aren't available, that's OK - we might only have Evolution proposals
+            }
+
+            // Add Swift Evolution proposals
+            if FileManager.default.fileExists(atPath: evolutionDirectory.path) {
+                do {
+                    let files = try FileManager.default.contentsOfDirectory(
+                        at: evolutionDirectory,
+                        includingPropertiesForKeys: nil
+                    )
+
+                    for file in files where file.pathExtension == "md"
+                        && (file.lastPathComponent.hasPrefix(Shared.Constants.Search.sePrefix) ||
+                            file.lastPathComponent.hasPrefix(Shared.Constants.Search.stPrefix)) {
+                        let proposalID = file.deletingPathExtension().lastPathComponent
+                        let resource = MCP.Core.Protocols.Resource(
+                            uri: "\(Shared.Constants.Search.swiftEvolutionScheme)\(proposalID)",
+                            name: proposalID,
+                            description: MCP.SharedTools.Copy.swiftEvolutionDescription,
+                            mimeType: MCP.SharedTools.Copy.mimeTypeMarkdown
+                        )
+                        resources.append(resource)
+                    }
+                } catch {
+                    // Evolution proposals directory doesn't exist or can't be read
+                }
+            }
+
+            // Add Apple Archive documentation
+            if FileManager.default.fileExists(atPath: archiveDirectory.path) {
+                do {
+                    let archiveResources = try listArchiveResources()
+                    resources.append(contentsOf: archiveResources)
+                } catch {
+                    // Archive directory doesn't exist or can't be read
+                }
+            }
+
+            // Sort by name
+            resources.sort { $0.name < $1.name }
+
+            return MCP.Core.Protocols.ListResourcesResult(resources: resources)
+        }
+
+        public func readResource(uri: String) async throws -> MCP.Core.Protocols.ReadResourceResult {
+            let markdown: String
+
+            // Try database first if search index is available
+            if let searchIndex {
+                if let dbContent = try await searchIndex.getDocumentContent(uri: uri, format: .markdown) {
+                    // Found in database - return markdown
+                    let contents = MCP.Core.Protocols.ResourceContents.text(
+                        MCP.Core.Protocols.TextResourceContents(
+                            uri: uri,
+                            mimeType: MCP.SharedTools.Copy.mimeTypeMarkdown,
+                            text: dbContent
+                        )
+                    )
+                    return MCP.Core.Protocols.ReadResourceResult(contents: [contents])
+                }
+            }
+
+            // Database lookup failed or no index - fall back to filesystem
+            if uri.hasPrefix(Shared.Constants.Search.appleDocsScheme) {
+                // Parse URI: apple-docs://framework/filename
+                guard let components = parseAppleDocsURI(uri) else {
+                    throw ToolError.invalidURI(uri)
+                }
+
+                let baseDir = configuration.crawler.outputDirectory
+                    .appendingPathComponent(components.framework)
+
+                // Try JSON file first (new format), then fall back to MD (old format)
+                let jsonPath = baseDir.appendingPathComponent("\(components.filename).json")
+                let mdFilename = "\(components.filename)\(Shared.Constants.FileName.markdownExtension)"
+                let mdPath = baseDir.appendingPathComponent(mdFilename)
+
+                if FileManager.default.fileExists(atPath: jsonPath.path) {
+                    // Read JSON and extract rawMarkdown
+                    let jsonData = try Data(contentsOf: jsonPath)
+                    let page = try Shared.Utils.JSONCoding.decode(Shared.Models.StructuredDocumentationPage.self, from: jsonData)
+                    guard let rawMarkdown = page.rawMarkdown else {
+                        throw ToolError.notFound(uri)
+                    }
+                    markdown = rawMarkdown
+                } else if FileManager.default.fileExists(atPath: mdPath.path) {
+                    // Fall back to markdown file
+                    markdown = try String(contentsOf: mdPath, encoding: .utf8)
+                } else {
+                    throw ToolError.notFound(uri)
+                }
+
+            } else if uri.hasPrefix(Shared.Constants.Search.swiftEvolutionScheme) {
+                // Parse URI: swift-evolution://SE-NNNN
+                guard let proposalID = parseEvolutionURI(uri) else {
+                    throw ToolError.invalidURI(uri)
+                }
+
+                // Find the proposal file
                 let files = try FileManager.default.contentsOfDirectory(
                     at: evolutionDirectory,
                     includingPropertiesForKeys: nil
                 )
 
-                for file in files where file.pathExtension == "md"
-                    && (file.lastPathComponent.hasPrefix(Shared.Constants.Search.sePrefix) ||
-                        file.lastPathComponent.hasPrefix(Shared.Constants.Search.stPrefix)) {
-                    let proposalID = file.deletingPathExtension().lastPathComponent
-                    let resource = MCP.Core.Protocols.Resource(
-                        uri: "\(Shared.Constants.Search.swiftEvolutionScheme)\(proposalID)",
-                        name: proposalID,
-                        description: MCPSharedTools.MCPCopy.swiftEvolutionDescription,
-                        mimeType: MCPSharedTools.MCPCopy.mimeTypeMarkdown
-                    )
-                    resources.append(resource)
-                }
-            } catch {
-                // Evolution proposals directory doesn't exist or can't be read
-            }
-        }
-
-        // Add Apple Archive documentation
-        if FileManager.default.fileExists(atPath: archiveDirectory.path) {
-            do {
-                let archiveResources = try listArchiveResources()
-                resources.append(contentsOf: archiveResources)
-            } catch {
-                // Archive directory doesn't exist or can't be read
-            }
-        }
-
-        // Sort by name
-        resources.sort { $0.name < $1.name }
-
-        return MCP.Core.Protocols.ListResourcesResult(resources: resources)
-    }
-
-    public func readResource(uri: String) async throws -> MCP.Core.Protocols.ReadResourceResult {
-        let markdown: String
-
-        // Try database first if search index is available
-        if let searchIndex {
-            if let dbContent = try await searchIndex.getDocumentContent(uri: uri, format: .markdown) {
-                // Found in database - return markdown
-                let contents = MCP.Core.Protocols.ResourceContents.text(
-                    MCP.Core.Protocols.TextResourceContents(
-                        uri: uri,
-                        mimeType: MCPSharedTools.MCPCopy.mimeTypeMarkdown,
-                        text: dbContent
-                    )
-                )
-                return MCP.Core.Protocols.ReadResourceResult(contents: [contents])
-            }
-        }
-
-        // Database lookup failed or no index - fall back to filesystem
-        if uri.hasPrefix(Shared.Constants.Search.appleDocsScheme) {
-            // Parse URI: apple-docs://framework/filename
-            guard let components = parseAppleDocsURI(uri) else {
-                throw ToolError.invalidURI(uri)
-            }
-
-            let baseDir = configuration.crawler.outputDirectory
-                .appendingPathComponent(components.framework)
-
-            // Try JSON file first (new format), then fall back to MD (old format)
-            let jsonPath = baseDir.appendingPathComponent("\(components.filename).json")
-            let mdFilename = "\(components.filename)\(Shared.Constants.FileName.markdownExtension)"
-            let mdPath = baseDir.appendingPathComponent(mdFilename)
-
-            if FileManager.default.fileExists(atPath: jsonPath.path) {
-                // Read JSON and extract rawMarkdown
-                let jsonData = try Data(contentsOf: jsonPath)
-                let page = try Shared.Utils.JSONCoding.decode(Shared.Models.StructuredDocumentationPage.self, from: jsonData)
-                guard let rawMarkdown = page.rawMarkdown else {
+                guard let file = files.first(where: { $0.lastPathComponent.hasPrefix(proposalID) }) else {
                     throw ToolError.notFound(uri)
                 }
-                markdown = rawMarkdown
-            } else if FileManager.default.fileExists(atPath: mdPath.path) {
-                // Fall back to markdown file
-                markdown = try String(contentsOf: mdPath, encoding: .utf8)
+
+                // Read markdown content from filesystem
+                markdown = try String(contentsOf: file, encoding: .utf8)
+
+            } else if uri.hasPrefix(Shared.Constants.Search.appleArchiveScheme) {
+                // Parse URI: apple-archive://guideUID/filename
+                guard let components = parseArchiveURI(uri) else {
+                    throw ToolError.invalidURI(uri)
+                }
+
+                // Construct file path: archive/{guideUID}/{filename}.md
+                let filePath = archiveDirectory
+                    .appendingPathComponent(components.guideUID)
+                    .appendingPathComponent("\(components.filename).md")
+
+                guard FileManager.default.fileExists(atPath: filePath.path) else {
+                    throw ToolError.notFound(uri)
+                }
+
+                markdown = try String(contentsOf: filePath, encoding: .utf8)
+
             } else {
-                throw ToolError.notFound(uri)
-            }
-
-        } else if uri.hasPrefix(Shared.Constants.Search.swiftEvolutionScheme) {
-            // Parse URI: swift-evolution://SE-NNNN
-            guard let proposalID = parseEvolutionURI(uri) else {
                 throw ToolError.invalidURI(uri)
             }
 
-            // Find the proposal file
-            let files = try FileManager.default.contentsOfDirectory(
-                at: evolutionDirectory,
-                includingPropertiesForKeys: nil
+            // Create resource contents
+            let contents = MCP.Core.Protocols.ResourceContents.text(
+                MCP.Core.Protocols.TextResourceContents(
+                    uri: uri,
+                    mimeType: MCP.SharedTools.Copy.mimeTypeMarkdown,
+                    text: markdown
+                )
             )
 
-            guard let file = files.first(where: { $0.lastPathComponent.hasPrefix(proposalID) }) else {
-                throw ToolError.notFound(uri)
-            }
-
-            // Read markdown content from filesystem
-            markdown = try String(contentsOf: file, encoding: .utf8)
-
-        } else if uri.hasPrefix(Shared.Constants.Search.appleArchiveScheme) {
-            // Parse URI: apple-archive://guideUID/filename
-            guard let components = parseArchiveURI(uri) else {
-                throw ToolError.invalidURI(uri)
-            }
-
-            // Construct file path: archive/{guideUID}/{filename}.md
-            let filePath = archiveDirectory
-                .appendingPathComponent(components.guideUID)
-                .appendingPathComponent("\(components.filename).md")
-
-            guard FileManager.default.fileExists(atPath: filePath.path) else {
-                throw ToolError.notFound(uri)
-            }
-
-            markdown = try String(contentsOf: filePath, encoding: .utf8)
-
-        } else {
-            throw ToolError.invalidURI(uri)
+            return MCP.Core.Protocols.ReadResourceResult(contents: [contents])
         }
 
-        // Create resource contents
-        let contents = MCP.Core.Protocols.ResourceContents.text(
-            MCP.Core.Protocols.TextResourceContents(
-                uri: uri,
-                mimeType: MCPSharedTools.MCPCopy.mimeTypeMarkdown,
-                text: markdown
-            )
-        )
+        public func listResourceTemplates(cursor: String?) async throws -> MCP.Core.Protocols.ListResourceTemplatesResult? {
+            let templates = [
+                MCP.Core.Protocols.ResourceTemplate(
+                    uriTemplate: MCP.SharedTools.Copy.templateAppleDocs,
+                    name: MCP.SharedTools.Copy.appleDocsTemplateName,
+                    description: MCP.SharedTools.Copy.appleDocsTemplateDescription,
+                    mimeType: MCP.SharedTools.Copy.mimeTypeMarkdown
+                ),
+                MCP.Core.Protocols.ResourceTemplate(
+                    uriTemplate: MCP.SharedTools.Copy.templateSwiftEvolution,
+                    name: MCP.SharedTools.Copy.swiftEvolutionDescription,
+                    description: MCP.SharedTools.Copy.swiftEvolutionTemplateDescription,
+                    mimeType: MCP.SharedTools.Copy.mimeTypeMarkdown
+                ),
+            ]
 
-        return MCP.Core.Protocols.ReadResourceResult(contents: [contents])
-    }
-
-    public func listResourceTemplates(cursor: String?) async throws -> MCP.Core.Protocols.ListResourceTemplatesResult? {
-        let templates = [
-            MCP.Core.Protocols.ResourceTemplate(
-                uriTemplate: MCPSharedTools.MCPCopy.templateAppleDocs,
-                name: MCPSharedTools.MCPCopy.appleDocsTemplateName,
-                description: MCPSharedTools.MCPCopy.appleDocsTemplateDescription,
-                mimeType: MCPSharedTools.MCPCopy.mimeTypeMarkdown
-            ),
-            MCP.Core.Protocols.ResourceTemplate(
-                uriTemplate: MCPSharedTools.MCPCopy.templateSwiftEvolution,
-                name: MCPSharedTools.MCPCopy.swiftEvolutionDescription,
-                description: MCPSharedTools.MCPCopy.swiftEvolutionTemplateDescription,
-                mimeType: MCPSharedTools.MCPCopy.mimeTypeMarkdown
-            ),
-        ]
-
-        return MCP.Core.Protocols.ListResourceTemplatesResult(resourceTemplates: templates)
-    }
-
-    // MARK: - Private Methods
-
-    private func loadMetadata() {
-        let metadataURL = configuration.changeDetection.metadataFile
-
-        guard FileManager.default.fileExists(atPath: metadataURL.path) else {
-            return
+            return MCP.Core.Protocols.ListResourceTemplatesResult(resourceTemplates: templates)
         }
 
-        do {
-            metadata = try Shared.Models.CrawlMetadata.load(from: metadataURL)
-        } catch {
-            Logging.Log.warning("Failed to load metadata: \(error)", category: .mcp)
+        // MARK: - Private Methods
+
+        private func loadMetadata() {
+            let metadataURL = configuration.changeDetection.metadataFile
+
+            guard FileManager.default.fileExists(atPath: metadataURL.path) else {
+                return
+            }
+
+            do {
+                metadata = try Shared.Models.CrawlMetadata.load(from: metadataURL)
+            } catch {
+                Logging.Log.warning("Failed to load metadata: \(error)", category: .mcp)
+            }
         }
-    }
 
-    // MARK: - Test Support
+        // MARK: - Test Support
 
-    /// Seed the cached metadata directly. Test-only path so MCPSupportTests
-    /// can exercise `listResources` against a hand-crafted `CrawlMetadata`
-    /// (including malformed-URL rows) without bootstrapping a real
-    /// crawl + metadata.json fixture on disk.
-    func injectMetadataForTesting(_ metadata: Shared.Models.CrawlMetadata) {
-        self.metadata = metadata
-    }
+        /// Seed the cached metadata directly. Test-only path so MCPSupportTests
+        /// can exercise `listResources` against a hand-crafted `CrawlMetadata`
+        /// (including malformed-URL rows) without bootstrapping a real
+        /// crawl + metadata.json fixture on disk.
+        func injectMetadataForTesting(_ metadata: Shared.Models.CrawlMetadata) {
+            self.metadata = metadata
+        }
 
-    // MARK: - Metadata
+        // MARK: - Metadata
 
-    private func getMetadata() async throws -> Shared.Models.CrawlMetadata {
-        if let metadata {
+        private func getMetadata() async throws -> Shared.Models.CrawlMetadata {
+            if let metadata {
+                return metadata
+            }
+
+            // Reload if not cached
+            loadMetadata()
+
+            guard let metadata else {
+                let cmd = "\(Shared.Constants.App.commandName) \(Shared.Constants.Command.crawl)"
+                throw ToolError.noData("No documentation has been crawled yet. Run '\(cmd)' first.")
+            }
+
             return metadata
         }
 
-        // Reload if not cached
-        loadMetadata()
+        private func parseAppleDocsURI(_ uri: String) -> (framework: String, filename: String)? {
+            // Expected format: apple-docs://framework/filename
+            guard uri.hasPrefix(Shared.Constants.Search.appleDocsScheme) else {
+                return nil
+            }
 
-        guard let metadata else {
-            let cmd = "\(Shared.Constants.App.commandName) \(Shared.Constants.Command.crawl)"
-            throw ToolError.noData("No documentation has been crawled yet. Run '\(cmd)' first.")
+            let path = uri.replacingOccurrences(of: Shared.Constants.Search.appleDocsScheme, with: "")
+            let components = path.split(separator: "/", maxSplits: 1)
+
+            guard components.count == 2 else {
+                return nil
+            }
+
+            return (framework: String(components[0]), filename: String(components[1]))
         }
 
-        return metadata
-    }
+        private func parseEvolutionURI(_ uri: String) -> String? {
+            // Expected format: swift-evolution://SE-NNNN
+            guard uri.hasPrefix(Shared.Constants.Search.swiftEvolutionScheme) else {
+                return nil
+            }
 
-    private func parseAppleDocsURI(_ uri: String) -> (framework: String, filename: String)? {
-        // Expected format: apple-docs://framework/filename
-        guard uri.hasPrefix(Shared.Constants.Search.appleDocsScheme) else {
-            return nil
+            let proposalID = uri.replacingOccurrences(of: Shared.Constants.Search.swiftEvolutionScheme, with: "")
+            return proposalID.isEmpty ? nil : proposalID
         }
 
-        let path = uri.replacingOccurrences(of: Shared.Constants.Search.appleDocsScheme, with: "")
-        let components = path.split(separator: "/", maxSplits: 1)
+        private func extractTitle(from urlString: String) -> String {
+            guard let url = URL(string: urlString) else {
+                return urlString
+            }
 
-        guard components.count == 2 else {
-            return nil
+            // Get the last path component and clean it up
+            let lastComponent = url.lastPathComponent
+            return lastComponent
+                .replacingOccurrences(of: "-", with: " ")
+                .replacingOccurrences(of: "_", with: " ")
+                .capitalized
         }
 
-        return (framework: String(components[0]), filename: String(components[1]))
-    }
+        private func listArchiveResources() throws -> [MCP.Core.Protocols.Resource] {
+            var resources: [MCP.Core.Protocols.Resource] = []
 
-    private func parseEvolutionURI(_ uri: String) -> String? {
-        // Expected format: swift-evolution://SE-NNNN
-        guard uri.hasPrefix(Shared.Constants.Search.swiftEvolutionScheme) else {
-            return nil
-        }
-
-        let proposalID = uri.replacingOccurrences(of: Shared.Constants.Search.swiftEvolutionScheme, with: "")
-        return proposalID.isEmpty ? nil : proposalID
-    }
-
-    private func extractTitle(from urlString: String) -> String {
-        guard let url = URL(string: urlString) else {
-            return urlString
-        }
-
-        // Get the last path component and clean it up
-        let lastComponent = url.lastPathComponent
-        return lastComponent
-            .replacingOccurrences(of: "-", with: " ")
-            .replacingOccurrences(of: "_", with: " ")
-            .capitalized
-    }
-
-    private func listArchiveResources() throws -> [MCP.Core.Protocols.Resource] {
-        var resources: [MCP.Core.Protocols.Resource] = []
-
-        let guides = try FileManager.default.contentsOfDirectory(
-            at: archiveDirectory,
-            includingPropertiesForKeys: nil
-        )
-
-        for guide in guides where guide.hasDirectoryPath {
-            let guideUID = guide.lastPathComponent
-            let files = try FileManager.default.contentsOfDirectory(
-                at: guide,
+            let guides = try FileManager.default.contentsOfDirectory(
+                at: archiveDirectory,
                 includingPropertiesForKeys: nil
             )
 
-            for file in files where file.pathExtension == "md" {
-                let filename = file.deletingPathExtension().lastPathComponent
-                let uri = "\(Shared.Constants.Search.appleArchiveScheme)\(guideUID)/\(filename)"
-                let resource = MCP.Core.Protocols.Resource(
-                    uri: uri,
-                    name: filename.replacingOccurrences(of: "-", with: " ").capitalized,
-                    description: "Apple Archive documentation",
-                    mimeType: MCPSharedTools.MCPCopy.mimeTypeMarkdown
+            for guide in guides where guide.hasDirectoryPath {
+                let guideUID = guide.lastPathComponent
+                let files = try FileManager.default.contentsOfDirectory(
+                    at: guide,
+                    includingPropertiesForKeys: nil
                 )
-                resources.append(resource)
+
+                for file in files where file.pathExtension == "md" {
+                    let filename = file.deletingPathExtension().lastPathComponent
+                    let uri = "\(Shared.Constants.Search.appleArchiveScheme)\(guideUID)/\(filename)"
+                    let resource = MCP.Core.Protocols.Resource(
+                        uri: uri,
+                        name: filename.replacingOccurrences(of: "-", with: " ").capitalized,
+                        description: "Apple Archive documentation",
+                        mimeType: MCP.SharedTools.Copy.mimeTypeMarkdown
+                    )
+                    resources.append(resource)
+                }
             }
+
+            return resources
         }
 
-        return resources
-    }
+        private func parseArchiveURI(_ uri: String) -> (guideUID: String, filename: String)? {
+            // Expected format: apple-archive://guideUID/filename
+            guard uri.hasPrefix(Shared.Constants.Search.appleArchiveScheme) else {
+                return nil
+            }
 
-    private func parseArchiveURI(_ uri: String) -> (guideUID: String, filename: String)? {
-        // Expected format: apple-archive://guideUID/filename
-        guard uri.hasPrefix(Shared.Constants.Search.appleArchiveScheme) else {
-            return nil
+            let path = uri.replacingOccurrences(of: Shared.Constants.Search.appleArchiveScheme, with: "")
+            let components = path.split(separator: "/", maxSplits: 1)
+
+            guard components.count == 2 else {
+                return nil
+            }
+
+            return (guideUID: String(components[0]), filename: String(components[1]))
         }
-
-        let path = uri.replacingOccurrences(of: Shared.Constants.Search.appleArchiveScheme, with: "")
-        let components = path.split(separator: "/", maxSplits: 1)
-
-        guard components.count == 2 else {
-            return nil
-        }
-
-        return (guideUID: String(components[0]), filename: String(components[1]))
     }
 }

--- a/Packages/Sources/MCP/Support/MCPSupport.swift
+++ b/Packages/Sources/MCP/Support/MCPSupport.swift
@@ -1,6 +1,14 @@
 import Foundation
+import MCP
 
-/// Namespace for MCP support utilities
-public enum MCPSupport {
-    // Namespace root - types defined in extensions
+// MARK: - MCP.Support Namespace
+
+/// Sub-namespace under the MCP root for support utilities — server-side
+/// helpers that aren't part of the cross-platform protocol runtime but ship
+/// alongside it in the same SPM target family.
+///
+/// Holds `MCP.Support.DocsResourceProvider`, the resource provider that
+/// serves crawled Apple documentation through the MCP resource interface.
+extension MCP {
+    public enum Support {}
 }

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -178,7 +178,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         if searchIndex != nil || sampleDatabase != nil {
             allTools.append(MCP.Core.Protocols.Tool(
                 name: Shared.Constants.Search.toolSearch,
-                description: MCPSharedTools.MCPCopy.toolSearchDescription,
+                description: MCP.SharedTools.Copy.toolSearchDescription,
                 inputSchema: objectSchema(
                     properties: searchProperties,
                     required: [Shared.Constants.Search.schemaParamQuery]
@@ -190,13 +190,13 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         if searchIndex != nil {
             allTools.append(MCP.Core.Protocols.Tool(
                 name: Shared.Constants.Search.toolListFrameworks,
-                description: MCPSharedTools.MCPCopy.toolListFrameworksDescription,
+                description: MCP.SharedTools.Copy.toolListFrameworksDescription,
                 inputSchema: objectSchema(properties: [:])
             ))
 
             allTools.append(MCP.Core.Protocols.Tool(
                 name: Shared.Constants.Search.toolReadDocument,
-                description: MCPSharedTools.MCPCopy.toolReadDocumentDescription,
+                description: MCP.SharedTools.Copy.toolReadDocumentDescription,
                 inputSchema: objectSchema(
                     properties: readDocumentProperties,
                     required: [Shared.Constants.Search.schemaParamURI]
@@ -208,13 +208,13 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         if sampleDatabase != nil {
             allTools.append(MCP.Core.Protocols.Tool(
                 name: Shared.Constants.Search.toolListSamples,
-                description: MCPSharedTools.MCPCopy.toolListSamplesDescription,
+                description: MCP.SharedTools.Copy.toolListSamplesDescription,
                 inputSchema: objectSchema(properties: [:])
             ))
 
             allTools.append(MCP.Core.Protocols.Tool(
                 name: Shared.Constants.Search.toolReadSample,
-                description: MCPSharedTools.MCPCopy.toolReadSampleDescription,
+                description: MCP.SharedTools.Copy.toolReadSampleDescription,
                 inputSchema: objectSchema(
                     properties: readSampleProperties,
                     required: [Shared.Constants.Search.schemaParamProjectId]
@@ -223,7 +223,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
             allTools.append(MCP.Core.Protocols.Tool(
                 name: Shared.Constants.Search.toolReadSampleFile,
-                description: MCPSharedTools.MCPCopy.toolReadSampleFileDescription,
+                description: MCP.SharedTools.Copy.toolReadSampleFileDescription,
                 inputSchema: objectSchema(
                     properties: readSampleFileProperties,
                     required: [
@@ -238,13 +238,13 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         if searchIndex != nil {
             allTools.append(MCP.Core.Protocols.Tool(
                 name: Shared.Constants.Search.toolSearchSymbols,
-                description: MCPSharedTools.MCPCopy.toolSearchSymbolsDescription,
+                description: MCP.SharedTools.Copy.toolSearchSymbolsDescription,
                 inputSchema: objectSchema(properties: searchSymbolsProperties)
             ))
 
             allTools.append(MCP.Core.Protocols.Tool(
                 name: Shared.Constants.Search.toolSearchPropertyWrappers,
-                description: MCPSharedTools.MCPCopy.toolSearchPropertyWrappersDescription,
+                description: MCP.SharedTools.Copy.toolSearchPropertyWrappersDescription,
                 inputSchema: objectSchema(
                     properties: searchPropertyWrappersProperties,
                     required: [Shared.Constants.Search.schemaParamWrapper]
@@ -253,7 +253,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
             allTools.append(MCP.Core.Protocols.Tool(
                 name: Shared.Constants.Search.toolSearchConcurrency,
-                description: MCPSharedTools.MCPCopy.toolSearchConcurrencyDescription,
+                description: MCP.SharedTools.Copy.toolSearchConcurrencyDescription,
                 inputSchema: objectSchema(
                     properties: searchConcurrencyProperties,
                     required: [Shared.Constants.Search.schemaParamPattern]
@@ -262,7 +262,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
             allTools.append(MCP.Core.Protocols.Tool(
                 name: Shared.Constants.Search.toolSearchConformances,
-                description: MCPSharedTools.MCPCopy.toolSearchConformancesDescription,
+                description: MCP.SharedTools.Copy.toolSearchConformancesDescription,
                 inputSchema: objectSchema(
                     properties: searchConformancesProperties,
                     required: [Shared.Constants.Search.schemaParamProtocol]
@@ -274,7 +274,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
     }
 
     public func callTool(name: String, arguments: [String: MCP.Core.Protocols.AnyCodable]?) async throws -> MCP.Core.Protocols.CallToolResult {
-        let args = ArgumentExtractor(arguments)
+        let args = MCP.SharedTools.ArgumentExtractor(arguments)
 
         switch name {
         case Shared.Constants.Search.toolSearch:
@@ -343,7 +343,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
     // MARK: - Unified Search Handler
 
-    private func handleSearch(args: ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
+    private func handleSearch(args: MCP.SharedTools.ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
         let query: String = try args.require(Shared.Constants.Search.schemaParamQuery)
         let source = args.optional(Shared.Constants.Search.schemaParamSource)
         let framework = args.optional(Shared.Constants.Search.schemaParamFramework)
@@ -614,7 +614,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
     // MARK: - Read Document
 
-    private func handleReadDocument(args: ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
+    private func handleReadDocument(args: MCP.SharedTools.ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
         guard let searchIndex else {
             throw ToolError.invalidArgument("index", "Documentation index not available")
         }
@@ -636,7 +636,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
     // MARK: - Sample Code Tools
 
-    private func handleListSamples(args: ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
+    private func handleListSamples(args: MCP.SharedTools.ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
         guard let sampleDatabase else {
             throw ToolError.invalidArgument("database", "Sample code database not available")
         }
@@ -675,7 +675,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         return MCP.Core.Protocols.CallToolResult(content: [.text(MCP.Core.Protocols.TextContent(text: markdown))])
     }
 
-    private func handleReadSample(args: ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
+    private func handleReadSample(args: MCP.SharedTools.ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
         guard let sampleDatabase else {
             throw ToolError.invalidArgument("database", "Sample code database not available")
         }
@@ -729,7 +729,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         return MCP.Core.Protocols.CallToolResult(content: [.text(MCP.Core.Protocols.TextContent(text: markdown))])
     }
 
-    private func handleReadSampleFile(args: ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
+    private func handleReadSampleFile(args: MCP.SharedTools.ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
         guard let sampleDatabase else {
             throw ToolError.invalidArgument("database", "Sample code database not available")
         }
@@ -763,7 +763,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
     // MARK: - Semantic Search Handlers (#81)
 
-    private func handleSearchSymbols(args: ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
+    private func handleSearchSymbols(args: MCP.SharedTools.ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
         guard let searchIndex else {
             throw ToolError.invalidArgument("index", "Documentation index not available")
         }
@@ -792,7 +792,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         return MCP.Core.Protocols.CallToolResult(content: [.text(MCP.Core.Protocols.TextContent(text: markdown))])
     }
 
-    private func handleSearchPropertyWrappers(args: ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
+    private func handleSearchPropertyWrappers(args: MCP.SharedTools.ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
         guard let searchIndex else {
             throw ToolError.invalidArgument("index", "Documentation index not available")
         }
@@ -818,7 +818,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         return MCP.Core.Protocols.CallToolResult(content: [.text(MCP.Core.Protocols.TextContent(text: markdown))])
     }
 
-    private func handleSearchConcurrency(args: ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
+    private func handleSearchConcurrency(args: MCP.SharedTools.ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
         guard let searchIndex else {
             throw ToolError.invalidArgument("index", "Documentation index not available")
         }
@@ -843,7 +843,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         return MCP.Core.Protocols.CallToolResult(content: [.text(MCP.Core.Protocols.TextContent(text: markdown))])
     }
 
-    private func handleSearchConformances(args: ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
+    private func handleSearchConformances(args: MCP.SharedTools.ArgumentExtractor) async throws -> MCP.Core.Protocols.CallToolResult {
         guard let searchIndex else {
             throw ToolError.invalidArgument("index", "Documentation index not available")
         }

--- a/Packages/Sources/Shared/Core/ToolError.swift
+++ b/Packages/Sources/Shared/Core/ToolError.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Unified error type for MCP tool and resource providers.
 /// Consolidates error handling across DocumentationToolProvider, SampleCodeToolProvider,
-/// CompositeToolProvider, and DocsResourceProvider.
+/// CompositeToolProvider, and MCP.Support.DocsResourceProvider.
 public enum ToolError: Error, LocalizedError, Sendable {
     /// Unknown tool name requested
     case unknownTool(String)

--- a/Packages/Tests/CLICommandTests/FetchTests/ResumeTests.swift
+++ b/Packages/Tests/CLICommandTests/FetchTests/ResumeTests.swift
@@ -728,7 +728,7 @@ struct ResumeAndStartCleanTests {
     // current `metadataFile`'s parent directory + framework + basename, so:
     //   * `validateMetadata` doesn't false-negative and wipe the saved session
     //   * `SearchIndexBuilder` reads pages from the right place
-    //   * `DocsResourceProvider` resolves correctly
+    //   * `MCP.Support.DocsResourceProvider` resolves correctly
 
     private static func writeFixturePagesAndFile(
         outputDir: URL,

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -68,7 +68,7 @@ struct MCPCommandTests {
             changeDetection: Shared.ChangeDetectionConfiguration(outputDirectory: tempDir),
             output: Shared.OutputConfiguration()
         )
-        let provider = DocsResourceProvider(configuration: config)
+        let provider = MCP.Support.DocsResourceProvider(configuration: config)
 
         await server.registerResourceProvider(provider)
 
@@ -112,7 +112,7 @@ struct MCPCommandTests {
             changeDetection: Shared.ChangeDetectionConfiguration(),
             output: Shared.OutputConfiguration()
         )
-        let provider = DocsResourceProvider(configuration: config)
+        let provider = MCP.Support.DocsResourceProvider(configuration: config)
 
         // Read resource
         let result = try await provider.readResource(uri: "apple-docs://swift/documentation_swift")
@@ -242,7 +242,7 @@ struct MCPCommandTests {
             changeDetection: Shared.ChangeDetectionConfiguration(),
             output: Shared.OutputConfiguration()
         )
-        let provider = DocsResourceProvider(configuration: config, evolutionDirectory: tempDir)
+        let provider = MCP.Support.DocsResourceProvider(configuration: config, evolutionDirectory: tempDir)
 
         // List resources
         let listResult = try await provider.listResources(cursor: nil as String?)
@@ -294,7 +294,7 @@ struct MCPCommandTests {
             changeDetection: Shared.ChangeDetectionConfiguration(),
             output: Shared.OutputConfiguration()
         )
-        let provider = DocsResourceProvider(configuration: config, evolutionDirectory: tempDir)
+        let provider = MCP.Support.DocsResourceProvider(configuration: config, evolutionDirectory: tempDir)
 
         // List resources — should include both SE and ST
         let listResult = try await provider.listResources(cursor: nil as String?)
@@ -330,7 +330,7 @@ struct MCPCommandTests {
             changeDetection: Shared.ChangeDetectionConfiguration(),
             output: Shared.OutputConfiguration()
         )
-        let provider = DocsResourceProvider(configuration: config)
+        let provider = MCP.Support.DocsResourceProvider(configuration: config)
 
         // Try to read non-existent resource
         await #expect(throws: ToolError.self) {
@@ -405,7 +405,7 @@ struct MCPServerIntegrationTests {
             changeDetection: Shared.ChangeDetectionConfiguration(),
             output: Shared.OutputConfiguration()
         )
-        let docsProvider = DocsResourceProvider(configuration: mcpConfig)
+        let docsProvider = MCP.Support.DocsResourceProvider(configuration: mcpConfig)
         let searchProvider = CompositeToolProvider(searchIndex: searchIndex, sampleDatabase: nil)
 
         await server.registerResourceProvider(docsProvider)

--- a/Packages/Tests/MCP/ClientTests/MCPClientTests.swift
+++ b/Packages/Tests/MCP/ClientTests/MCPClientTests.swift
@@ -1,3 +1,4 @@
+import MCP
 @testable import MCPClient
 import Testing
 
@@ -5,21 +6,21 @@ import Testing
 struct MCPClientTests {
     @Test("Initialize with server command")
     func initWithCommand() async {
-        let client = MCPClient(serverCommand: "cupertino", serverArguments: ["serve"])
+        let client = MCP.Client(serverCommand: "cupertino", serverArguments: ["serve"])
         let connected = await client.isConnected
         #expect(connected == false)
     }
 
     @Test("Initialize with full command array")
     func initWithCommandArray() async {
-        let client = MCPClient(command: ["npx", "-y", "@modelcontextprotocol/server-memory"])
+        let client = MCP.Client(command: ["npx", "-y", "@modelcontextprotocol/server-memory"])
         let connected = await client.isConnected
         #expect(connected == false)
     }
 
     @Test("Create cupertino client")
     func createCupertinoClient() async {
-        let client = MCPClient.cupertino()
+        let client = MCP.Client.cupertino()
         let connected = await client.isConnected
         #expect(connected == false)
     }

--- a/Packages/Tests/MCP/SharedToolsTests/ArgumentExtractorTests.swift
+++ b/Packages/Tests/MCP/SharedToolsTests/ArgumentExtractorTests.swift
@@ -4,20 +4,20 @@ import SharedConstants
 import SharedCore
 import Testing
 
-@Suite("ArgumentExtractor")
+@Suite("MCP.SharedTools.ArgumentExtractor")
 struct ArgumentExtractorTests {
     // MARK: - Required arguments
 
     @Test("require returns string value when present")
     func requireReturnsStringValue() throws {
         let args: [String: MCP.Core.Protocols.AnyCodable] = ["query": MCP.Core.Protocols.AnyCodable("swiftui")]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(try extractor.require("query") == "swiftui")
     }
 
     @Test("require throws missingArgument when key absent")
     func requireThrowsWhenAbsent() {
-        let extractor = ArgumentExtractor(nil)
+        let extractor = MCP.SharedTools.ArgumentExtractor(nil)
         #expect(throws: ToolError.self) {
             _ = try extractor.require("query")
         }
@@ -26,7 +26,7 @@ struct ArgumentExtractorTests {
     @Test("require throws when value has wrong type")
     func requireThrowsOnWrongType() {
         let args: [String: MCP.Core.Protocols.AnyCodable] = ["query": MCP.Core.Protocols.AnyCodable(42)]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(throws: ToolError.self) {
             _ = try extractor.require("query")
         }
@@ -35,14 +35,14 @@ struct ArgumentExtractorTests {
     @Test("requireInt returns int value")
     func requireIntReturnsValue() throws {
         let args: [String: MCP.Core.Protocols.AnyCodable] = ["limit": MCP.Core.Protocols.AnyCodable(5)]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(try extractor.requireInt("limit") == 5)
     }
 
     @Test("requireBool returns bool value")
     func requireBoolReturnsValue() throws {
         let args: [String: MCP.Core.Protocols.AnyCodable] = ["include_archive": MCP.Core.Protocols.AnyCodable(true)]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(try extractor.requireBool("include_archive") == true)
     }
 
@@ -50,27 +50,27 @@ struct ArgumentExtractorTests {
 
     @Test("optional returns nil when absent")
     func optionalReturnsNilWhenAbsent() {
-        let extractor = ArgumentExtractor(nil)
+        let extractor = MCP.SharedTools.ArgumentExtractor(nil)
         #expect(extractor.optional("framework") == nil)
     }
 
     @Test("optional returns value when present")
     func optionalReturnsValueWhenPresent() {
         let args: [String: MCP.Core.Protocols.AnyCodable] = ["framework": MCP.Core.Protocols.AnyCodable("swiftui")]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(extractor.optional("framework") == "swiftui")
     }
 
     @Test("optional with default returns default when absent")
     func optionalWithDefaultReturnsDefault() {
-        let extractor = ArgumentExtractor(nil)
+        let extractor = MCP.SharedTools.ArgumentExtractor(nil)
         #expect(extractor.optional("language", default: "en") == "en")
     }
 
     @Test("optional with default returns value when present")
     func optionalWithDefaultReturnsValue() {
         let args: [String: MCP.Core.Protocols.AnyCodable] = ["language": MCP.Core.Protocols.AnyCodable("de")]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(extractor.optional("language", default: "en") == "de")
     }
 
@@ -78,7 +78,7 @@ struct ArgumentExtractorTests {
 
     @Test("limit returns the default when absent")
     func limitReturnsDefaultWhenAbsent() {
-        let extractor = ArgumentExtractor(nil)
+        let extractor = MCP.SharedTools.ArgumentExtractor(nil)
         #expect(extractor.limit() == Shared.Constants.Limit.defaultSearchLimit)
     }
 
@@ -87,7 +87,7 @@ struct ArgumentExtractorTests {
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
             Shared.Constants.Search.schemaParamLimit: MCP.Core.Protocols.AnyCodable(15),
         ]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(extractor.limit() == 15)
     }
 
@@ -96,7 +96,7 @@ struct ArgumentExtractorTests {
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
             Shared.Constants.Search.schemaParamLimit: MCP.Core.Protocols.AnyCodable(9999),
         ]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(extractor.limit() == Shared.Constants.Limit.maxSearchLimit)
     }
 
@@ -104,7 +104,7 @@ struct ArgumentExtractorTests {
 
     @Test("format returns formatValueJSON when absent")
     func formatReturnsJSONDefault() {
-        let extractor = ArgumentExtractor(nil)
+        let extractor = MCP.SharedTools.ArgumentExtractor(nil)
         #expect(extractor.format() == Shared.Constants.Search.formatValueJSON)
     }
 
@@ -115,7 +115,7 @@ struct ArgumentExtractorTests {
                 Shared.Constants.Search.formatValueMarkdown
             ),
         ]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(extractor.format() == Shared.Constants.Search.formatValueMarkdown)
     }
 
@@ -123,7 +123,7 @@ struct ArgumentExtractorTests {
 
     @Test("includeArchive defaults to false")
     func includeArchiveDefaultsFalse() {
-        let extractor = ArgumentExtractor(nil)
+        let extractor = MCP.SharedTools.ArgumentExtractor(nil)
         #expect(extractor.includeArchive() == false)
     }
 
@@ -132,7 +132,7 @@ struct ArgumentExtractorTests {
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
             Shared.Constants.Search.schemaParamIncludeArchive: MCP.Core.Protocols.AnyCodable(true),
         ]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(extractor.includeArchive() == true)
     }
 
@@ -140,13 +140,13 @@ struct ArgumentExtractorTests {
 
     @Test("minIOS reads supplied value, nil when absent")
     func minIOSReadsValue() {
-        let absent = ArgumentExtractor(nil)
+        let absent = MCP.SharedTools.ArgumentExtractor(nil)
         #expect(absent.minIOS() == nil)
 
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
             Shared.Constants.Search.schemaParamMinIOS: MCP.Core.Protocols.AnyCodable("17.0"),
         ]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(extractor.minIOS() == "17.0")
     }
 
@@ -158,7 +158,7 @@ struct ArgumentExtractorTests {
             Shared.Constants.Search.schemaParamMinWatchOS: MCP.Core.Protocols.AnyCodable("10.0"),
             Shared.Constants.Search.schemaParamMinVisionOS: MCP.Core.Protocols.AnyCodable("1.0"),
         ]
-        let extractor = ArgumentExtractor(args)
+        let extractor = MCP.SharedTools.ArgumentExtractor(args)
         #expect(extractor.minMacOS() == "14.0")
         #expect(extractor.minTvOS() == "17.0")
         #expect(extractor.minWatchOS() == "10.0")

--- a/Packages/Tests/MCP/SupportTests/DocsResourceProviderMalformedURLSkipTests.swift
+++ b/Packages/Tests/MCP/SupportTests/DocsResourceProviderMalformedURLSkipTests.swift
@@ -9,7 +9,7 @@ import SharedModels
 import Testing
 
 // Covers the malformed-URL skip path added to
-// `DocsResourceProvider.listResources` in PR #288: a row in
+// `MCP.Support.DocsResourceProvider.listResources` in PR #288: a row in
 // `CrawlMetadata.pages` whose URL key fails `URL(string:)` is skipped
 // rather than crashing the listing call. The previous force-unwrap form
 // would crash on the same input.
@@ -19,15 +19,15 @@ import Testing
 // a `metadata.json` fixture to whatever directory the configuration is
 // pointing at.
 
-@Suite("DocsResourceProvider malformed-URL skip", .serialized)
+@Suite("MCP.Support.DocsResourceProvider malformed-URL skip", .serialized)
 struct DocsResourceProviderMalformedURLSkipTests {
-    private func makeProvider(in tempRoot: URL) -> DocsResourceProvider {
+    private func makeProvider(in tempRoot: URL) -> MCP.Support.DocsResourceProvider {
         // All-defaults Configuration is fine: we inject metadata via the
         // test seam, so the provider never touches the on-disk paths the
         // configuration would otherwise point at.
         let evolutionDir = tempRoot.appendingPathComponent("swift-evolution")
         let archiveDir = tempRoot.appendingPathComponent("archive")
-        return DocsResourceProvider(
+        return MCP.Support.DocsResourceProvider(
             configuration: Shared.Configuration(),
             evolutionDirectory: evolutionDir,
             archiveDirectory: archiveDir,


### PR DESCRIPTION
Three sibling SPM targets — `MCPClient`, `MCPSupport`, `MCPSharedTools` — now extend the same `MCP` namespace root that `MCP.Core` uses (#350). Every public type they expose moves into `MCP.<sub>.<X>`.

## Renames

### MCP/Client/

| Before | After |
|---|---|
| `MCPClient` (actor) | `MCP.Client` |
| `MCPClientError` | `MCP.ClientError` |
| `extension MCPClient { ... }` | `extension MCP.Client { ... }` |

`MCPClientError` stays as a **sibling** of `MCP.Client` rather than nesting inside the actor as `MCP.Client.Error`. Nesting would force every `catch let error as MCPClientError` to become `catch let error as Client.Error`, which inside the actor body collides with the bare `Error` Swift.Error protocol and produces ambiguous catch-pattern resolution. Sibling is clean.

### MCP/Support/

| Before | After |
|---|---|
| `public enum MCPSupport {}` (own module's root) | `extension MCP { public enum Support {} }` |
| `DocsResourceProvider` (actor) | `MCP.Support.DocsResourceProvider` |

### MCP/SharedTools/

| Before | After |
|---|---|
| `public enum MCPCopy` | `MCP.SharedTools.Copy` (drops `MCP` prefix — parent namespace supplies it) |
| `ArgumentExtractor` (struct) | `MCP.SharedTools.ArgumentExtractor` |

New `MCPSharedTools.swift` declares the sub-namespace anchor: `extension MCP { public enum SharedTools {} }`.

## Mechanics

- Each subtarget's public types wrap in `extension MCP.<sub> { ... }`.
- Subnamespace anchors live in the natural file per target (no anchor needed for Client since the actor IS the type).
- External callers swept: `DocsResourceProvider` references in `CrawlerState`, `ServeCommand`, `DoctorCommand`, `ToolError`, plus the test mirrors. `MCPCopy` + `ArgumentExtractor` in `CompositeToolProvider`, `DocsResourceProvider`, `ArgumentExtractorTests`. `MCPClient` in `MCPClientTests`.
- `MockAIAgent` retains its own **local** `actor MCPClient` + `enum MCPClientError` unchanged — they're private to the mock-agent demo target and don't reference the renamed module types.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Previous: #348 Foundation, #350 MCP.Core, #351 Shared, #352 Command, #353 CoreProtocols, #354 Cleanup+Services.