### PR TITLE
refactor(Sample): relocate sample-formatter types under Sample.Format.{Markdown,JSON,Text}

### DIFF
--- a/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
+++ b/Packages/Sources/CLI/Commands/ReadSampleFileCommand.swift
@@ -55,10 +55,10 @@ extension Command {
             case .text:
                 outputText(file)
             case .json:
-                let formatter = SampleFileJSONFormatter()
+                let formatter = Sample.Format.JSON.File()
                 Logging.Log.output(formatter.format(file))
             case .markdown:
-                let formatter = SampleFileMarkdownFormatter()
+                let formatter = Sample.Format.Markdown.File()
                 Logging.Log.output(formatter.format(file))
             }
         }

--- a/Packages/Sources/CLI/Commands/SearchCommand+SourceRunners.swift
+++ b/Packages/Sources/CLI/Commands/SearchCommand+SourceRunners.swift
@@ -114,13 +114,13 @@ extension Command.Search {
 
         switch format {
         case .text:
-            let formatter = SampleSearchTextFormatter(query: query, framework: framework, teasers: teasers)
+            let formatter = Sample.Format.Text.Search(query: query, framework: framework, teasers: teasers)
             Logging.Log.output(formatter.format(result))
         case .json:
-            let formatter = SampleSearchJSONFormatter(query: query, framework: framework)
+            let formatter = Sample.Format.JSON.Search(query: query, framework: framework)
             Logging.Log.output(formatter.format(result))
         case .markdown:
-            let formatter = SampleSearchMarkdownFormatter(query: query, framework: framework, teasers: teasers)
+            let formatter = Sample.Format.Markdown.Search(query: query, framework: framework, teasers: teasers)
             Logging.Log.output(formatter.format(result))
         }
     }

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -527,7 +527,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         )
 
         // Use shared formatter
-        let formatter = SampleSearchMarkdownFormatter(query: query, framework: framework, teasers: teasers)
+        let formatter = Sample.Format.Markdown.Search(query: query, framework: framework, teasers: teasers)
         let markdown = formatter.format(result)
 
         return MCP.Core.Protocols.CallToolResult(content: [.text(MCP.Core.Protocols.TextContent(text: markdown))])

--- a/Packages/Sources/Services/Formatters/SampleJSONFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleJSONFormatter.swift
@@ -57,65 +57,73 @@ private struct FileSearchJSONOutput: Encodable {
 // MARK: - Sample Search JSON Formatter
 
 /// Formats sample search results as JSON
-public struct SampleSearchJSONFormatter: ResultFormatter {
-    private let query: String
-    private let framework: String?
+extension Sample.Format.JSON {
+    public struct Search: ResultFormatter {
+        private let query: String
+        private let framework: String?
 
-    public init(query: String, framework: String? = nil) {
-        self.query = query
-        self.framework = framework
-    }
-
-    public func format(_ result: Sample.Search.Result) -> String {
-        struct Output: Encodable {
-            let query: String
-            let framework: String?
-            let projects: [ProjectJSONOutput]
-            let files: [FileSearchJSONOutput]
+        public init(query: String, framework: String? = nil) {
+            self.query = query
+            self.framework = framework
         }
 
-        let output = Output(
-            query: query,
-            framework: framework,
-            projects: result.projects.map { ProjectJSONOutput(from: $0) },
-            files: result.files.map { FileSearchJSONOutput(from: $0) }
-        )
+        public func format(_ result: Sample.Search.Result) -> String {
+            struct Output: Encodable {
+                let query: String
+                let framework: String?
+                let projects: [ProjectJSONOutput]
+                let files: [FileSearchJSONOutput]
+            }
 
-        return encodeJSON(output)
+            let output = Output(
+                query: query,
+                framework: framework,
+                projects: result.projects.map { ProjectJSONOutput(from: $0) },
+                files: result.files.map { FileSearchJSONOutput(from: $0) }
+            )
+
+            return encodeJSON(output)
+        }
     }
 }
 
 // MARK: - Sample List JSON Formatter
 
 /// Formats sample project list as JSON
-public struct SampleListJSONFormatter: ResultFormatter {
-    public init() {}
+extension Sample.Format.JSON {
+    public struct List: ResultFormatter {
+        public init() {}
 
-    public func format(_ projects: [Sample.Index.Project]) -> String {
-        let output = projects.map { ProjectJSONOutput(from: $0) }
-        return encodeJSON(output)
+        public func format(_ projects: [Sample.Index.Project]) -> String {
+            let output = projects.map { ProjectJSONOutput(from: $0) }
+            return encodeJSON(output)
+        }
     }
 }
 
 // MARK: - Sample Project JSON Formatter
 
 /// Formats a single sample project as JSON
-public struct SampleProjectJSONFormatter: ResultFormatter {
-    public init() {}
+extension Sample.Format.JSON {
+    public struct Project: ResultFormatter {
+        public init() {}
 
-    public func format(_ project: Sample.Index.Project) -> String {
-        encodeJSON(ProjectJSONOutput(from: project))
+        public func format(_ project: Sample.Index.Project) -> String {
+            encodeJSON(ProjectJSONOutput(from: project))
+        }
     }
 }
 
 // MARK: - Sample File JSON Formatter
 
 /// Formats a sample file as JSON
-public struct SampleFileJSONFormatter: ResultFormatter {
-    public init() {}
+extension Sample.Format.JSON {
+    public struct File: ResultFormatter {
+        public init() {}
 
-    public func format(_ file: Sample.Index.File) -> String {
-        encodeJSON(FileJSONOutput(from: file))
+        public func format(_ file: Sample.Index.File) -> String {
+            encodeJSON(FileJSONOutput(from: file))
+        }
     }
 }
 

--- a/Packages/Sources/Services/Formatters/SampleMarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleMarkdownFormatter.swift
@@ -6,159 +6,167 @@ import SharedCore
 // MARK: - Sample Search Markdown Formatter
 
 /// Formats sample search results as markdown
-public struct SampleSearchMarkdownFormatter: ResultFormatter {
-    private let query: String
-    private let framework: String?
-    private let teasers: TeaserResults?
+extension Sample.Format.Markdown {
+    public struct Search: ResultFormatter {
+        private let query: String
+        private let framework: String?
+        private let teasers: TeaserResults?
 
-    public init(query: String, framework: String? = nil, teasers: TeaserResults? = nil) {
-        self.query = query
-        self.framework = framework
-        self.teasers = teasers
-    }
-
-    public func format(_ result: Sample.Search.Result) -> String {
-        var output = "# Sample Code Search: \"\(query)\"\n\n"
-
-        // Tell the AI what source this is
-        output += "_Source: **\(Shared.Constants.SourcePrefix.samples)**_\n\n"
-
-        if let framework {
-            output += "_Filtered to framework: **\(framework)**_\n\n"
+        public init(query: String, framework: String? = nil, teasers: TeaserResults? = nil) {
+            self.query = query
+            self.framework = framework
+            self.teasers = teasers
         }
 
-        // Projects
-        output += "## Projects (\(result.projects.count) found)\n\n"
+        public func format(_ result: Sample.Search.Result) -> String {
+            var output = "# Sample Code Search: \"\(query)\"\n\n"
 
-        if result.projects.isEmpty {
-            output += "_No matching projects found._\n\n"
-        } else {
-            for (index, project) in result.projects.enumerated() {
-                output += "### \(index + 1). \(project.title)\n\n"
-                output += "- **ID:** `\(project.id)`\n"
-                output += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
-                output += "- **Files:** \(project.fileCount)\n\n"
+            // Tell the AI what source this is
+            output += "_Source: **\(Shared.Constants.SourcePrefix.samples)**_\n\n"
 
-                if !project.description.isEmpty {
-                    output += "\(project.description)\n\n"
+            if let framework {
+                output += "_Filtered to framework: **\(framework)**_\n\n"
+            }
+
+            // Projects
+            output += "## Projects (\(result.projects.count) found)\n\n"
+
+            if result.projects.isEmpty {
+                output += "_No matching projects found._\n\n"
+            } else {
+                for (index, project) in result.projects.enumerated() {
+                    output += "### \(index + 1). \(project.title)\n\n"
+                    output += "- **ID:** `\(project.id)`\n"
+                    output += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
+                    output += "- **Files:** \(project.fileCount)\n\n"
+
+                    if !project.description.isEmpty {
+                        output += "\(project.description)\n\n"
+                    }
                 }
             }
-        }
 
-        // Files
-        if !result.files.isEmpty {
-            output += "\n## Matching Files (\(result.files.count) found)\n\n"
+            // Files
+            if !result.files.isEmpty {
+                output += "\n## Matching Files (\(result.files.count) found)\n\n"
 
-            for (index, file) in result.files.prefix(10).enumerated() {
-                output += "### \(index + 1). \(file.filename)\n\n"
-                output += "- **Project:** `\(file.projectId)`\n"
-                output += "- **Path:** `\(file.path)`\n\n"
-                output += "> \(file.snippet)\n\n"
+                for (index, file) in result.files.prefix(10).enumerated() {
+                    output += "### \(index + 1). \(file.filename)\n\n"
+                    output += "- **Project:** `\(file.projectId)`\n"
+                    output += "- **Path:** `\(file.path)`\n\n"
+                    output += "> \(file.snippet)\n\n"
+                }
             }
+
+            // Footer: tips and guidance
+            let footer = SearchFooter.singleSource(
+                Shared.Constants.SourcePrefix.samples,
+                teasers: teasers
+            )
+            output += footer.formatMarkdown()
+
+            return output
         }
-
-        // Footer: tips and guidance
-        let footer = SearchFooter.singleSource(
-            Shared.Constants.SourcePrefix.samples,
-            teasers: teasers
-        )
-        output += footer.formatMarkdown()
-
-        return output
     }
 }
 
 // MARK: - Sample List Markdown Formatter
 
 /// Formats sample project list as markdown
-public struct SampleListMarkdownFormatter: ResultFormatter {
-    private let totalCount: Int
-    private let framework: String?
+extension Sample.Format.Markdown {
+    public struct List: ResultFormatter {
+        private let totalCount: Int
+        private let framework: String?
 
-    public init(totalCount: Int, framework: String? = nil) {
-        self.totalCount = totalCount
-        self.framework = framework
-    }
-
-    public func format(_ projects: [Sample.Index.Project]) -> String {
-        var output = "# Sample Projects\n\n"
-
-        if let framework {
-            output += "_Filtered to framework: **\(framework)**_\n\n"
+        public init(totalCount: Int, framework: String? = nil) {
+            self.totalCount = totalCount
+            self.framework = framework
         }
 
-        output += "Showing \(projects.count) of \(totalCount) total projects.\n\n"
+        public func format(_ projects: [Sample.Index.Project]) -> String {
+            var output = "# Sample Projects\n\n"
 
-        if projects.isEmpty {
-            output += "_No sample projects found._\n"
-        } else {
-            for (index, project) in projects.enumerated() {
-                output += "## \(index + 1). \(project.title)\n\n"
-                output += "- **ID:** `\(project.id)`\n"
-                output += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
-                output += "- **Files:** \(project.fileCount)\n\n"
+            if let framework {
+                output += "_Filtered to framework: **\(framework)**_\n\n"
+            }
 
-                if !project.description.isEmpty {
-                    output += "\(project.description.truncated(to: Shared.Constants.Limit.summaryTruncationLength))\n\n"
+            output += "Showing \(projects.count) of \(totalCount) total projects.\n\n"
+
+            if projects.isEmpty {
+                output += "_No sample projects found._\n"
+            } else {
+                for (index, project) in projects.enumerated() {
+                    output += "## \(index + 1). \(project.title)\n\n"
+                    output += "- **ID:** `\(project.id)`\n"
+                    output += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
+                    output += "- **Files:** \(project.fileCount)\n\n"
+
+                    if !project.description.isEmpty {
+                        output += "\(project.description.truncated(to: Shared.Constants.Limit.summaryTruncationLength))\n\n"
+                    }
                 }
             }
+
+            // Footer: tips and guidance
+            let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples)
+            output += footer.formatMarkdown()
+
+            return output
         }
-
-        // Footer: tips and guidance
-        let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples)
-        output += footer.formatMarkdown()
-
-        return output
     }
 }
 
 // MARK: - Sample Project Markdown Formatter
 
 /// Formats a single sample project as markdown
-public struct SampleProjectMarkdownFormatter: ResultFormatter {
-    public init() {}
+extension Sample.Format.Markdown {
+    public struct Project: ResultFormatter {
+        public init() {}
 
-    public func format(_ project: Sample.Index.Project) -> String {
-        var output = "# \(project.title)\n\n"
-        output += "- **ID:** `\(project.id)`\n"
-        output += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
-        output += "- **Files:** \(project.fileCount)\n\n"
+        public func format(_ project: Sample.Index.Project) -> String {
+            var output = "# \(project.title)\n\n"
+            output += "- **ID:** `\(project.id)`\n"
+            output += "- **Frameworks:** \(project.frameworks.joined(separator: ", "))\n"
+            output += "- **Files:** \(project.fileCount)\n\n"
 
-        if !project.description.isEmpty {
-            output += "## Description\n\n\(project.description)\n"
+            if !project.description.isEmpty {
+                output += "## Description\n\n\(project.description)\n"
+            }
+
+            // Footer: tips and guidance
+            let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples)
+            output += footer.formatMarkdown()
+
+            return output
         }
-
-        // Footer: tips and guidance
-        let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples)
-        output += footer.formatMarkdown()
-
-        return output
     }
 }
 
 // MARK: - Sample File Markdown Formatter
 
 /// Formats a sample file as markdown
-public struct SampleFileMarkdownFormatter: ResultFormatter {
-    public init() {}
+extension Sample.Format.Markdown {
+    public struct File: ResultFormatter {
+        public init() {}
 
-    public func format(_ file: Sample.Index.File) -> String {
-        // Determine language for syntax highlighting
-        let language = file.filename.hasSuffix(".swift") ? "swift" :
-            file.filename.hasSuffix(".m") ? "objc" :
-            file.filename.hasSuffix(".h") ? "objc" :
-            file.filename.hasSuffix(".json") ? "json" :
-            file.filename.hasSuffix(".plist") ? "xml" : ""
+        public func format(_ file: Sample.Index.File) -> String {
+            // Determine language for syntax highlighting
+            let language = file.filename.hasSuffix(".swift") ? "swift" :
+                file.filename.hasSuffix(".m") ? "objc" :
+                file.filename.hasSuffix(".h") ? "objc" :
+                file.filename.hasSuffix(".json") ? "json" :
+                file.filename.hasSuffix(".plist") ? "xml" : ""
 
-        var output = "# \(file.filename)\n\n"
-        output += "- **Project:** `\(file.projectId)`\n"
-        output += "- **Path:** `\(file.path)`\n\n"
-        output += "```\(language)\n\(file.content)\n```\n"
+            var output = "# \(file.filename)\n\n"
+            output += "- **Project:** `\(file.projectId)`\n"
+            output += "- **Path:** `\(file.path)`\n\n"
+            output += "```\(language)\n\(file.content)\n```\n"
 
-        // Footer: tips and guidance
-        let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples)
-        output += footer.formatMarkdown()
+            // Footer: tips and guidance
+            let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples)
+            output += footer.formatMarkdown()
 
-        return output
+            return output
+        }
     }
 }

--- a/Packages/Sources/Services/Formatters/SampleTextFormatter.swift
+++ b/Packages/Sources/Services/Formatters/SampleTextFormatter.swift
@@ -6,122 +6,128 @@ import SharedCore
 // MARK: - Sample Search Text Formatter
 
 /// Formats sample search results as plain text for CLI output
-public struct SampleSearchTextFormatter: ResultFormatter {
-    private let query: String
-    private let framework: String?
-    private let teasers: TeaserResults?
+extension Sample.Format.Text {
+    public struct Search: ResultFormatter {
+        private let query: String
+        private let framework: String?
+        private let teasers: TeaserResults?
 
-    public init(query: String, framework: String? = nil, teasers: TeaserResults? = nil) {
-        self.query = query
-        self.framework = framework
-        self.teasers = teasers
-    }
-
-    public func format(_ result: Sample.Search.Result) -> String {
-        if result.isEmpty {
-            return "No results found for '\(query)'"
+        public init(query: String, framework: String? = nil, teasers: TeaserResults? = nil) {
+            self.query = query
+            self.framework = framework
+            self.teasers = teasers
         }
 
-        var output = "Search Results for '\(query)'\n"
+        public func format(_ result: Sample.Search.Result) -> String {
+            if result.isEmpty {
+                return "No results found for '\(query)'"
+            }
 
-        if let framework {
-            output += "Filtered by: \(framework)\n"
-        }
+            var output = "Search Results for '\(query)'\n"
 
-        output += "\n"
+            if let framework {
+                output += "Filtered by: \(framework)\n"
+            }
 
-        // Projects
-        if !result.projects.isEmpty {
-            output += "Projects (\(result.projects.count) found):\n\n"
+            output += "\n"
 
-            for (index, project) in result.projects.enumerated() {
-                output += "[\(index + 1)] \(project.title)\n"
-                output += "    ID: \(project.id)\n"
-                output += "    Frameworks: \(project.frameworks.joined(separator: ", "))\n"
-                output += "    Files: \(project.fileCount)\n"
+            // Projects
+            if !result.projects.isEmpty {
+                output += "Projects (\(result.projects.count) found):\n\n"
 
-                if !project.description.isEmpty {
-                    let maxLen = Shared.Constants.Limit.summaryTruncationLength
-                    output += "    \(project.description.truncated(to: maxLen))\n"
+                for (index, project) in result.projects.enumerated() {
+                    output += "[\(index + 1)] \(project.title)\n"
+                    output += "    ID: \(project.id)\n"
+                    output += "    Frameworks: \(project.frameworks.joined(separator: ", "))\n"
+                    output += "    Files: \(project.fileCount)\n"
+
+                    if !project.description.isEmpty {
+                        let maxLen = Shared.Constants.Limit.summaryTruncationLength
+                        output += "    \(project.description.truncated(to: maxLen))\n"
+                    }
+
+                    output += "\n"
                 }
-
-                output += "\n"
             }
-        }
 
-        // Files
-        if !result.files.isEmpty {
-            output += "Matching Files (\(result.files.count) found):\n\n"
+            // Files
+            if !result.files.isEmpty {
+                output += "Matching Files (\(result.files.count) found):\n\n"
 
-            for (index, file) in result.files.prefix(10).enumerated() {
-                output += "[\(index + 1)] \(file.filename)\n"
-                output += "    Project: \(file.projectId)\n"
-                output += "    Path: \(file.path)\n"
-                output += "    > \(file.snippet)\n"
-                output += "\n"
+                for (index, file) in result.files.prefix(10).enumerated() {
+                    output += "[\(index + 1)] \(file.filename)\n"
+                    output += "    Project: \(file.projectId)\n"
+                    output += "    Path: \(file.path)\n"
+                    output += "    > \(file.snippet)\n"
+                    output += "\n"
+                }
             }
+
+            // Footer: teasers, tips, and guidance
+            let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples, teasers: teasers)
+            output += footer.formatText()
+
+            return output
         }
-
-        // Footer: teasers, tips, and guidance
-        let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples, teasers: teasers)
-        output += footer.formatText()
-
-        return output
     }
 }
 
 // MARK: - Sample List Text Formatter
 
 /// Formats sample project list as plain text for CLI output
-public struct SampleListTextFormatter: ResultFormatter {
-    private let totalCount: Int
+extension Sample.Format.Text {
+    public struct List: ResultFormatter {
+        private let totalCount: Int
 
-    public init(totalCount: Int) {
-        self.totalCount = totalCount
-    }
-
-    public func format(_ projects: [Sample.Index.Project]) -> String {
-        if projects.isEmpty {
-            return "No sample projects found. Run 'cupertino save --samples' to build the sample index."
+        public init(totalCount: Int) {
+            self.totalCount = totalCount
         }
 
-        var output = "Sample Projects (\(projects.count) of \(totalCount) total):\n\n"
+        public func format(_ projects: [Sample.Index.Project]) -> String {
+            if projects.isEmpty {
+                return "No sample projects found. Run 'cupertino save --samples' to build the sample index."
+            }
 
-        for (index, project) in projects.enumerated() {
-            output += "[\(index + 1)] \(project.title)\n"
-            output += "    ID: \(project.id)\n"
-            output += "    Frameworks: \(project.frameworks.joined(separator: ", "))\n"
-            output += "    Files: \(project.fileCount)\n\n"
+            var output = "Sample Projects (\(projects.count) of \(totalCount) total):\n\n"
+
+            for (index, project) in projects.enumerated() {
+                output += "[\(index + 1)] \(project.title)\n"
+                output += "    ID: \(project.id)\n"
+                output += "    Frameworks: \(project.frameworks.joined(separator: ", "))\n"
+                output += "    Files: \(project.fileCount)\n\n"
+            }
+
+            // Footer: tips and guidance
+            let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples)
+            output += footer.formatText()
+
+            return output
         }
-
-        // Footer: tips and guidance
-        let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples)
-        output += footer.formatText()
-
-        return output
     }
 }
 
 // MARK: - Sample Project Text Formatter
 
 /// Formats a single sample project as plain text
-public struct SampleProjectTextFormatter: ResultFormatter {
-    public init() {}
+extension Sample.Format.Text {
+    public struct Project: ResultFormatter {
+        public init() {}
 
-    public func format(_ project: Sample.Index.Project) -> String {
-        var output = "Project: \(project.title)\n"
-        output += "ID: \(project.id)\n"
-        output += "Frameworks: \(project.frameworks.joined(separator: ", "))\n"
-        output += "Files: \(project.fileCount)\n\n"
+        public func format(_ project: Sample.Index.Project) -> String {
+            var output = "Project: \(project.title)\n"
+            output += "ID: \(project.id)\n"
+            output += "Frameworks: \(project.frameworks.joined(separator: ", "))\n"
+            output += "Files: \(project.fileCount)\n\n"
 
-        if !project.description.isEmpty {
-            output += "Description:\n\(project.description)\n"
+            if !project.description.isEmpty {
+                output += "Description:\n\(project.description)\n"
+            }
+
+            // Footer: tips and guidance
+            let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples)
+            output += footer.formatText()
+
+            return output
         }
-
-        // Footer: tips and guidance
-        let footer = SearchFooter.singleSource(Shared.Constants.SourcePrefix.samples)
-        output += footer.formatText()
-
-        return output
     }
 }


### PR DESCRIPTION
Completes the cross-cutting **Sample** namespacing (#356 → #361). The 11 sample-flavoured `ResultFormatter` conformers in `Services/Formatters/` move into the `Sample.Format.<medium>.<role>` tree. Each leaf drops both the `Sample` prefix and the output-medium suffix — the namespace path supplies all of that.

## Renames

### Text formatters

| Before | After |
|---|---|
| `SampleSearchTextFormatter`   | `Sample.Format.Text.Search` |
| `SampleListTextFormatter`     | `Sample.Format.Text.List` |
| `SampleProjectTextFormatter`  | `Sample.Format.Text.Project` |

### JSON formatters

| Before | After |
|---|---|
| `SampleSearchJSONFormatter`   | `Sample.Format.JSON.Search` |
| `SampleListJSONFormatter`     | `Sample.Format.JSON.List` |
| `SampleProjectJSONFormatter`  | `Sample.Format.JSON.Project` |
| `SampleFileJSONFormatter`     | `Sample.Format.JSON.File` |

### Markdown formatters

| Before | After |
|---|---|
| `SampleSearchMarkdownFormatter`   | `Sample.Format.Markdown.Search` |
| `SampleListMarkdownFormatter`     | `Sample.Format.Markdown.List` |
| `SampleProjectMarkdownFormatter`  | `Sample.Format.Markdown.Project` |
| `SampleFileMarkdownFormatter`     | `Sample.Format.Markdown.File` |

`Sample.Format.Text` has no `File` variant — sample-file display is Markdown/JSON only.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

The `Sample.*` cross-cutting namespace tree is now complete. Previous Sample-related: #356, #357, #358, #360, #361.