### PR TITLE
refactor(Sample): relocate Services + Search sample types under Sample.Services / Sample.Search

### DIFF
--- a/Packages/Sources/CLI/Commands/SearchCommand+SmartReport.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand+SmartReport.swift
@@ -23,7 +23,7 @@ extension Command.Search {
     struct FetcherPlan {
         let fetchers: [any Search.CandidateFetcher]
         let searchIndex: SearchModule.Index?
-        let sampleService: SampleSearchService?
+        let sampleService: Sample.Search.Service?
     }
 
     /// Docs-backed sources in a consistent order. `apple-archive` is included
@@ -163,7 +163,7 @@ extension Command.Search {
         skip: Bool,
         availability: SearchModule.PackageQuery.AvailabilityFilter?,
         into fetchers: inout [any Search.CandidateFetcher]
-    ) async -> SampleSearchService? {
+    ) async -> Sample.Search.Service? {
         guard !skip else { return nil }
         let url = override.map { URL(fileURLWithPath: $0).expandingTildeInPath }
             ?? SampleIndex.defaultDatabasePath
@@ -174,8 +174,8 @@ extension Command.Search {
             return nil
         }
         do {
-            let service = try await SampleSearchService(dbPath: url)
-            fetchers.append(Services.SampleCandidateFetcher(
+            let service = try await Sample.Search.Service(dbPath: url)
+            fetchers.append(Sample.Services.CandidateFetcher(
                 service: service,
                 availability: availability
             ))

--- a/Packages/Sources/CLI/Commands/SearchCommand+SourceRunners.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand+SourceRunners.swift
@@ -78,7 +78,7 @@ extension Command.Search {
         let dbPath = resolveSampleDbPath()
 
         let result = try await Services.ServiceContainer.withSampleService(dbPath: dbPath) { service in
-            try await service.search(SampleQuery(
+            try await service.search(Sample.Search.Query(
                 text: query,
                 framework: framework,
                 searchFiles: true,

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -15,7 +15,7 @@ import SharedUtils
 public actor CompositeToolProvider: MCP.Core.ToolProvider {
     // Use service layer for consistency with CLI
     private let docsService: DocsSearchService?
-    private let sampleService: SampleSearchService?
+    private let sampleService: Sample.Search.Service?
 
     // Keep direct access for low-level operations (list frameworks, read document)
     private let searchIndex: Search.Index?
@@ -33,7 +33,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         }
 
         if let sampleDatabase {
-            sampleService = SampleSearchService(database: sampleDatabase)
+            sampleService = Sample.Search.Service(database: sampleDatabase)
         } else {
             sampleService = nil
         }
@@ -511,7 +511,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         }
 
         // Use service layer (same as CLI)
-        let result = try await sampleService.search(SampleQuery(
+        let result = try await sampleService.search(Sample.Search.Query(
             text: query,
             framework: framework,
             searchFiles: true,

--- a/Packages/Sources/Services/Formatters/SampleJSONFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleJSONFormatter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SampleIndex
+import SharedConstants
 import SharedCore
 
 // MARK: - Shared JSON Output Types
@@ -65,7 +66,7 @@ public struct SampleSearchJSONFormatter: ResultFormatter {
         self.framework = framework
     }
 
-    public func format(_ result: SampleSearchResult) -> String {
+    public func format(_ result: Sample.Search.Result) -> String {
         struct Output: Encodable {
             let query: String
             let framework: String?

--- a/Packages/Sources/Services/Formatters/SampleMarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleMarkdownFormatter.swift
@@ -17,7 +17,7 @@ public struct SampleSearchMarkdownFormatter: ResultFormatter {
         self.teasers = teasers
     }
 
-    public func format(_ result: SampleSearchResult) -> String {
+    public func format(_ result: Sample.Search.Result) -> String {
         var output = "# Sample Code Search: \"\(query)\"\n\n"
 
         // Tell the AI what source this is

--- a/Packages/Sources/Services/Formatters/SampleTextFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleTextFormatter.swift
@@ -17,7 +17,7 @@ public struct SampleSearchTextFormatter: ResultFormatter {
         self.teasers = teasers
     }
 
-    public func format(_ result: SampleSearchResult) -> String {
+    public func format(_ result: Sample.Search.Result) -> String {
         if result.isEmpty {
             return "No results found for '\(query)'"
         }

--- a/Packages/Sources/Services/ReadCommands/ReadService.swift
+++ b/Packages/Sources/Services/ReadCommands/ReadService.swift
@@ -16,7 +16,7 @@ import SharedCore
 /// with the bundled corpus.
 ///
 /// Lives in `Services` because it composes existing per-source readers
-/// (`DocsSearchService.read`, `SampleSearchService.getProject` /
+/// (`DocsSearchService.read`, `Sample.Search.Service.getProject` /
 /// `getFile`, `Search.PackageQuery.fileContent`). Both `cupertino read`
 /// (CLI) and the MCP layer call into this one entry point so behaviour
 /// stays identical across transports.

--- a/Packages/Sources/Services/ReadCommands/SampleSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/SampleSearchService.swift
@@ -6,55 +6,59 @@ import SharedCore
 // MARK: - Sample Search Query
 
 /// Query parameters for sample code searches
-public struct SampleQuery: Sendable {
-    public let text: String
-    public let framework: String?
-    public let searchFiles: Bool
-    public let limit: Int
-    /// Optional platform filter (#233). When set together with
-    /// `minVersion`, restricts results to projects whose
-    /// `min_<platform>` column is non-NULL and lex-≤ the requested
-    /// version. nil on either disables the filter.
-    public let platform: String?
-    public let minVersion: String?
+extension Sample.Search {
+    public struct Query: Sendable {
+        public let text: String
+        public let framework: String?
+        public let searchFiles: Bool
+        public let limit: Int
+        /// Optional platform filter (#233). When set together with
+        /// `minVersion`, restricts results to projects whose
+        /// `min_<platform>` column is non-NULL and lex-≤ the requested
+        /// version. nil on either disables the filter.
+        public let platform: String?
+        public let minVersion: String?
 
-    public init(
-        text: String,
-        framework: String? = nil,
-        searchFiles: Bool = true,
-        limit: Int = Shared.Constants.Limit.defaultSearchLimit,
-        platform: String? = nil,
-        minVersion: String? = nil
-    ) {
-        self.text = text
-        self.framework = framework
-        self.searchFiles = searchFiles
-        self.limit = min(limit, Shared.Constants.Limit.maxSearchLimit)
-        self.platform = platform
-        self.minVersion = minVersion
+        public init(
+            text: String,
+            framework: String? = nil,
+            searchFiles: Bool = true,
+            limit: Int = Shared.Constants.Limit.defaultSearchLimit,
+            platform: String? = nil,
+            minVersion: String? = nil
+        ) {
+            self.text = text
+            self.framework = framework
+            self.searchFiles = searchFiles
+            self.limit = min(limit, Shared.Constants.Limit.maxSearchLimit)
+            self.platform = platform
+            self.minVersion = minVersion
+        }
     }
 }
 
 // MARK: - Sample Search Result
 
 /// Combined result from project and file searches
-public struct SampleSearchResult: Sendable {
-    public let projects: [SampleIndex.Project]
-    public let files: [SampleIndex.Database.FileSearchResult]
+extension Sample.Search {
+    public struct Result: Sendable {
+        public let projects: [SampleIndex.Project]
+        public let files: [SampleIndex.Database.FileSearchResult]
 
-    public init(projects: [SampleIndex.Project], files: [SampleIndex.Database.FileSearchResult]) {
-        self.projects = projects
-        self.files = files
-    }
+        public init(projects: [SampleIndex.Project], files: [SampleIndex.Database.FileSearchResult]) {
+            self.projects = projects
+            self.files = files
+        }
 
-    /// Check if the result is empty
-    public var isEmpty: Bool {
-        projects.isEmpty && files.isEmpty
-    }
+        /// Check if the result is empty
+        public var isEmpty: Bool {
+            projects.isEmpty && files.isEmpty
+        }
 
-    /// Total count of results
-    public var totalCount: Int {
-        projects.count + files.count
+        /// Total count of results
+        public var totalCount: Int {
+            projects.count + files.count
+        }
     }
 }
 
@@ -62,91 +66,93 @@ public struct SampleSearchResult: Sendable {
 
 /// Service for searching Apple sample code projects and files.
 /// Wraps SampleIndex.Database with a clean interface.
-public actor SampleSearchService {
-    private let database: SampleIndex.Database
+extension Sample.Search {
+    public actor Service {
+        private let database: SampleIndex.Database
 
-    /// Initialize with an existing database
-    public init(database: SampleIndex.Database) {
-        self.database = database
-    }
-
-    /// Initialize with a database path
-    public init(dbPath: URL) async throws {
-        database = try await SampleIndex.Database(dbPath: dbPath)
-    }
-
-    // MARK: - Search Methods
-
-    /// Search with a specialized query
-    public func search(_ query: SampleQuery) async throws -> SampleSearchResult {
-        let projects = try await database.searchProjects(
-            query: query.text,
-            framework: query.framework,
-            limit: query.limit
-        )
-
-        var files: [SampleIndex.Database.FileSearchResult] = []
-        if query.searchFiles {
-            files = try await database.searchFiles(
-                query: query.text,
-                projectId: nil,
-                limit: query.limit,
-                platform: query.platform,
-                minVersion: query.minVersion
-            )
+        /// Initialize with an existing database
+        public init(database: SampleIndex.Database) {
+            self.database = database
         }
 
-        return SampleSearchResult(projects: projects, files: files)
-    }
+        /// Initialize with a database path
+        public init(dbPath: URL) async throws {
+            database = try await SampleIndex.Database(dbPath: dbPath)
+        }
 
-    /// Simple text search
-    public func search(text: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> SampleSearchResult {
-        try await search(SampleQuery(text: text, limit: limit))
-    }
+        // MARK: - Search Methods
 
-    /// Search within a specific framework
-    public func search(text: String, framework: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> SampleSearchResult {
-        try await search(SampleQuery(text: text, framework: framework, limit: limit))
-    }
+        /// Search with a specialized query
+        public func search(_ query: Sample.Search.Query) async throws -> Sample.Search.Result {
+            let projects = try await database.searchProjects(
+                query: query.text,
+                framework: query.framework,
+                limit: query.limit
+            )
 
-    // MARK: - Project Access
+            var files: [SampleIndex.Database.FileSearchResult] = []
+            if query.searchFiles {
+                files = try await database.searchFiles(
+                    query: query.text,
+                    projectId: nil,
+                    limit: query.limit,
+                    platform: query.platform,
+                    minVersion: query.minVersion
+                )
+            }
 
-    /// Get a project by ID
-    public func getProject(id: String) async throws -> SampleIndex.Project? {
-        try await database.getProject(id: id)
-    }
+            return Sample.Search.Result(projects: projects, files: files)
+        }
 
-    /// List all projects
-    public func listProjects(framework: String? = nil, limit: Int = 50) async throws -> [SampleIndex.Project] {
-        try await database.listProjects(framework: framework, limit: limit)
-    }
+        /// Simple text search
+        public func search(text: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> Sample.Search.Result {
+            try await search(Sample.Search.Query(text: text, limit: limit))
+        }
 
-    /// Get total project count
-    public func projectCount() async throws -> Int {
-        try await database.projectCount()
-    }
+        /// Search within a specific framework
+        public func search(text: String, framework: String, limit: Int = Shared.Constants.Limit.defaultSearchLimit) async throws -> Sample.Search.Result {
+            try await search(Sample.Search.Query(text: text, framework: framework, limit: limit))
+        }
 
-    // MARK: - File Access
+        // MARK: - Project Access
 
-    /// Get a file by project ID and path
-    public func getFile(projectId: String, path: String) async throws -> SampleIndex.File? {
-        try await database.getFile(projectId: projectId, path: path)
-    }
+        /// Get a project by ID
+        public func getProject(id: String) async throws -> SampleIndex.Project? {
+            try await database.getProject(id: id)
+        }
 
-    /// List files in a project
-    public func listFiles(projectId: String, folder: String? = nil) async throws -> [SampleIndex.File] {
-        try await database.listFiles(projectId: projectId, folder: folder)
-    }
+        /// List all projects
+        public func listProjects(framework: String? = nil, limit: Int = 50) async throws -> [SampleIndex.Project] {
+            try await database.listProjects(framework: framework, limit: limit)
+        }
 
-    /// Get total file count
-    public func fileCount() async throws -> Int {
-        try await database.fileCount()
-    }
+        /// Get total project count
+        public func projectCount() async throws -> Int {
+            try await database.projectCount()
+        }
 
-    // MARK: - Lifecycle
+        // MARK: - File Access
 
-    /// Disconnect from the database
-    public func disconnect() async {
-        await database.disconnect()
+        /// Get a file by project ID and path
+        public func getFile(projectId: String, path: String) async throws -> SampleIndex.File? {
+            try await database.getFile(projectId: projectId, path: path)
+        }
+
+        /// List files in a project
+        public func listFiles(projectId: String, folder: String? = nil) async throws -> [SampleIndex.File] {
+            try await database.listFiles(projectId: projectId, folder: folder)
+        }
+
+        /// Get total file count
+        public func fileCount() async throws -> Int {
+            try await database.fileCount()
+        }
+
+        // MARK: - Lifecycle
+
+        /// Disconnect from the database
+        public func disconnect() async {
+            await database.disconnect()
+        }
     }
 }

--- a/Packages/Sources/Services/SampleCandidateFetcher.swift
+++ b/Packages/Sources/Services/SampleCandidateFetcher.swift
@@ -6,10 +6,10 @@ import SharedCore
 
 // MARK: - Sample candidate fetcher (#230)
 
-/// Adapter that bridges `SampleSearchService` into the
+/// Adapter that bridges `Sample.Search.Service` into the
 /// `Search.SmartQuery` fan-out used by `cupertino ask`.
 ///
-/// Wraps `SampleSearchService.search(text:limit:)` and emits one
+/// Wraps `Sample.Search.Service.search(text:limit:)` and emits one
 /// `Search.SmartCandidate` per matched file, scored on the file's
 /// FTS rank. Project-level matches are ignored at this layer — file
 /// chunks already cite their owning project through the metadata
@@ -20,15 +20,15 @@ import SharedCore
 /// `Search` would force a hard dep on `SampleIndex` for every consumer
 /// that just wants the docs corpus. `Services` already imports both
 /// `SampleIndex` and `Search`, so the fetcher slots in cleanly.
-extension Services {
-    public struct SampleCandidateFetcher: Search.CandidateFetcher {
+extension Sample.Services {
+    public struct CandidateFetcher: Search.CandidateFetcher {
         public let sourceName: String = Shared.Constants.SourcePrefix.samples
 
-        private let service: SampleSearchService
+        private let service: Sample.Search.Service
         private let availability: Search.PackageQuery.AvailabilityFilter?
 
         public init(
-            service: SampleSearchService,
+            service: Sample.Search.Service,
             availability: Search.PackageQuery.AvailabilityFilter? = nil
         ) {
             self.service = service
@@ -36,7 +36,7 @@ extension Services {
         }
 
         public func fetch(question: String, limit: Int) async throws -> [Search.SmartCandidate] {
-            let query = SampleQuery(
+            let query = Sample.Search.Query(
                 text: question,
                 limit: limit,
                 platform: availability?.platform,

--- a/Packages/Sources/Services/ServiceContainer.swift
+++ b/Packages/Sources/Services/ServiceContainer.swift
@@ -13,7 +13,7 @@ extension Services {
     public actor ServiceContainer {
         private var docsService: DocsSearchService?
         private var higService: HIGSearchService?
-        private var sampleService: SampleSearchService?
+        private var sampleService: Sample.Search.Service?
 
         private let searchDbPath: URL
         private let sampleDbPath: URL?
@@ -53,7 +53,7 @@ extension Services {
         }
 
         /// Get or create the sample search service
-        public func getSampleService() async throws -> SampleSearchService {
+        public func getSampleService() async throws -> Sample.Search.Service {
             if let service = sampleService {
                 return service
             }
@@ -62,7 +62,7 @@ extension Services {
                 throw ToolError.noData("Sample database path not configured")
             }
 
-            let service = try await SampleSearchService(dbPath: dbPath)
+            let service = try await Sample.Search.Service(dbPath: dbPath)
             sampleService = service
             return service
         }
@@ -135,13 +135,13 @@ extension Services {
         /// Execute an operation with a sample service, handling lifecycle
         public static func withSampleService<T: Sendable>(
             dbPath: URL,
-            operation: (SampleSearchService) async throws -> T
+            operation: (Sample.Search.Service) async throws -> T
         ) async throws -> T {
             guard Shared.Utils.PathResolver.exists(dbPath) else {
                 throw ToolError.noData("Sample database not found at \(dbPath.path). Run 'cupertino save --samples' to build the index.")
             }
 
-            let service = try await SampleSearchService(dbPath: dbPath)
+            let service = try await Sample.Search.Service(dbPath: dbPath)
             let result = try await operation(service)
             await service.disconnect()
             return result

--- a/Packages/Sources/Services/Services.swift
+++ b/Packages/Sources/Services/Services.swift
@@ -29,7 +29,7 @@
 /// Namespace for the service layer: a `ServiceContainer` that owns service
 /// lifecycle, the `SearchService` protocol + `SearchQuery` / `SearchFilters`
 /// inputs, and the concrete service actors that live in `Services/ReadCommands/`
-/// (`DocsSearchService`, `HIGSearchService`, `SampleSearchService`,
+/// (`DocsSearchService`, `HIGSearchService`, `Sample.Search.Service`,
 /// `UnifiedSearchService`, `TeaserService`, `ReadService`).
 ///
 /// Result formatters in `Services/Formatters/` also extend this same root

--- a/Packages/Tests/ServicesTests/ServicesTests.swift
+++ b/Packages/Tests/ServicesTests/ServicesTests.swift
@@ -92,11 +92,11 @@ struct ServicesTests {
         #expect(query.limit == 30)
     }
 
-    // MARK: - SampleQuery Tests
+    // MARK: - Sample.Search.Query Tests
 
-    @Test("SampleQuery initializes with defaults")
+    @Test("Sample.Search.Query initializes with defaults")
     func sampleQueryDefaults() {
-        let query = SampleQuery(text: "SwiftUI")
+        let query = Sample.Search.Query(text: "SwiftUI")
 
         #expect(query.text == "SwiftUI")
         #expect(query.framework == nil)
@@ -104,9 +104,9 @@ struct ServicesTests {
         #expect(query.limit == Shared.Constants.Limit.defaultSearchLimit)
     }
 
-    @Test("SampleSearchResult isEmpty check")
+    @Test("Sample.Search.Result isEmpty check")
     func sampleSearchResultIsEmpty() {
-        let empty = SampleSearchResult(projects: [], files: [])
+        let empty = Sample.Search.Result(projects: [], files: [])
         #expect(empty.isEmpty == true)
         #expect(empty.totalCount == 0)
     }
@@ -143,9 +143,9 @@ struct FormatConfigTests {
     }
 }
 
-// MARK: - Services.SampleCandidateFetcher (#230)
+// MARK: - Sample.Services.CandidateFetcher (#230)
 
-@Suite("Services.SampleCandidateFetcher (#230)")
+@Suite("Sample.Services.CandidateFetcher (#230)")
 struct SampleCandidateFetcherTests {
     @Test("sourceName matches the canonical samples prefix")
     func sourceNameIsSamples() async throws {
@@ -156,10 +156,10 @@ struct SampleCandidateFetcherTests {
             .appendingPathComponent("samples-fetcher-test-\(UUID().uuidString).db")
         defer { try? FileManager.default.removeItem(at: tempDB) }
 
-        let service = try await SampleSearchService(dbPath: tempDB)
+        let service = try await Sample.Search.Service(dbPath: tempDB)
         defer { Task { await service.disconnect() } }
 
-        let fetcher = Services.SampleCandidateFetcher(service: service)
+        let fetcher = Sample.Services.CandidateFetcher(service: service)
         #expect(fetcher.sourceName == Shared.Constants.SourcePrefix.samples)
     }
 
@@ -169,10 +169,10 @@ struct SampleCandidateFetcherTests {
             .appendingPathComponent("samples-fetcher-test-\(UUID().uuidString).db")
         defer { try? FileManager.default.removeItem(at: tempDB) }
 
-        let service = try await SampleSearchService(dbPath: tempDB)
+        let service = try await Sample.Search.Service(dbPath: tempDB)
         defer { Task { await service.disconnect() } }
 
-        let fetcher = Services.SampleCandidateFetcher(service: service)
+        let fetcher = Sample.Services.CandidateFetcher(service: service)
         let candidates = try await fetcher.fetch(question: "swiftui list", limit: 5)
         #expect(candidates.isEmpty)
     }


### PR DESCRIPTION
Continues the cross-cutting Sample namespacing (#356, #357). Sample-flavoured types in the Services SPM target move into their `Sample.<sub>` sub-namespaces, dropping the 'Sample' prefix once the parent namespace supplies it.

## Renames

| Before | After |
|---|---|
| `Services.SampleCandidateFetcher` | `Sample.Services.CandidateFetcher` |
| `SampleQuery` (Services/ReadCommands) | `Sample.Search.Query` |
| `SampleSearchResult` (Services/ReadCommands) | `Sample.Search.Result` |
| `SampleSearchService` (Services/ReadCommands) | `Sample.Search.Service` |

## Mechanics

- `Services/SampleCandidateFetcher.swift` retargets `extension Services { struct SampleCandidateFetcher }` to `extension Sample.Services { struct CandidateFetcher }`.
- `Services/ReadCommands/SampleSearchService.swift` wraps its three top-level types individually in `extension Sample.Search { ... }` blocks; the internal cross-references between `Service` / `Query` / `Result` fully qualify to `Sample.Search.X`.
- 10 caller files swept across `CompositeToolProvider`, `ServiceContainer`, `Services` docstring, CLI `SearchCommand+*`, the three `Sample*Formatter` files, `ReadService`, and `ServicesTests`.
- `import SharedConstants` added to every file that newly references `Sample.*` and didn't already have it.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Previous Sample-related: #356 (foundation + `Sample.Cleanup.Cleaner`), #357 (`Sample.Core`). Next: `Sample.Indexer` + `Sample.Atom` (Search SPM target), `Sample.Index` (whole SampleIndex target), `Sample.Format.*` (Markdown / JSON / Text).