### PR TITLE
refactor(Core): nest WebKitFetcherError, WebKitCrawlerError, PackageDownloadError under their parent namespaces

### DIFF
--- a/Packages/Sources/Core/PackageIndexing/PackageDocumentationDownloader.swift
+++ b/Packages/Sources/Core/PackageIndexing/PackageDocumentationDownloader.swift
@@ -129,35 +129,37 @@ extension Core {
 
 // MARK: - Errors
 
-public enum PackageDownloadError: Error, LocalizedError {
-    case readmeNotFound
-    case invalidInput
-    case networkError(Error)
-    case fileSystemError(Error)
+extension Core {
+    public enum PackageDownloadError: Error, LocalizedError {
+        case readmeNotFound
+        case invalidInput
+        case networkError(Error)
+        case fileSystemError(Error)
 
-    public var errorDescription: String? {
-        switch self {
-        case .readmeNotFound:
-            return "README.md not found in repository"
-        case .invalidInput:
-            return "Invalid owner or repository name"
-        case let .networkError(error):
-            return "Network error: \(error.localizedDescription)"
-        case let .fileSystemError(error):
-            return "File system error: \(error.localizedDescription)"
+        public var errorDescription: String? {
+            switch self {
+            case .readmeNotFound:
+                return "README.md not found in repository"
+            case .invalidInput:
+                return "Invalid owner or repository name"
+            case let .networkError(error):
+                return "Network error: \(error.localizedDescription)"
+            case let .fileSystemError(error):
+                return "File system error: \(error.localizedDescription)"
+            }
         }
-    }
 
-    public var recoverySuggestion: String? {
-        switch self {
-        case .readmeNotFound:
-            return "The repository may not have a README.md file"
-        case .invalidInput:
-            return "Owner and repository names must contain only alphanumeric characters, hyphens, and underscores"
-        case .networkError:
-            return "Check your internet connection and try again"
-        case .fileSystemError:
-            return "Check disk space and file permissions"
+        public var recoverySuggestion: String? {
+            switch self {
+            case .readmeNotFound:
+                return "The repository may not have a README.md file"
+            case .invalidInput:
+                return "Owner and repository names must contain only alphanumeric characters, hyphens, and underscores"
+            case .networkError:
+                return "Check your internet connection and try again"
+            case .fileSystemError:
+                return "Check disk space and file permissions"
+            }
         }
     }
 }

--- a/Packages/Sources/Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift
+++ b/Packages/Sources/Core/WKWebCrawler/Engines/WKWebCrawlerEngine.swift
@@ -121,16 +121,18 @@ extension WKWebCrawler {
 
 // MARK: - WebKit Crawler Errors
 
-public enum WebKitCrawlerError: Error, LocalizedError {
-    case transformFailed
-    case unsupportedPlatform
+extension WKWebCrawler {
+    public enum WebKitCrawlerError: Error, LocalizedError {
+        case transformFailed
+        case unsupportedPlatform
 
-    public var errorDescription: String? {
-        switch self {
-        case .transformFailed:
-            return "Failed to transform HTML content to Markdown"
-        case .unsupportedPlatform:
-            return "WKWebView-based crawling is not available on this platform"
+        public var errorDescription: String? {
+            switch self {
+            case .transformFailed:
+                return "Failed to transform HTML content to Markdown"
+            case .unsupportedPlatform:
+                return "WKWebView-based crawling is not available on this platform"
+            }
         }
     }
 }

--- a/Packages/Sources/Core/WKWebCrawler/Fetchers/WKWebContentFetcher.swift
+++ b/Packages/Sources/Core/WKWebCrawler/Fetchers/WKWebContentFetcher.swift
@@ -145,19 +145,21 @@ extension WKWebCrawler.ContentFetcher: WKNavigationDelegate {
 
 // MARK: - WebKit Fetcher Errors
 
-public enum WebKitFetcherError: Error, LocalizedError {
-    case timeout
-    case invalidHTML
-    case unsupportedPlatform
+extension WKWebCrawler {
+    public enum WebKitFetcherError: Error, LocalizedError {
+        case timeout
+        case invalidHTML
+        case unsupportedPlatform
 
-    public var errorDescription: String? {
-        switch self {
-        case .timeout:
-            return "Page load timeout"
-        case .invalidHTML:
-            return "Invalid HTML received from JavaScript evaluation"
-        case .unsupportedPlatform:
-            return "WKWebView is not available on this platform"
+        public var errorDescription: String? {
+            switch self {
+            case .timeout:
+                return "Page load timeout"
+            case .invalidHTML:
+                return "Invalid HTML received from JavaScript evaluation"
+            case .unsupportedPlatform:
+                return "WKWebView is not available on this platform"
+            }
         }
     }
 }

--- a/Packages/Tests/CoreTests/PackageDocumentationDownloaderTests.swift
+++ b/Packages/Tests/CoreTests/PackageDocumentationDownloaderTests.swift
@@ -69,7 +69,7 @@ struct PackageDocumentationDownloaderTests {
                 outputDirectory: tempDir
             )
 
-            await #expect(throws: PackageDownloadError.self) {
+            await #expect(throws: Core.PackageDownloadError.self) {
                 try await downloader.downloadREADME(
                     owner: "invalid-owner-\(UUID().uuidString)",
                     repo: "nonexistent-repo-\(UUID().uuidString)"
@@ -188,7 +188,7 @@ struct PackageDocumentationDownloaderTests {
                 outputDirectory: tempDir
             )
 
-            await #expect(throws: PackageDownloadError.self) {
+            await #expect(throws: Core.PackageDownloadError.self) {
                 try await downloader.downloadREADME(
                     owner: "../../../etc",
                     repo: "passwd"


### PR DESCRIPTION
Three small type-level cleanups for file-scope error enums left behind by earlier extraction PRs.

## Renames

| Before | After |
|---|---|
| `WebKitFetcherError`       | `WKWebCrawler.WebKitFetcherError` |
| `WebKitCrawlerError`       | `WKWebCrawler.WebKitCrawlerError` |
| `PackageDownloadError`     | `Core.PackageDownloadError` |

## Audit notes (follow-up items captured, not fixed here)

The audit while doing these renames surfaced two existing filename/namespace mismatches from earlier PRs:

- **WKWebCrawler is still a top-level enum**, not `Core.WKWebCrawler`. File-rename PRs (#366 in particular) named the files `Core.WKWebCrawler+*.swift` but the actual type namespace inside is just `extension WKWebCrawler { ... }`. Follow-up PR to either (a) re-anchor `WKWebCrawler` under `Core` or (b) rename filenames back to `WKWebCrawler+*.swift`.
- **`Core.PackageIndexing` sub-namespace doesn't exist** either — files in `Core/PackageIndexing/` use `extension Core { ... }`. The file-rename PR (#371) named them `Core.PackageIndexing+*.swift` anticipating a future sub-namespace. `PackageDownloadError` lands at `Core.*` for now to match the rest of PackageIndexing; a follow-up adds the `Core.PackageIndexing` sub-namespace + migrates all PackageIndexing types.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183.