### PR TITLE
refactor(Sample): relocate the SampleIndex SPM target's types under Sample.Index

### DIFF
--- a/Packages/Sources/CLI/Commands/DoctorCommand.swift
+++ b/Packages/Sources/CLI/Commands/DoctorCommand.swift
@@ -134,7 +134,7 @@ extension Command {
             let entries: [(String, URL)] = [
                 ("search.db", URL(fileURLWithPath: searchDB).expandingTildeInPath),
                 ("packages.db", Shared.Constants.defaultPackagesDatabase),
-                ("samples.db", SampleIndex.defaultDatabasePath),
+                ("samples.db", Sample.Index.defaultDatabasePath),
             ]
             for (label, url) in entries {
                 guard FileManager.default.fileExists(atPath: url.path) else {
@@ -283,7 +283,7 @@ extension Command {
         /// download + cleanup. Missing is a warning (server runs without it; the
         /// sample-code search just isn't available).
         private func checkSamplesDatabase() {
-            let samplesDBURL = SampleIndex.defaultDatabasePath
+            let samplesDBURL = Sample.Index.defaultDatabasePath
 
             Logging.Log.output("🧪 Sample Code Index (samples.db)")
 

--- a/Packages/Sources/CLI/Commands/ListSamplesCommand.swift
+++ b/Packages/Sources/CLI/Commands/ListSamplesCommand.swift
@@ -3,6 +3,7 @@ import Foundation
 import Logging
 import SampleIndex
 import Services
+import SharedConstants
 import SharedCore
 import SharedUtils
 
@@ -70,12 +71,12 @@ extension Command {
             if let sampleDb {
                 return URL(fileURLWithPath: sampleDb).expandingTildeInPath
             }
-            return SampleIndex.defaultDatabasePath
+            return Sample.Index.defaultDatabasePath
         }
 
         // MARK: - Output Formatting
 
-        private func outputText(_ projects: [SampleIndex.Project], totalProjects: Int, totalFiles: Int) {
+        private func outputText(_ projects: [Sample.Index.Project], totalProjects: Int, totalFiles: Int) {
             Logging.Log.output("Sample Code Projects")
             Logging.Log.output("Total: \(totalProjects) projects, \(totalFiles) files")
 
@@ -99,7 +100,7 @@ extension Command {
             }
         }
 
-        private func outputJSON(_ projects: [SampleIndex.Project], totalProjects: Int, totalFiles: Int) {
+        private func outputJSON(_ projects: [Sample.Index.Project], totalProjects: Int, totalFiles: Int) {
             struct Output: Encodable {
                 let totalProjects: Int
                 let totalFiles: Int
@@ -143,7 +144,7 @@ extension Command {
             }
         }
 
-        private func outputMarkdown(_ projects: [SampleIndex.Project], totalProjects: Int, totalFiles: Int) {
+        private func outputMarkdown(_ projects: [Sample.Index.Project], totalProjects: Int, totalFiles: Int) {
             Logging.Log.output("# Sample Code Projects\n")
             Logging.Log.output("Total: **\(totalProjects)** projects, **\(totalFiles)** files\n")
 

--- a/Packages/Sources/CLI/Commands/ReadSampleCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadSampleCommand.swift
@@ -66,12 +66,12 @@ extension Command {
             if let sampleDb {
                 return URL(fileURLWithPath: sampleDb).expandingTildeInPath
             }
-            return SampleIndex.defaultDatabasePath
+            return Sample.Index.defaultDatabasePath
         }
 
         // MARK: - Output Formatting
 
-        private func outputText(_ project: SampleIndex.Project, files: [SampleIndex.File]) {
+        private func outputText(_ project: Sample.Index.Project, files: [Sample.Index.File]) {
             Logging.Log.output(project.title)
             Logging.Log.output(String(repeating: "=", count: project.title.count))
             Logging.Log.output("")
@@ -112,7 +112,7 @@ extension Command {
             Logging.Log.output("Tip: Use 'cupertino read-sample-file \(project.id) <path>' to view source code")
         }
 
-        private func outputJSON(_ project: SampleIndex.Project, files: [SampleIndex.File]) {
+        private func outputJSON(_ project: Sample.Index.Project, files: [Sample.Index.File]) {
             struct Output: Encodable {
                 let id: String
                 let title: String
@@ -150,7 +150,7 @@ extension Command {
             }
         }
 
-        private func outputMarkdown(_ project: SampleIndex.Project, files: [SampleIndex.File]) {
+        private func outputMarkdown(_ project: Sample.Index.Project, files: [Sample.Index.File]) {
             Logging.Log.output("# \(project.title)\n")
             Logging.Log.output("**Project ID:** `\(project.id)`\n")
 

--- a/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
@@ -69,12 +69,12 @@ extension Command {
             if let sampleDb {
                 return URL(fileURLWithPath: sampleDb).expandingTildeInPath
             }
-            return SampleIndex.defaultDatabasePath
+            return Sample.Index.defaultDatabasePath
         }
 
         // MARK: - Output Formatting
 
-        private func outputText(_ file: SampleIndex.File) {
+        private func outputText(_ file: Sample.Index.File) {
             Logging.Log.output("// File: \(file.path)")
             Logging.Log.output("// Project: \(file.projectId)")
             Logging.Log.output("// Size: \(Shared.Utils.Formatting.formatBytes(file.size))")

--- a/Packages/Sources/CLI/Commands/SaveCommand+Indexers.swift
+++ b/Packages/Sources/CLI/Commands/SaveCommand+Indexers.swift
@@ -136,7 +136,7 @@ extension Command.Save {
 
     func runSamplesIndexerSafely() async throws {
         let sampleCodeURL = samplesDir.map { URL(fileURLWithPath: $0).expandingTildeInPath }
-            ?? SampleIndex.defaultSampleCodeDirectory
+            ?? Sample.Index.defaultSampleCodeDirectory
         guard FileManager.default.fileExists(atPath: sampleCodeURL.path) else {
             Logging.ConsoleLogger.info(
                 "ℹ️  sample-code directory not found at \(sampleCodeURL.path) — skipping samples step. "
@@ -149,7 +149,7 @@ extension Command.Save {
 
     func runSamplesIndexer(sampleCodeURL: URL) async throws {
         let dbURL = samplesDB.map { URL(fileURLWithPath: $0).expandingTildeInPath }
-            ?? SampleIndex.defaultDatabasePath
+            ?? Sample.Index.defaultDatabasePath
 
         let request = Indexer.SamplesService.Request(
             sampleCodeDir: sampleCodeURL,

--- a/Packages/Sources/CLI/Commands/SearchCommand+SmartReport.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand+SmartReport.swift
@@ -166,7 +166,7 @@ extension Command.Search {
     ) async -> Sample.Search.Service? {
         guard !skip else { return nil }
         let url = override.map { URL(fileURLWithPath: $0).expandingTildeInPath }
-            ?? SampleIndex.defaultDatabasePath
+            ?? Sample.Index.defaultDatabasePath
         guard FileManager.default.fileExists(atPath: url.path) else {
             Logging.ConsoleLogger.info(
                 "ℹ️  samples.db not found at \(url.path) — skipping samples."

--- a/Packages/Sources/CLI/Commands/SearchCommand.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand.swift
@@ -280,7 +280,7 @@ extension Command {
             if let sampleDb {
                 return URL(fileURLWithPath: sampleDb).expandingTildeInPath
             }
-            return SampleIndex.defaultDatabasePath
+            return Sample.Index.defaultDatabasePath
         }
     }
 }

--- a/Packages/Sources/CLI/Commands/ServeCommand.swift
+++ b/Packages/Sources/CLI/Commands/ServeCommand.swift
@@ -149,8 +149,8 @@ extension Command {
             }
         }
 
-        private func loadSampleIndex() async -> SampleIndex.Database? {
-            let sampleDBURL = SampleIndex.defaultDatabasePath
+        private func loadSampleIndex() async -> Sample.Index.Database? {
+            let sampleDBURL = Sample.Index.defaultDatabasePath
             guard FileManager.default.fileExists(atPath: sampleDBURL.path) else {
                 let infoMsg = "ℹ️  Sample code index not found at: \(sampleDBURL.path)"
                 let cmd = "\(Shared.Constants.App.commandName) index"
@@ -160,7 +160,7 @@ extension Command {
             }
 
             do {
-                return try await SampleIndex.Database(dbPath: sampleDBURL)
+                return try await Sample.Index.Database(dbPath: sampleDBURL)
             } catch {
                 let errorMsg = "⚠️  Failed to load sample index: \(error)"
                 let cmd = "\(Shared.Constants.App.commandName) index"
@@ -199,7 +199,7 @@ extension Command {
             }
 
             // Add samples DB path if it exists
-            let sampleDBURL = SampleIndex.defaultDatabasePath
+            let sampleDBURL = Sample.Index.defaultDatabasePath
             if FileManager.default.fileExists(atPath: sampleDBURL.path) {
                 messages.append("   Samples DB: \(sampleDBURL.path)")
             }
@@ -216,7 +216,7 @@ extension Command {
 
             // Check if either database exists
             let hasSearchDB = fileManager.fileExists(atPath: searchDB.path)
-            let hasSamplesDB = fileManager.fileExists(atPath: SampleIndex.defaultDatabasePath.path)
+            let hasSamplesDB = fileManager.fileExists(atPath: Sample.Index.defaultDatabasePath.path)
 
             return hasSearchDB || hasSamplesDB
         }

--- a/Packages/Sources/Indexer/SamplesIndexerService.swift
+++ b/Packages/Sources/Indexer/SamplesIndexerService.swift
@@ -7,7 +7,7 @@ import SharedCore
 
 extension Indexer {
     /// Build `samples.db` from extracted sample-code zips at
-    /// `~/.cupertino/sample-code/`. Wraps `SampleIndex.Builder` and emits
+    /// `~/.cupertino/sample-code/`. Wraps `Sample.Index.Builder` and emits
     /// progress events.
     public enum SamplesService {
         public struct Request: Sendable {
@@ -17,8 +17,8 @@ extension Indexer {
             public let force: Bool
 
             public init(
-                sampleCodeDir: URL = SampleIndex.defaultSampleCodeDirectory,
-                samplesDB: URL = SampleIndex.defaultDatabasePath,
+                sampleCodeDir: URL = Sample.Index.defaultSampleCodeDirectory,
+                samplesDB: URL = Sample.Index.defaultDatabasePath,
                 clear: Bool = false,
                 force: Bool = false
             ) {
@@ -89,7 +89,7 @@ extension Indexer {
                 try FileManager.default.removeItem(at: request.samplesDB)
             }
 
-            let database = try await SampleIndex.Database(dbPath: request.samplesDB)
+            let database = try await Sample.Index.Database(dbPath: request.samplesDB)
             if request.clear {
                 handler(.clearingExistingIndex)
                 try await database.clearAll()
@@ -106,7 +106,7 @@ extension Indexer {
             handler(.catalogLoaded(entryCount: catalogEntries.count))
 
             let entries = catalogEntries.map { entry in
-                SampleIndex.SampleCodeEntryInfo(
+                Sample.Index.SampleCodeEntryInfo(
                     title: entry.title,
                     description: entry.description,
                     frameworks: [entry.framework],
@@ -116,7 +116,7 @@ extension Indexer {
             }
 
             handler(.indexingStart)
-            let builder = SampleIndex.Builder(
+            let builder = Sample.Index.Builder(
                 database: database,
                 sampleCodeDirectory: request.sampleCodeDir
             )

--- a/Packages/Sources/SampleIndex/SampleAvailabilitySidecar.swift
+++ b/Packages/Sources/SampleIndex/SampleAvailabilitySidecar.swift
@@ -1,5 +1,6 @@
 import ASTIndexer
 import Foundation
+import SharedConstants
 
 /// Per-sample availability sidecar JSON written next to each zip in
 /// `~/.cupertino/sample-code/<projectId>.availability.json` by `cupertino
@@ -11,50 +12,52 @@ import Foundation
 /// names, same `Attribute` element type — so a future cross-corpus
 /// consumer can decode both with one loader. samples.db schema isn't
 /// extended in this phase; see the parent issue for phases 2+.
-public struct SampleAvailabilitySidecar: Codable, Sendable, Equatable {
-    public let version: String
-    public let annotatedAt: Date
-    public let projectId: String
-    public let deploymentTargets: [String: String]
-    public let fileAvailability: [FileEntry]
-    public let stats: Stats
+extension Sample.Index {
+    public struct AvailabilitySidecar: Codable, Sendable, Equatable {
+        public let version: String
+        public let annotatedAt: Date
+        public let projectId: String
+        public let deploymentTargets: [String: String]
+        public let fileAvailability: [FileEntry]
+        public let stats: Stats
 
-    public struct FileEntry: Codable, Sendable, Equatable {
-        public let relpath: String
-        public let attributes: [ASTIndexer.AvailabilityParsers.Attribute]
+        public struct FileEntry: Codable, Sendable, Equatable {
+            public let relpath: String
+            public let attributes: [ASTIndexer.AvailabilityParsers.Attribute]
+
+            public init(
+                relpath: String,
+                attributes: [ASTIndexer.AvailabilityParsers.Attribute]
+            ) {
+                self.relpath = relpath
+                self.attributes = attributes
+            }
+        }
+
+        public struct Stats: Codable, Sendable, Equatable {
+            public let filesWithAvailability: Int
+            public let totalAttributes: Int
+
+            public init(filesWithAvailability: Int, totalAttributes: Int) {
+                self.filesWithAvailability = filesWithAvailability
+                self.totalAttributes = totalAttributes
+            }
+        }
 
         public init(
-            relpath: String,
-            attributes: [ASTIndexer.AvailabilityParsers.Attribute]
+            version: String,
+            annotatedAt: Date,
+            projectId: String,
+            deploymentTargets: [String: String],
+            fileAvailability: [FileEntry],
+            stats: Stats
         ) {
-            self.relpath = relpath
-            self.attributes = attributes
+            self.version = version
+            self.annotatedAt = annotatedAt
+            self.projectId = projectId
+            self.deploymentTargets = deploymentTargets
+            self.fileAvailability = fileAvailability
+            self.stats = stats
         }
-    }
-
-    public struct Stats: Codable, Sendable, Equatable {
-        public let filesWithAvailability: Int
-        public let totalAttributes: Int
-
-        public init(filesWithAvailability: Int, totalAttributes: Int) {
-            self.filesWithAvailability = filesWithAvailability
-            self.totalAttributes = totalAttributes
-        }
-    }
-
-    public init(
-        version: String,
-        annotatedAt: Date,
-        projectId: String,
-        deploymentTargets: [String: String],
-        fileAvailability: [FileEntry],
-        stats: Stats
-    ) {
-        self.version = version
-        self.annotatedAt = annotatedAt
-        self.projectId = projectId
-        self.deploymentTargets = deploymentTargets
-        self.fileAvailability = fileAvailability
-        self.stats = stats
     }
 }

--- a/Packages/Sources/SampleIndex/SampleFile.swift
+++ b/Packages/Sources/SampleIndex/SampleFile.swift
@@ -1,8 +1,9 @@
 import Foundation
+import SharedConstants
 
 // MARK: - Sample File Model
 
-extension SampleIndex {
+extension Sample.Index {
     /// Represents an indexed source file within a sample project
     public struct File: Sendable, Codable, Equatable {
         /// Project ID this file belongs to

--- a/Packages/Sources/SampleIndex/SampleIndex.swift
+++ b/Packages/Sources/SampleIndex/SampleIndex.swift
@@ -2,12 +2,18 @@ import Foundation
 import SharedConstants
 import SharedCore
 
-// MARK: - SampleIndex Namespace
+// MARK: - Sample.Index Module Anchor
 
-/// SampleIndex provides indexing and search for Apple sample code projects.
-/// Unlike the main Search database, SampleIndex uses a separate database
-/// (`~/.cupertino/samples.db`) optimized for code-level search.
-public enum SampleIndex {
+/// `Sample.Index` provides indexing and search for Apple sample code projects.
+/// Unlike the main Search database, Sample.Index uses a separate database
+/// (`~/.cupertino/samples.db`) optimised for code-level search.
+///
+/// The namespace enum itself is declared in `SharedConstants/Sample.swift`
+/// alongside the other `Sample.*` sub-namespaces. This file contributes the
+/// module-scope static helpers (`defaultDatabasePath`,
+/// `defaultSampleCodeDirectory`, `minColumn(for:)`) and acts as the
+/// SampleIndex SPM target's anchor.
+extension Sample.Index {
     /// Default database path for source code search index
     public static var defaultDatabasePath: URL {
         Shared.Constants.defaultBaseDirectory

--- a/Packages/Sources/SampleIndex/SampleIndexBuilder.swift
+++ b/Packages/Sources/SampleIndex/SampleIndexBuilder.swift
@@ -10,7 +10,7 @@ import SharedCore
 // Justification: This actor manages complete ZIP extraction and indexing workflow.
 // Breaking into smaller types would fragment the cohesive indexing logic.
 
-extension SampleIndex {
+extension Sample.Index {
     /// Builds the sample index by extracting ZIP files and indexing their contents
     public actor Builder {
         private let database: Database
@@ -22,7 +22,7 @@ extension SampleIndex {
 
         public init(
             database: Database,
-            sampleCodeDirectory: URL = SampleIndex.defaultSampleCodeDirectory
+            sampleCodeDirectory: URL = Sample.Index.defaultSampleCodeDirectory
         ) {
             self.database = database
             self.sampleCodeDirectory = sampleCodeDirectory
@@ -273,7 +273,7 @@ extension SampleIndex {
             // occurrences while we're already walking the swift sources.
             // Same shape as #219's per-package `availability.json`.
             // Phase 2 also persists each file's attrs into samples.db.
-            var fileAvailability: [SampleAvailabilitySidecar.FileEntry] = []
+            var fileAvailability: [Sample.Index.AvailabilitySidecar.FileEntry] = []
             let encoder = JSONEncoder()
             for file in files {
                 // Compute the per-file @available JSON before indexFile so
@@ -287,7 +287,7 @@ extension SampleIndex {
                             availableAttrsJSON = String(data: data, encoding: .utf8)
                         }
                         fileAvailability.append(
-                            SampleAvailabilitySidecar.FileEntry(
+                            Sample.Index.AvailabilitySidecar.FileEntry(
                                 relpath: file.path,
                                 attributes: attrs
                             )
@@ -347,11 +347,11 @@ extension SampleIndex {
             nextTo zipURL: URL,
             projectId: String,
             deploymentTargets: [String: String],
-            fileAvailability: [SampleAvailabilitySidecar.FileEntry]
+            fileAvailability: [Sample.Index.AvailabilitySidecar.FileEntry]
         ) throws {
             let sortedFiles = fileAvailability.sorted { $0.relpath < $1.relpath }
             let totalAttrs = sortedFiles.reduce(0) { $0 + $1.attributes.count }
-            let sidecar = SampleAvailabilitySidecar(
+            let sidecar = Sample.Index.AvailabilitySidecar(
                 version: "1.0",
                 annotatedAt: Date(),
                 projectId: projectId,
@@ -643,7 +643,7 @@ extension SampleIndex {
                 )
 
                 // Skip non-indexable files
-                guard SampleIndex.shouldIndex(path: relativePath) else {
+                guard Sample.Index.shouldIndex(path: relativePath) else {
                     continue
                 }
 

--- a/Packages/Sources/SampleIndex/SampleIndexDatabase.swift
+++ b/Packages/Sources/SampleIndex/SampleIndexDatabase.swift
@@ -9,7 +9,7 @@ import SQLite3
 
 // swiftlint:disable type_body_length file_length function_body_length
 
-extension SampleIndex {
+extension Sample.Index {
     /// SQLite FTS5-based database for sample code indexing and search
     public actor Database {
         /// Current schema version
@@ -28,7 +28,7 @@ extension SampleIndex {
         private let dbPath: URL
         private var isInitialized = false
 
-        public init(dbPath: URL = SampleIndex.defaultDatabasePath) async throws {
+        public init(dbPath: URL = Sample.Index.defaultDatabasePath) async throws {
             self.dbPath = dbPath
 
             // Ensure directory exists
@@ -86,7 +86,7 @@ extension SampleIndex {
             guard sqlite3_open(dbPath.path, &dbPointer) == SQLITE_OK else {
                 let errorMessage = String(cString: sqlite3_errmsg(dbPointer))
                 sqlite3_close(dbPointer)
-                throw SampleIndex.Error.sqliteError("Failed to open database: \(errorMessage)")
+                throw Sample.Index.Error.sqliteError("Failed to open database: \(errorMessage)")
             }
 
             database = dbPointer
@@ -94,7 +94,7 @@ extension SampleIndex {
 
         private func setSchemaVersion() async throws {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = "PRAGMA user_version = \(Self.schemaVersion)"
@@ -103,13 +103,13 @@ extension SampleIndex {
 
             guard sqlite3_exec(database, sql, nil, nil, &errorPointer) == SQLITE_OK else {
                 let errorMessage = errorPointer.map { String(cString: $0) } ?? "Unknown error"
-                throw SampleIndex.Error.sqliteError("Failed to set schema version: \(errorMessage)")
+                throw Sample.Index.Error.sqliteError("Failed to set schema version: \(errorMessage)")
             }
         }
 
         private func createTables() async throws {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = """
@@ -238,7 +238,7 @@ extension SampleIndex {
 
             guard sqlite3_exec(database, sql, nil, nil, &errorPointer) == SQLITE_OK else {
                 let errorMessage = errorPointer.map { String(cString: $0) } ?? "Unknown error"
-                throw SampleIndex.Error.sqliteError("Failed to create tables: \(errorMessage)")
+                throw Sample.Index.Error.sqliteError("Failed to create tables: \(errorMessage)")
             }
         }
 
@@ -247,7 +247,7 @@ extension SampleIndex {
         /// Index a sample project
         public func indexProject(_ project: Project) async throws {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             // Insert into projects table
@@ -263,7 +263,7 @@ extension SampleIndex {
 
             guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
                 let errorMessage = String(cString: sqlite3_errmsg(database))
-                throw SampleIndex.Error.prepareFailed("Project insert: \(errorMessage)")
+                throw Sample.Index.Error.prepareFailed("Project insert: \(errorMessage)")
             }
 
             let frameworksString = project.frameworks.joined(separator: ",")
@@ -306,7 +306,7 @@ extension SampleIndex {
 
             guard sqlite3_step(statement) == SQLITE_DONE else {
                 let errorMessage = String(cString: sqlite3_errmsg(database))
-                throw SampleIndex.Error.insertFailed("Project insert: \(errorMessage)")
+                throw Sample.Index.Error.insertFailed("Project insert: \(errorMessage)")
             }
 
             // Insert into FTS5
@@ -342,7 +342,7 @@ extension SampleIndex {
         /// Index a source file
         public func indexFile(_ file: File) async throws {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             // Insert into files table
@@ -357,7 +357,7 @@ extension SampleIndex {
 
             guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
                 let errorMessage = String(cString: sqlite3_errmsg(database))
-                throw SampleIndex.Error.prepareFailed("File insert: \(errorMessage)")
+                throw Sample.Index.Error.prepareFailed("File insert: \(errorMessage)")
             }
 
             sqlite3_bind_text(statement, 1, (file.projectId as NSString).utf8String, -1, nil)
@@ -379,7 +379,7 @@ extension SampleIndex {
 
             guard sqlite3_step(statement) == SQLITE_DONE else {
                 let errorMessage = String(cString: sqlite3_errmsg(database))
-                throw SampleIndex.Error.insertFailed("File insert: \(errorMessage)")
+                throw Sample.Index.Error.insertFailed("File insert: \(errorMessage)")
             }
 
             // Insert into FTS5
@@ -406,7 +406,7 @@ extension SampleIndex {
         /// Get the file ID for a project/path combination
         public func getFileId(projectId: String, path: String) async throws -> Int64? {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = "SELECT id FROM files WHERE project_id = ? AND path = ?;"
@@ -436,7 +436,7 @@ extension SampleIndex {
             symbols: [ASTIndexer.Symbol]
         ) async throws {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = """
@@ -539,7 +539,7 @@ extension SampleIndex {
             imports: [ASTIndexer.Import]
         ) async throws {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = """
@@ -573,11 +573,11 @@ extension SampleIndex {
             limit: Int = 20
         ) async throws -> [Project] {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
-                throw SampleIndex.Error.invalidQuery("Query cannot be empty")
+                throw Sample.Index.Error.invalidQuery("Query cannot be empty")
             }
 
             // Build FTS5 query: tokenize natural language, drop
@@ -606,7 +606,7 @@ extension SampleIndex {
 
             guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
                 let errorMessage = String(cString: sqlite3_errmsg(database))
-                throw SampleIndex.Error.searchFailed("Project search: \(errorMessage)")
+                throw Sample.Index.Error.searchFailed("Project search: \(errorMessage)")
             }
 
             var paramIndex: Int32 = 1
@@ -676,11 +676,11 @@ extension SampleIndex {
             minVersion: String? = nil
         ) async throws -> [FileSearchResult] {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
-                throw SampleIndex.Error.invalidQuery("Query cannot be empty")
+                throw Sample.Index.Error.invalidQuery("Query cannot be empty")
             }
 
             // Build FTS5 query: tokenize natural language, drop
@@ -697,7 +697,7 @@ extension SampleIndex {
             // used in #220's PackageQuery.
             let platformColumn: String?
             if platform != nil, minVersion != nil {
-                platformColumn = SampleIndex.minColumn(for: platform ?? "")
+                platformColumn = Sample.Index.minColumn(for: platform ?? "")
             } else {
                 platformColumn = nil
             }
@@ -734,7 +734,7 @@ extension SampleIndex {
 
             guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
                 let errorMessage = String(cString: sqlite3_errmsg(database))
-                throw SampleIndex.Error.searchFailed("File search: \(errorMessage)")
+                throw Sample.Index.Error.searchFailed("File search: \(errorMessage)")
             }
 
             var paramIndex: Int32 = 1
@@ -786,7 +786,7 @@ extension SampleIndex {
         /// Get a project by ID
         public func getProject(id: String) async throws -> Project? {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = """
@@ -853,7 +853,7 @@ extension SampleIndex {
         /// Get a file by project ID and path
         public func getFile(projectId: String, path: String) async throws -> File? {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = """
@@ -901,7 +901,7 @@ extension SampleIndex {
         /// List all files in a project
         public func listFiles(projectId: String, folder: String? = nil) async throws -> [File] {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             var sql = """
@@ -957,7 +957,7 @@ extension SampleIndex {
             limit: Int = 100
         ) async throws -> [Project] {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             var sql = """
@@ -1025,7 +1025,7 @@ extension SampleIndex {
         /// Get project count
         public func projectCount() async throws -> Int {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = "SELECT COUNT(*) FROM projects;"
@@ -1044,7 +1044,7 @@ extension SampleIndex {
         /// Get file count
         public func fileCount() async throws -> Int {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = "SELECT COUNT(*) FROM files;"
@@ -1063,7 +1063,7 @@ extension SampleIndex {
         /// Get total symbol count (#81)
         public func symbolCount() async throws -> Int {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = "SELECT COUNT(*) FROM file_symbols;"
@@ -1082,7 +1082,7 @@ extension SampleIndex {
         /// Get total import count (#81)
         public func importCount() async throws -> Int {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = "SELECT COUNT(*) FROM file_imports;"
@@ -1101,7 +1101,7 @@ extension SampleIndex {
         /// Clear all data
         public func clearAll() async throws {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             let sql = """
@@ -1116,14 +1116,14 @@ extension SampleIndex {
 
             guard sqlite3_exec(database, sql, nil, nil, &errorPointer) == SQLITE_OK else {
                 let errorMessage = errorPointer.map { String(cString: $0) } ?? "Unknown error"
-                throw SampleIndex.Error.sqliteError("Failed to clear: \(errorMessage)")
+                throw Sample.Index.Error.sqliteError("Failed to clear: \(errorMessage)")
             }
         }
 
         /// Delete a project and its files
         public func deleteProject(id: String) async throws {
             guard let database else {
-                throw SampleIndex.Error.databaseNotInitialized
+                throw Sample.Index.Error.databaseNotInitialized
             }
 
             // Delete files first (FTS, then main table)

--- a/Packages/Sources/SampleIndex/SampleIndexError.swift
+++ b/Packages/Sources/SampleIndex/SampleIndexError.swift
@@ -1,8 +1,9 @@
 import Foundation
+import SharedConstants
 
 // MARK: - Sample Index Errors
 
-extension SampleIndex {
+extension Sample.Index {
     /// Errors that can occur during sample code indexing and search
     public enum Error: Swift.Error, LocalizedError, Sendable {
         case databaseNotInitialized

--- a/Packages/Sources/SampleIndex/SampleProject.swift
+++ b/Packages/Sources/SampleIndex/SampleProject.swift
@@ -1,8 +1,9 @@
 import Foundation
+import SharedConstants
 
 // MARK: - Sample Project Model
 
-extension SampleIndex {
+extension Sample.Index {
     /// Represents an indexed sample code project
     public struct Project: Sendable, Codable, Equatable {
         /// Unique identifier (slug from ZIP filename)

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -19,9 +19,9 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
     // Keep direct access for low-level operations (list frameworks, read document)
     private let searchIndex: Search.Index?
-    private let sampleDatabase: SampleIndex.Database?
+    private let sampleDatabase: Sample.Index.Database?
 
-    public init(searchIndex: Search.Index?, sampleDatabase: SampleIndex.Database?) {
+    public init(searchIndex: Search.Index?, sampleDatabase: Sample.Index.Database?) {
         self.searchIndex = searchIndex
         self.sampleDatabase = sampleDatabase
 

--- a/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
@@ -235,7 +235,7 @@ public struct FrameworksMarkdownFormatter: ResultFormatter {
 public struct UnifiedSearchInput: Sendable {
     public let docResults: [Search.Result]
     public let archiveResults: [Search.Result]
-    public let sampleResults: [SampleIndex.Project]
+    public let sampleResults: [Sample.Index.Project]
     public let higResults: [Search.Result]
     public let swiftEvolutionResults: [Search.Result]
     public let swiftOrgResults: [Search.Result]
@@ -246,7 +246,7 @@ public struct UnifiedSearchInput: Sendable {
     public init(
         docResults: [Search.Result] = [],
         archiveResults: [Search.Result] = [],
-        sampleResults: [SampleIndex.Project] = [],
+        sampleResults: [Sample.Index.Project] = [],
         higResults: [Search.Result] = [],
         swiftEvolutionResults: [Search.Result] = [],
         swiftOrgResults: [Search.Result] = [],
@@ -281,7 +281,7 @@ public struct UnifiedSearchInput: Sendable {
     public struct SourceSection: Sendable {
         public let info: Shared.Constants.SourcePrefix.SourceInfo
         public let docResults: [Search.Result]
-        public let sampleResults: [SampleIndex.Project]
+        public let sampleResults: [Sample.Index.Project]
 
         public var isEmpty: Bool {
             docResults.isEmpty && sampleResults.isEmpty
@@ -307,7 +307,7 @@ public struct UnifiedSearchInput: Sendable {
         /// Create from sample results if not empty, nil otherwise
         public static func fromSamples(
             _ info: Shared.Constants.SourcePrefix.SourceInfo,
-            _ results: [SampleIndex.Project]
+            _ results: [Sample.Index.Project]
         ) -> SourceSection? {
             guard !results.isEmpty else { return nil }
             return SourceSection(info: info, docResults: [], sampleResults: results)
@@ -468,7 +468,7 @@ public struct UnifiedSearchMarkdownFormatter: ResultFormatter {
         return output
     }
 
-    private func formatSampleResults(_ projects: [SampleIndex.Project]) -> String {
+    private func formatSampleResults(_ projects: [Sample.Index.Project]) -> String {
         var output = ""
         let maxLen = Shared.Constants.Limit.summaryTruncationLength
         for project in projects {

--- a/Packages/Sources/Services/Formatters/SampleJSONFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleJSONFormatter.swift
@@ -13,7 +13,7 @@ private struct ProjectJSONOutput: Encodable {
     let frameworks: [String]
     let fileCount: Int
 
-    init(from project: SampleIndex.Project) {
+    init(from project: Sample.Index.Project) {
         id = project.id
         title = project.title
         description = project.description
@@ -22,14 +22,14 @@ private struct ProjectJSONOutput: Encodable {
     }
 }
 
-/// File output for JSON encoding (from SampleIndex.File)
+/// File output for JSON encoding (from Sample.Index.File)
 private struct FileJSONOutput: Encodable {
     let projectId: String
     let path: String
     let filename: String
     let content: String
 
-    init(from file: SampleIndex.File) {
+    init(from file: Sample.Index.File) {
         projectId = file.projectId
         path = file.path
         filename = file.filename
@@ -45,7 +45,7 @@ private struct FileSearchJSONOutput: Encodable {
     let snippet: String
     let rank: Double
 
-    init(from result: SampleIndex.Database.FileSearchResult) {
+    init(from result: Sample.Index.Database.FileSearchResult) {
         projectId = result.projectId
         path = result.path
         filename = result.filename
@@ -91,7 +91,7 @@ public struct SampleSearchJSONFormatter: ResultFormatter {
 public struct SampleListJSONFormatter: ResultFormatter {
     public init() {}
 
-    public func format(_ projects: [SampleIndex.Project]) -> String {
+    public func format(_ projects: [Sample.Index.Project]) -> String {
         let output = projects.map { ProjectJSONOutput(from: $0) }
         return encodeJSON(output)
     }
@@ -103,7 +103,7 @@ public struct SampleListJSONFormatter: ResultFormatter {
 public struct SampleProjectJSONFormatter: ResultFormatter {
     public init() {}
 
-    public func format(_ project: SampleIndex.Project) -> String {
+    public func format(_ project: Sample.Index.Project) -> String {
         encodeJSON(ProjectJSONOutput(from: project))
     }
 }
@@ -114,7 +114,7 @@ public struct SampleProjectJSONFormatter: ResultFormatter {
 public struct SampleFileJSONFormatter: ResultFormatter {
     public init() {}
 
-    public func format(_ file: SampleIndex.File) -> String {
+    public func format(_ file: Sample.Index.File) -> String {
         encodeJSON(FileJSONOutput(from: file))
     }
 }

--- a/Packages/Sources/Services/Formatters/SampleMarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleMarkdownFormatter.swift
@@ -80,7 +80,7 @@ public struct SampleListMarkdownFormatter: ResultFormatter {
         self.framework = framework
     }
 
-    public func format(_ projects: [SampleIndex.Project]) -> String {
+    public func format(_ projects: [Sample.Index.Project]) -> String {
         var output = "# Sample Projects\n\n"
 
         if let framework {
@@ -118,7 +118,7 @@ public struct SampleListMarkdownFormatter: ResultFormatter {
 public struct SampleProjectMarkdownFormatter: ResultFormatter {
     public init() {}
 
-    public func format(_ project: SampleIndex.Project) -> String {
+    public func format(_ project: Sample.Index.Project) -> String {
         var output = "# \(project.title)\n\n"
         output += "- **ID:** `\(project.id)`\n"
         output += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
@@ -142,7 +142,7 @@ public struct SampleProjectMarkdownFormatter: ResultFormatter {
 public struct SampleFileMarkdownFormatter: ResultFormatter {
     public init() {}
 
-    public func format(_ file: SampleIndex.File) -> String {
+    public func format(_ file: Sample.Index.File) -> String {
         // Determine language for syntax highlighting
         let language = file.filename.hasSuffix(".swift") ? "swift" :
             file.filename.hasSuffix(".m") ? "objc" :

--- a/Packages/Sources/Services/Formatters/SampleTextFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleTextFormatter.swift
@@ -80,7 +80,7 @@ public struct SampleListTextFormatter: ResultFormatter {
         self.totalCount = totalCount
     }
 
-    public func format(_ projects: [SampleIndex.Project]) -> String {
+    public func format(_ projects: [Sample.Index.Project]) -> String {
         if projects.isEmpty {
             return "No sample projects found. Run 'cupertino save --samples' to build the sample index."
         }
@@ -108,7 +108,7 @@ public struct SampleListTextFormatter: ResultFormatter {
 public struct SampleProjectTextFormatter: ResultFormatter {
     public init() {}
 
-    public func format(_ project: SampleIndex.Project) -> String {
+    public func format(_ project: Sample.Index.Project) -> String {
         var output = "Project: \(project.title)\n"
         output += "ID: \(project.id)\n"
         output += "Frameworks: \(project.frameworks.joined(separator: ", "))\n"

--- a/Packages/Sources/Services/Formatters/TeaserResults.swift
+++ b/Packages/Sources/Services/Formatters/TeaserResults.swift
@@ -10,7 +10,7 @@ import SharedCore
 /// Used by both MCP and CLI to show hints about other sources.
 public struct TeaserResults: Sendable {
     public var appleDocs: [Search.Result]
-    public var samples: [SampleIndex.Project]
+    public var samples: [Sample.Index.Project]
     public var archive: [Search.Result]
     public var hig: [Search.Result]
     public var swiftEvolution: [Search.Result]
@@ -20,7 +20,7 @@ public struct TeaserResults: Sendable {
 
     public init(
         appleDocs: [Search.Result] = [],
-        samples: [SampleIndex.Project] = [],
+        samples: [Sample.Index.Project] = [],
         archive: [Search.Result] = [],
         hig: [Search.Result] = [],
         swiftEvolution: [Search.Result] = [],

--- a/Packages/Sources/Services/Formatters/UnifiedSearchFormatters.swift
+++ b/Packages/Sources/Services/Formatters/UnifiedSearchFormatters.swift
@@ -93,7 +93,7 @@ public struct UnifiedSearchTextFormatter: ResultFormatter {
         return output
     }
 
-    private func formatSampleResults(_ projects: [SampleIndex.Project], sourceNumber: Int) -> String {
+    private func formatSampleResults(_ projects: [Sample.Index.Project], sourceNumber: Int) -> String {
         var output = ""
         for (index, project) in projects.enumerated() {
             let resultNumber = index + 1
@@ -237,7 +237,7 @@ private struct SampleJSONOutput: Encodable {
     let fileCount: Int
     let description: String
 
-    init(from project: SampleIndex.Project) {
+    init(from project: Sample.Index.Project) {
         id = project.id
         title = project.title
         frameworks = project.frameworks

--- a/Packages/Sources/Services/ReadCommands/ReadService.swift
+++ b/Packages/Sources/Services/ReadCommands/ReadService.swift
@@ -185,7 +185,7 @@ public enum ReadService {
         allowFallback: Bool,
         packagesDB: URL?
     ) async throws -> Result {
-        let dbURL = samplesDB ?? SampleIndex.defaultDatabasePath
+        let dbURL = samplesDB ?? Sample.Index.defaultDatabasePath
         guard FileManager.default.fileExists(atPath: dbURL.path) else {
             if allowFallback {
                 return try await readFromPackages(

--- a/Packages/Sources/Services/ReadCommands/SampleSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/SampleSearchService.swift
@@ -42,10 +42,10 @@ extension Sample.Search {
 /// Combined result from project and file searches
 extension Sample.Search {
     public struct Result: Sendable {
-        public let projects: [SampleIndex.Project]
-        public let files: [SampleIndex.Database.FileSearchResult]
+        public let projects: [Sample.Index.Project]
+        public let files: [Sample.Index.Database.FileSearchResult]
 
-        public init(projects: [SampleIndex.Project], files: [SampleIndex.Database.FileSearchResult]) {
+        public init(projects: [Sample.Index.Project], files: [Sample.Index.Database.FileSearchResult]) {
             self.projects = projects
             self.files = files
         }
@@ -65,19 +65,19 @@ extension Sample.Search {
 // MARK: - Sample Search Service
 
 /// Service for searching Apple sample code projects and files.
-/// Wraps SampleIndex.Database with a clean interface.
+/// Wraps Sample.Index.Database with a clean interface.
 extension Sample.Search {
     public actor Service {
-        private let database: SampleIndex.Database
+        private let database: Sample.Index.Database
 
         /// Initialize with an existing database
-        public init(database: SampleIndex.Database) {
+        public init(database: Sample.Index.Database) {
             self.database = database
         }
 
         /// Initialize with a database path
         public init(dbPath: URL) async throws {
-            database = try await SampleIndex.Database(dbPath: dbPath)
+            database = try await Sample.Index.Database(dbPath: dbPath)
         }
 
         // MARK: - Search Methods
@@ -90,7 +90,7 @@ extension Sample.Search {
                 limit: query.limit
             )
 
-            var files: [SampleIndex.Database.FileSearchResult] = []
+            var files: [Sample.Index.Database.FileSearchResult] = []
             if query.searchFiles {
                 files = try await database.searchFiles(
                     query: query.text,
@@ -117,12 +117,12 @@ extension Sample.Search {
         // MARK: - Project Access
 
         /// Get a project by ID
-        public func getProject(id: String) async throws -> SampleIndex.Project? {
+        public func getProject(id: String) async throws -> Sample.Index.Project? {
             try await database.getProject(id: id)
         }
 
         /// List all projects
-        public func listProjects(framework: String? = nil, limit: Int = 50) async throws -> [SampleIndex.Project] {
+        public func listProjects(framework: String? = nil, limit: Int = 50) async throws -> [Sample.Index.Project] {
             try await database.listProjects(framework: framework, limit: limit)
         }
 
@@ -134,12 +134,12 @@ extension Sample.Search {
         // MARK: - File Access
 
         /// Get a file by project ID and path
-        public func getFile(projectId: String, path: String) async throws -> SampleIndex.File? {
+        public func getFile(projectId: String, path: String) async throws -> Sample.Index.File? {
             try await database.getFile(projectId: projectId, path: path)
         }
 
         /// List files in a project
-        public func listFiles(projectId: String, folder: String? = nil) async throws -> [SampleIndex.File] {
+        public func listFiles(projectId: String, folder: String? = nil) async throws -> [Sample.Index.File] {
             try await database.listFiles(projectId: projectId, folder: folder)
         }
 

--- a/Packages/Sources/Services/ReadCommands/TeaserService.swift
+++ b/Packages/Sources/Services/ReadCommands/TeaserService.swift
@@ -11,10 +11,10 @@ import SharedUtils
 /// Consolidates teaser logic previously duplicated between CLI and MCP.
 public actor TeaserService {
     private let searchIndex: Search.Index?
-    private let sampleDatabase: SampleIndex.Database?
+    private let sampleDatabase: Sample.Index.Database?
 
     /// Initialize with existing database connections
-    public init(searchIndex: Search.Index?, sampleDatabase: SampleIndex.Database?) {
+    public init(searchIndex: Search.Index?, sampleDatabase: Sample.Index.Database?) {
         self.searchIndex = searchIndex
         self.sampleDatabase = sampleDatabase
     }
@@ -28,7 +28,7 @@ public actor TeaserService {
         }
 
         if let sampleDbPath, Shared.Utils.PathResolver.exists(sampleDbPath) {
-            sampleDatabase = try await SampleIndex.Database(dbPath: sampleDbPath)
+            sampleDatabase = try await Sample.Index.Database(dbPath: sampleDbPath)
         } else {
             sampleDatabase = nil
         }
@@ -114,7 +114,7 @@ public actor TeaserService {
     // MARK: - Individual Teaser Fetchers
 
     /// Fetch a few sample projects as teaser
-    public func fetchTeaserSamples(query: String, framework: String?) async -> [SampleIndex.Project] {
+    public func fetchTeaserSamples(query: String, framework: String?) async -> [Sample.Index.Project] {
         guard let sampleDatabase else { return [] }
 
         do {
@@ -164,7 +164,7 @@ extension Services.ServiceContainer {
         operation: (TeaserService) async throws -> T
     ) async throws -> T {
         let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
-        let resolvedSamplePath = sampleDbPath ?? SampleIndex.defaultDatabasePath
+        let resolvedSamplePath = sampleDbPath ?? Sample.Index.defaultDatabasePath
 
         let service = try await TeaserService(
             searchDbPath: Shared.Utils.PathResolver.exists(resolvedSearchPath) ? resolvedSearchPath : nil,

--- a/Packages/Sources/Services/ReadCommands/UnifiedSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/UnifiedSearchService.swift
@@ -11,10 +11,10 @@ import SharedUtils
 /// Consolidates search logic previously duplicated between CLI and MCP.
 public actor UnifiedSearchService {
     private let searchIndex: Search.Index?
-    private let sampleDatabase: SampleIndex.Database?
+    private let sampleDatabase: Sample.Index.Database?
 
     /// Initialize with existing database connections
-    public init(searchIndex: Search.Index?, sampleDatabase: SampleIndex.Database?) {
+    public init(searchIndex: Search.Index?, sampleDatabase: Sample.Index.Database?) {
         self.searchIndex = searchIndex
         self.sampleDatabase = sampleDatabase
     }
@@ -28,7 +28,7 @@ public actor UnifiedSearchService {
         }
 
         if let sampleDbPath, Shared.Utils.PathResolver.exists(sampleDbPath) {
-            sampleDatabase = try await SampleIndex.Database(dbPath: sampleDbPath)
+            sampleDatabase = try await Sample.Index.Database(dbPath: sampleDbPath)
         } else {
             sampleDatabase = nil
         }
@@ -142,7 +142,7 @@ public actor UnifiedSearchService {
         query: String,
         framework: String?,
         limit: Int
-    ) async -> [SampleIndex.Project] {
+    ) async -> [Sample.Index.Project] {
         guard let sampleDatabase else { return [] }
 
         do {
@@ -175,7 +175,7 @@ extension Services.ServiceContainer {
         operation: (UnifiedSearchService) async throws -> T
     ) async throws -> T {
         let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
-        let resolvedSamplePath = sampleDbPath ?? SampleIndex.defaultDatabasePath
+        let resolvedSamplePath = sampleDbPath ?? Sample.Index.defaultDatabasePath
 
         let service = try await UnifiedSearchService(
             searchDbPath: Shared.Utils.PathResolver.exists(resolvedSearchPath) ? resolvedSearchPath : nil,

--- a/Packages/Tests/ASTIndexerTests/SymbolDatabaseIntegrationTests.swift
+++ b/Packages/Tests/ASTIndexerTests/SymbolDatabaseIntegrationTests.swift
@@ -5,6 +5,7 @@ import ASTIndexer
 import Foundation
 import SampleIndex
 import Search
+import SharedConstants
 import SharedCore
 import Testing
 
@@ -128,13 +129,13 @@ struct SearchDbSymbolIntegrationTests {
 @Suite("Samples.db Symbol Integration", .serialized)
 struct SamplesDbSymbolIntegrationTests {
     /// Create a test sample database
-    private func createTestSampleDatabase() async throws -> (SampleIndex.Database, () -> Void) {
+    private func createTestSampleDatabase() async throws -> (Sample.Index.Database, () -> Void) {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("sample-symbol-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 
         let dbPath = tempDir.appendingPathComponent("samples.db")
-        let database = try await SampleIndex.Database(dbPath: dbPath)
+        let database = try await Sample.Index.Database(dbPath: dbPath)
 
         let cleanup: () -> Void = {
             try? FileManager.default.removeItem(at: tempDir)
@@ -149,7 +150,7 @@ struct SamplesDbSymbolIntegrationTests {
         defer { cleanup() }
 
         // Create project
-        let project = SampleIndex.Project(
+        let project = Sample.Index.Project(
             id: "observable-sample",
             title: "Observable Sample",
             description: "Sample showing @Observable usage",
@@ -182,7 +183,7 @@ struct SamplesDbSymbolIntegrationTests {
         }
         """
 
-        let file = SampleIndex.File(
+        let file = Sample.Index.File(
             projectId: "observable-sample",
             path: "Sources/AppState.swift",
             content: swiftSource
@@ -220,7 +221,7 @@ struct SamplesDbSymbolIntegrationTests {
         let (database, cleanup) = try await createTestSampleDatabase()
         defer { cleanup() }
 
-        let project = SampleIndex.Project(
+        let project = Sample.Index.Project(
             id: "multi-file-sample",
             title: "Multi-File Sample",
             description: "Sample with multiple Swift files",
@@ -270,7 +271,7 @@ struct SamplesDbSymbolIntegrationTests {
         var totalSymbols = 0
 
         for (path, content) in files {
-            let file = SampleIndex.File(
+            let file = Sample.Index.File(
                 projectId: "multi-file-sample",
                 path: path,
                 content: content

--- a/Packages/Tests/MockAIAgentTests/MCPIntegrationTests.swift
+++ b/Packages/Tests/MockAIAgentTests/MCPIntegrationTests.swift
@@ -370,7 +370,7 @@ struct CupertinoServerFixture {
         // Ensure samples.db exists at the production path so
         // `Command.Serve.checkForData()` sees data. Empty schema is fine —
         // these tests check MCP framing, not query results.
-        let sampleDBPath = SampleIndex.defaultDatabasePath
+        let sampleDBPath = Sample.Index.defaultDatabasePath
         if !FileManager.default.fileExists(atPath: sampleDBPath.path) {
             // Synchronous setup of the schema via a blocking task hop.
             // Swift Testing's @Test functions are async, so we can spin up
@@ -378,7 +378,7 @@ struct CupertinoServerFixture {
             // cupertino reads it. Use a dispatch semaphore.
             let sem = DispatchSemaphore(value: 0)
             Task {
-                if let db = try? await SampleIndex.Database(dbPath: sampleDBPath) {
+                if let db = try? await Sample.Index.Database(dbPath: sampleDBPath) {
                     await db.disconnect()
                 }
                 sem.signal()

--- a/Packages/Tests/SampleIndexTests/SampleIndexBasePathDerivationTests.swift
+++ b/Packages/Tests/SampleIndexTests/SampleIndexBasePathDerivationTests.swift
@@ -16,16 +16,16 @@ struct SampleIndexBasePathDerivationTests {
         base.path.hasSuffix("/") ? base.path : base.path + "/"
     }
 
-    @Test("SampleIndex.defaultDatabasePath sits under defaultBaseDirectory")
+    @Test("Sample.Index.defaultDatabasePath sits under defaultBaseDirectory")
     func samplesDatabaseUnderBase() {
-        let path = SampleIndex.defaultDatabasePath
+        let path = Sample.Index.defaultDatabasePath
         #expect(path.path.hasPrefix(basePrefix))
         #expect(path.lastPathComponent == "samples.db")
     }
 
-    @Test("SampleIndex.defaultSampleCodeDirectory sits under defaultBaseDirectory")
+    @Test("Sample.Index.defaultSampleCodeDirectory sits under defaultBaseDirectory")
     func sampleCodeDirUnderBase() {
-        let path = SampleIndex.defaultSampleCodeDirectory
+        let path = Sample.Index.defaultSampleCodeDirectory
         #expect(path.path.hasPrefix(basePrefix))
         #expect(path.lastPathComponent == "sample-code")
     }

--- a/Packages/Tests/SampleIndexTests/SampleIndexTests.swift
+++ b/Packages/Tests/SampleIndexTests/SampleIndexTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import SampleIndex
+import SharedConstants
 import Testing
 
 @Suite("SampleIndex Tests")
@@ -7,7 +8,7 @@ struct SampleIndexTests {
     @Test("Project ID extraction from filename")
     func projectIdFromFilename() {
         // Test that the File model extracts path components correctly
-        let file = SampleIndex.File(
+        let file = Sample.Index.File(
             projectId: "test-project",
             path: "Sources/Views/ContentView.swift",
             content: "import SwiftUI"
@@ -22,19 +23,19 @@ struct SampleIndexTests {
     @Test("Indexable file extensions")
     func indexableExtensions() {
         // Swift files should be indexed
-        #expect(SampleIndex.shouldIndex(path: "main.swift"))
-        #expect(SampleIndex.shouldIndex(path: "ViewController.m"))
-        #expect(SampleIndex.shouldIndex(path: "Header.h"))
+        #expect(Sample.Index.shouldIndex(path: "main.swift"))
+        #expect(Sample.Index.shouldIndex(path: "ViewController.m"))
+        #expect(Sample.Index.shouldIndex(path: "Header.h"))
 
         // Binary files should not be indexed
-        #expect(!SampleIndex.shouldIndex(path: "image.png"))
-        #expect(!SampleIndex.shouldIndex(path: "model.usdz"))
-        #expect(!SampleIndex.shouldIndex(path: "binary.dat"))
+        #expect(!Sample.Index.shouldIndex(path: "image.png"))
+        #expect(!Sample.Index.shouldIndex(path: "model.usdz"))
+        #expect(!Sample.Index.shouldIndex(path: "binary.dat"))
     }
 
     @Test("Project model creation")
     func projectModel() {
-        let project = SampleIndex.Project(
+        let project = Sample.Index.Project(
             id: "sample-app",
             title: "Sample App",
             description: "A sample application",
@@ -58,7 +59,7 @@ struct SampleIndexTests {
 struct SamplesAvailabilityPersistenceTests {
     @Test("Project carries deployment targets + availability source")
     func projectInitWithAvailability() {
-        let project = SampleIndex.Project(
+        let project = Sample.Index.Project(
             id: "swiftui-list",
             title: "SwiftUI List",
             description: "Sample showing List",
@@ -78,7 +79,7 @@ struct SamplesAvailabilityPersistenceTests {
 
     @Test("Project default init leaves availability empty + nil")
     func projectInitWithoutAvailability() {
-        let project = SampleIndex.Project(
+        let project = Sample.Index.Project(
             id: "x",
             title: "x",
             description: "x",
@@ -96,7 +97,7 @@ struct SamplesAvailabilityPersistenceTests {
     @Test("File carries availableAttrsJSON when supplied")
     func fileInitWithAttrs() {
         let json = "[{\"line\":12,\"raw\":\"(iOS 17, *)\",\"platforms\":[\"iOS\",\"*\"]}]"
-        let file = SampleIndex.File(
+        let file = Sample.Index.File(
             projectId: "p",
             path: "Sources/Foo.swift",
             content: "import SwiftUI",
@@ -107,7 +108,7 @@ struct SamplesAvailabilityPersistenceTests {
 
     @Test("File default init leaves availableAttrsJSON nil")
     func fileInitWithoutAttrs() {
-        let file = SampleIndex.File(
+        let file = Sample.Index.File(
             projectId: "p",
             path: "Sources/Foo.swift",
             content: "import SwiftUI"
@@ -121,10 +122,10 @@ struct SamplesAvailabilityPersistenceTests {
             .appendingPathComponent("samples-roundtrip-\(UUID().uuidString).db")
         defer { try? FileManager.default.removeItem(at: dbURL) }
 
-        let database = try await SampleIndex.Database(dbPath: dbURL)
+        let database = try await Sample.Index.Database(dbPath: dbURL)
         defer { Task { await database.disconnect() } }
 
-        let project = SampleIndex.Project(
+        let project = Sample.Index.Project(
             id: "test-roundtrip",
             title: "Test",
             description: "Test desc",
@@ -150,10 +151,10 @@ struct SamplesAvailabilityPersistenceTests {
             .appendingPathComponent("samples-file-roundtrip-\(UUID().uuidString).db")
         defer { try? FileManager.default.removeItem(at: dbURL) }
 
-        let database = try await SampleIndex.Database(dbPath: dbURL)
+        let database = try await Sample.Index.Database(dbPath: dbURL)
         defer { Task { await database.disconnect() } }
 
-        let project = SampleIndex.Project(
+        let project = Sample.Index.Project(
             id: "p1",
             title: "x",
             description: "x",
@@ -167,7 +168,7 @@ struct SamplesAvailabilityPersistenceTests {
         try await database.indexProject(project)
 
         let json = "[{\"line\":7,\"raw\":\"(iOS 17, *)\",\"platforms\":[\"iOS\",\"*\"]}]"
-        let file = SampleIndex.File(
+        let file = Sample.Index.File(
             projectId: "p1",
             path: "Sources/Foo.swift",
             content: "@available(iOS 17, *) func foo() {}",

--- a/Packages/Tests/SearchToolProviderTests/CupertinoSearchToolProviderTests.swift
+++ b/Packages/Tests/SearchToolProviderTests/CupertinoSearchToolProviderTests.swift
@@ -124,15 +124,15 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
 }
 
 /// Creates a temporary sample database for testing
-func createTestSampleDatabase() async throws -> (database: SampleIndex.Database, cleanup: () -> Void) {
+func createTestSampleDatabase() async throws -> (database: Sample.Index.Database, cleanup: () -> Void) {
     let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("sample-test-\(UUID().uuidString)")
     try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 
     let dbPath = tempDir.appendingPathComponent("samples.db")
-    let database = try await SampleIndex.Database(dbPath: dbPath)
+    let database = try await Sample.Index.Database(dbPath: dbPath)
 
     // Add sample project using correct API
-    let project = SampleIndex.Project(
+    let project = Sample.Index.Project(
         id: "animating-views-sample",
         title: "Animating Views in SwiftUI",
         description: "Learn how to animate views using SwiftUI.",
@@ -146,7 +146,7 @@ func createTestSampleDatabase() async throws -> (database: SampleIndex.Database,
     try await database.indexProject(project)
 
     // Add sample file using correct API
-    let file = SampleIndex.File(
+    let file = Sample.Index.File(
         projectId: "animating-views-sample",
         path: "ContentView.swift",
         content: "import SwiftUI\n\nstruct ContentView: View {\n    @State var isAnimating = false\n}"
@@ -992,8 +992,8 @@ struct UnifiedSearchFormatterTests {
         )
     }
 
-    private func makeSampleProject() -> SampleIndex.Project {
-        SampleIndex.Project(
+    private func makeSampleProject() -> Sample.Index.Project {
+        Sample.Index.Project(
             id: "test-sample",
             title: "Test Sample",
             description: "A test sample project",


### PR DESCRIPTION
Continues the cross-cutting Sample namespacing (#356 → #360). The entire **SampleIndex SPM target** — already internally namespaced as `SampleIndex.<X>` — now lives at `Sample.Index.<X>`. The SPM target name stays `SampleIndex` (Package.swift), only the Swift-level namespace moves.

## Renames

| Before | After |
|---|---|
| `public enum SampleIndex` (namespace + static helpers) | `Sample.Index` (declared in #356; helpers contributed here via extension) |
| `SampleIndex.Builder`         | `Sample.Index.Builder` |
| `SampleIndex.Database`        | `Sample.Index.Database` |
| `SampleIndex.Project`         | `Sample.Index.Project` |
| `SampleIndex.File`            | `Sample.Index.File` |
| `SampleIndex.Error`           | `Sample.Index.Error` |
| `SampleIndex.IndexProgress`   | `Sample.Index.IndexProgress` |
| `SampleIndex.SampleCodeEntryInfo` | `Sample.Index.SampleCodeEntryInfo` |
| `SampleAvailabilitySidecar` (file scope) | `Sample.Index.AvailabilitySidecar` |

## Mechanics

- `Sources/SampleIndex/SampleIndex.swift` drops `public enum SampleIndex { ... }` and re-declares its static helpers (`defaultDatabasePath`, `defaultSampleCodeDirectory`, `minColumn(for:)`) as `extension Sample.Index { ... }`. The namespace itself is declared in `SharedConstants/Sample.swift` (#356).
- The five other files in the target retarget their `extension SampleIndex` blocks to `extension Sample.Index`.
- `SampleAvailabilitySidecar.swift`'s file-scope public struct wraps as `extension Sample.Index { public struct AvailabilitySidecar { ... } }`.
- Internal cross-references in `SampleIndexBuilder.swift` + `SampleIndexDatabase.swift` to old-style `SampleIndex.<staticHelper>` rewrite to `Sample.Index.<staticHelper>`.
- `import SharedConstants` added to every file that newly needs it.
- **25 caller files swept** across Indexer, SearchToolProvider, CLI/Commands, Services/Formatters, Services/ReadCommands, MockAIAgentTests, SearchToolProviderTests, SampleIndexTests, ASTIndexerTests.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Previous Sample-related: #356 (foundation + `Sample.Cleanup.Cleaner`), #357 (`Sample.Core`), #358 (`Sample.Services` + `Sample.Search`), #360 (`Sample.Indexer` + `Sample.Atom`). Next: `Sample.Format.*` (Markdown / JSON / Text formatter family).