### PR TITLE
refactor(Sample): open cross-cutting Sample namespace; first sub-area is Sample.Cleanup.Cleaner

### DIFF
--- a/Packages/Sources/CLI/CleanupModuleAlias.swift
+++ b/Packages/Sources/CLI/CleanupModuleAlias.swift
@@ -9,7 +9,7 @@ import Cleanup
 // enclosing types before imported modules.
 //
 // `CleanupModule` pins the SPM target so callers in the CLI target can
-// write `CleanupModule.SampleCodeCleaner` and reach the actual module type.
+// write `Sample.Cleanup.Cleaner` and reach the actual module type.
 // One declaration covers every file in the CLI target.
 
 typealias CleanupModule = Cleanup

--- a/Packages/Sources/CLI/Commands/CleanupCommand.swift
+++ b/Packages/Sources/CLI/Commands/CleanupCommand.swift
@@ -79,7 +79,7 @@ extension Command {
                 Logging.Log.output("")
             }
 
-            let cleaner = CleanupModule.SampleCodeCleaner(
+            let cleaner = Sample.Cleanup.Cleaner(
                 sampleCodeDirectory: directory,
                 dryRun: dryRun,
                 keepOriginals: keepOriginals

--- a/Packages/Sources/Cleanup/Cleanup.swift
+++ b/Packages/Sources/Cleanup/Cleanup.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - Cleanup Namespace
 
 /// Namespace for sample-code post-fetch cleanup operations. Holds
-/// `Cleanup.SampleCodeCleaner` (the actor that prunes orphaned sample
+/// `Sample.Cleanup.Cleaner` (the actor that prunes orphaned sample
 /// archives + manifests after a fetch run) and any related types added
 /// later.
 public enum Cleanup {}

--- a/Packages/Sources/Cleanup/SampleCodeCleaner.swift
+++ b/Packages/Sources/Cleanup/SampleCodeCleaner.swift
@@ -6,10 +6,12 @@ import SharedModels
 
 // MARK: - Sample Code Cleaner
 
-extension Cleanup {
+extension Sample.Cleanup {
     /// Actor for cleaning sample code archives by removing unnecessary files
-    /// such as .git folders, .DS_Store, build artifacts, etc.
-    public actor SampleCodeCleaner {
+    /// such as .git folders, .DS_Store, build artifacts, etc. Previously
+    /// `Cleanup.SampleCodeCleaner`; nested under `Sample.Cleanup` per the
+    /// cross-cutting Sample namespace policy.
+    public actor Cleaner {
         private let sampleCodeDirectory: URL
         private let dryRun: Bool
         private let keepOriginals: Bool

--- a/Packages/Sources/Shared/Constants/Sample.swift
+++ b/Packages/Sources/Shared/Constants/Sample.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+// MARK: - Sample Namespace
+
+/// Cross-cutting namespace for every type whose responsibility is Apple sample
+/// code — fetching, indexing, cleaning, querying, formatting. The previous
+/// layout spread these types across module-folder namespaces (Cleanup,
+/// Services, Core, SampleIndex, Search), making it hard to see at a glance
+/// which corner of the system handles samples. Pulling them all under
+/// `Sample.*` gives one entry point with sub-namespaces mirroring the
+/// originating module so provenance stays readable.
+///
+/// Layout:
+/// - `Sample.Cleanup.*`   — sample-archive post-fetch cleanup (was Cleanup).
+/// - `Sample.Core.*`      — sample-code catalog + fetch primitives that
+///                          live in the Core SPM target.
+/// - `Sample.Services.*`  — sample-flavoured Services components
+///                          (`CandidateFetcher` etc.).
+/// - `Sample.Search.*`    — sample search service + query / result types
+///                          (was Services.ReadCommands.SampleSearchService).
+/// - `Sample.Index.*`     — the SampleIndex SPM target's contents.
+/// - `Sample.Indexer`     — search indexer for sample code (was
+///                          Search.SampleCodeIndexer).
+/// - `Sample.Atom`        — `ResultAtom` conformance for sample search
+///                          hits (was Search.SampleAtom).
+/// - `Sample.Format.*`    — sample-flavoured `ResultFormatter`s in
+///                          Markdown / JSON / Text.
+///
+/// Sub-namespaces are declared as empty enums here so any SPM target that
+/// imports SharedConstants can extend them with concrete types via
+/// `extension Sample.<sub> { ... }`. Concrete types follow in the per-area
+/// PRs (this file just opens the surface).
+public enum Sample {
+    /// Sample-archive post-fetch cleanup. The actor that prunes orphaned
+    /// archives + manifests after a fetch run lives here as
+    /// `Sample.Cleanup.Cleaner`.
+    public enum Cleanup {}
+
+    /// Sample-code catalog + fetch primitives shipped in the Core SPM target:
+    /// `Catalog`, `Entry`, `Statistics`, `Progress`, `Project`.
+    public enum Core {}
+
+    /// Sample-flavoured Services components. Currently holds
+    /// `Sample.Services.CandidateFetcher` (the `Search.CandidateFetcher`
+    /// implementation that returns sample-code hits).
+    public enum Services {}
+
+    /// Sample search-service surface: the `Service` actor that wraps a
+    /// SampleIndex database, plus the `Query` and `Result` value types.
+    public enum Search {}
+
+    /// The SampleIndex SPM target's contents — index database + builder +
+    /// availability sidecar.
+    public enum Index {}
+
+    /// Sample-flavoured `ResultFormatter`s. Sub-namespaces split by output
+    /// medium: `Sample.Format.Markdown.*`, `Sample.Format.JSON.*`,
+    /// `Sample.Format.Text.*`.
+    public enum Format {
+        /// Markdown-rendering formatters for sample search hits, sample
+        /// project listings, sample-file content.
+        public enum Markdown {}
+
+        /// JSON-encoding formatters for the same.
+        public enum JSON {}
+
+        /// Plain-text formatters for the same.
+        public enum Text {}
+    }
+}

--- a/Packages/Tests/CleanupTests/SampleCodeCleanerTests.swift
+++ b/Packages/Tests/CleanupTests/SampleCodeCleanerTests.swift
@@ -6,7 +6,7 @@ import SharedModels
 import Testing
 import TestSupport
 
-// MARK: - Cleanup.SampleCodeCleaner Tests
+// MARK: - Sample.Cleanup.Cleaner Tests
 
 @Test("CleanupProgress percentage calculation")
 func cleanupProgressPercentage() {


### PR DESCRIPTION
Opens a top-level `public enum Sample` namespace declared in SharedConstants (so every SPM target that touches sample code can reach it through their existing SharedConstants import) and starts moving sample-prefixed types into sub-namespaces that mirror the originating module.

## Target layout (full, declared in this PR; types follow per sub-area)

```
Sample
├─ Cleanup           (Sources/Cleanup/)
│  └─ Cleaner        (was Cleanup.SampleCodeCleaner)
├─ Core              (Sources/Core/)
│  ├─ Catalog        (was Core.SampleCodeCatalog)
│  ├─ Entry          (was Core.SampleCodeEntry)
│  ├─ Statistics     (was Core.SampleStatistics)
│  ├─ Progress       (was Core.SampleProgress)
│  └─ Project        (was Core.SampleProject)
├─ Services          (Sources/Services/)
│  └─ CandidateFetcher  (was Services.SampleCandidateFetcher)
├─ Search            (Services/ReadCommands/SampleSearchService.swift)
│  ├─ Service        (was SampleSearchService)
│  ├─ Query          (was SampleQuery)
│  └─ Result         (was SampleSearchResult)
├─ Index             (Sources/SampleIndex/)
│  └─ … (whole SampleIndex SPM target moves here)
├─ Indexer           (was Search.SampleCodeIndexer)
├─ Atom              (was Search.SampleAtom)
└─ Format
   ├─ Markdown.*     (Sample*MarkdownFormatter)
   ├─ JSON.*         (Sample*JSONFormatter)
   └─ Text.*         (Sample*TextFormatter)
```

This PR **opens the namespace + relocates only the Cleanup sub-area** so the pattern is concrete and buildable. Six more PRs follow for Core, Services, Search, Index, Indexer/Atom, Format.

## Renames in this PR

| Before | After |
|---|---|
| `Cleanup.SampleCodeCleaner` | `Sample.Cleanup.Cleaner` |

The `Cleanup` SPM module still exists (`Sources/Cleanup/Cleanup.swift` declares `public enum Cleanup {}`), it's just empty for now. Future per-module cleanup types that aren't sample-flavoured can land there.

## Mechanics

- `Sources/Shared/Constants/Sample.swift` declares the full nested namespace tree.
- `Cleanup/SampleCodeCleaner.swift` rewraps `extension Cleanup { actor SampleCodeCleaner }` as `extension Sample.Cleanup { actor Cleaner }`.
- 4 caller files swept: `Cleanup.swift` docstring, `CleanupModuleAlias.swift`, `CleanupCommand.swift` (uses `CleanupModule.SampleCodeCleaner` → `Sample.Cleanup.Cleaner`), `SampleCodeCleanerTests.swift`.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Previous: #348 Foundation, #350 MCP.Core, #351 Shared, #352 Command, #353 CoreProtocols, #354 Cleanup+Services, #355 MCP subtargets.