### PR TITLE
refactor(Release): nest every <Name>Command under the Release.Command namespace; sweep callers

### DIFF
--- a/Packages/Sources/ReleaseTool/BumpCommand.swift
+++ b/Packages/Sources/ReleaseTool/BumpCommand.swift
@@ -3,223 +3,225 @@ import Foundation
 
 // MARK: - Bump Command
 
-struct BumpCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "bump",
-        abstract: "Bump version in all required files"
-    )
-
-    @Argument(help: "New version (e.g., 0.5.0) or bump type (major, minor, patch)")
-    var versionOrType: String
-
-    @Flag(name: .long, help: "Preview changes without modifying files")
-    var dryRun: Bool = false
-
-    @Option(name: .long, help: "Path to repository root")
-    var repoRoot: String?
-
-    // MARK: - File Paths
-
-    private struct FilePaths {
-        let constants: URL
-        let readme: URL
-        let changelog: URL
-        let deployment: URL
-
-        init(root: URL) {
-            constants = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
-            readme = root.appendingPathComponent("README.md")
-            changelog = root.appendingPathComponent("CHANGELOG.md")
-            deployment = root.appendingPathComponent("docs/DEPLOYMENT.md")
-        }
-    }
-
-    private func filePaths(root: URL) -> FilePaths {
-        FilePaths(root: root)
-    }
-
-    // MARK: - Run
-
-    mutating func run() async throws {
-        let root = try findRepoRoot()
-        let paths = filePaths(root: root)
-
-        // Get current version
-        let currentVersion = try readCurrentVersion(from: paths.constants)
-        Console.info("📦 Current version: \(currentVersion)")
-
-        // Determine new version
-        let newVersion: Version
-        if let bumpType = BumpType(rawValue: versionOrType.lowercased()) {
-            newVersion = currentVersion.bumped(bumpType)
-        } else if let explicit = Version(versionOrType) {
-            newVersion = explicit
-        } else {
-            throw BumpError.invalidVersion(versionOrType)
-        }
-
-        Console.info("🎯 New version: \(newVersion)")
-
-        if dryRun {
-            Console.info("\n🏃 Dry run - would update:")
-            Console.substep("Constants.swift: \(currentVersion) → \(newVersion)")
-            Console.substep("README.md: Version badge")
-            Console.substep("CHANGELOG.md: Add \(newVersion) section")
-            Console.substep("DEPLOYMENT.md: Version header")
-            return
-        }
-
-        // Update files
-        Console.step(1, "Updating Constants.swift...")
-        try updateConstants(at: paths.constants, to: newVersion)
-        Console.substep("✓ Updated version = \"\(newVersion)\"")
-
-        Console.step(2, "Updating README.md...")
-        try updateReadme(at: paths.readme, to: newVersion)
-        Console.substep("✓ Updated Version: \(newVersion)")
-
-        Console.step(3, "Updating CHANGELOG.md...")
-        try updateChangelog(at: paths.changelog, version: newVersion)
-        Console.substep("✓ Added ## \(newVersion) section")
-
-        Console.step(4, "Updating DEPLOYMENT.md...")
-        try updateDeployment(at: paths.deployment, to: newVersion)
-        Console.substep("✓ Updated Version: \(newVersion)")
-
-        Console.success("Version bumped to \(newVersion)")
-        Console.info("\nNext steps:")
-        Console.info("  1. Edit CHANGELOG.md to add release notes")
-        Console.info("  2. Run: cupertino-rel tag --version \(newVersion)")
-    }
-
-    // MARK: - Find Repo Root
-
-    private func findRepoRoot() throws -> URL {
-        if let root = repoRoot {
-            return URL(fileURLWithPath: root)
-        }
-
-        // Try to find git root
-        let output = try Shell.run("git rev-parse --show-toplevel")
-        return URL(fileURLWithPath: output)
-    }
-
-    // MARK: - Read Current Version
-
-    private func readCurrentVersion(from url: URL) throws -> Version {
-        let content = try String(contentsOf: url, encoding: .utf8)
-
-        // Match: public static let version = "X.Y.Z"
-        let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
-              let versionRange = Range(match.range(at: 1), in: content) else {
-            throw BumpError.versionNotFound(url.path)
-        }
-
-        guard let version = Version(String(content[versionRange])) else {
-            throw BumpError.invalidVersion(String(content[versionRange]))
-        }
-
-        return version
-    }
-
-    // MARK: - Update Constants.swift
-
-    private func updateConstants(at url: URL, to version: Version) throws {
-        var content = try String(contentsOf: url, encoding: .utf8)
-
-        let pattern = #"(public\s+static\s+let\s+version\s*=\s*")(\d+\.\d+\.\d+)(")"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            throw BumpError.updateFailed(url.path)
-        }
-
-        content = regex.stringByReplacingMatches(
-            in: content,
-            range: NSRange(content.startIndex..., in: content),
-            withTemplate: "$1\(version)$3"
+extension Release.Command {
+    struct Bump: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "bump",
+            abstract: "Bump version in all required files"
         )
 
-        try content.write(to: url, atomically: true, encoding: .utf8)
-    }
+        @Argument(help: "New version (e.g., 0.5.0) or bump type (major, minor, patch)")
+        var versionOrType: String
 
-    // MARK: - Update README.md
+        @Flag(name: .long, help: "Preview changes without modifying files")
+        var dryRun: Bool = false
 
-    private func updateReadme(at url: URL, to version: Version) throws {
-        var content = try String(contentsOf: url, encoding: .utf8)
+        @Option(name: .long, help: "Path to repository root")
+        var repoRoot: String?
 
-        // Update **Version:** X.Y.Z
-        let pattern = #"(\*\*Version:\*\*\s*)\d+\.\d+\.\d+"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            throw BumpError.updateFailed(url.path)
+        // MARK: - File Paths
+
+        private struct FilePaths {
+            let constants: URL
+            let readme: URL
+            let changelog: URL
+            let deployment: URL
+
+            init(root: URL) {
+                constants = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+                readme = root.appendingPathComponent("README.md")
+                changelog = root.appendingPathComponent("CHANGELOG.md")
+                deployment = root.appendingPathComponent("docs/DEPLOYMENT.md")
+            }
         }
 
-        content = regex.stringByReplacingMatches(
-            in: content,
-            range: NSRange(content.startIndex..., in: content),
-            withTemplate: "$1\(version)"
-        )
-
-        try content.write(to: url, atomically: true, encoding: .utf8)
-    }
-
-    // MARK: - Update CHANGELOG.md
-
-    private func updateChangelog(at url: URL, version: Version) throws {
-        var content = try String(contentsOf: url, encoding: .utf8)
-
-        // Find first ## heading (existing version) and insert new section before it
-        let today = ISO8601DateFormatter.string(
-            from: Date(),
-            timeZone: .current,
-            formatOptions: [.withFullDate, .withDashSeparatorInDate]
-        )
-
-        let newSection = """
-        ## \(version) (\(today))
-
-        ### Added
-        -
-
-        ### Changed
-        -
-
-        ### Fixed
-        -
-
-        """
-
-        // Insert after # Changelog header
-        if let range = content.range(of: "\n## ") {
-            content.insert(contentsOf: "\n\(newSection)", at: range.lowerBound)
-        } else if let range = content.range(of: "# Changelog\n") {
-            content.insert(contentsOf: "\n\(newSection)", at: range.upperBound)
-        } else {
-            // Prepend if no existing structure
-            content = "# Changelog\n\n\(newSection)\n\(content)"
+        private func filePaths(root: URL) -> FilePaths {
+            FilePaths(root: root)
         }
 
-        try content.write(to: url, atomically: true, encoding: .utf8)
-    }
+        // MARK: - Run
 
-    // MARK: - Update DEPLOYMENT.md
+        mutating func run() async throws {
+            let root = try findRepoRoot()
+            let paths = filePaths(root: root)
 
-    private func updateDeployment(at url: URL, to version: Version) throws {
-        var content = try String(contentsOf: url, encoding: .utf8)
+            // Get current version
+            let currentVersion = try readCurrentVersion(from: paths.constants)
+            Console.info("📦 Current version: \(currentVersion)")
 
-        // Update **Version:** X.Y.Z
-        let pattern = #"(\*\*Version:\*\*\s*)\d+\.\d+\.\d+"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            throw BumpError.updateFailed(url.path)
+            // Determine new version
+            let newVersion: Version
+            if let bumpType = BumpType(rawValue: versionOrType.lowercased()) {
+                newVersion = currentVersion.bumped(bumpType)
+            } else if let explicit = Version(versionOrType) {
+                newVersion = explicit
+            } else {
+                throw BumpError.invalidVersion(versionOrType)
+            }
+
+            Console.info("🎯 New version: \(newVersion)")
+
+            if dryRun {
+                Console.info("\n🏃 Dry run - would update:")
+                Console.substep("Constants.swift: \(currentVersion) → \(newVersion)")
+                Console.substep("README.md: Version badge")
+                Console.substep("CHANGELOG.md: Add \(newVersion) section")
+                Console.substep("DEPLOYMENT.md: Version header")
+                return
+            }
+
+            // Update files
+            Console.step(1, "Updating Constants.swift...")
+            try updateConstants(at: paths.constants, to: newVersion)
+            Console.substep("✓ Updated version = \"\(newVersion)\"")
+
+            Console.step(2, "Updating README.md...")
+            try updateReadme(at: paths.readme, to: newVersion)
+            Console.substep("✓ Updated Version: \(newVersion)")
+
+            Console.step(3, "Updating CHANGELOG.md...")
+            try updateChangelog(at: paths.changelog, version: newVersion)
+            Console.substep("✓ Added ## \(newVersion) section")
+
+            Console.step(4, "Updating DEPLOYMENT.md...")
+            try updateDeployment(at: paths.deployment, to: newVersion)
+            Console.substep("✓ Updated Version: \(newVersion)")
+
+            Console.success("Version bumped to \(newVersion)")
+            Console.info("\nNext steps:")
+            Console.info("  1. Edit CHANGELOG.md to add release notes")
+            Console.info("  2. Run: cupertino-rel tag --version \(newVersion)")
         }
 
-        content = regex.stringByReplacingMatches(
-            in: content,
-            range: NSRange(content.startIndex..., in: content),
-            withTemplate: "$1\(version)"
-        )
+        // MARK: - Find Repo Root
 
-        try content.write(to: url, atomically: true, encoding: .utf8)
+        private func findRepoRoot() throws -> URL {
+            if let root = repoRoot {
+                return URL(fileURLWithPath: root)
+            }
+
+            // Try to find git root
+            let output = try Shell.run("git rev-parse --show-toplevel")
+            return URL(fileURLWithPath: output)
+        }
+
+        // MARK: - Read Current Version
+
+        private func readCurrentVersion(from url: URL) throws -> Version {
+            let content = try String(contentsOf: url, encoding: .utf8)
+
+            // Match: public static let version = "X.Y.Z"
+            let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
+            guard let regex = try? NSRegularExpression(pattern: pattern),
+                  let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
+                  let versionRange = Range(match.range(at: 1), in: content) else {
+                throw BumpError.versionNotFound(url.path)
+            }
+
+            guard let version = Version(String(content[versionRange])) else {
+                throw BumpError.invalidVersion(String(content[versionRange]))
+            }
+
+            return version
+        }
+
+        // MARK: - Update Constants.swift
+
+        private func updateConstants(at url: URL, to version: Version) throws {
+            var content = try String(contentsOf: url, encoding: .utf8)
+
+            let pattern = #"(public\s+static\s+let\s+version\s*=\s*")(\d+\.\d+\.\d+)(")"#
+            guard let regex = try? NSRegularExpression(pattern: pattern) else {
+                throw BumpError.updateFailed(url.path)
+            }
+
+            content = regex.stringByReplacingMatches(
+                in: content,
+                range: NSRange(content.startIndex..., in: content),
+                withTemplate: "$1\(version)$3"
+            )
+
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        // MARK: - Update README.md
+
+        private func updateReadme(at url: URL, to version: Version) throws {
+            var content = try String(contentsOf: url, encoding: .utf8)
+
+            // Update **Version:** X.Y.Z
+            let pattern = #"(\*\*Version:\*\*\s*)\d+\.\d+\.\d+"#
+            guard let regex = try? NSRegularExpression(pattern: pattern) else {
+                throw BumpError.updateFailed(url.path)
+            }
+
+            content = regex.stringByReplacingMatches(
+                in: content,
+                range: NSRange(content.startIndex..., in: content),
+                withTemplate: "$1\(version)"
+            )
+
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        // MARK: - Update CHANGELOG.md
+
+        private func updateChangelog(at url: URL, version: Version) throws {
+            var content = try String(contentsOf: url, encoding: .utf8)
+
+            // Find first ## heading (existing version) and insert new section before it
+            let today = ISO8601DateFormatter.string(
+                from: Date(),
+                timeZone: .current,
+                formatOptions: [.withFullDate, .withDashSeparatorInDate]
+            )
+
+            let newSection = """
+            ## \(version) (\(today))
+
+            ### Added
+            -
+
+            ### Changed
+            -
+
+            ### Fixed
+            -
+
+            """
+
+            // Insert after # Changelog header
+            if let range = content.range(of: "\n## ") {
+                content.insert(contentsOf: "\n\(newSection)", at: range.lowerBound)
+            } else if let range = content.range(of: "# Changelog\n") {
+                content.insert(contentsOf: "\n\(newSection)", at: range.upperBound)
+            } else {
+                // Prepend if no existing structure
+                content = "# Changelog\n\n\(newSection)\n\(content)"
+            }
+
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        // MARK: - Update DEPLOYMENT.md
+
+        private func updateDeployment(at url: URL, to version: Version) throws {
+            var content = try String(contentsOf: url, encoding: .utf8)
+
+            // Update **Version:** X.Y.Z
+            let pattern = #"(\*\*Version:\*\*\s*)\d+\.\d+\.\d+"#
+            guard let regex = try? NSRegularExpression(pattern: pattern) else {
+                throw BumpError.updateFailed(url.path)
+            }
+
+            content = regex.stringByReplacingMatches(
+                in: content,
+                range: NSRange(content.startIndex..., in: content),
+                withTemplate: "$1\(version)"
+            )
+
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        }
     }
 }
 

--- a/Packages/Sources/ReleaseTool/DatabaseReleaseCommand.swift
+++ b/Packages/Sources/ReleaseTool/DatabaseReleaseCommand.swift
@@ -14,153 +14,155 @@ import SharedUtils
 // All three databases ship in a single zip and a single GitHub release on
 // `mihaelamj/cupertino-docs`, so `cupertino setup` is one download.
 
-struct DatabaseReleaseCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "databases",
-        abstract: "Package and upload search.db + samples.db + packages.db to GitHub Releases (cupertino-docs)"
-    )
-
-    @Option(
-        name: .long,
-        help: "Directory containing search.db, samples.db, and packages.db. Defaults to ~/.cupertino/."
-    )
-    var baseDir: String?
-
-    @Option(name: .long, help: "GitHub repository (owner/repo)")
-    var repo: String = "mihaelamj/cupertino-docs"
-
-    @Flag(name: .long, help: "Create release without uploading (dry run)")
-    var dryRun: Bool = false
-
-    @Option(name: .long, help: "Path to repository root")
-    var repoRoot: String?
-
-    @Flag(
-        name: .long,
-        help: """
-        Allow publishing without packages.db. By default the command refuses if any of the three
-        databases is missing — a partial release would silently ship a stale packages corpus.
-        """
-    )
-    var allowMissingPackages: Bool = false
-
-    private static let searchDBFilename = Shared.Constants.FileName.searchDatabase
-    private static let samplesDBFilename = Shared.Constants.FileName.samplesDatabase
-    private static let packagesDBFilename = Shared.Constants.FileName.packagesIndexDatabase
-
-    mutating func run() async throws {
-        let root = try ReleasePublishing.findRepoRoot(override: repoRoot)
-        let version = try ReleasePublishing.readCurrentVersion(from: root)
-
-        Console.info("📦 Database Release \(version.tag)\n")
-
-        let baseURL = baseDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
-            ?? Shared.Constants.defaultBaseDirectory
-
-        // Resolve the three database paths. search.db and samples.db are
-        // always required; packages.db is required by default but the
-        // operator can opt in to a partial release with --allow-missing-packages.
-        let searchDBURL = baseURL.appendingPathComponent(Self.searchDBFilename)
-        let samplesDBURL = baseURL.appendingPathComponent(Self.samplesDBFilename)
-        let packagesDBURL = baseURL.appendingPathComponent(Self.packagesDBFilename)
-
-        guard FileManager.default.fileExists(atPath: searchDBURL.path) else {
-            throw ReleasePublishingError.missingDatabase(Self.searchDBFilename, baseURL.path)
-        }
-        guard FileManager.default.fileExists(atPath: samplesDBURL.path) else {
-            throw ReleasePublishingError.missingDatabase(Self.samplesDBFilename, baseURL.path)
-        }
-        let packagesDBPresent = FileManager.default.fileExists(atPath: packagesDBURL.path)
-        if !packagesDBPresent, !allowMissingPackages {
-            throw ReleasePublishingError.missingDatabase(Self.packagesDBFilename, baseURL.path)
-        }
-
-        // Sizes (informational)
-        let searchSize = try ReleasePublishing.fileSize(at: searchDBURL)
-        let samplesSize = try ReleasePublishing.fileSize(at: samplesDBURL)
-        let packagesSize = try packagesDBPresent ? (ReleasePublishing.fileSize(at: packagesDBURL)) : 0
-        Console.info("📊 Database sizes:")
-        Console.substep("search.db:   \(Shared.Utils.Formatting.formatBytes(searchSize))")
-        Console.substep("samples.db:  \(Shared.Utils.Formatting.formatBytes(samplesSize))")
-        if packagesDBPresent {
-            Console.substep("packages.db: \(Shared.Utils.Formatting.formatBytes(packagesSize))")
-        } else {
-            Console.warning("packages.db: missing (continuing because --allow-missing-packages was passed)")
-        }
-
-        // Bundle. The zip name still uses the historical "cupertino-databases-"
-        // prefix so existing `cupertino setup` clients keep working.
-        var bundled: [URL] = [searchDBURL, samplesDBURL]
-        if packagesDBPresent {
-            bundled.append(packagesDBURL)
-        }
-        let zipFilename = "cupertino-databases-\(version.tag).zip"
-        let zipURL = baseURL.appendingPathComponent(zipFilename)
-        Console.info("\n📁 Creating \(zipFilename)...")
-        try ReleasePublishing.createZip(containing: bundled, at: zipURL)
-
-        let zipSize = try ReleasePublishing.fileSize(at: zipURL)
-        Console.substep("✓ Created (\(Shared.Utils.Formatting.formatBytes(zipSize)))")
-
-        Console.info("\n🔐 Calculating SHA256...")
-        let sha256 = try ReleasePublishing.calculateSHA256(of: zipURL)
-        Console.substep(sha256)
-
-        if dryRun {
-            Console.info("\n🏃 Dry run - skipping upload")
-            Console.substep("Zip file: \(zipURL.path)")
-            return
-        }
-
-        let token = try ReleasePublishing.resolveToken()
-
-        Console.info("\n🔍 Checking for existing release...")
-        let releaseExists = try await ReleasePublishing.checkReleaseExists(
-            repo: repo, tag: version.tag, token: token
+extension Release.Command {
+    struct Database: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "databases",
+            abstract: "Package and upload search.db + samples.db + packages.db to GitHub Releases (cupertino-docs)"
         )
-        if releaseExists {
-            Console.substep("Release \(version.tag) exists, updating...")
-            try await ReleasePublishing.deleteRelease(repo: repo, tag: version.tag, token: token)
+
+        @Option(
+            name: .long,
+            help: "Directory containing search.db, samples.db, and packages.db. Defaults to ~/.cupertino/."
+        )
+        var baseDir: String?
+
+        @Option(name: .long, help: "GitHub repository (owner/repo)")
+        var repo: String = "mihaelamj/cupertino-docs"
+
+        @Flag(name: .long, help: "Create release without uploading (dry run)")
+        var dryRun: Bool = false
+
+        @Option(name: .long, help: "Path to repository root")
+        var repoRoot: String?
+
+        @Flag(
+            name: .long,
+            help: """
+            Allow publishing without packages.db. By default the command refuses if any of the three
+            databases is missing — a partial release would silently ship a stale packages corpus.
+            """
+        )
+        var allowMissingPackages: Bool = false
+
+        private static let searchDBFilename = Shared.Constants.FileName.searchDatabase
+        private static let samplesDBFilename = Shared.Constants.FileName.samplesDatabase
+        private static let packagesDBFilename = Shared.Constants.FileName.packagesIndexDatabase
+
+        mutating func run() async throws {
+            let root = try ReleasePublishing.findRepoRoot(override: repoRoot)
+            let version = try ReleasePublishing.readCurrentVersion(from: root)
+
+            Console.info("📦 Database Release \(version.tag)\n")
+
+            let baseURL = baseDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
+                ?? Shared.Constants.defaultBaseDirectory
+
+            // Resolve the three database paths. search.db and samples.db are
+            // always required; packages.db is required by default but the
+            // operator can opt in to a partial release with --allow-missing-packages.
+            let searchDBURL = baseURL.appendingPathComponent(Self.searchDBFilename)
+            let samplesDBURL = baseURL.appendingPathComponent(Self.samplesDBFilename)
+            let packagesDBURL = baseURL.appendingPathComponent(Self.packagesDBFilename)
+
+            guard FileManager.default.fileExists(atPath: searchDBURL.path) else {
+                throw ReleasePublishingError.missingDatabase(Self.searchDBFilename, baseURL.path)
+            }
+            guard FileManager.default.fileExists(atPath: samplesDBURL.path) else {
+                throw ReleasePublishingError.missingDatabase(Self.samplesDBFilename, baseURL.path)
+            }
+            let packagesDBPresent = FileManager.default.fileExists(atPath: packagesDBURL.path)
+            if !packagesDBPresent, !allowMissingPackages {
+                throw ReleasePublishingError.missingDatabase(Self.packagesDBFilename, baseURL.path)
+            }
+
+            // Sizes (informational)
+            let searchSize = try ReleasePublishing.fileSize(at: searchDBURL)
+            let samplesSize = try ReleasePublishing.fileSize(at: samplesDBURL)
+            let packagesSize = try packagesDBPresent ? (ReleasePublishing.fileSize(at: packagesDBURL)) : 0
+            Console.info("📊 Database sizes:")
+            Console.substep("search.db:   \(Shared.Utils.Formatting.formatBytes(searchSize))")
+            Console.substep("samples.db:  \(Shared.Utils.Formatting.formatBytes(samplesSize))")
+            if packagesDBPresent {
+                Console.substep("packages.db: \(Shared.Utils.Formatting.formatBytes(packagesSize))")
+            } else {
+                Console.warning("packages.db: missing (continuing because --allow-missing-packages was passed)")
+            }
+
+            // Bundle. The zip name still uses the historical "cupertino-databases-"
+            // prefix so existing `cupertino setup` clients keep working.
+            var bundled: [URL] = [searchDBURL, samplesDBURL]
+            if packagesDBPresent {
+                bundled.append(packagesDBURL)
+            }
+            let zipFilename = "cupertino-databases-\(version.tag).zip"
+            let zipURL = baseURL.appendingPathComponent(zipFilename)
+            Console.info("\n📁 Creating \(zipFilename)...")
+            try ReleasePublishing.createZip(containing: bundled, at: zipURL)
+
+            let zipSize = try ReleasePublishing.fileSize(at: zipURL)
+            Console.substep("✓ Created (\(Shared.Utils.Formatting.formatBytes(zipSize)))")
+
+            Console.info("\n🔐 Calculating SHA256...")
+            let sha256 = try ReleasePublishing.calculateSHA256(of: zipURL)
+            Console.substep(sha256)
+
+            if dryRun {
+                Console.info("\n🏃 Dry run - skipping upload")
+                Console.substep("Zip file: \(zipURL.path)")
+                return
+            }
+
+            let token = try ReleasePublishing.resolveToken()
+
+            Console.info("\n🔍 Checking for existing release...")
+            let releaseExists = try await ReleasePublishing.checkReleaseExists(
+                repo: repo, tag: version.tag, token: token
+            )
+            if releaseExists {
+                Console.substep("Release \(version.tag) exists, updating...")
+                try await ReleasePublishing.deleteRelease(repo: repo, tag: version.tag, token: token)
+            }
+
+            Console.info("\n🚀 Creating release \(version.tag)...")
+            let bundledNames = bundled.map(\.lastPathComponent).joined(separator: ", ")
+            let body = """
+            Pre-built databases for instant Cupertino setup. Bundled: \(bundledNames).
+
+            ## Quick Install
+
+            ```bash
+            cupertino setup
+            ```
+
+            ## SHA256
+
+            ```
+            \(sha256)  \(zipFilename)
+            ```
+            """
+            let uploadURL = try await ReleasePublishing.createRelease(
+                repo: repo,
+                tag: version.tag,
+                token: token,
+                name: "Pre-built Databases \(version.tag) (\(bundledNames))",
+                body: body
+            )
+            Console.substep("✓ Release created")
+
+            Console.info("\n⬆️  Uploading \(zipFilename)...")
+            try await ReleasePublishing.uploadAsset(
+                uploadURL: uploadURL,
+                file: zipURL,
+                filename: zipFilename,
+                token: token
+            )
+            Console.substep("✓ Upload complete")
+
+            try? FileManager.default.removeItem(at: zipURL)
+
+            Console.success("Release \(version.tag) published!")
+            Console.info("   https://github.com/\(repo)/releases/tag/\(version.tag)")
         }
-
-        Console.info("\n🚀 Creating release \(version.tag)...")
-        let bundledNames = bundled.map(\.lastPathComponent).joined(separator: ", ")
-        let body = """
-        Pre-built databases for instant Cupertino setup. Bundled: \(bundledNames).
-
-        ## Quick Install
-
-        ```bash
-        cupertino setup
-        ```
-
-        ## SHA256
-
-        ```
-        \(sha256)  \(zipFilename)
-        ```
-        """
-        let uploadURL = try await ReleasePublishing.createRelease(
-            repo: repo,
-            tag: version.tag,
-            token: token,
-            name: "Pre-built Databases \(version.tag) (\(bundledNames))",
-            body: body
-        )
-        Console.substep("✓ Release created")
-
-        Console.info("\n⬆️  Uploading \(zipFilename)...")
-        try await ReleasePublishing.uploadAsset(
-            uploadURL: uploadURL,
-            file: zipURL,
-            filename: zipFilename,
-            token: token
-        )
-        Console.substep("✓ Upload complete")
-
-        try? FileManager.default.removeItem(at: zipURL)
-
-        Console.success("Release \(version.tag) published!")
-        Console.info("   https://github.com/\(repo)/releases/tag/\(version.tag)")
     }
 }

--- a/Packages/Sources/ReleaseTool/DocsUpdateCommand.swift
+++ b/Packages/Sources/ReleaseTool/DocsUpdateCommand.swift
@@ -3,208 +3,210 @@ import Foundation
 
 // MARK: - Docs Update Command
 
-struct DocsUpdateCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "docs-update",
-        abstract: "Update documentation databases and bump minor version",
-        discussion: """
-        Workflow for documentation-only updates (no code changes):
-        1. Run 'cupertino save' to rebuild search index
-        2. Query database for document/framework counts
-        3. Update README.md with new counts
-        4. Bump minor version (e.g., 0.4.0 → 0.5.0)
-        5. Optionally continue with tag and database upload
+extension Release.Command {
+    struct DocsUpdate: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "docs-update",
+            abstract: "Update documentation databases and bump minor version",
+            discussion: """
+            Workflow for documentation-only updates (no code changes):
+            1. Run 'cupertino save' to rebuild search index
+            2. Query database for document/framework counts
+            3. Update README.md with new counts
+            4. Bump minor version (e.g., 0.4.0 → 0.5.0)
+            5. Optionally continue with tag and database upload
 
-        Use this after updating crawled documentation (fetch or manual copy).
-        """
-    )
+            Use this after updating crawled documentation (fetch or manual copy).
+            """
+        )
 
-    @Flag(name: .long, help: "Preview changes without executing")
-    var dryRun: Bool = false
+        @Flag(name: .long, help: "Preview changes without executing")
+        var dryRun: Bool = false
 
-    @Flag(name: .long, help: "Skip running 'cupertino save'")
-    var skipSave: Bool = false
+        @Flag(name: .long, help: "Skip running 'cupertino save'")
+        var skipSave: Bool = false
 
-    @Flag(name: .long, help: "Continue with tag and upload after bump")
-    var release: Bool = false
+        @Flag(name: .long, help: "Continue with tag and upload after bump")
+        var release: Bool = false
 
-    @Option(name: .long, help: "Path to repository root")
-    var repoRoot: String?
+        @Option(name: .long, help: "Path to repository root")
+        var repoRoot: String?
 
-    // MARK: - Run
+        // MARK: - Run
 
-    mutating func run() async throws {
-        let root = try findRepoRoot()
-        let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
-        let readmePath = root.appendingPathComponent("README.md")
+        mutating func run() async throws {
+            let root = try findRepoRoot()
+            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+            let readmePath = root.appendingPathComponent("README.md")
 
-        Console.info("📚 Documentation Update Workflow")
-        Console.info("")
+            Console.info("📚 Documentation Update Workflow")
+            Console.info("")
 
-        if dryRun {
-            Console.warning("DRY RUN - No changes will be made\n")
-        }
-
-        // Step 1: Run cupertino save
-        Console.step(1, "Rebuild search index")
-        if skipSave {
-            Console.substep("Skipping (--skip-save)")
-        } else if dryRun {
-            Console.substep("Would run: cupertino save")
-        } else {
-            Console.substep("Running 'cupertino save'...")
-            try Shell.runInteractive("cupertino save")
-            Console.substep("✓ Search index rebuilt")
-        }
-
-        // Step 2: Query database for counts
-        Console.step(2, "Query database statistics")
-        let (docCount, frameworkCount) = try await getDocumentStats()
-        Console.substep("✓ Documents: \(formatNumber(docCount))")
-        Console.substep("✓ Frameworks: \(frameworkCount)")
-
-        // Step 3: Update README.md
-        Console.step(3, "Update README.md with new counts")
-        let statsMsg = "\(formatNumber(docCount))+ documentation pages across \(frameworkCount) frameworks"
-        if dryRun {
-            Console.substep("Would update to: '\(statsMsg)'")
-        } else {
-            try updateReadmeStats(at: readmePath, documents: docCount, frameworks: frameworkCount)
-            Console.substep("✓ Updated to '\(statsMsg)'")
-        }
-
-        // Step 4: Bump minor version
-        Console.step(4, "Bump minor version")
-        let currentVersion = try readCurrentVersion(from: constantsPath)
-        let newVersion = currentVersion.bumped(.minor)
-        Console.substep("Version: \(currentVersion) → \(newVersion)")
-
-        var bumpCmd = BumpCommand()
-        bumpCmd.versionOrType = newVersion.description
-        bumpCmd.dryRun = dryRun
-        bumpCmd.repoRoot = root.path
-        try await bumpCmd.run()
-
-        // Step 5: Optionally continue with release
-        if release {
-            Console.step(5, "Continue with tag and upload")
-
-            if !dryRun {
-                Console.info("\n    Please edit CHANGELOG.md to add release notes.")
-                Console.info("    Press Enter when done...")
-                _ = readLine()
+            if dryRun {
+                Console.warning("DRY RUN - No changes will be made\n")
             }
 
-            var tagCmd = TagCommand()
-            tagCmd.version = newVersion.description
-            tagCmd.dryRun = dryRun
-            tagCmd.push = true
-            tagCmd.repoRoot = root.path
-            try await tagCmd.run()
-
-            Console.substep("Waiting for GitHub Actions...")
-            if !dryRun {
-                Console.info("\n    Wait for GitHub Actions to complete, then run:")
-                Console.info("    cupertino-rel databases")
-                Console.info("    cupertino-rel homebrew --version \(newVersion)")
+            // Step 1: Run cupertino save
+            Console.step(1, "Rebuild search index")
+            if skipSave {
+                Console.substep("Skipping (--skip-save)")
+            } else if dryRun {
+                Console.substep("Would run: cupertino save")
+            } else {
+                Console.substep("Running 'cupertino save'...")
+                try Shell.runInteractive("cupertino save")
+                Console.substep("✓ Search index rebuilt")
             }
-        } else {
-            Console.info("\nNext steps:")
-            Console.info("  1. Review changes: git diff")
-            Console.info("  2. Edit CHANGELOG.md")
-            Console.info("  3. Tag and release: cupertino-rel tag --version \(newVersion) --push")
-            Console.info("  4. After GitHub Actions: cupertino-rel databases")
-            Console.info("  5. Update Homebrew: cupertino-rel homebrew --version \(newVersion)")
-        }
 
-        Console.info("")
-        Console.success("Documentation update prepared: \(formatNumber(docCount))+ docs, \(frameworkCount) frameworks")
-    }
+            // Step 2: Query database for counts
+            Console.step(2, "Query database statistics")
+            let (docCount, frameworkCount) = try await getDocumentStats()
+            Console.substep("✓ Documents: \(formatNumber(docCount))")
+            Console.substep("✓ Frameworks: \(frameworkCount)")
 
-    // MARK: - Helpers
-
-    private func findRepoRoot() throws -> URL {
-        if let root = repoRoot {
-            return URL(fileURLWithPath: root)
-        }
-        let output = try Shell.run("git rev-parse --show-toplevel")
-        return URL(fileURLWithPath: output)
-    }
-
-    private func readCurrentVersion(from url: URL) throws -> Version {
-        let content = try String(contentsOf: url, encoding: .utf8)
-        let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
-              let versionRange = Range(match.range(at: 1), in: content),
-              let version = Version(String(content[versionRange])) else {
-            throw DocsUpdateError.versionNotFound
-        }
-        return version
-    }
-
-    private func getDocumentStats() async throws -> (documents: Int, frameworks: Int) {
-        // Always query - we need the counts even in dry-run to show what would be written
-        // Query using cupertino list-frameworks and parse output
-        let output = try Shell.run("cupertino list-frameworks 2>/dev/null || echo 'error'")
-
-        if output.contains("error") || output.isEmpty {
-            throw DocsUpdateError.databaseQueryFailed
-        }
-
-        // Parse output like:
-        // Available Frameworks (284 total, 200725 documents):
-
-        var totalDocs = 0
-        var frameworkCount = 0
-
-        // Look for "Available Frameworks (X total, Y documents):"
-        let pattern = #"\((\d+)\s+total,\s+(\d+)\s+documents\)"#
-        if let regex = try? NSRegularExpression(pattern: pattern),
-           let match = regex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)) {
-            if let fwRange = Range(match.range(at: 1), in: output),
-               let docRange = Range(match.range(at: 2), in: output) {
-                frameworkCount = Int(output[fwRange]) ?? 0
-                totalDocs = Int(output[docRange]) ?? 0
+            // Step 3: Update README.md
+            Console.step(3, "Update README.md with new counts")
+            let statsMsg = "\(formatNumber(docCount))+ documentation pages across \(frameworkCount) frameworks"
+            if dryRun {
+                Console.substep("Would update to: '\(statsMsg)'")
+            } else {
+                try updateReadmeStats(at: readmePath, documents: docCount, frameworks: frameworkCount)
+                Console.substep("✓ Updated to '\(statsMsg)'")
             }
+
+            // Step 4: Bump minor version
+            Console.step(4, "Bump minor version")
+            let currentVersion = try readCurrentVersion(from: constantsPath)
+            let newVersion = currentVersion.bumped(.minor)
+            Console.substep("Version: \(currentVersion) → \(newVersion)")
+
+            var bumpCmd = Release.Command.Bump()
+            bumpCmd.versionOrType = newVersion.description
+            bumpCmd.dryRun = dryRun
+            bumpCmd.repoRoot = root.path
+            try await bumpCmd.run()
+
+            // Step 5: Optionally continue with release
+            if release {
+                Console.step(5, "Continue with tag and upload")
+
+                if !dryRun {
+                    Console.info("\n    Please edit CHANGELOG.md to add release notes.")
+                    Console.info("    Press Enter when done...")
+                    _ = readLine()
+                }
+
+                var tagCmd = Release.Command.Tag()
+                tagCmd.version = newVersion.description
+                tagCmd.dryRun = dryRun
+                tagCmd.push = true
+                tagCmd.repoRoot = root.path
+                try await tagCmd.run()
+
+                Console.substep("Waiting for GitHub Actions...")
+                if !dryRun {
+                    Console.info("\n    Wait for GitHub Actions to complete, then run:")
+                    Console.info("    cupertino-rel databases")
+                    Console.info("    cupertino-rel homebrew --version \(newVersion)")
+                }
+            } else {
+                Console.info("\nNext steps:")
+                Console.info("  1. Review changes: git diff")
+                Console.info("  2. Edit CHANGELOG.md")
+                Console.info("  3. Tag and release: cupertino-rel tag --version \(newVersion) --push")
+                Console.info("  4. After GitHub Actions: cupertino-rel databases")
+                Console.info("  5. Update Homebrew: cupertino-rel homebrew --version \(newVersion)")
+            }
+
+            Console.info("")
+            Console.success("Documentation update prepared: \(formatNumber(docCount))+ docs, \(frameworkCount) frameworks")
         }
 
-        if totalDocs == 0 {
-            throw DocsUpdateError.databaseQueryFailed
+        // MARK: - Helpers
+
+        private func findRepoRoot() throws -> URL {
+            if let root = repoRoot {
+                return URL(fileURLWithPath: root)
+            }
+            let output = try Shell.run("git rev-parse --show-toplevel")
+            return URL(fileURLWithPath: output)
         }
 
-        return (totalDocs, frameworkCount)
-    }
-
-    private func updateReadmeStats(at url: URL, documents: Int, frameworks: Int) throws {
-        var content = try String(contentsOf: url, encoding: .utf8)
-
-        // Update pattern: "X+ documentation pages across Y frameworks"
-        // or "X,XXX+ documentation pages across Y frameworks"
-        let pattern = #"(\d+[,\d]*\+?\s+documentation pages across\s+)\d+(\s+frameworks)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            throw DocsUpdateError.readmeUpdateFailed
+        private func readCurrentVersion(from url: URL) throws -> Version {
+            let content = try String(contentsOf: url, encoding: .utf8)
+            let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
+            guard let regex = try? NSRegularExpression(pattern: pattern),
+                  let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
+                  let versionRange = Range(match.range(at: 1), in: content),
+                  let version = Version(String(content[versionRange])) else {
+                throw DocsUpdateError.versionNotFound
+            }
+            return version
         }
 
-        let formattedDocs = formatNumber(documents)
-        let replacement = "\(formattedDocs)+ documentation pages across \(frameworks) frameworks"
+        private func getDocumentStats() async throws -> (documents: Int, frameworks: Int) {
+            // Always query - we need the counts even in dry-run to show what would be written
+            // Query using cupertino list-frameworks and parse output
+            let output = try Shell.run("cupertino list-frameworks 2>/dev/null || echo 'error'")
 
-        // Find and replace the pattern
-        if let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
-           let range = Range(match.range, in: content) {
-            content.replaceSubrange(range, with: replacement)
-        } else {
-            throw DocsUpdateError.readmeUpdateFailed
+            if output.contains("error") || output.isEmpty {
+                throw DocsUpdateError.databaseQueryFailed
+            }
+
+            // Parse output like:
+            // Available Frameworks (284 total, 200725 documents):
+
+            var totalDocs = 0
+            var frameworkCount = 0
+
+            // Look for "Available Frameworks (X total, Y documents):"
+            let pattern = #"\((\d+)\s+total,\s+(\d+)\s+documents\)"#
+            if let regex = try? NSRegularExpression(pattern: pattern),
+               let match = regex.firstMatch(in: output, range: NSRange(output.startIndex..., in: output)) {
+                if let fwRange = Range(match.range(at: 1), in: output),
+                   let docRange = Range(match.range(at: 2), in: output) {
+                    frameworkCount = Int(output[fwRange]) ?? 0
+                    totalDocs = Int(output[docRange]) ?? 0
+                }
+            }
+
+            if totalDocs == 0 {
+                throw DocsUpdateError.databaseQueryFailed
+            }
+
+            return (totalDocs, frameworkCount)
         }
 
-        try content.write(to: url, atomically: true, encoding: .utf8)
-    }
+        private func updateReadmeStats(at url: URL, documents: Int, frameworks: Int) throws {
+            var content = try String(contentsOf: url, encoding: .utf8)
 
-    private func formatNumber(_ number: Int) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.groupingSeparator = ","
-        return formatter.string(from: NSNumber(value: number)) ?? "\(number)"
+            // Update pattern: "X+ documentation pages across Y frameworks"
+            // or "X,XXX+ documentation pages across Y frameworks"
+            let pattern = #"(\d+[,\d]*\+?\s+documentation pages across\s+)\d+(\s+frameworks)"#
+            guard let regex = try? NSRegularExpression(pattern: pattern) else {
+                throw DocsUpdateError.readmeUpdateFailed
+            }
+
+            let formattedDocs = formatNumber(documents)
+            let replacement = "\(formattedDocs)+ documentation pages across \(frameworks) frameworks"
+
+            // Find and replace the pattern
+            if let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
+               let range = Range(match.range, in: content) {
+                content.replaceSubrange(range, with: replacement)
+            } else {
+                throw DocsUpdateError.readmeUpdateFailed
+            }
+
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        private func formatNumber(_ number: Int) -> String {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.groupingSeparator = ","
+            return formatter.string(from: NSNumber(value: number)) ?? "\(number)"
+        }
     }
 }
 

--- a/Packages/Sources/ReleaseTool/FullCommand.swift
+++ b/Packages/Sources/ReleaseTool/FullCommand.swift
@@ -3,180 +3,182 @@ import Foundation
 
 // MARK: - Full Command
 
-struct FullCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "full",
-        abstract: "Run the complete release workflow"
-    )
+extension Release.Command {
+    struct Full: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "full",
+            abstract: "Run the complete release workflow"
+        )
 
-    @Argument(help: "New version (e.g., 0.5.0) or bump type (major, minor, patch)")
-    var versionOrType: String
+        @Argument(help: "New version (e.g., 0.5.0) or bump type (major, minor, patch)")
+        var versionOrType: String
 
-    @Flag(name: .long, help: "Preview all steps without executing")
-    var dryRun: Bool = false
+        @Flag(name: .long, help: "Preview all steps without executing")
+        var dryRun: Bool = false
 
-    @Flag(name: .long, help: "Skip waiting for GitHub Actions")
-    var skipWait: Bool = false
+        @Flag(name: .long, help: "Skip waiting for GitHub Actions")
+        var skipWait: Bool = false
 
-    @Flag(name: .long, help: "Skip database upload")
-    var skipDatabases: Bool = false
+        @Flag(name: .long, help: "Skip database upload")
+        var skipDatabases: Bool = false
 
-    @Flag(name: .long, help: "Skip Homebrew formula update")
-    var skipHomebrew: Bool = false
+        @Flag(name: .long, help: "Skip Homebrew formula update")
+        var skipHomebrew: Bool = false
 
-    @Option(name: .long, help: "Path to repository root")
-    var repoRoot: String?
+        @Option(name: .long, help: "Path to repository root")
+        var repoRoot: String?
 
-    // MARK: - Run
+        // MARK: - Run
 
-    mutating func run() async throws {
-        let root = try findRepoRoot()
-        let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+        mutating func run() async throws {
+            let root = try findRepoRoot()
+            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
 
-        // Get current version
-        let currentVersion = try readCurrentVersion(from: constantsPath)
+            // Get current version
+            let currentVersion = try readCurrentVersion(from: constantsPath)
 
-        // Determine new version
-        let newVersion: Version
-        if let bumpType = BumpType(rawValue: versionOrType.lowercased()) {
-            newVersion = currentVersion.bumped(bumpType)
-        } else if let explicit = Version(versionOrType) {
-            newVersion = explicit
-        } else {
-            throw FullReleaseError.invalidVersion(versionOrType)
-        }
-
-        Console.info("🚀 Cupertino Release Workflow")
-        Console.info("   Current: \(currentVersion) → New: \(newVersion)")
-        Console.info("")
-
-        if dryRun {
-            Console.warning("DRY RUN - No changes will be made\n")
-        }
-
-        // Step 1: Bump version
-        Console.step(1, "Bump version in all files")
-        var bumpCmd = BumpCommand()
-        bumpCmd.versionOrType = newVersion.description
-        bumpCmd.dryRun = dryRun
-        bumpCmd.repoRoot = root.path
-        try await bumpCmd.run()
-
-        // Step 2: Edit changelog (prompt user)
-        Console.step(2, "Edit CHANGELOG.md")
-        if !dryRun {
-            Console.info("    Please edit CHANGELOG.md to add release notes.")
-            Console.info("    Press Enter when done...")
-            _ = readLine()
-        } else {
-            Console.substep("Would prompt user to edit CHANGELOG.md")
-        }
-
-        // Step 3: Create tag and push
-        Console.step(3, "Create git tag and push")
-        var tagCmd = TagCommand()
-        tagCmd.version = newVersion.description
-        tagCmd.dryRun = dryRun
-        tagCmd.push = true
-        tagCmd.repoRoot = root.path
-        try await tagCmd.run()
-
-        // Step 4: Wait for GitHub Actions
-        if !skipWait {
-            Console.step(4, "Wait for GitHub Actions build")
-            if dryRun {
-                Console.substep("Would wait for GitHub Actions to complete")
+            // Determine new version
+            let newVersion: Version
+            if let bumpType = BumpType(rawValue: versionOrType.lowercased()) {
+                newVersion = currentVersion.bumped(bumpType)
+            } else if let explicit = Version(versionOrType) {
+                newVersion = explicit
             } else {
-                try await waitForGitHubActions(version: newVersion)
-            }
-        } else {
-            Console.step(4, "Skipping GitHub Actions wait (--skip-wait)")
-        }
-
-        // Step 5: Upload databases
-        if !skipDatabases {
-            Console.step(5, "Upload databases to cupertino-docs")
-            var dbCmd = DatabaseReleaseCommand()
-            dbCmd.dryRun = dryRun
-            dbCmd.repoRoot = root.path
-            try await dbCmd.run()
-        } else {
-            Console.step(5, "Skipping database upload (--skip-databases)")
-        }
-
-        // Step 6: Update Homebrew
-        if !skipHomebrew {
-            Console.step(6, "Update Homebrew formula")
-            var brewCmd = HomebrewCommand()
-            brewCmd.version = newVersion.description
-            brewCmd.dryRun = dryRun
-            brewCmd.repoRoot = root.path
-            try await brewCmd.run()
-        } else {
-            Console.step(6, "Skipping Homebrew update (--skip-homebrew)")
-        }
-
-        // Done
-        Console.info("")
-        Console.success("Release \(newVersion) complete!")
-        Console.info("")
-        Console.info("Verify:")
-        Console.info("  • GitHub Release: https://github.com/mihaelamj/cupertino/releases/tag/\(newVersion.tag)")
-        Console.info("  • Databases: https://github.com/mihaelamj/cupertino-docs/releases/tag/\(newVersion.tag)")
-        Console.info("  • Homebrew: brew info cupertino")
-    }
-
-    // MARK: - Helpers
-
-    private func findRepoRoot() throws -> URL {
-        if let root = repoRoot {
-            return URL(fileURLWithPath: root)
-        }
-        let output = try Shell.run("git rev-parse --show-toplevel")
-        return URL(fileURLWithPath: output)
-    }
-
-    private func readCurrentVersion(from url: URL) throws -> Version {
-        let content = try String(contentsOf: url, encoding: .utf8)
-        let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
-              let versionRange = Range(match.range(at: 1), in: content),
-              let version = Version(String(content[versionRange])) else {
-            throw FullReleaseError.versionNotFound
-        }
-        return version
-    }
-
-    private func waitForGitHubActions(version: Version) async throws {
-        Console.substep("Waiting for GitHub Actions to build \(version.tag)...")
-
-        let maxAttempts = 60 // 30 minutes max
-        let delaySeconds: UInt64 = 30
-
-        for attempt in 1...maxAttempts {
-            // Check if release asset exists
-            let assetURL = URL.knownGood(
-                "https://github.com/mihaelamj/cupertino/releases/download/\(version.tag)/cupertino-\(version.tag)-macos-universal.tar.gz"
-            )
-
-            var request = URLRequest(url: assetURL)
-            request.httpMethod = "HEAD"
-
-            let (_, response) = try await URLSession.shared.data(for: request)
-            if let httpResponse = response as? HTTPURLResponse,
-               httpResponse.statusCode == 200 {
-                Console.substep("✓ Build complete!")
-                return
+                throw FullReleaseError.invalidVersion(versionOrType)
             }
 
-            if attempt < maxAttempts {
-                Console.substep("Attempt \(attempt)/\(maxAttempts) - build not ready, waiting 30s...")
-                try await Task.sleep(nanoseconds: delaySeconds * 1000000000)
+            Console.info("🚀 Cupertino Release Workflow")
+            Console.info("   Current: \(currentVersion) → New: \(newVersion)")
+            Console.info("")
+
+            if dryRun {
+                Console.warning("DRY RUN - No changes will be made\n")
             }
+
+            // Step 1: Bump version
+            Console.step(1, "Bump version in all files")
+            var bumpCmd = Release.Command.Bump()
+            bumpCmd.versionOrType = newVersion.description
+            bumpCmd.dryRun = dryRun
+            bumpCmd.repoRoot = root.path
+            try await bumpCmd.run()
+
+            // Step 2: Edit changelog (prompt user)
+            Console.step(2, "Edit CHANGELOG.md")
+            if !dryRun {
+                Console.info("    Please edit CHANGELOG.md to add release notes.")
+                Console.info("    Press Enter when done...")
+                _ = readLine()
+            } else {
+                Console.substep("Would prompt user to edit CHANGELOG.md")
+            }
+
+            // Step 3: Create tag and push
+            Console.step(3, "Create git tag and push")
+            var tagCmd = Release.Command.Tag()
+            tagCmd.version = newVersion.description
+            tagCmd.dryRun = dryRun
+            tagCmd.push = true
+            tagCmd.repoRoot = root.path
+            try await tagCmd.run()
+
+            // Step 4: Wait for GitHub Actions
+            if !skipWait {
+                Console.step(4, "Wait for GitHub Actions build")
+                if dryRun {
+                    Console.substep("Would wait for GitHub Actions to complete")
+                } else {
+                    try await waitForGitHubActions(version: newVersion)
+                }
+            } else {
+                Console.step(4, "Skipping GitHub Actions wait (--skip-wait)")
+            }
+
+            // Step 5: Upload databases
+            if !skipDatabases {
+                Console.step(5, "Upload databases to cupertino-docs")
+                var dbCmd = Release.Command.Database()
+                dbCmd.dryRun = dryRun
+                dbCmd.repoRoot = root.path
+                try await dbCmd.run()
+            } else {
+                Console.step(5, "Skipping database upload (--skip-databases)")
+            }
+
+            // Step 6: Update Homebrew
+            if !skipHomebrew {
+                Console.step(6, "Update Homebrew formula")
+                var brewCmd = Release.Command.Homebrew()
+                brewCmd.version = newVersion.description
+                brewCmd.dryRun = dryRun
+                brewCmd.repoRoot = root.path
+                try await brewCmd.run()
+            } else {
+                Console.step(6, "Skipping Homebrew update (--skip-homebrew)")
+            }
+
+            // Done
+            Console.info("")
+            Console.success("Release \(newVersion) complete!")
+            Console.info("")
+            Console.info("Verify:")
+            Console.info("  • GitHub Release: https://github.com/mihaelamj/cupertino/releases/tag/\(newVersion.tag)")
+            Console.info("  • Databases: https://github.com/mihaelamj/cupertino-docs/releases/tag/\(newVersion.tag)")
+            Console.info("  • Homebrew: brew info cupertino")
         }
 
-        throw FullReleaseError.buildTimeout
+        // MARK: - Helpers
+
+        private func findRepoRoot() throws -> URL {
+            if let root = repoRoot {
+                return URL(fileURLWithPath: root)
+            }
+            let output = try Shell.run("git rev-parse --show-toplevel")
+            return URL(fileURLWithPath: output)
+        }
+
+        private func readCurrentVersion(from url: URL) throws -> Version {
+            let content = try String(contentsOf: url, encoding: .utf8)
+            let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
+            guard let regex = try? NSRegularExpression(pattern: pattern),
+                  let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
+                  let versionRange = Range(match.range(at: 1), in: content),
+                  let version = Version(String(content[versionRange])) else {
+                throw FullReleaseError.versionNotFound
+            }
+            return version
+        }
+
+        private func waitForGitHubActions(version: Version) async throws {
+            Console.substep("Waiting for GitHub Actions to build \(version.tag)...")
+
+            let maxAttempts = 60 // 30 minutes max
+            let delaySeconds: UInt64 = 30
+
+            for attempt in 1...maxAttempts {
+                // Check if release asset exists
+                let assetURL = URL.knownGood(
+                    "https://github.com/mihaelamj/cupertino/releases/download/\(version.tag)/cupertino-\(version.tag)-macos-universal.tar.gz"
+                )
+
+                var request = URLRequest(url: assetURL)
+                request.httpMethod = "HEAD"
+
+                let (_, response) = try await URLSession.shared.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse,
+                   httpResponse.statusCode == 200 {
+                    Console.substep("✓ Build complete!")
+                    return
+                }
+
+                if attempt < maxAttempts {
+                    Console.substep("Attempt \(attempt)/\(maxAttempts) - build not ready, waiting 30s...")
+                    try await Task.sleep(nanoseconds: delaySeconds * 1000000000)
+                }
+            }
+
+            throw FullReleaseError.buildTimeout
+        }
     }
 }
 

--- a/Packages/Sources/ReleaseTool/HomebrewCommand.swift
+++ b/Packages/Sources/ReleaseTool/HomebrewCommand.swift
@@ -3,196 +3,198 @@ import Foundation
 
 // MARK: - Homebrew Command
 
-struct HomebrewCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "homebrew",
-        abstract: "Update Homebrew formula with new version"
-    )
-
-    @Option(name: .long, help: "Version to release (e.g., 0.5.0)")
-    var version: String?
-
-    @Flag(name: .long, help: "Preview changes without modifying files")
-    var dryRun: Bool = false
-
-    @Option(name: .long, help: "Path to homebrew-tap repository")
-    var tapPath: String?
-
-    @Option(name: .long, help: "GitHub repository for CLI releases")
-    var repo: String = "mihaelamj/cupertino"
-
-    @Option(name: .long, help: "Path to repository root")
-    var repoRoot: String?
-
-    // MARK: - Run
-
-    mutating func run() async throws {
-        let root = try findRepoRoot()
-
-        // Get version
-        let releaseVersion: Version
-        if let versionString = version {
-            guard let parsed = Version(versionString) else {
-                throw HomebrewError.invalidVersion(versionString)
-            }
-            releaseVersion = parsed
-        } else {
-            releaseVersion = try readCurrentVersion(from: root)
-        }
-
-        Console.info("🍺 Updating Homebrew formula for version \(releaseVersion)")
-
-        // Get SHA256 from GitHub release
-        Console.step(1, "Fetching SHA256 from GitHub release...")
-        let sha256 = try await fetchSHA256(version: releaseVersion)
-        Console.substep("SHA256: \(sha256)")
-
-        // Clone or update tap repository
-        let tapURL: URL
-        if let path = tapPath {
-            tapURL = URL(fileURLWithPath: path)
-        } else {
-            Console.step(2, "Cloning homebrew-tap repository...")
-            tapURL = try cloneTap()
-        }
-
-        let formulaPath = tapURL.appendingPathComponent("Formula/cupertino.rb")
-
-        // Update formula
-        Console.step(3, "Updating formula...")
-        if dryRun {
-            Console.substep("Would update: \(formulaPath.path)")
-            Console.substep("  url → .../\(releaseVersion.tag)/cupertino-\(releaseVersion.tag)-macos-universal.tar.gz")
-            Console.substep("  sha256 → \(sha256)")
-            Console.substep("  version → \(releaseVersion)")
-        } else {
-            try updateFormula(at: formulaPath, version: releaseVersion, sha256: sha256)
-            Console.substep("✓ Formula updated")
-        }
-
-        // Commit and push
-        Console.step(4, "Committing changes...")
-        if dryRun {
-            Console.substep("Would run: git add Formula/cupertino.rb")
-            Console.substep("Would run: git commit -m \"chore: bump cupertino to \(releaseVersion)\"")
-            Console.substep("Would run: git push")
-        } else {
-            let originalDir = FileManager.default.currentDirectoryPath
-            FileManager.default.changeCurrentDirectoryPath(tapURL.path)
-
-            try Shell.run("git add Formula/cupertino.rb")
-            try Shell.run("git commit -m \"chore: bump cupertino to \(releaseVersion)\"")
-            try Shell.run("git push")
-
-            FileManager.default.changeCurrentDirectoryPath(originalDir)
-            Console.substep("✓ Changes pushed to homebrew-tap")
-        }
-
-        // Cleanup temp directory if we cloned
-        if tapPath == nil {
-            try? FileManager.default.removeItem(at: tapURL)
-        }
-
-        Console.success("Homebrew formula updated to \(releaseVersion)")
-        Console.info("\nUsers can now run:")
-        Console.info("  brew update && brew upgrade cupertino")
-    }
-
-    // MARK: - Helpers
-
-    private func findRepoRoot() throws -> URL {
-        if let root = repoRoot {
-            return URL(fileURLWithPath: root)
-        }
-        let output = try Shell.run("git rev-parse --show-toplevel")
-        return URL(fileURLWithPath: output)
-    }
-
-    private func readCurrentVersion(from root: URL) throws -> Version {
-        let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
-        let content = try String(contentsOf: constantsPath, encoding: .utf8)
-        let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
-              let versionRange = Range(match.range(at: 1), in: content),
-              let version = Version(String(content[versionRange])) else {
-            throw HomebrewError.versionNotFound
-        }
-        return version
-    }
-
-    private func fetchSHA256(version: Version) async throws -> String {
-        let sha256URL = URL.knownGood(
-            "https://github.com/\(repo)/releases/download/\(version.tag)/cupertino-\(version.tag)-macos-universal.tar.gz.sha256"
+extension Release.Command {
+    struct Homebrew: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "homebrew",
+            abstract: "Update Homebrew formula with new version"
         )
 
-        let (data, response) = try await URLSession.shared.data(from: sha256URL)
-        guard let httpResponse = response as? HTTPURLResponse,
-              httpResponse.statusCode == 200 else {
-            throw HomebrewError.sha256NotFound(version.tag)
+        @Option(name: .long, help: "Version to release (e.g., 0.5.0)")
+        var version: String?
+
+        @Flag(name: .long, help: "Preview changes without modifying files")
+        var dryRun: Bool = false
+
+        @Option(name: .long, help: "Path to homebrew-tap repository")
+        var tapPath: String?
+
+        @Option(name: .long, help: "GitHub repository for CLI releases")
+        var repo: String = "mihaelamj/cupertino"
+
+        @Option(name: .long, help: "Path to repository root")
+        var repoRoot: String?
+
+        // MARK: - Run
+
+        mutating func run() async throws {
+            let root = try findRepoRoot()
+
+            // Get version
+            let releaseVersion: Version
+            if let versionString = version {
+                guard let parsed = Version(versionString) else {
+                    throw HomebrewError.invalidVersion(versionString)
+                }
+                releaseVersion = parsed
+            } else {
+                releaseVersion = try readCurrentVersion(from: root)
+            }
+
+            Console.info("🍺 Updating Homebrew formula for version \(releaseVersion)")
+
+            // Get SHA256 from GitHub release
+            Console.step(1, "Fetching SHA256 from GitHub release...")
+            let sha256 = try await fetchSHA256(version: releaseVersion)
+            Console.substep("SHA256: \(sha256)")
+
+            // Clone or update tap repository
+            let tapURL: URL
+            if let path = tapPath {
+                tapURL = URL(fileURLWithPath: path)
+            } else {
+                Console.step(2, "Cloning homebrew-tap repository...")
+                tapURL = try cloneTap()
+            }
+
+            let formulaPath = tapURL.appendingPathComponent("Formula/cupertino.rb")
+
+            // Update formula
+            Console.step(3, "Updating formula...")
+            if dryRun {
+                Console.substep("Would update: \(formulaPath.path)")
+                Console.substep("  url → .../\(releaseVersion.tag)/cupertino-\(releaseVersion.tag)-macos-universal.tar.gz")
+                Console.substep("  sha256 → \(sha256)")
+                Console.substep("  version → \(releaseVersion)")
+            } else {
+                try updateFormula(at: formulaPath, version: releaseVersion, sha256: sha256)
+                Console.substep("✓ Formula updated")
+            }
+
+            // Commit and push
+            Console.step(4, "Committing changes...")
+            if dryRun {
+                Console.substep("Would run: git add Formula/cupertino.rb")
+                Console.substep("Would run: git commit -m \"chore: bump cupertino to \(releaseVersion)\"")
+                Console.substep("Would run: git push")
+            } else {
+                let originalDir = FileManager.default.currentDirectoryPath
+                FileManager.default.changeCurrentDirectoryPath(tapURL.path)
+
+                try Shell.run("git add Formula/cupertino.rb")
+                try Shell.run("git commit -m \"chore: bump cupertino to \(releaseVersion)\"")
+                try Shell.run("git push")
+
+                FileManager.default.changeCurrentDirectoryPath(originalDir)
+                Console.substep("✓ Changes pushed to homebrew-tap")
+            }
+
+            // Cleanup temp directory if we cloned
+            if tapPath == nil {
+                try? FileManager.default.removeItem(at: tapURL)
+            }
+
+            Console.success("Homebrew formula updated to \(releaseVersion)")
+            Console.info("\nUsers can now run:")
+            Console.info("  brew update && brew upgrade cupertino")
         }
 
-        guard let content = String(data: data, encoding: .utf8),
-              let sha256 = content.split(separator: " ").first else {
-            throw HomebrewError.invalidSHA256
+        // MARK: - Helpers
+
+        private func findRepoRoot() throws -> URL {
+            if let root = repoRoot {
+                return URL(fileURLWithPath: root)
+            }
+            let output = try Shell.run("git rev-parse --show-toplevel")
+            return URL(fileURLWithPath: output)
         }
 
-        return String(sha256).trimmingCharacters(in: .whitespacesAndNewlines)
-    }
+        private func readCurrentVersion(from root: URL) throws -> Version {
+            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+            let content = try String(contentsOf: constantsPath, encoding: .utf8)
+            let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
+            guard let regex = try? NSRegularExpression(pattern: pattern),
+                  let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
+                  let versionRange = Range(match.range(at: 1), in: content),
+                  let version = Version(String(content[versionRange])) else {
+                throw HomebrewError.versionNotFound
+            }
+            return version
+        }
 
-    private func cloneTap() throws -> URL {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("homebrew-tap-\(UUID().uuidString)")
-        try Shell.run("git clone https://github.com/mihaelamj/homebrew-tap.git \(tempDir.path)")
-        return tempDir
-    }
-
-    private func updateFormula(at url: URL, version: Version, sha256: String) throws {
-        var content = try String(contentsOf: url, encoding: .utf8)
-
-        // Update URL
-        let urlPattern = #"(url\s+")https://github\.com/[^"]+/releases/download/v[\d.]+/"#
-            + #"cupertino-v[\d.]+-macos-universal\.tar\.gz(")"#
-        if let regex = try? NSRegularExpression(pattern: urlPattern) {
-            let newURL = "https://github.com/\(repo)/releases/download/\(version.tag)/"
-                + "cupertino-\(version.tag)-macos-universal.tar.gz"
-            content = regex.stringByReplacingMatches(
-                in: content,
-                range: NSRange(content.startIndex..., in: content),
-                withTemplate: "$1\(newURL)$2"
+        private func fetchSHA256(version: Version) async throws -> String {
+            let sha256URL = URL.knownGood(
+                "https://github.com/\(repo)/releases/download/\(version.tag)/cupertino-\(version.tag)-macos-universal.tar.gz.sha256"
             )
+
+            let (data, response) = try await URLSession.shared.data(from: sha256URL)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                throw HomebrewError.sha256NotFound(version.tag)
+            }
+
+            guard let content = String(data: data, encoding: .utf8),
+                  let sha256 = content.split(separator: " ").first else {
+                throw HomebrewError.invalidSHA256
+            }
+
+            return String(sha256).trimmingCharacters(in: .whitespacesAndNewlines)
         }
 
-        // Update SHA256
-        let sha256Pattern = #"(sha256\s+")[a-f0-9]+(")"#
-        if let regex = try? NSRegularExpression(pattern: sha256Pattern) {
-            content = regex.stringByReplacingMatches(
-                in: content,
-                range: NSRange(content.startIndex..., in: content),
-                withTemplate: "$1\(sha256)$2"
-            )
+        private func cloneTap() throws -> URL {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("homebrew-tap-\(UUID().uuidString)")
+            try Shell.run("git clone https://github.com/mihaelamj/homebrew-tap.git \(tempDir.path)")
+            return tempDir
         }
 
-        // Update version
-        let versionPattern = #"(version\s+")[\d.]+(")"#
-        if let regex = try? NSRegularExpression(pattern: versionPattern) {
-            content = regex.stringByReplacingMatches(
-                in: content,
-                range: NSRange(content.startIndex..., in: content),
-                withTemplate: "$1\(version)$2"
-            )
-        }
+        private func updateFormula(at url: URL, version: Version, sha256: String) throws {
+            var content = try String(contentsOf: url, encoding: .utf8)
 
-        // Update test assertion
-        let testPattern = #"(assert_match\s+")[\d.]+(",)"#
-        if let regex = try? NSRegularExpression(pattern: testPattern) {
-            content = regex.stringByReplacingMatches(
-                in: content,
-                range: NSRange(content.startIndex..., in: content),
-                withTemplate: "$1\(version)$2"
-            )
-        }
+            // Update URL
+            let urlPattern = #"(url\s+")https://github\.com/[^"]+/releases/download/v[\d.]+/"#
+                + #"cupertino-v[\d.]+-macos-universal\.tar\.gz(")"#
+            if let regex = try? NSRegularExpression(pattern: urlPattern) {
+                let newURL = "https://github.com/\(repo)/releases/download/\(version.tag)/"
+                    + "cupertino-\(version.tag)-macos-universal.tar.gz"
+                content = regex.stringByReplacingMatches(
+                    in: content,
+                    range: NSRange(content.startIndex..., in: content),
+                    withTemplate: "$1\(newURL)$2"
+                )
+            }
 
-        try content.write(to: url, atomically: true, encoding: .utf8)
+            // Update SHA256
+            let sha256Pattern = #"(sha256\s+")[a-f0-9]+(")"#
+            if let regex = try? NSRegularExpression(pattern: sha256Pattern) {
+                content = regex.stringByReplacingMatches(
+                    in: content,
+                    range: NSRange(content.startIndex..., in: content),
+                    withTemplate: "$1\(sha256)$2"
+                )
+            }
+
+            // Update version
+            let versionPattern = #"(version\s+")[\d.]+(")"#
+            if let regex = try? NSRegularExpression(pattern: versionPattern) {
+                content = regex.stringByReplacingMatches(
+                    in: content,
+                    range: NSRange(content.startIndex..., in: content),
+                    withTemplate: "$1\(version)$2"
+                )
+            }
+
+            // Update test assertion
+            let testPattern = #"(assert_match\s+")[\d.]+(",)"#
+            if let regex = try? NSRegularExpression(pattern: testPattern) {
+                content = regex.stringByReplacingMatches(
+                    in: content,
+                    range: NSRange(content.startIndex..., in: content),
+                    withTemplate: "$1\(version)$2"
+                )
+            }
+
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        }
     }
 }
 

--- a/Packages/Sources/ReleaseTool/Release.swift
+++ b/Packages/Sources/ReleaseTool/Release.swift
@@ -1,0 +1,19 @@
+import ArgumentParser
+
+// MARK: - Release Namespace
+
+/// Namespace for the `cupertino-rel` binary (the release-automation tool).
+/// Holds every subcommand under `Release.Command.<Name>`, mirroring the
+/// `Command.<Name>` pattern used for the main `cupertino` CLI (#352).
+///
+/// The root `ReleaseCLI` (the `AsyncParsableCommand` that holds
+/// `subcommands: [...]`) stays at file scope in `ReleaseCLI.swift` — it's
+/// the dispatcher, not a subcommand. The helper enums
+/// `ReleasePublishing` and `ReleasePublishingError` also stay where they
+/// are for now (a follow-up may fold them into `Release.Publishing.*`).
+enum Release {
+    /// Sub-namespace for `AsyncParsableCommand` subcommands of `cupertino-rel`:
+    /// `Release.Command.Bump`, `.Tag`, `.Database`, `.Homebrew`, `.DocsUpdate`,
+    /// `.Full`.
+    enum Command {}
+}

--- a/Packages/Sources/ReleaseTool/ReleaseCLI.swift
+++ b/Packages/Sources/ReleaseTool/ReleaseCLI.swift
@@ -23,14 +23,14 @@ struct ReleaseCLI: AsyncParsableCommand {
         """,
         version: Shared.Constants.App.version,
         subcommands: [
-            BumpCommand.self,
-            TagCommand.self,
-            DatabaseReleaseCommand.self,
-            HomebrewCommand.self,
-            DocsUpdateCommand.self,
-            FullCommand.self,
+            Release.Command.Bump.self,
+            Release.Command.Tag.self,
+            Release.Command.Database.self,
+            Release.Command.Homebrew.self,
+            Release.Command.DocsUpdate.self,
+            Release.Command.Full.self,
         ],
-        defaultSubcommand: FullCommand.self
+        defaultSubcommand: Release.Command.Full.self
     )
 }
 

--- a/Packages/Sources/ReleaseTool/ReleasePublishingHelpers.swift
+++ b/Packages/Sources/ReleaseTool/ReleasePublishingHelpers.swift
@@ -6,7 +6,7 @@ import SharedUtils
 // MARK: - Shared publishing helpers
 
 //
-// Used by `DatabaseReleaseCommand`. Lives in a separate file so future
+// Used by `Release.Command.Database`. Lives in a separate file so future
 // release-tool subcommands (e.g. a separate Homebrew artifact pass, or a
 // per-corpus release that targets a different GitHub repo) can reuse the
 // same zip / sha256 / GitHub-API code without copy-pasting.

--- a/Packages/Sources/ReleaseTool/TagCommand.swift
+++ b/Packages/Sources/ReleaseTool/TagCommand.swift
@@ -3,134 +3,136 @@ import Foundation
 
 // MARK: - Tag Command
 
-struct TagCommand: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
-        commandName: "tag",
-        abstract: "Commit changes and create git tag"
-    )
+extension Release.Command {
+    struct Tag: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "tag",
+            abstract: "Commit changes and create git tag"
+        )
 
-    @Option(name: .long, help: "Version to tag (e.g., 0.5.0)")
-    var version: String?
+        @Option(name: .long, help: "Version to tag (e.g., 0.5.0)")
+        var version: String?
 
-    @Flag(name: .long, help: "Preview commands without executing")
-    var dryRun: Bool = false
+        @Flag(name: .long, help: "Preview commands without executing")
+        var dryRun: Bool = false
 
-    @Flag(name: .long, help: "Push tag to origin after creation")
-    var push: Bool = false
+        @Flag(name: .long, help: "Push tag to origin after creation")
+        var push: Bool = false
 
-    @Option(name: .long, help: "Path to repository root")
-    var repoRoot: String?
+        @Option(name: .long, help: "Path to repository root")
+        var repoRoot: String?
 
-    // MARK: - Run
+        // MARK: - Run
 
-    mutating func run() async throws {
-        let root = try findRepoRoot()
-        let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+        mutating func run() async throws {
+            let root = try findRepoRoot()
+            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
 
-        // Get version from Constants.swift or argument
-        let tagVersion: Version
-        if let versionString = version {
-            guard let parsed = Version(versionString) else {
-                throw TagError.invalidVersion(versionString)
-            }
-            tagVersion = parsed
-        } else {
-            tagVersion = try readCurrentVersion(from: constantsPath)
-        }
-
-        Console.info("📦 Tagging version: \(tagVersion)")
-
-        // Check for uncommitted changes
-        let status = try Shell.run("git status --porcelain")
-        let hasChanges = !status.isEmpty
-
-        if hasChanges {
-            Console.step(1, "Staging and committing changes...")
-            if dryRun {
-                Console.substep("Would run: git add -A")
-                Console.substep("Would run: git commit -m \"chore: bump version to \(tagVersion)\"")
+            // Get version from Constants.swift or argument
+            let tagVersion: Version
+            if let versionString = version {
+                guard let parsed = Version(versionString) else {
+                    throw TagError.invalidVersion(versionString)
+                }
+                tagVersion = parsed
             } else {
-                try Shell.run("git add -A")
-                try Shell.run("git commit -m \"chore: bump version to \(tagVersion)\"")
-                Console.substep("✓ Changes committed")
-            }
-        } else {
-            Console.step(1, "No uncommitted changes")
-        }
-
-        // Verify version in committed code matches
-        Console.step(2, "Verifying version in source...")
-        if dryRun {
-            Console.substep("Would verify version matches \(tagVersion)")
-        } else {
-            let committedVersion = try readCurrentVersion(from: constantsPath)
-            guard committedVersion.description == tagVersion.description else {
-                throw TagError.versionMismatch(expected: tagVersion.description, found: committedVersion.description)
-            }
-            Console.substep("✓ Version verified: \(committedVersion)")
-        }
-
-        // Create tag
-        Console.step(3, "Creating tag \(tagVersion.tag)...")
-        if dryRun {
-            Console.substep("Would run: git tag -a \(tagVersion.tag) -m \"\(tagVersion.tag)\"")
-        } else {
-            // Check if tag exists
-            let tagExists = (try? Shell.run("git rev-parse \(tagVersion.tag)")) != nil
-            if tagExists {
-                throw TagError.tagExists(tagVersion.tag)
+                tagVersion = try readCurrentVersion(from: constantsPath)
             }
 
-            try Shell.run("git tag -a \(tagVersion.tag) -m \"\(tagVersion.tag)\"")
-            Console.substep("✓ Tag created")
-        }
+            Console.info("📦 Tagging version: \(tagVersion)")
 
-        // Push if requested
-        if push {
-            Console.step(4, "Pushing to origin...")
-            if dryRun {
-                Console.substep("Would run: git push origin main")
-                Console.substep("Would run: git push origin \(tagVersion.tag)")
+            // Check for uncommitted changes
+            let status = try Shell.run("git status --porcelain")
+            let hasChanges = !status.isEmpty
+
+            if hasChanges {
+                Console.step(1, "Staging and committing changes...")
+                if dryRun {
+                    Console.substep("Would run: git add -A")
+                    Console.substep("Would run: git commit -m \"chore: bump version to \(tagVersion)\"")
+                } else {
+                    try Shell.run("git add -A")
+                    try Shell.run("git commit -m \"chore: bump version to \(tagVersion)\"")
+                    Console.substep("✓ Changes committed")
+                }
             } else {
-                try Shell.run("git push origin main")
-                Console.substep("✓ Pushed main branch")
-                try Shell.run("git push origin \(tagVersion.tag)")
-                Console.substep("✓ Pushed tag \(tagVersion.tag)")
+                Console.step(1, "No uncommitted changes")
             }
+
+            // Verify version in committed code matches
+            Console.step(2, "Verifying version in source...")
+            if dryRun {
+                Console.substep("Would verify version matches \(tagVersion)")
+            } else {
+                let committedVersion = try readCurrentVersion(from: constantsPath)
+                guard committedVersion.description == tagVersion.description else {
+                    throw TagError.versionMismatch(expected: tagVersion.description, found: committedVersion.description)
+                }
+                Console.substep("✓ Version verified: \(committedVersion)")
+            }
+
+            // Create tag
+            Console.step(3, "Creating tag \(tagVersion.tag)...")
+            if dryRun {
+                Console.substep("Would run: git tag -a \(tagVersion.tag) -m \"\(tagVersion.tag)\"")
+            } else {
+                // Check if tag exists
+                let tagExists = (try? Shell.run("git rev-parse \(tagVersion.tag)")) != nil
+                if tagExists {
+                    throw TagError.tagExists(tagVersion.tag)
+                }
+
+                try Shell.run("git tag -a \(tagVersion.tag) -m \"\(tagVersion.tag)\"")
+                Console.substep("✓ Tag created")
+            }
+
+            // Push if requested
+            if push {
+                Console.step(4, "Pushing to origin...")
+                if dryRun {
+                    Console.substep("Would run: git push origin main")
+                    Console.substep("Would run: git push origin \(tagVersion.tag)")
+                } else {
+                    try Shell.run("git push origin main")
+                    Console.substep("✓ Pushed main branch")
+                    try Shell.run("git push origin \(tagVersion.tag)")
+                    Console.substep("✓ Pushed tag \(tagVersion.tag)")
+                }
+            }
+
+            Console.success("Tag \(tagVersion.tag) created")
+
+            if !push {
+                Console.info("\nTo push:")
+                Console.info("  git push origin main && git push origin \(tagVersion.tag)")
+            }
+
+            Console.info("\nNext steps:")
+            Console.info("  1. Wait for GitHub Actions to build the CLI binary")
+            Console.info("  2. Run: cupertino-rel homebrew --version \(tagVersion)")
         }
 
-        Console.success("Tag \(tagVersion.tag) created")
+        // MARK: - Helpers
 
-        if !push {
-            Console.info("\nTo push:")
-            Console.info("  git push origin main && git push origin \(tagVersion.tag)")
+        private func findRepoRoot() throws -> URL {
+            if let root = repoRoot {
+                return URL(fileURLWithPath: root)
+            }
+            let output = try Shell.run("git rev-parse --show-toplevel")
+            return URL(fileURLWithPath: output)
         }
 
-        Console.info("\nNext steps:")
-        Console.info("  1. Wait for GitHub Actions to build the CLI binary")
-        Console.info("  2. Run: cupertino-rel homebrew --version \(tagVersion)")
-    }
-
-    // MARK: - Helpers
-
-    private func findRepoRoot() throws -> URL {
-        if let root = repoRoot {
-            return URL(fileURLWithPath: root)
+        private func readCurrentVersion(from url: URL) throws -> Version {
+            let content = try String(contentsOf: url, encoding: .utf8)
+            let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
+            guard let regex = try? NSRegularExpression(pattern: pattern),
+                  let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
+                  let versionRange = Range(match.range(at: 1), in: content),
+                  let version = Version(String(content[versionRange])) else {
+                throw TagError.versionNotFound
+            }
+            return version
         }
-        let output = try Shell.run("git rev-parse --show-toplevel")
-        return URL(fileURLWithPath: output)
-    }
-
-    private func readCurrentVersion(from url: URL) throws -> Version {
-        let content = try String(contentsOf: url, encoding: .utf8)
-        let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: content, range: NSRange(content.startIndex..., in: content)),
-              let versionRange = Range(match.range(at: 1), in: content),
-              let version = Version(String(content[versionRange])) else {
-            throw TagError.versionNotFound
-        }
-        return version
     }
 }
 


### PR DESCRIPTION
Mirrors the `Command.<Name>` pattern from #352 for the **cupertino-rel** binary (the release-automation tool). Each subcommand of the release CLI now reads as `Release.Command.<Name>`.

## Renames

| Before | After |
|---|---|
| `BumpCommand`             | `Release.Command.Bump` |
| `TagCommand`              | `Release.Command.Tag` |
| `DatabaseReleaseCommand`  | `Release.Command.Database` |
| `HomebrewCommand`         | `Release.Command.Homebrew` |
| `DocsUpdateCommand`       | `Release.Command.DocsUpdate` |
| `FullCommand`             | `Release.Command.Full` |

`DatabaseReleaseCommand` drops **both** `Release` (the parent namespace supplies it) and `Command` (the sub-namespace supplies it), leaving the leaf as just `Database`.

## Mechanics

- New `Sources/ReleaseTool/Release.swift` declares `enum Release { enum Command {} }`.
- Each `<Name>Command.swift` wraps its `struct <Name>Command: AsyncParsableCommand` in `extension Release.Command { struct <Name>: AsyncParsableCommand { ... } }`.
- `ReleaseCLI.swift`'s `subcommands: [...]` list + `defaultSubcommand` retarget to `Release.Command.<Name>.self`.
- `ReleasePublishingHelpers.swift`'s docstring reference rewrites for accuracy.

The root `@main struct ReleaseCLI: AsyncParsableCommand` stays at file scope (it's the dispatcher, not a subcommand). `ReleasePublishing` and `ReleasePublishingError` also stay at file scope for this PR — a follow-up may fold them into `Release.Publishing.*` if you want the same treatment.

`swift-argument-parser` conformance preserved on every struct.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Follows #352 (`Command.<Name>` for the main `cupertino` CLI).