### PR TITLE
refactor(Sample): relocate Core sample types under Sample.Core; sweep callers

### DIFF
--- a/Packages/Sources/CLI/CleanupModuleAlias.swift
+++ b/Packages/Sources/CLI/CleanupModuleAlias.swift
@@ -1,4 +1,5 @@
 import Cleanup
+import SharedConstants
 
 // MARK: - Cleanup Module Disambiguator
 

--- a/Packages/Sources/Cleanup/Cleanup.swift
+++ b/Packages/Sources/Cleanup/Cleanup.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SharedConstants
 
 // MARK: - Cleanup Namespace
 

--- a/Packages/Sources/Core/GitHubSampleCodeFetcher.swift
+++ b/Packages/Sources/Core/GitHubSampleCodeFetcher.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Logging
+import SharedConstants
 import SharedCore
 
 // MARK: - GitHub Sample Code Fetcher
@@ -61,14 +62,14 @@ public final class GitHubSampleCodeFetcher {
     }
 
     /// List all available sample code projects
-    public func listProjects() async throws -> [SampleProject] {
+    public func listProjects() async throws -> [Sample.Core.Project] {
         let repoPath = outputDirectory.appendingPathComponent(repoName)
 
         guard FileManager.default.fileExists(atPath: repoPath.path) else {
             throw GitHubFetcherError.repositoryNotCloned
         }
 
-        var projects: [SampleProject] = []
+        var projects: [Sample.Core.Project] = []
         let contents = try FileManager.default.contentsOfDirectory(
             at: repoPath,
             includingPropertiesForKeys: [.isDirectoryKey]
@@ -90,7 +91,7 @@ public final class GitHubSampleCodeFetcher {
             )
 
             if hasXcodeproj || hasPackageSwift {
-                let project = SampleProject(
+                let project = Sample.Core.Project(
                     id: item.lastPathComponent,
                     name: formatProjectName(item.lastPathComponent),
                     path: item
@@ -225,15 +226,17 @@ public final class GitHubSampleCodeFetcher {
 
 // MARK: - Models
 
-public struct SampleProject: Sendable {
-    public let id: String
-    public let name: String
-    public let path: URL
+extension Sample.Core {
+    public struct Project: Sendable {
+        public let id: String
+        public let name: String
+        public let path: URL
 
-    public init(id: String, name: String, path: URL) {
-        self.id = id
-        self.name = name
-        self.path = path
+        public init(id: String, name: String, path: URL) {
+            self.id = id
+            self.name = name
+            self.path = path
+        }
     }
 }
 

--- a/Packages/Sources/Core/SampleCodeCatalog.swift
+++ b/Packages/Sources/Core/SampleCodeCatalog.swift
@@ -11,24 +11,26 @@ import SharedConstants
 import SharedCore
 
 /// Represents a sample code project from Apple
-public struct SampleCodeEntry: Codable, Sendable {
-    public let title: String
-    public let url: String
-    public let framework: String
-    public let description: String
-    public let zipFilename: String
-    public let webURL: String
+extension Sample.Core {
+    public struct Entry: Codable, Sendable {
+        public let title: String
+        public let url: String
+        public let framework: String
+        public let description: String
+        public let zipFilename: String
+        public let webURL: String
 
-    public init(
-        title: String, url: String, framework: String,
-        description: String, zipFilename: String, webURL: String
-    ) {
-        self.title = title
-        self.url = url
-        self.framework = framework
-        self.description = description
-        self.zipFilename = zipFilename
-        self.webURL = webURL
+        public init(
+            title: String, url: String, framework: String,
+            description: String, zipFilename: String, webURL: String
+        ) {
+            self.title = title
+            self.url = url
+            self.framework = framework
+            self.description = description
+            self.zipFilename = zipFilename
+            self.webURL = webURL
+        }
     }
 }
 
@@ -37,7 +39,7 @@ struct SampleCodeCatalogJSON: Codable {
     let version: String
     let lastCrawled: String
     let count: Int
-    let entries: [SampleCodeEntry]
+    let entries: [Sample.Core.Entry]
 }
 
 /// Complete catalog of all Apple sample code projects.
@@ -48,168 +50,170 @@ struct SampleCodeCatalogJSON: Codable {
 /// fallback (#215). Callers (e.g. `SearchIndexBuilder`) should check
 /// `loadedSource` and warn the user when the catalog is missing so the
 /// fix is obvious: run fetch.
-public enum SampleCodeCatalog {
-    /// File name written by `SampleCodeDownloader` next to the fetched zips
-    /// so `cupertino save` can pick up the freshly-discovered metadata.
-    public static let onDiskCatalogFilename = "catalog.json"
+extension Sample.Core {
+    public enum Catalog {
+        /// File name written by `SampleCodeDownloader` next to the fetched zips
+        /// so `cupertino save` can pick up the freshly-discovered metadata.
+        public static let onDiskCatalogFilename = "catalog.json"
 
-    /// Source the catalog was loaded from on the most recent `loadCatalog`
-    /// call. Useful for telling users via the build log whether their save
-    /// is indexing real data or skipping for lack of input.
-    public enum Source: String, Sendable {
-        /// `<sample-code-dir>/catalog.json` was found and decoded successfully.
-        case onDisk
-        /// No on-disk catalog (file absent or unparseable). Caller should
-        /// hint at running `cupertino fetch --type code` to populate it.
-        case missing
-    }
-
-    /// Cached catalog data (thread-safe via actor isolation)
-    private actor Cache {
-        var catalog: SampleCodeCatalogJSON?
-        var source: Source?
-
-        func get() -> (SampleCodeCatalogJSON, Source)? {
-            guard let catalog, let source else { return nil }
-            return (catalog, source)
+        /// Source the catalog was loaded from on the most recent `loadCatalog`
+        /// call. Useful for telling users via the build log whether their save
+        /// is indexing real data or skipping for lack of input.
+        public enum Source: String, Sendable {
+            /// `<sample-code-dir>/catalog.json` was found and decoded successfully.
+            case onDisk
+            /// No on-disk catalog (file absent or unparseable). Caller should
+            /// hint at running `cupertino fetch --type code` to populate it.
+            case missing
         }
 
-        func set(_ newCatalog: SampleCodeCatalogJSON, source: Source) {
-            catalog = newCatalog
-            self.source = source
+        /// Cached catalog data (thread-safe via actor isolation)
+        private actor Cache {
+            var catalog: SampleCodeCatalogJSON?
+            var source: Source?
+
+            func get() -> (SampleCodeCatalogJSON, Source)? {
+                guard let catalog, let source else { return nil }
+                return (catalog, source)
+            }
+
+            func set(_ newCatalog: SampleCodeCatalogJSON, source: Source) {
+                catalog = newCatalog
+                self.source = source
+            }
+
+            func clear() {
+                catalog = nil
+                source = nil
+            }
         }
 
-        func clear() {
-            catalog = nil
-            source = nil
-        }
-    }
+        private static let cache = Cache()
 
-    private static let cache = Cache()
-
-    /// Reset the cached catalog. Used by tests to force `loadCatalog` to
-    /// re-evaluate disk state between cases.
-    public static func resetCache() async {
-        await cache.clear()
-    }
-
-    /// Load catalog from `<sample-code-dir>/catalog.json`. Returns an empty
-    /// catalog if the file is missing or unparseable (#215: no embedded
-    /// fallback). The result + source are cached for the process lifetime;
-    /// call `resetCache` to re-evaluate. Honours
-    /// `setTestOverrideDirectory` so integration tests can sandbox.
-    private static func loadCatalog() async -> SampleCodeCatalogJSON {
-        if let cached = await cache.get() {
-            return cached.0
+        /// Reset the cached catalog. Used by tests to force `loadCatalog` to
+        /// re-evaluate disk state between cases.
+        public static func resetCache() async {
+            await cache.clear()
         }
 
-        if let onDisk = await loadFromDiskRespectingOverride() {
-            await cache.set(onDisk, source: .onDisk)
-            return onDisk
+        /// Load catalog from `<sample-code-dir>/catalog.json`. Returns an empty
+        /// catalog if the file is missing or unparseable (#215: no embedded
+        /// fallback). The result + source are cached for the process lifetime;
+        /// call `resetCache` to re-evaluate. Honours
+        /// `setTestOverrideDirectory` so integration tests can sandbox.
+        private static func loadCatalog() async -> SampleCodeCatalogJSON {
+            if let cached = await cache.get() {
+                return cached.0
+            }
+
+            if let onDisk = await loadFromDiskRespectingOverride() {
+                await cache.set(onDisk, source: .onDisk)
+                return onDisk
+            }
+
+            let empty = SampleCodeCatalogJSON(
+                version: "missing",
+                lastCrawled: "",
+                count: 0,
+                entries: []
+            )
+            await cache.set(empty, source: .missing)
+            return empty
         }
 
-        let empty = SampleCodeCatalogJSON(
-            version: "missing",
-            lastCrawled: "",
-            count: 0,
-            entries: []
-        )
-        await cache.set(empty, source: .missing)
-        return empty
-    }
+        /// Test-only override for the default sample-code directory. When set
+        /// via `setTestOverrideDirectory`, `loadFromDisk()` (no-arg) reads from
+        /// here instead of `Shared.Constants.defaultSampleCodeDirectory`. Lets
+        /// integration tests sandbox without polluting user data and without
+        /// requiring callers to plumb a directory through every API.
+        /// Production code must never set this.
+        private actor TestOverride {
+            var directory: URL?
+            func get() -> URL? {
+                directory
+            }
 
-    /// Test-only override for the default sample-code directory. When set
-    /// via `setTestOverrideDirectory`, `loadFromDisk()` (no-arg) reads from
-    /// here instead of `Shared.Constants.defaultSampleCodeDirectory`. Lets
-    /// integration tests sandbox without polluting user data and without
-    /// requiring callers to plumb a directory through every API.
-    /// Production code must never set this.
-    private actor TestOverride {
-        var directory: URL?
-        func get() -> URL? {
-            directory
+            func set(_ url: URL?) {
+                directory = url
+            }
         }
 
-        func set(_ url: URL?) {
-            directory = url
+        private static let testOverride = TestOverride()
+
+        /// Set a test-only override for the default sample-code directory.
+        /// Pass `nil` to clear. `internal` so production code can't reach it.
+        static func setTestOverrideDirectory(_ url: URL?) async {
+            await testOverride.set(url)
         }
-    }
 
-    private static let testOverride = TestOverride()
-
-    /// Set a test-only override for the default sample-code directory.
-    /// Pass `nil` to clear. `internal` so production code can't reach it.
-    static func setTestOverrideDirectory(_ url: URL?) async {
-        await testOverride.set(url)
-    }
-
-    /// Read `<sample-code-dir>/catalog.json` if present and parseable.
-    /// `internal` so tests can drive it directly. The no-arg form reads
-    /// from `Shared.Constants.defaultSampleCodeDirectory`; tests pass an
-    /// explicit path or use the async `loadFromDiskRespectingOverride`
-    /// below to honour the test override.
-    static func loadFromDisk(at directory: URL? = nil) -> SampleCodeCatalogJSON? {
-        let dir = directory ?? Shared.Constants.defaultSampleCodeDirectory
-        let url = dir.appendingPathComponent(onDiskCatalogFilename)
-        guard let data = try? Data(contentsOf: url) else { return nil }
-        return try? JSONDecoder().decode(SampleCodeCatalogJSON.self, from: data)
-    }
-
-    /// Async load that respects the test override. Production code calls
-    /// `loadCatalog` (which calls this); tests that want allEntries to
-    /// sandbox set the override via `setTestOverrideDirectory` first.
-    private static func loadFromDiskRespectingOverride() async -> SampleCodeCatalogJSON? {
-        let dir = await testOverride.get() ?? Shared.Constants.defaultSampleCodeDirectory
-        return loadFromDisk(at: dir)
-    }
-
-    /// Which source the cached catalog was loaded from. Returns nil before
-    /// the first `loadCatalog` call.
-    public static var loadedSource: Source? {
-        get async {
-            await cache.get()?.1
+        /// Read `<sample-code-dir>/catalog.json` if present and parseable.
+        /// `internal` so tests can drive it directly. The no-arg form reads
+        /// from `Shared.Constants.defaultSampleCodeDirectory`; tests pass an
+        /// explicit path or use the async `loadFromDiskRespectingOverride`
+        /// below to honour the test override.
+        static func loadFromDisk(at directory: URL? = nil) -> SampleCodeCatalogJSON? {
+            let dir = directory ?? Shared.Constants.defaultSampleCodeDirectory
+            let url = dir.appendingPathComponent(onDiskCatalogFilename)
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            return try? JSONDecoder().decode(SampleCodeCatalogJSON.self, from: data)
         }
-    }
 
-    /// Total number of sample code entries
-    public static var count: Int {
-        get async {
-            await loadCatalog().count
+        /// Async load that respects the test override. Production code calls
+        /// `loadCatalog` (which calls this); tests that want allEntries to
+        /// sandbox set the override via `setTestOverrideDirectory` first.
+        private static func loadFromDiskRespectingOverride() async -> SampleCodeCatalogJSON? {
+            let dir = await testOverride.get() ?? Shared.Constants.defaultSampleCodeDirectory
+            return loadFromDisk(at: dir)
         }
-    }
 
-    /// Last crawled date
-    public static var lastCrawled: String {
-        get async {
-            await loadCatalog().lastCrawled
+        /// Which source the cached catalog was loaded from. Returns nil before
+        /// the first `loadCatalog` call.
+        public static var loadedSource: Source? {
+            get async {
+                await cache.get()?.1
+            }
         }
-    }
 
-    /// Catalog version
-    public static var version: String {
-        get async {
-            await loadCatalog().version
+        /// Total number of sample code entries
+        public static var count: Int {
+            get async {
+                await loadCatalog().count
+            }
         }
-    }
 
-    /// All sample code entries
-    public static var allEntries: [SampleCodeEntry] {
-        get async {
-            await loadCatalog().entries
+        /// Last crawled date
+        public static var lastCrawled: String {
+            get async {
+                await loadCatalog().lastCrawled
+            }
         }
-    }
 
-    /// Get entries for a specific framework
-    public static func entries(for framework: String) async -> [SampleCodeEntry] {
-        await allEntries.filter { $0.framework.lowercased() == framework.lowercased() }
-    }
+        /// Catalog version
+        public static var version: String {
+            get async {
+                await loadCatalog().version
+            }
+        }
 
-    /// Search entries by title or description
-    public static func search(_ query: String) async -> [SampleCodeEntry] {
-        let lowercasedQuery = query.lowercased()
-        return await allEntries.filter { entry in
-            entry.title.lowercased().contains(lowercasedQuery) ||
-                entry.description.lowercased().contains(lowercasedQuery)
+        /// All sample code entries
+        public static var allEntries: [Sample.Core.Entry] {
+            get async {
+                await loadCatalog().entries
+            }
+        }
+
+        /// Get entries for a specific framework
+        public static func entries(for framework: String) async -> [Sample.Core.Entry] {
+            await allEntries.filter { $0.framework.lowercased() == framework.lowercased() }
+        }
+
+        /// Search entries by title or description
+        public static func search(_ query: String) async -> [Sample.Core.Entry] {
+            let lowercasedQuery = query.lowercased()
+            return await allEntries.filter { entry in
+                entry.title.lowercased().contains(lowercasedQuery) ||
+                    entry.description.lowercased().contains(lowercasedQuery)
+            }
         }
     }
 }

--- a/Packages/Sources/Core/SampleCodeDownloader.swift
+++ b/Packages/Sources/Core/SampleCodeDownloader.swift
@@ -69,8 +69,8 @@ public final class SampleCodeDownloader {
     // MARK: - Public API
 
     /// Download sample code projects
-    public func download(onProgress: (@Sendable (SampleProgress) -> Void)? = nil) async throws -> SampleStatistics {
-        var stats = SampleStatistics(startTime: Date())
+    public func download(onProgress: (@Sendable (Sample.Core.Progress) -> Void)? = nil) async throws -> Sample.Core.Statistics {
+        var stats = Sample.Core.Statistics(startTime: Date())
 
         logInfo("🚀 Starting sample code downloader")
         logInfo("   Source: \(sampleCodeListURL)")
@@ -109,7 +109,7 @@ public final class SampleCodeDownloader {
 
                 // Progress callback
                 if let onProgress {
-                    let progress = SampleProgress(
+                    let progress = Sample.Core.Progress(
                         current: index + 1,
                         total: samplesToDownload.count,
                         sampleName: sample.name,
@@ -148,7 +148,7 @@ public final class SampleCodeDownloader {
     /// Exposed `internal` so tests can drive it independently of a full
     /// `download()` run.
     func writeCatalogJSON() async {
-        let catalogURL = outputDirectory.appendingPathComponent(SampleCodeCatalog.onDiskCatalogFilename)
+        let catalogURL = outputDirectory.appendingPathComponent(Sample.Core.Catalog.onDiskCatalogFilename)
         do {
             guard let listingURL = URL(string: Shared.Constants.BaseURL.appleSampleCodeJSON) else {
                 logError("Could not construct Apple sample-code listing URL — skipping catalog.json write.")
@@ -187,7 +187,7 @@ public final class SampleCodeDownloader {
             return nil
         }
 
-        var entries: [SampleCodeEntry] = []
+        var entries: [Sample.Core.Entry] = []
         for (_, ref) in refs {
             guard ref["role"] as? String == "sampleCode",
                   let title = ref["title"] as? String,
@@ -210,7 +210,7 @@ public final class SampleCodeDownloader {
             let zipFilename = "\(framework.lowercased().replacingOccurrences(of: "_", with: "-"))-\(slug).zip"
             let webURL = "https://developer.apple.com\(urlString)"
 
-            entries.append(SampleCodeEntry(
+            entries.append(Sample.Core.Entry(
                 title: title,
                 url: urlString,
                 framework: framework,
@@ -318,7 +318,7 @@ public final class SampleCodeDownloader {
 
     func downloadSample(
         _ sample: SampleMetadata,
-        stats: inout SampleStatistics
+        stats: inout Sample.Core.Statistics
     ) async throws {
         logInfo("📦 [\(stats.totalSamples + 1)] \(sample.name)")
 
@@ -750,7 +750,7 @@ public final class SampleCodeDownloader {
         Logging.Log.error(errorMessage, category: .samples)
     }
 
-    private func logStatistics(_ stats: SampleStatistics) {
+    private func logStatistics(_ stats: Sample.Core.Statistics) {
         let messages = [
             "📊 Statistics:",
             "   Total samples: \(stats.totalSamples)",
@@ -776,46 +776,50 @@ struct SampleMetadata {
     let slug: String
 }
 
-public struct SampleStatistics: Sendable {
-    public var totalSamples: Int = 0
-    public var downloadedSamples: Int = 0
-    public var skippedSamples: Int = 0
-    public var errors: Int = 0
-    public var startTime: Date?
-    public var endTime: Date?
+extension Sample.Core {
+    public struct Statistics: Sendable {
+        public var totalSamples: Int = 0
+        public var downloadedSamples: Int = 0
+        public var skippedSamples: Int = 0
+        public var errors: Int = 0
+        public var startTime: Date?
+        public var endTime: Date?
 
-    public init(
-        totalSamples: Int = 0,
-        downloadedSamples: Int = 0,
-        skippedSamples: Int = 0,
-        errors: Int = 0,
-        startTime: Date? = nil,
-        endTime: Date? = nil
-    ) {
-        self.totalSamples = totalSamples
-        self.downloadedSamples = downloadedSamples
-        self.skippedSamples = skippedSamples
-        self.errors = errors
-        self.startTime = startTime
-        self.endTime = endTime
-    }
-
-    public var duration: TimeInterval? {
-        guard let start = startTime, let end = endTime else {
-            return nil
+        public init(
+            totalSamples: Int = 0,
+            downloadedSamples: Int = 0,
+            skippedSamples: Int = 0,
+            errors: Int = 0,
+            startTime: Date? = nil,
+            endTime: Date? = nil
+        ) {
+            self.totalSamples = totalSamples
+            self.downloadedSamples = downloadedSamples
+            self.skippedSamples = skippedSamples
+            self.errors = errors
+            self.startTime = startTime
+            self.endTime = endTime
         }
-        return end.timeIntervalSince(start)
+
+        public var duration: TimeInterval? {
+            guard let start = startTime, let end = endTime else {
+                return nil
+            }
+            return end.timeIntervalSince(start)
+        }
     }
 }
 
-public struct SampleProgress: Sendable {
-    public let current: Int
-    public let total: Int
-    public let sampleName: String
-    public let stats: SampleStatistics
+extension Sample.Core {
+    public struct Progress: Sendable {
+        public let current: Int
+        public let total: Int
+        public let sampleName: String
+        public let stats: Sample.Core.Statistics
 
-    public var percentage: Double {
-        Double(current) / Double(total) * 100
+        public var percentage: Double {
+            Double(current) / Double(total) * 100
+        }
     }
 }
 

--- a/Packages/Sources/Indexer/SamplesIndexerService.swift
+++ b/Packages/Sources/Indexer/SamplesIndexerService.swift
@@ -2,6 +2,7 @@ import Core
 import CoreProtocols
 import Foundation
 import SampleIndex
+import SharedConstants
 import SharedCore
 
 extension Indexer {
@@ -101,7 +102,7 @@ extension Indexer {
             }
 
             handler(.loadingCatalog)
-            let catalogEntries = await SampleCodeCatalog.allEntries
+            let catalogEntries = await Sample.Core.Catalog.allEntries
             handler(.catalogLoaded(entryCount: catalogEntries.count))
 
             let entries = catalogEntries.map { entry in

--- a/Packages/Sources/SampleIndex/SampleIndexBuilder.swift
+++ b/Packages/Sources/SampleIndex/SampleIndexBuilder.swift
@@ -55,7 +55,7 @@ extension SampleIndex {
 
         /// Index all sample code projects from the sample-code directory
         /// - Parameters:
-        ///   - entries: Sample code entries with metadata (from SampleCodeCatalog)
+        ///   - entries: Sample code entries with metadata (from Sample.Core.Catalog)
         ///   - forceReindex: If true, reindex even if project already exists
         ///   - progress: Optional progress callback
         /// - Returns: Number of projects indexed
@@ -207,7 +207,7 @@ extension SampleIndex {
         /// Index a single project from a ZIP file
         /// - Parameters:
         ///   - zipURL: URL to the ZIP file
-        ///   - entry: Optional metadata from SampleCodeCatalog
+        ///   - entry: Optional metadata from Sample.Core.Catalog
         ///   - forceReindex: If true, delete existing and reindex
         /// - Returns: Number of files indexed
         public func indexProject(
@@ -474,7 +474,7 @@ extension SampleIndex {
         /// Index a single project from an extracted directory
         /// - Parameters:
         ///   - directoryURL: URL to the project directory
-        ///   - entry: Optional metadata from SampleCodeCatalog
+        ///   - entry: Optional metadata from Sample.Core.Catalog
         ///   - forceReindex: If true, delete existing and reindex
         /// - Returns: Number of files indexed
         public func indexProjectDirectory(
@@ -674,7 +674,7 @@ extension SampleIndex {
 
     // MARK: - Sample Code Entry Info
 
-    /// Minimal info needed from SampleCodeCatalog for indexing
+    /// Minimal info needed from Sample.Core.Catalog for indexing
     public struct SampleCodeEntryInfo: Sendable {
         public let title: String
         public let description: String

--- a/Packages/Sources/Search/SearchIndexBuilder.swift
+++ b/Packages/Sources/Search/SearchIndexBuilder.swift
@@ -1164,14 +1164,14 @@ extension Search {
             // (<sample-code-dir>/catalog.json, written by
             // `cupertino fetch --type code`). The previous embedded fallback
             // was deleted in #215 — auto-discovery is the source of truth.
-            let entries = await SampleCodeCatalog.allEntries
-            let source = await SampleCodeCatalog.loadedSource ?? .missing
+            let entries = await Sample.Core.Catalog.allEntries
+            let source = await Sample.Core.Catalog.loadedSource ?? .missing
             switch source {
             case .onDisk:
                 logInfo("📦 Indexing sample code catalog from on-disk catalog.json (#214)...")
             case .missing:
                 let path = Shared.Constants.defaultSampleCodeDirectory
-                    .appendingPathComponent(SampleCodeCatalog.onDiskCatalogFilename)
+                    .appendingPathComponent(Sample.Core.Catalog.onDiskCatalogFilename)
                     .path
                 logInfo("⚠️  No sample-code catalog at \(path) — skipping sample-code indexing.")
                 logInfo("    Run `cupertino fetch --type code` to populate the catalog, then re-run save.")

--- a/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
+++ b/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
@@ -350,7 +350,7 @@ struct SaveCommandTests {
 
     // The two sample-code SaveTests cases that lived here previously
     // ("Index sample code catalog from bundled resources" + "Sample code
-    // catalog respects framework filter") assumed `SampleCodeCatalog`
+    // catalog respects framework filter") assumed `Sample.Core.Catalog`
     // always returned ~600 entries from the embedded blob. After #215
     // deleted that blob, the catalog only exists when
     // `<sample-code-dir>/catalog.json` is present, so a CI machine with
@@ -360,7 +360,7 @@ struct SaveCommandTests {
     //  - Disk-fixture loading + format invariants:
     //    `Tests/CoreTests/SampleCodeCatalogTests.swift`
     //  - Save→search-of-sample-code integration: deferred until we have a
-    //    test seam for injecting a sample-code dir into `SampleCodeCatalog`
+    //    test seam for injecting a sample-code dir into `Sample.Core.Catalog`
     //    (the cached load currently reads from
     //    `Shared.Constants.defaultSampleCodeDirectory` directly, so a test
     //    can't sandbox without polluting user data).

--- a/Packages/Tests/CoreTests/CupertinoCoreTests.swift
+++ b/Packages/Tests/CoreTests/CupertinoCoreTests.swift
@@ -17,7 +17,7 @@ import TestSupport
     #expect(markdown.contains("# Title"))
 }
 
-// MARK: - SampleCodeCatalog Tests
+// MARK: - Sample.Core.Catalog Tests
 
 //
 // The 5 legacy tests in this section assumed the embedded catalog was

--- a/Packages/Tests/CoreTests/SampleCodeCatalogTests.swift
+++ b/Packages/Tests/CoreTests/SampleCodeCatalogTests.swift
@@ -1,14 +1,15 @@
 @testable import Core
 import CoreProtocols
 import Foundation
+import SharedConstants
 import Testing
 
-/// Coverage for #214: `SampleCodeCatalog` should prefer the on-disk
+/// Coverage for #214: `Sample.Core.Catalog` should prefer the on-disk
 /// `catalog.json` (written by `cupertino fetch --type code`) over the
 /// embedded snapshot, and gracefully fall back when the on-disk file is
 /// missing or malformed. Also covers
 /// `SampleCodeDownloader.transformAppleListingToCatalog`.
-@Suite("SampleCodeCatalog disk-first loading (#214)")
+@Suite("Sample.Core.Catalog disk-first loading (#214)")
 struct SampleCodeCatalogTests {
     // MARK: - loadFromDisk
 
@@ -16,7 +17,7 @@ struct SampleCodeCatalogTests {
     func diskMissing() throws {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        #expect(SampleCodeCatalog.loadFromDisk(at: dir) == nil)
+        #expect(Sample.Core.Catalog.loadFromDisk(at: dir) == nil)
     }
 
     @Test("loadFromDisk returns nil when catalog.json is malformed")
@@ -24,7 +25,7 @@ struct SampleCodeCatalogTests {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try Self.writeCatalog(in: dir, contents: "{ this is not valid json")
-        #expect(SampleCodeCatalog.loadFromDisk(at: dir) == nil)
+        #expect(Sample.Core.Catalog.loadFromDisk(at: dir) == nil)
     }
 
     @Test("loadFromDisk decodes a valid catalog.json")
@@ -32,7 +33,7 @@ struct SampleCodeCatalogTests {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try Self.writeCatalog(in: dir, contents: Self.validCatalogJSON(count: 2))
-        let catalog = SampleCodeCatalog.loadFromDisk(at: dir)
+        let catalog = Sample.Core.Catalog.loadFromDisk(at: dir)
         #expect(catalog != nil)
         #expect(catalog?.count == 2)
         #expect(catalog?.entries.count == 2)
@@ -44,7 +45,7 @@ struct SampleCodeCatalogTests {
     func diskDefaultPath() {
         // Just exercise the default-arg overload — no file there in test env,
         // expect nil rather than a crash.
-        _ = SampleCodeCatalog.loadFromDisk()
+        _ = Sample.Core.Catalog.loadFromDisk()
     }
 
     // MARK: - loadCatalog (end-to-end via allEntries)
@@ -55,12 +56,12 @@ struct SampleCodeCatalogTests {
 
     @Test("allEntries returns empty + .missing source when no on-disk catalog")
     func endToEndMissing() async {
-        await SampleCodeCatalog.resetCache()
+        await Sample.Core.Catalog.resetCache()
         // The test machine MAY have ~/.cupertino-dev/sample-code/catalog.json,
         // in which case loadedSource is .onDisk and entries is non-empty.
         // On a fresh CI machine it should be .missing with no entries.
-        let entries = await SampleCodeCatalog.allEntries
-        let source = await SampleCodeCatalog.loadedSource
+        let entries = await Sample.Core.Catalog.allEntries
+        let source = await Sample.Core.Catalog.loadedSource
         switch source {
         case .onDisk:
             #expect(!entries.isEmpty)
@@ -130,7 +131,7 @@ struct SampleCodeCatalogTests {
     func writeCatalogRoundTrip() throws {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let catalogURL = dir.appendingPathComponent(SampleCodeCatalog.onDiskCatalogFilename)
+        let catalogURL = dir.appendingPathComponent(Sample.Core.Catalog.onDiskCatalogFilename)
 
         let original = try #require(
             SampleCodeDownloader.transformAppleListingToCatalog(
@@ -144,8 +145,8 @@ struct SampleCodeCatalogTests {
         let attrs = try FileManager.default.attributesOfItem(atPath: catalogURL.path)
         #expect((attrs[.size] as? Int ?? 0) > 0)
 
-        // Re-load through SampleCodeCatalog.loadFromDisk → byte-equivalent catalog
-        let reloaded = try #require(SampleCodeCatalog.loadFromDisk(at: dir))
+        // Re-load through Sample.Core.Catalog.loadFromDisk → byte-equivalent catalog
+        let reloaded = try #require(Sample.Core.Catalog.loadFromDisk(at: dir))
         #expect(reloaded.count == original.count)
         #expect(reloaded.entries.map(\.title) == original.entries.map(\.title))
         #expect(reloaded.entries.map(\.framework) == original.entries.map(\.framework))
@@ -155,7 +156,7 @@ struct SampleCodeCatalogTests {
     func writeCatalogOverwrite() throws {
         let dir = try Self.makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let catalogURL = dir.appendingPathComponent(SampleCodeCatalog.onDiskCatalogFilename)
+        let catalogURL = dir.appendingPathComponent(Sample.Core.Catalog.onDiskCatalogFilename)
 
         // Pre-existing junk content at the target path
         try "stale junk".write(to: catalogURL, atomically: true, encoding: .utf8)
@@ -170,7 +171,7 @@ struct SampleCodeCatalogTests {
         try SampleCodeDownloader.writeCatalog(real, to: catalogURL)
 
         // Old content gone, new content parses
-        let reloaded = try #require(SampleCodeCatalog.loadFromDisk(at: dir))
+        let reloaded = try #require(Sample.Core.Catalog.loadFromDisk(at: dir))
         #expect(!reloaded.entries.isEmpty)
     }
 
@@ -182,12 +183,12 @@ struct SampleCodeCatalogTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         try Self.writeCatalog(in: dir, contents: Self.validCatalogJSON(count: 2))
 
-        await SampleCodeCatalog.setTestOverrideDirectory(dir)
-        await SampleCodeCatalog.resetCache()
-        defer { Task { await SampleCodeCatalog.setTestOverrideDirectory(nil); await SampleCodeCatalog.resetCache() } }
+        await Sample.Core.Catalog.setTestOverrideDirectory(dir)
+        await Sample.Core.Catalog.resetCache()
+        defer { Task { await Sample.Core.Catalog.setTestOverrideDirectory(nil); await Sample.Core.Catalog.resetCache() } }
 
-        let entries = await SampleCodeCatalog.allEntries
-        let source = await SampleCodeCatalog.loadedSource
+        let entries = await Sample.Core.Catalog.allEntries
+        let source = await Sample.Core.Catalog.loadedSource
 
         #expect(entries.count == 2)
         #expect(source == .onDisk)
@@ -200,12 +201,12 @@ struct SampleCodeCatalogTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         // Intentionally no catalog.json written
 
-        await SampleCodeCatalog.setTestOverrideDirectory(dir)
-        await SampleCodeCatalog.resetCache()
-        defer { Task { await SampleCodeCatalog.setTestOverrideDirectory(nil); await SampleCodeCatalog.resetCache() } }
+        await Sample.Core.Catalog.setTestOverrideDirectory(dir)
+        await Sample.Core.Catalog.resetCache()
+        defer { Task { await Sample.Core.Catalog.setTestOverrideDirectory(nil); await Sample.Core.Catalog.resetCache() } }
 
-        let entries = await SampleCodeCatalog.allEntries
-        let source = await SampleCodeCatalog.loadedSource
+        let entries = await Sample.Core.Catalog.allEntries
+        let source = await Sample.Core.Catalog.loadedSource
 
         #expect(entries.isEmpty)
         #expect(source == .missing)
@@ -221,7 +222,7 @@ struct SampleCodeCatalogTests {
     }
 
     private static func writeCatalog(in dir: URL, contents: String) throws {
-        let url = dir.appendingPathComponent(SampleCodeCatalog.onDiskCatalogFilename)
+        let url = dir.appendingPathComponent(Sample.Core.Catalog.onDiskCatalogFilename)
         try contents.write(to: url, atomically: true, encoding: .utf8)
     }
 

--- a/Packages/Tests/CoreTests/SampleCodeDownloaderMalformedURLSkipTests.swift
+++ b/Packages/Tests/CoreTests/SampleCodeDownloaderMalformedURLSkipTests.swift
@@ -1,6 +1,7 @@
 @testable import Core
 import CoreProtocols
 import Foundation
+import SharedConstants
 import SharedCore
 import Testing
 
@@ -30,7 +31,7 @@ struct SampleCodeDownloaderMalformedURLSkipTests {
         defer { try? FileManager.default.removeItem(at: outputDir) }
 
         let downloader = SampleCodeDownloader(outputDirectory: outputDir)
-        var stats = SampleStatistics()
+        var stats = Sample.Core.Statistics()
         let badSample = SampleMetadata(name: "Bad Sample", url: "", slug: "bad-sample")
 
         // If the guard fires before createWebView (the PR #288 ordering),
@@ -59,7 +60,7 @@ struct SampleCodeDownloaderMalformedURLSkipTests {
         defer { try? FileManager.default.removeItem(at: outputDir) }
 
         let downloader = SampleCodeDownloader(outputDirectory: outputDir)
-        var stats = SampleStatistics()
+        var stats = Sample.Core.Statistics()
         let badSample = SampleMetadata(name: "Bad Sample 2", url: "ht tp://x", slug: "bad-sample-2")
 
         try await downloader.downloadSample(badSample, stats: &stats)
@@ -75,7 +76,7 @@ struct SampleCodeDownloaderMalformedURLSkipTests {
         defer { try? FileManager.default.removeItem(at: outputDir) }
 
         let downloader = SampleCodeDownloader(outputDirectory: outputDir)
-        var stats = SampleStatistics()
+        var stats = Sample.Core.Statistics()
 
         try await downloader.downloadSample(
             SampleMetadata(name: "A", url: "", slug: "a"),

--- a/Packages/Tests/CoreTests/SampleCodeDownloaderTests.swift
+++ b/Packages/Tests/CoreTests/SampleCodeDownloaderTests.swift
@@ -104,11 +104,11 @@ struct SampleCodeDownloaderTests {
         #expect(slug == "fruta_building_a_feature_rich_app")
     }
 
-    // MARK: - SampleStatistics Tests
+    // MARK: - Sample.Core.Statistics Tests
 
-    @Test("SampleStatistics initializes with zeros")
+    @Test("Sample.Core.Statistics initializes with zeros")
     func statisticsInitializesWithZeros() {
-        let stats = SampleStatistics()
+        let stats = Sample.Core.Statistics()
 
         #expect(stats.totalSamples == 0)
         #expect(stats.downloadedSamples == 0)
@@ -116,9 +116,9 @@ struct SampleCodeDownloaderTests {
         #expect(stats.errors == 0)
     }
 
-    @Test("SampleStatistics tracks counts")
+    @Test("Sample.Core.Statistics tracks counts")
     func statisticsTracksCounts() {
-        var stats = SampleStatistics(startTime: Date())
+        var stats = Sample.Core.Statistics(startTime: Date())
         stats.totalSamples = 606
         stats.downloadedSamples = 500
         stats.skippedSamples = 100
@@ -130,28 +130,28 @@ struct SampleCodeDownloaderTests {
         #expect(stats.errors == 6)
     }
 
-    @Test("SampleStatistics calculates duration")
+    @Test("Sample.Core.Statistics calculates duration")
     func statisticsCalculatesDuration() {
-        var stats = SampleStatistics(startTime: Date())
+        var stats = Sample.Core.Statistics(startTime: Date())
         stats.endTime = stats.startTime?.addingTimeInterval(7200) // 2 hours
 
         let duration = stats.duration
         #expect(duration == 7200.0)
     }
 
-    @Test("SampleStatistics duration is nil without end time")
+    @Test("Sample.Core.Statistics duration is nil without end time")
     func statisticsDurationNilWithoutEndTime() {
-        let stats = SampleStatistics(startTime: Date())
+        let stats = Sample.Core.Statistics(startTime: Date())
 
         #expect(stats.duration == nil)
     }
 
-    // MARK: - SampleProgress Tests
+    // MARK: - Sample.Core.Progress Tests
 
-    @Test("SampleProgress tracks download progress")
+    @Test("Sample.Core.Progress tracks download progress")
     func progressTracksProgress() {
-        let stats = SampleStatistics()
-        let progress = SampleProgress(
+        let stats = Sample.Core.Statistics()
+        let progress = Sample.Core.Progress(
             current: 100,
             total: 606,
             sampleName: "Building a Document-Based App",
@@ -164,10 +164,10 @@ struct SampleCodeDownloaderTests {
         #expect(abs(progress.percentage - 16.5) < 0.1) // ~16.5%
     }
 
-    @Test("SampleProgress calculates percentage correctly")
+    @Test("Sample.Core.Progress calculates percentage correctly")
     func progressCalculatesPercentage() {
-        let stats = SampleStatistics()
-        let progress = SampleProgress(
+        let stats = Sample.Core.Statistics()
+        let progress = Sample.Core.Progress(
             current: 303,
             total: 606,
             sampleName: "Test Sample",

--- a/Packages/Tests/Shared/CoreTests/ModelsTests.swift
+++ b/Packages/Tests/Shared/CoreTests/ModelsTests.swift
@@ -263,7 +263,7 @@ func crawlStatisticsNoDuration() {
     #expect(stats.duration == nil)
 }
 
-// Note: CrawlSessionState, SwiftPackageEntry, SampleCodeEntry, and PriorityPackageCatalogData
+// Note: CrawlSessionState, SwiftPackageEntry, Sample.Core.Entry, and PriorityPackageCatalogData
 // have more complex tests in Core module
 
 // MARK: - StructuredDocumentationPage Declaration and Kind Tests


### PR DESCRIPTION
Continues the cross-cutting Sample namespacing from #356. The five sample-prefixed types currently living in the Core SPM target move to `Sample.Core.<Name>`, dropping their `Sample` prefix (the parent namespace supplies it).

## Renames

| Before | After |
|---|---|
| `SampleCodeEntry`     | `Sample.Core.Entry` |
| `SampleCodeCatalog`   | `Sample.Core.Catalog` |
| `SampleStatistics`    | `Sample.Core.Statistics` |
| `SampleProgress`      | `Sample.Core.Progress` |
| `SampleProject`       | `Sample.Core.Project` |

## Mechanics

- `Sources/Core/SampleCodeCatalog.swift`, `SampleCodeDownloader.swift`, `GitHubSampleCodeFetcher.swift` each wrap their public types as `extension Sample.Core { public X <NewName> { ... } }`.
- Internal cross-references within each file updated to the new qualified path.
- 9 caller files swept: `SampleIndexBuilder`, `SearchIndexBuilder`, `SamplesIndexerService`, plus test mirrors.
- `import SharedConstants` added to every file that newly references `Sample.*` and didn't already have it (SharedConstants declares the Sample namespace tree, per #356).

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Previous Sample-related: #356 (foundation + Sample.Cleanup.Cleaner). Next: Sample.Services, Sample.Search, Sample.Index, Sample.Indexer / Sample.Atom, Sample.Format.