### PR TITLE
refactor(Services.Formatters): open sub-namespace, nest ResultFormatter + SearchResultFormatConfig, rename file

### DIFF
--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -456,9 +456,9 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         )
 
         // Configure empty message to suggest archive if not already searching it
-        var config = SearchResultFormatConfig.mcpDefault
+        var config = Services.Formatters.SearchResultFormatConfig.mcpDefault
         if results.isEmpty, !includeArchive, source != Shared.Constants.SourcePrefix.appleArchive {
-            config = SearchResultFormatConfig(
+            config = Services.Formatters.SearchResultFormatConfig(
                 showScore: true,
                 showWordCount: true,
                 showSource: false,

--- a/Packages/Sources/Services/Formatters/HIGFormatters.swift
+++ b/Packages/Sources/Services/Formatters/HIGFormatters.swift
@@ -6,7 +6,7 @@ import SharedCore
 // MARK: - HIG Text Formatter
 
 /// Formats HIG search results as plain text for CLI output
-public struct HIGTextFormatter: ResultFormatter {
+public struct HIGTextFormatter: Services.Formatters.ResultFormatter {
     private let query: HIGQuery
     private let teasers: TeaserResults?
 
@@ -64,7 +64,7 @@ public struct HIGTextFormatter: ResultFormatter {
 // MARK: - HIG JSON Formatter
 
 /// Formats HIG search results as JSON for programmatic access
-public struct HIGJSONFormatter: ResultFormatter {
+public struct HIGJSONFormatter: Services.Formatters.ResultFormatter {
     private let query: HIGQuery
 
     public init(query: HIGQuery) {

--- a/Packages/Sources/Services/Formatters/JSONFormatter.swift
+++ b/Packages/Sources/Services/Formatters/JSONFormatter.swift
@@ -5,7 +5,7 @@ import SharedCore
 // MARK: - JSON Search Result Formatter
 
 /// Formats search results as JSON for CLI --format json
-public struct JSONSearchResultFormatter: ResultFormatter {
+public struct JSONSearchResultFormatter: Services.Formatters.ResultFormatter {
     public init() {}
 
     public func format(_ results: [Search.Result]) -> String {
@@ -23,7 +23,7 @@ public struct JSONSearchResultFormatter: ResultFormatter {
 // MARK: - Frameworks JSON Formatter
 
 /// Formats framework list as JSON
-public struct FrameworksJSONFormatter: ResultFormatter {
+public struct FrameworksJSONFormatter: Services.Formatters.ResultFormatter {
     public init() {}
 
     public func format(_ frameworks: [String: Int]) -> String {

--- a/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
@@ -7,17 +7,17 @@ import SharedCore
 // MARK: - Markdown Search Result Formatter
 
 /// Formats search results as markdown for MCP tools and CLI --format markdown
-public struct MarkdownSearchResultFormatter: ResultFormatter {
+public struct MarkdownSearchResultFormatter: Services.Formatters.ResultFormatter {
     private let query: String
     private let filters: Services.SearchFilters?
-    private let config: SearchResultFormatConfig
+    private let config: Services.Formatters.SearchResultFormatConfig
     private let teasers: TeaserResults?
     private let showPlatformTip: Bool
 
     public init(
         query: String,
         filters: Services.SearchFilters? = nil,
-        config: SearchResultFormatConfig = .mcpDefault,
+        config: Services.Formatters.SearchResultFormatConfig = .mcpDefault,
         teasers: TeaserResults? = nil,
         showPlatformTip: Bool = true
     ) {
@@ -119,14 +119,14 @@ public struct MarkdownSearchResultFormatter: ResultFormatter {
 // MARK: - HIG Markdown Formatter
 
 /// Formats HIG search results as markdown
-public struct HIGMarkdownFormatter: ResultFormatter {
+public struct HIGMarkdownFormatter: Services.Formatters.ResultFormatter {
     private let query: HIGQuery
-    private let config: SearchResultFormatConfig
+    private let config: Services.Formatters.SearchResultFormatConfig
     private let teasers: TeaserResults?
 
     public init(
         query: HIGQuery,
-        config: SearchResultFormatConfig = .mcpDefault,
+        config: Services.Formatters.SearchResultFormatConfig = .mcpDefault,
         teasers: TeaserResults? = nil
     ) {
         self.query = query
@@ -196,7 +196,7 @@ public struct HIGMarkdownFormatter: ResultFormatter {
 // MARK: - Frameworks Markdown Formatter
 
 /// Formats framework list as markdown
-public struct FrameworksMarkdownFormatter: ResultFormatter {
+public struct FrameworksMarkdownFormatter: Services.Formatters.ResultFormatter {
     private let totalDocs: Int
 
     public init(totalDocs: Int) {
@@ -378,15 +378,15 @@ public struct UnifiedSearchInput: Sendable {
 }
 
 /// Formats unified search results (ALL sources) as markdown
-public struct UnifiedSearchMarkdownFormatter: ResultFormatter {
+public struct UnifiedSearchMarkdownFormatter: Services.Formatters.ResultFormatter {
     private let query: String
     private let framework: String?
-    private let config: SearchResultFormatConfig
+    private let config: Services.Formatters.SearchResultFormatConfig
 
     public init(
         query: String,
         framework: String? = nil,
-        config: SearchResultFormatConfig = .mcpDefault
+        config: Services.Formatters.SearchResultFormatConfig = .mcpDefault
     ) {
         self.query = query
         self.framework = framework

--- a/Packages/Sources/Services/Formatters/Sample.Format.JSON+Search.swift
+++ b/Packages/Sources/Services/Formatters/Sample.Format.JSON+Search.swift
@@ -58,7 +58,7 @@ private struct FileSearchJSONOutput: Encodable {
 
 /// Formats sample search results as JSON
 extension Sample.Format.JSON {
-    public struct Search: ResultFormatter {
+    public struct Search: Services.Formatters.ResultFormatter {
         private let query: String
         private let framework: String?
 
@@ -91,7 +91,7 @@ extension Sample.Format.JSON {
 
 /// Formats sample project list as JSON
 extension Sample.Format.JSON {
-    public struct List: ResultFormatter {
+    public struct List: Services.Formatters.ResultFormatter {
         public init() {}
 
         public func format(_ projects: [Sample.Index.Project]) -> String {
@@ -105,7 +105,7 @@ extension Sample.Format.JSON {
 
 /// Formats a single sample project as JSON
 extension Sample.Format.JSON {
-    public struct Project: ResultFormatter {
+    public struct Project: Services.Formatters.ResultFormatter {
         public init() {}
 
         public func format(_ project: Sample.Index.Project) -> String {
@@ -118,7 +118,7 @@ extension Sample.Format.JSON {
 
 /// Formats a sample file as JSON
 extension Sample.Format.JSON {
-    public struct File: ResultFormatter {
+    public struct File: Services.Formatters.ResultFormatter {
         public init() {}
 
         public func format(_ file: Sample.Index.File) -> String {

--- a/Packages/Sources/Services/Formatters/Sample.Format.Markdown+Search.swift
+++ b/Packages/Sources/Services/Formatters/Sample.Format.Markdown+Search.swift
@@ -7,7 +7,7 @@ import SharedCore
 
 /// Formats sample search results as markdown
 extension Sample.Format.Markdown {
-    public struct Search: ResultFormatter {
+    public struct Search: Services.Formatters.ResultFormatter {
         private let query: String
         private let framework: String?
         private let teasers: TeaserResults?
@@ -74,7 +74,7 @@ extension Sample.Format.Markdown {
 
 /// Formats sample project list as markdown
 extension Sample.Format.Markdown {
-    public struct List: ResultFormatter {
+    public struct List: Services.Formatters.ResultFormatter {
         private let totalCount: Int
         private let framework: String?
 
@@ -120,7 +120,7 @@ extension Sample.Format.Markdown {
 
 /// Formats a single sample project as markdown
 extension Sample.Format.Markdown {
-    public struct Project: ResultFormatter {
+    public struct Project: Services.Formatters.ResultFormatter {
         public init() {}
 
         public func format(_ project: Sample.Index.Project) -> String {
@@ -146,7 +146,7 @@ extension Sample.Format.Markdown {
 
 /// Formats a sample file as markdown
 extension Sample.Format.Markdown {
-    public struct File: ResultFormatter {
+    public struct File: Services.Formatters.ResultFormatter {
         public init() {}
 
         public func format(_ file: Sample.Index.File) -> String {

--- a/Packages/Sources/Services/Formatters/Sample.Format.Text+Search.swift
+++ b/Packages/Sources/Services/Formatters/Sample.Format.Text+Search.swift
@@ -7,7 +7,7 @@ import SharedCore
 
 /// Formats sample search results as plain text for CLI output
 extension Sample.Format.Text {
-    public struct Search: ResultFormatter {
+    public struct Search: Services.Formatters.ResultFormatter {
         private let query: String
         private let framework: String?
         private let teasers: TeaserResults?
@@ -76,7 +76,7 @@ extension Sample.Format.Text {
 
 /// Formats sample project list as plain text for CLI output
 extension Sample.Format.Text {
-    public struct List: ResultFormatter {
+    public struct List: Services.Formatters.ResultFormatter {
         private let totalCount: Int
 
         public init(totalCount: Int) {
@@ -110,7 +110,7 @@ extension Sample.Format.Text {
 
 /// Formats a single sample project as plain text
 extension Sample.Format.Text {
-    public struct Project: ResultFormatter {
+    public struct Project: Services.Formatters.ResultFormatter {
         public init() {}
 
         public func format(_ project: Sample.Index.Project) -> String {

--- a/Packages/Sources/Services/Formatters/Services.Formatters+ResultFormatter.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatters+ResultFormatter.swift
@@ -4,54 +4,58 @@ import SharedCore
 
 // MARK: - Result Formatter Protocol
 
-/// Protocol for formatting search results to different output formats
-public protocol ResultFormatter {
-    associatedtype Input
-    func format(_ input: Input) -> String
+extension Services.Formatters {
+    /// Protocol for formatting search results to different output formats
+    public protocol ResultFormatter {
+        associatedtype Input
+        func format(_ input: Input) -> String
+    }
 }
 
 // MARK: - Search Result Format Configuration
 
-/// Configuration for search result formatting
-public struct SearchResultFormatConfig: Sendable {
-    public let showScore: Bool
-    public let showWordCount: Bool
-    public let showSource: Bool
-    public let showAvailability: Bool
-    public let showSeparators: Bool
-    public let emptyMessage: String
+extension Services.Formatters {
+    /// Configuration for search result formatting
+    public struct SearchResultFormatConfig: Sendable {
+        public let showScore: Bool
+        public let showWordCount: Bool
+        public let showSource: Bool
+        public let showAvailability: Bool
+        public let showSeparators: Bool
+        public let emptyMessage: String
 
-    public init(
-        showScore: Bool = false,
-        showWordCount: Bool = false,
-        showSource: Bool = true,
-        showAvailability: Bool = false,
-        showSeparators: Bool = false,
-        emptyMessage: String = "No results found"
-    ) {
-        self.showScore = showScore
-        self.showWordCount = showWordCount
-        self.showSource = showSource
-        self.showAvailability = showAvailability
-        self.showSeparators = showSeparators
-        self.emptyMessage = emptyMessage
+        public init(
+            showScore: Bool = false,
+            showWordCount: Bool = false,
+            showSource: Bool = true,
+            showAvailability: Bool = false,
+            showSeparators: Bool = false,
+            emptyMessage: String = "No results found"
+        ) {
+            self.showScore = showScore
+            self.showWordCount = showWordCount
+            self.showSource = showSource
+            self.showAvailability = showAvailability
+            self.showSeparators = showSeparators
+            self.emptyMessage = emptyMessage
+        }
+
+        /// Shared configuration for both CLI and MCP markdown output (identical results)
+        public static let shared = SearchResultFormatConfig(
+            showScore: true,
+            showWordCount: true,
+            showSource: false,
+            showAvailability: true,
+            showSeparators: true,
+            emptyMessage: "_No results found. Try broader search terms._"
+        )
+
+        /// Alias for CLI (uses shared config for identical output)
+        public static let cliDefault = shared
+
+        /// Alias for MCP (uses shared config for identical output)
+        public static let mcpDefault = shared
     }
-
-    /// Shared configuration for both CLI and MCP markdown output (identical results)
-    public static let shared = SearchResultFormatConfig(
-        showScore: true,
-        showWordCount: true,
-        showSource: false,
-        showAvailability: true,
-        showSeparators: true,
-        emptyMessage: "_No results found. Try broader search terms._"
-    )
-
-    /// Alias for CLI (uses shared config for identical output)
-    public static let cliDefault = shared
-
-    /// Alias for MCP (uses shared config for identical output)
-    public static let mcpDefault = shared
 }
 
 // MARK: - String Utilities

--- a/Packages/Sources/Services/Formatters/TextFormatter.swift
+++ b/Packages/Sources/Services/Formatters/TextFormatter.swift
@@ -6,16 +6,16 @@ import SharedCore
 // MARK: - Text Search Result Formatter
 
 /// Formats search results as plain text for CLI output
-public struct TextSearchResultFormatter: ResultFormatter {
+public struct TextSearchResultFormatter: Services.Formatters.ResultFormatter {
     private let query: String
     private let source: String?
-    private let config: SearchResultFormatConfig
+    private let config: Services.Formatters.SearchResultFormatConfig
     private let teasers: TeaserResults?
 
     public init(
         query: String,
         source: String? = nil,
-        config: SearchResultFormatConfig = .cliDefault,
+        config: Services.Formatters.SearchResultFormatConfig = .cliDefault,
         teasers: TeaserResults? = nil
     ) {
         self.query = query
@@ -84,7 +84,7 @@ public struct TextSearchResultFormatter: ResultFormatter {
 // MARK: - Frameworks Text Formatter
 
 /// Formats framework list as plain text for CLI output
-public struct FrameworksTextFormatter: ResultFormatter {
+public struct FrameworksTextFormatter: Services.Formatters.ResultFormatter {
     private let totalDocs: Int
 
     public init(totalDocs: Int) {

--- a/Packages/Sources/Services/Formatters/UnifiedSearchFormatters.swift
+++ b/Packages/Sources/Services/Formatters/UnifiedSearchFormatters.swift
@@ -7,12 +7,12 @@ import SharedCore
 // MARK: - Text Formatter for Unified Search
 
 /// Formats unified search results as plain text for CLI output
-public struct UnifiedSearchTextFormatter: ResultFormatter {
+public struct UnifiedSearchTextFormatter: Services.Formatters.ResultFormatter {
     private let query: String
     private let framework: String?
-    private let config: SearchResultFormatConfig
+    private let config: Services.Formatters.SearchResultFormatConfig
 
-    public init(query: String, framework: String?, config: SearchResultFormatConfig = .cliDefault) {
+    public init(query: String, framework: String?, config: Services.Formatters.SearchResultFormatConfig = .cliDefault) {
         self.query = query
         self.framework = framework
         self.config = config
@@ -112,7 +112,7 @@ public struct UnifiedSearchTextFormatter: ResultFormatter {
 // MARK: - JSON Formatter for Unified Search
 
 /// Formats unified search results as JSON for programmatic access
-public struct UnifiedSearchJSONFormatter: ResultFormatter {
+public struct UnifiedSearchJSONFormatter: Services.Formatters.ResultFormatter {
     private let query: String
     private let framework: String?
 

--- a/Packages/Sources/Services/README.md
+++ b/Packages/Sources/Services/README.md
@@ -2,36 +2,39 @@
 
 The Services module provides a unified service layer for search operations across documentation sources. It abstracts database access and result formatting, allowing both CLI commands and MCP tool providers to share the same business logic.
 
+All public types now live under the `Services` namespace (per the namespacing sweep tracked in #183). Sample-flavoured services live under the cross-cutting `Sample` namespace: the sample search service is `Sample.Search.Service`, the sample-flavoured formatters live under `Sample.Format.{Markdown,JSON,Text}.*`, and the sample-flavoured candidate fetcher is `Sample.Services.CandidateFetcher`.
+
 ## Architecture
 
 ```
-                     ┌─────────────────────┐
-                     │  ServiceContainer   │
-                     │  (Lifecycle Mgmt)   │
-                     └─────────┬───────────┘
-                               │
-       ┌───────────────────────┼───────────────────────┐
-       │                       │                       │
-       ▼                       ▼                       ▼
-┌──────────────┐      ┌──────────────┐      ┌──────────────┐
-│DocsSearchSvc │      │ HIGSearchSvc │      │SampleSearchSvc│
-│ (Search.Index)│      │  (delegates) │      │ (SampleIndex) │
-└──────────────┘      └──────────────┘      └──────────────┘
-       │                       │                       │
-       └───────────────────────┼───────────────────────┘
-                               │
-                               ▼
-                     ┌─────────────────────┐
-                     │     Formatters      │
-                     │ (Text/JSON/Markdown)│
-                     └─────────────────────┘
+                       ┌──────────────────────────────┐
+                       │  Services.ServiceContainer   │
+                       │      (Lifecycle Mgmt)        │
+                       └──────────────┬───────────────┘
+                                      │
+        ┌─────────────────────────────┼─────────────────────────────┐
+        │                             │                             │
+        ▼                             ▼                             ▼
+┌──────────────────┐         ┌──────────────────┐         ┌──────────────────────┐
+│ DocsSearchService│         │  HIGSearchService│         │ Sample.Search.Service│
+│   (Search.Index) │         │    (delegates)   │         │     (Sample.Index)   │
+└──────────────────┘         └──────────────────┘         └──────────────────────┘
+        │                             │                             │
+        └─────────────────────────────┼─────────────────────────────┘
+                                      │
+                                      ▼
+                       ┌──────────────────────────────┐
+                       │     Services.Formatters      │
+                       │ + Sample.Format.{Md,JSON,Txt}│
+                       │      (Text/JSON/Markdown)    │
+                       └──────────────────────────────┘
 ```
 
 ## Services
 
 ### DocsSearchService
 
-Wraps `Search.Index` for searching Apple documentation, Swift Evolution proposals, Swift.org docs, and more.
+Wraps `Search.Index` for searching Apple documentation, Swift Evolution proposals, Swift.org docs, and more. Currently still at file scope inside the `Services` SPM target; will move to `Services.DocsSearchService` once the `Services/ReadCommands/` type-wrap PR lands.
 
 ```swift
 let service = try await DocsSearchService(dbPath: dbPath)
@@ -40,7 +43,7 @@ let service = try await DocsSearchService(dbPath: dbPath)
 let results = try await service.search(text: "View")
 
 // Search with filters
-let results = try await service.search(SearchQuery(
+let results = try await service.search(Services.SearchQuery(
     text: "Button",
     source: "apple-docs",
     framework: "swiftui",
@@ -77,15 +80,15 @@ let results = try await service.search(HIGQuery(
 await service.disconnect()
 ```
 
-### SampleSearchService
+### Sample.Search.Service
 
-Wraps `SampleIndex.Database` for searching Apple sample code projects and files.
+Wraps `Sample.Index.Database` for searching Apple sample code projects and files. Lives under the cross-cutting `Sample` namespace alongside `Sample.Search.Query` and `Sample.Search.Result`.
 
 ```swift
-let service = try await SampleSearchService(dbPath: dbPath)
+let service = try await Sample.Search.Service(dbPath: dbPath)
 
 // Search projects and files
-let result = try await service.search(SampleQuery(
+let result = try await service.search(Sample.Search.Query(
     text: "SwiftUI",
     framework: "swiftui",
     searchFiles: true,
@@ -106,25 +109,25 @@ let file = try await service.getFile(projectId: projectId, path: "ContentView.sw
 await service.disconnect()
 ```
 
-## ServiceContainer
+## Services.ServiceContainer
 
 Manages service lifecycle with convenient factory methods.
 
 ```swift
-// Managed lifecycle - service automatically disconnected
-try await ServiceContainer.withDocsService { service in
+// Managed lifecycle — service automatically disconnected
+try await Services.ServiceContainer.withDocsService { service in
     let results = try await service.search(text: "Actor")
     return results
 }
 
 // HIG service with managed lifecycle
-try await ServiceContainer.withHIGService { service in
+try await Services.ServiceContainer.withHIGService { service in
     let results = try await service.search(text: "buttons")
     return results
 }
 
 // Sample service with managed lifecycle
-try await ServiceContainer.withSampleService(dbPath: sampleDbPath) { service in
+try await Services.ServiceContainer.withSampleService(dbPath: sampleDbPath) { service in
     let results = try await service.search(text: "SwiftUI")
     return results
 }
@@ -132,7 +135,7 @@ try await ServiceContainer.withSampleService(dbPath: sampleDbPath) { service in
 
 ## Query Types
 
-### SearchQuery
+### Services.SearchQuery
 
 General-purpose query for documentation searches.
 
@@ -147,7 +150,7 @@ General-purpose query for documentation searches.
 
 ### HIGQuery
 
-Specialized query for Human Interface Guidelines.
+Specialized query for Human Interface Guidelines (file-scope today; will move to `Services.HIGQuery` in the `Services/ReadCommands/` wrap PR).
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
@@ -156,7 +159,7 @@ Specialized query for Human Interface Guidelines.
 | `category` | `String?` | `nil` | foundations, patterns, components, etc. |
 | `limit` | `Int` | 20 | Max results |
 
-### SampleQuery
+### Sample.Search.Query
 
 Query for sample code searches.
 
@@ -169,34 +172,39 @@ Query for sample code searches.
 
 ## Formatters
 
-### MarkdownSearchResultFormatter
+`Services/Formatters/*` ships two formatter families:
+
+- The `Services.Formatters.*` family (general-purpose `MarkdownSearchResultFormatter`, `TextSearchResultFormatter`, `JSONSearchResultFormatter`, `Frameworks*Formatter`, HIG-specific, unified-search) — wrap pass in progress; type names still flat at file scope for now.
+- The `Sample.Format.{Markdown,JSON,Text}.*` family (`Search` / `List` / `Project` / `File` per medium), already nested under the cross-cutting `Sample` namespace (#362).
+
+### Services.Formatters.MarkdownSearchResultFormatter
 
 Formats search results as markdown for MCP tools.
 
 ```swift
-let formatter = MarkdownSearchResultFormatter(
+let formatter = Services.Formatters.MarkdownSearchResultFormatter(
     query: "View",
-    filters: SearchFilters(framework: "swiftui"),
+    filters: Services.SearchFilters(framework: "swiftui"),
     config: .mcpDefault
 )
 let markdown = formatter.format(results)
 ```
 
-### TextSearchResultFormatter
+### Services.Formatters.TextSearchResultFormatter
 
 Formats search results as plain text for CLI output.
 
 ```swift
-let formatter = TextSearchResultFormatter(query: "View")
+let formatter = Services.Formatters.TextSearchResultFormatter(query: "View")
 let text = formatter.format(results)
 ```
 
-### JSONSearchResultFormatter
+### Services.Formatters.JSONSearchResultFormatter
 
 Formats search results as JSON.
 
 ```swift
-let formatter = JSONSearchResultFormatter()
+let formatter = Services.Formatters.JSONSearchResultFormatter()
 let json = formatter.format(results)
 ```
 
@@ -204,13 +212,13 @@ let json = formatter.format(results)
 
 ```swift
 // CLI defaults: no score/word count, show source, no separators
-let cliConfig = SearchResultFormatConfig.cliDefault
+let cliConfig = Services.Formatters.SearchResultFormatConfig.cliDefault
 
 // MCP defaults: show score/word count, separators between results
-let mcpConfig = SearchResultFormatConfig.mcpDefault
+let mcpConfig = Services.Formatters.SearchResultFormatConfig.mcpDefault
 
 // Custom configuration
-let config = SearchResultFormatConfig(
+let config = Services.Formatters.SearchResultFormatConfig(
     showScore: true,
     showWordCount: false,
     showSource: true,
@@ -223,15 +231,15 @@ let config = SearchResultFormatConfig(
 
 ```
 Services
-├── Shared (ToolError, PathResolver, Constants)
-├── Search (Search.Index, Search.Result)
-└── SampleIndex (Database, Project, File)
+├── Shared           (Shared.Core.ToolError, Shared.Utils.PathResolver, Shared.Constants)
+├── Search           (Search.Index, Search.Result, Search.SmartQuery, Search.PackageQuery)
+└── SampleIndex      (Sample.Index.Database, Sample.Index.Project, Sample.Index.File)
 ```
 
 ## Design Principles
 
 1. **Single Responsibility**: Each service wraps one database type
-2. **Composition**: HIGSearchService delegates to DocsSearchService
-3. **Lifecycle Management**: ServiceContainer handles connections
-4. **Type Safety**: Specialized query types for each search domain
-5. **Flexibility**: Formatters separate output from business logic
+2. **Composition**: `HIGSearchService` delegates to `DocsSearchService`
+3. **Lifecycle Management**: `Services.ServiceContainer` handles connections
+4. **Type Safety**: Specialized query types for each search domain (`Services.SearchQuery`, `Services.HIGQuery`, `Sample.Search.Query`)
+5. **Flexibility**: Formatters separate output from business logic (`Services.Formatters.*` for general, `Sample.Format.*` for sample-specific)

--- a/Packages/Sources/Services/Services.swift
+++ b/Packages/Sources/Services/Services.swift
@@ -26,13 +26,27 @@
 
 // MARK: - Services Namespace
 
-/// Namespace for the service layer: a `ServiceContainer` that owns service
-/// lifecycle, the `SearchService` protocol + `SearchQuery` / `SearchFilters`
-/// inputs, and the concrete service actors that live in `Services/ReadCommands/`
-/// (`DocsSearchService`, `HIGSearchService`, `Sample.Search.Service`,
-/// `UnifiedSearchService`, `TeaserService`, `ReadService`).
+/// Namespace for the service layer.
 ///
-/// Result formatters in `Services/Formatters/` also extend this same root
-/// (`Services.MarkdownSearchResultFormatter`, `Services.JSONSearchResultFormatter`,
-/// `Services.TextSearchResultFormatter`, etc.).
-public enum Services {}
+/// Layout:
+/// - `Services.ServiceContainer`, `Services.SearchService` protocol,
+///   `Services.SearchQuery`, `Services.SearchFilters` — root-level lifecycle
+///   + protocol surface.
+/// - `Services.Formatters.*` — result-formatter family in
+///   `Sources/Services/Formatters/` (`ResultFormatter` protocol,
+///   `SearchResultFormatConfig`, `Markdown/JSON/Text` formatters,
+///   footer + HIG + unified-search variants).
+/// - Concrete service actors in `Services/ReadCommands/`
+///   (`DocsSearchService`, `HIGSearchService`, `UnifiedSearchService`,
+///   `TeaserService`, `ReadService`) still live at file scope and will
+///   move to `Services.*` once their wrap PRs land.
+///
+/// Sample-flavoured services live under the cross-cutting `Sample` root:
+/// `Sample.Search.Service`, `Sample.Format.{Markdown,JSON,Text}.*`,
+/// `Sample.Services.CandidateFetcher`.
+public enum Services {
+    /// Sub-namespace for result-formatter types. Mirrors
+    /// `Sources/Services/Formatters/`. Each concrete formatter conforms
+    /// to `Services.Formatters.ResultFormatter`.
+    public enum Formatters {}
+}

--- a/Packages/Tests/ServicesTests/ServicesTests.swift
+++ b/Packages/Tests/ServicesTests/ServicesTests.swift
@@ -118,8 +118,8 @@ struct ServicesTests {
 struct FormatConfigTests {
     @Test("CLI and MCP configs are identical")
     func configsAreIdentical() {
-        let cli = SearchResultFormatConfig.cliDefault
-        let mcp = SearchResultFormatConfig.mcpDefault
+        let cli = Services.Formatters.SearchResultFormatConfig.cliDefault
+        let mcp = Services.Formatters.SearchResultFormatConfig.mcpDefault
 
         // CLI and MCP must produce identical output
         #expect(cli.showScore == mcp.showScore)
@@ -132,7 +132,7 @@ struct FormatConfigTests {
 
     @Test("Shared config has expected values")
     func sharedConfigValues() {
-        let config = SearchResultFormatConfig.shared
+        let config = Services.Formatters.SearchResultFormatConfig.shared
 
         #expect(config.showScore == true)
         #expect(config.showWordCount == true)


### PR DESCRIPTION
First per-file PR in the Services/Formatters wrap series. Opens **`Services.Formatters`** as a sub-namespace of `Services` and moves the foundational `ResultFormatter` protocol + `SearchResultFormatConfig` struct under it. Every other formatter conforms to `ResultFormatter`, so landing this first means the rest of the formatters can wrap incrementally without re-touching call sites.

Also updates the Services README architecture diagram (it had stale `SampleSearchSvc` / `Search.Index` labels — now reads `Sample.Search.Service` + `Sample.Index` to match #361 and #369).

## Renames

| Before | After |
|---|---|
| `ResultFormatter` (protocol)         | `Services.Formatters.ResultFormatter` |
| `SearchResultFormatConfig` (struct)  | `Services.Formatters.SearchResultFormatConfig` |

## File rename

| Before | After |
|---|---|
| `Services/Formatters/ResultFormatter.swift` | `Services/Formatters/Services.Formatters+ResultFormatter.swift` *(carries protocol + config + the file-scope `public extension String` helper that stays unchanged — extends a system type)* |

## Mechanics

- `Services.swift` gains `public enum Formatters {}` inside `enum Services`.
- `ResultFormatter.swift` wraps both top-level types in `extension Services.Formatters { ... }`.
- The `public extension String` helper stays at file scope (not part of the namespace pass).
- 10 caller files swept across `Services/Formatters/` (every other formatter conforming via `:`), `SearchToolProvider/CompositeToolProvider.swift`, `ServicesTests`. Sweep is string- and comment-aware.

## Inside-Services-module resolution

Files inside the Services SPM target reference `Services.Formatters.X`. The module name `Services` and the namespace enum `Services` share a name; Swift's name lookup resolves `Services.X` to the enum first when both are in scope. Cross-cutting files (`Sample.Format.*` in this same SPM target) sit in `extension Sample.Format.<medium>` scopes that **are not** inside `extension Services`, so they write the qualified `Services.Formatters.ResultFormatter` explicitly — resolves via the enum.

## Verification

- `xcrun swift build` clean.
- `xcrun swift test`: **1300/1300 passing**.

Part of the namespacing sweep tracked in #183. Next per-file PRs in `Services/Formatters/`: `JSONFormatter`, `MarkdownFormatter`, `TextFormatter`, `HIGFormatters`, `FooterFormatter`, `TeaserResults`, `UnifiedSearchFormatters`.