### PR TITLE
refactor(Core): nest 4 crawler companion-type families; rename files to Core+<Crawler>.swift

### DIFF
--- a/Packages/Sources/CLI/Commands/Command+Fetch.swift
+++ b/Packages/Sources/CLI/Commands/Command+Fetch.swift
@@ -962,10 +962,10 @@ extension Command {
             Logging.ConsoleLogger.info("\n📁 Output: \(outputURL.path)/")
         }
 
-        private func loadArchiveGuides() async throws -> [ArchiveGuideInfo] {
+        private func loadArchiveGuides() async throws -> [Core.AppleArchiveCrawler.GuideInfo] {
             // If start URL is provided, use it (no framework info available)
             if let startURL, let url = URL(string: startURL) {
-                return [ArchiveGuideInfo(url: url, framework: "")]
+                return [Core.AppleArchiveCrawler.GuideInfo(url: url, framework: "")]
             }
 
             // Otherwise use the curated list of essential archive guides with framework info

--- a/Packages/Sources/Core/Core+AppleArchiveCrawler.swift
+++ b/Packages/Sources/Core/Core+AppleArchiveCrawler.swift
@@ -18,12 +18,12 @@ extension Core {
     @MainActor
     public final class AppleArchiveCrawler {
         private let outputDirectory: URL
-        private let guides: [ArchiveGuideInfo]
+        private let guides: [GuideInfo]
         private let forceRecrawl: Bool
 
         public init(
             outputDirectory: URL,
-            guides: [ArchiveGuideInfo],
+            guides: [GuideInfo],
             forceRecrawl: Bool = false
         ) {
             self.outputDirectory = outputDirectory
@@ -37,7 +37,7 @@ extension Core {
             guideURLs: [URL],
             forceRecrawl: Bool = false
         ) {
-            let guides = guideURLs.map { ArchiveGuideInfo(url: $0, framework: "") }
+            let guides = guideURLs.map { GuideInfo(url: $0, framework: "") }
             self.init(outputDirectory: outputDirectory, guides: guides, forceRecrawl: forceRecrawl)
         }
 
@@ -45,9 +45,9 @@ extension Core {
 
         /// Crawl all specified archive guides
         public func crawl(
-            onProgress: (@Sendable (ArchiveProgress) -> Void)? = nil
-        ) async throws -> ArchiveStatistics {
-            var stats = ArchiveStatistics(startTime: Date())
+            onProgress: (@Sendable (Progress) -> Void)? = nil
+        ) async throws -> Statistics {
+            var stats = Statistics(startTime: Date())
 
             logInfo("Starting Apple Archive crawler")
             logInfo("   Output: \(outputDirectory.path)")
@@ -93,7 +93,7 @@ extension Core {
 
                             // Progress callback
                             if let onProgress {
-                                let progress = ArchiveProgress(
+                                let progress = Progress(
                                     currentGuide: currentGuide,
                                     totalGuides: guides.count,
                                     currentPage: index + 1,
@@ -139,14 +139,14 @@ extension Core {
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200
             else {
-                throw ArchiveCrawlerError.invalidResponse(bookURL)
+                throw Error.invalidResponse(bookURL)
             }
 
             return try JSONDecoder().decode(BookJSON.self, from: data)
         }
 
-        private func extractPages(from book: BookJSON, baseURL: URL) -> [ArchivePage] {
-            var pages: [ArchivePage] = []
+        private func extractPages(from book: BookJSON, baseURL: URL) -> [Page] {
+            var pages: [Page] = []
             var seenHrefs: Set<String> = []
 
             func extractFromSections(_ sections: [BookSection], parentPath: String = "") {
@@ -167,7 +167,7 @@ extension Core {
 
                         seenHrefs.insert(cleanHref)
                         let pageURL = baseURL.appendingPathComponent(cleanHref)
-                        let page = ArchivePage(
+                        let page = Page(
                             title: section.title,
                             href: cleanHref,
                             url: pageURL,
@@ -189,10 +189,10 @@ extension Core {
         }
 
         private func crawlPage(
-            _ page: ArchivePage,
+            _ page: Page,
             to guideDir: URL,
             framework: String,
-            stats: inout ArchiveStatistics
+            stats: inout Statistics
         ) async throws {
             // Determine output path - preserve directory structure
             let relativePath = page.href.replacingOccurrences(of: ".html", with: ".md")
@@ -215,11 +215,11 @@ extension Core {
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200
             else {
-                throw ArchiveCrawlerError.invalidResponse(page.url)
+                throw Error.invalidResponse(page.url)
             }
 
             guard let html = String(data: data, encoding: .utf8) else {
-                throw ArchiveCrawlerError.invalidEncoding
+                throw Error.invalidEncoding
             }
 
             // Parse HTML to extract metadata and content
@@ -240,7 +240,7 @@ extension Core {
             stats.totalPages += 1
         }
 
-        private func parseArchiveHTML(_ html: String, page: ArchivePage) -> ParsedArchivePage {
+        private func parseArchiveHTML(_ html: String, page: Page) -> ParsedPage {
             // Extract metadata from meta tags
             let bookTitle = extractMetaContent(from: html, name: "book-title") ?? "Unknown"
             let chapterId = extractMetaContent(from: html, name: "chapterId")
@@ -252,7 +252,7 @@ extension Core {
             // Extract article content
             let content = extractArticleContent(from: html)
 
-            return ParsedArchivePage(
+            return ParsedPage(
                 title: page.title,
                 bookTitle: bookTitle,
                 chapterId: chapterId,
@@ -314,7 +314,7 @@ extension Core {
             return String(html[articleStart.upperBound..<articleEnd.lowerBound])
         }
 
-        private func convertToMarkdown(_ parsed: ParsedArchivePage, framework: String) -> String {
+        private func convertToMarkdown(_ parsed: ParsedPage, framework: String) -> String {
             var lines: [String] = []
 
             // YAML front matter
@@ -549,7 +549,7 @@ extension Core {
             Logging.Log.error("Error: \(message)", category: .archive)
         }
 
-        private func logStatistics(_ stats: ArchiveStatistics) {
+        private func logStatistics(_ stats: Statistics) {
             let messages = [
                 "Statistics:",
                 "   Total guides: \(stats.totalGuides)",
@@ -572,168 +572,176 @@ extension Core {
 
 // MARK: - Models
 
-/// Guide info containing URL and framework name for archive crawling
-public struct ArchiveGuideInfo: Sendable {
-    public let url: URL
-    public let framework: String
+extension Core.AppleArchiveCrawler {
+    /// Guide info containing URL and framework name for archive crawling
+    public struct GuideInfo: Sendable {
+        public let url: URL
+        public let framework: String
 
-    public init(url: URL, framework: String) {
-        self.url = url
-        self.framework = framework
+        public init(url: URL, framework: String) {
+            self.url = url
+            self.framework = framework
+        }
     }
-}
 
-/// Represents the book.json structure from Apple Archive
-public struct BookJSON: Codable, Sendable {
-    public let type: String?
-    public let title: String
-    public let technology: String?
-    public let version: String?
-    public let sections: [BookSection]
-    public let uid: String
+    /// Represents the book.json structure from Apple Archive
+    public struct BookJSON: Codable, Sendable {
+        public let type: String?
+        public let title: String
+        public let technology: String?
+        public let version: String?
+        public let sections: [BookSection]
+        public let uid: String
 
-    public init(
-        type: String? = nil,
-        title: String,
-        technology: String? = nil,
-        version: String? = nil,
-        sections: [BookSection],
-        uid: String
-    ) {
-        self.type = type
-        self.title = title
-        self.technology = technology
-        self.version = version
-        self.sections = sections
-        self.uid = uid
+        public init(
+            type: String? = nil,
+            title: String,
+            technology: String? = nil,
+            version: String? = nil,
+            sections: [BookSection],
+            uid: String
+        ) {
+            self.type = type
+            self.title = title
+            self.technology = technology
+            self.version = version
+            self.sections = sections
+            self.uid = uid
+        }
     }
-}
 
-/// Section within book.json
-public struct BookSection: Codable, Sendable {
-    public let title: String
-    public let href: String?
-    public let aref: String?
-    public let type: String?
-    public let isPart: Bool?
-    public let sections: [BookSection]?
+    /// Section within book.json
+    public struct BookSection: Codable, Sendable {
+        public let title: String
+        public let href: String?
+        public let aref: String?
+        public let type: String?
+        public let isPart: Bool?
+        public let sections: [BookSection]?
 
-    public init(
-        title: String,
-        href: String? = nil,
-        aref: String? = nil,
-        type: String? = nil,
-        isPart: Bool? = nil,
-        sections: [BookSection]? = nil
-    ) {
-        self.title = title
-        self.href = href
-        self.aref = aref
-        self.type = type
-        self.isPart = isPart
-        self.sections = sections
+        public init(
+            title: String,
+            href: String? = nil,
+            aref: String? = nil,
+            type: String? = nil,
+            isPart: Bool? = nil,
+            sections: [BookSection]? = nil
+        ) {
+            self.title = title
+            self.href = href
+            self.aref = aref
+            self.type = type
+            self.isPart = isPart
+            self.sections = sections
+        }
     }
-}
 
-/// Represents a page to crawl
-struct ArchivePage {
-    let title: String
-    let href: String
-    let url: URL
-    let type: String
-    let aref: String?
-}
+    /// Represents a page to crawl
+    struct Page {
+        let title: String
+        let href: String
+        let url: URL
+        let type: String
+        let aref: String?
+    }
 
-/// Parsed content from an archive HTML page
-struct ParsedArchivePage {
-    let title: String
-    let bookTitle: String
-    let chapterId: String?
-    let date: String?
-    let description: String?
-    let identifier: String?
-    let platforms: String?
-    let content: String
-    let href: String
+    /// Parsed content from an archive HTML page
+    struct ParsedPage {
+        let title: String
+        let bookTitle: String
+        let chapterId: String?
+        let date: String?
+        let description: String?
+        let identifier: String?
+        let platforms: String?
+        let content: String
+        let href: String
+    }
 }
 
 // MARK: - Statistics
 
-public struct ArchiveStatistics: Sendable {
-    public var totalGuides: Int = 0
-    public var totalPages: Int = 0
-    public var newPages: Int = 0
-    public var updatedPages: Int = 0
-    public var skippedPages: Int = 0
-    public var errors: Int = 0
-    public var startTime: Date?
-    public var endTime: Date?
+extension Core.AppleArchiveCrawler {
+    public struct Statistics: Sendable {
+        public var totalGuides: Int = 0
+        public var totalPages: Int = 0
+        public var newPages: Int = 0
+        public var updatedPages: Int = 0
+        public var skippedPages: Int = 0
+        public var errors: Int = 0
+        public var startTime: Date?
+        public var endTime: Date?
 
-    public init(
-        totalGuides: Int = 0,
-        totalPages: Int = 0,
-        newPages: Int = 0,
-        updatedPages: Int = 0,
-        skippedPages: Int = 0,
-        errors: Int = 0,
-        startTime: Date? = nil,
-        endTime: Date? = nil
-    ) {
-        self.totalGuides = totalGuides
-        self.totalPages = totalPages
-        self.newPages = newPages
-        self.updatedPages = updatedPages
-        self.skippedPages = skippedPages
-        self.errors = errors
-        self.startTime = startTime
-        self.endTime = endTime
-    }
-
-    public var duration: TimeInterval? {
-        guard let start = startTime, let end = endTime else {
-            return nil
+        public init(
+            totalGuides: Int = 0,
+            totalPages: Int = 0,
+            newPages: Int = 0,
+            updatedPages: Int = 0,
+            skippedPages: Int = 0,
+            errors: Int = 0,
+            startTime: Date? = nil,
+            endTime: Date? = nil
+        ) {
+            self.totalGuides = totalGuides
+            self.totalPages = totalPages
+            self.newPages = newPages
+            self.updatedPages = updatedPages
+            self.skippedPages = skippedPages
+            self.errors = errors
+            self.startTime = startTime
+            self.endTime = endTime
         }
-        return end.timeIntervalSince(start)
+
+        public var duration: TimeInterval? {
+            guard let start = startTime, let end = endTime else {
+                return nil
+            }
+            return end.timeIntervalSince(start)
+        }
     }
 }
 
 // MARK: - Progress
 
-public struct ArchiveProgress: Sendable {
-    public let currentGuide: Int
-    public let totalGuides: Int
-    public let currentPage: Int
-    public let totalPages: Int
-    public let guideName: String
-    public let pageName: String
-    public let stats: ArchiveStatistics
+extension Core.AppleArchiveCrawler {
+    public struct Progress: Sendable {
+        public let currentGuide: Int
+        public let totalGuides: Int
+        public let currentPage: Int
+        public let totalPages: Int
+        public let guideName: String
+        public let pageName: String
+        public let stats: Statistics
 
-    public var percentage: Double {
-        let guideProgress = Double(currentGuide - 1) / Double(totalGuides)
-        let pageProgress = Double(currentPage) / Double(max(totalPages, 1)) / Double(totalGuides)
-        return (guideProgress + pageProgress) * 100
-    }
+        public var percentage: Double {
+            let guideProgress = Double(currentGuide - 1) / Double(totalGuides)
+            let pageProgress = Double(currentPage) / Double(max(totalPages, 1)) / Double(totalGuides)
+            return (guideProgress + pageProgress) * 100
+        }
 
-    public var currentItem: String {
-        "\(guideName) - \(pageName)"
+        public var currentItem: String {
+            "\(guideName) - \(pageName)"
+        }
     }
 }
 
 // MARK: - Errors
 
-public enum ArchiveCrawlerError: Error, LocalizedError {
-    case invalidResponse(URL)
-    case invalidEncoding
-    case bookJSONNotFound(URL)
+extension Core.AppleArchiveCrawler {
+    public enum Error: Swift.Error, LocalizedError, Sendable {
+        case invalidResponse(URL)
+        case invalidEncoding
+        case bookJSONNotFound(URL)
 
-    public var errorDescription: String? {
-        switch self {
-        case .invalidResponse(let url):
-            return "Invalid response from \(url)"
-        case .invalidEncoding:
-            return "Invalid text encoding"
-        case .bookJSONNotFound(let url):
-            return "book.json not found at \(url)"
+        public var errorDescription: String? {
+            switch self {
+            case .invalidResponse(let url):
+                return "Invalid response from \(url)"
+            case .invalidEncoding:
+                return "Invalid text encoding"
+            case .bookJSONNotFound(let url):
+                return "book.json not found at \(url)"
+            }
         }
     }
 }

--- a/Packages/Sources/Core/Core+ArchiveGuideCatalog.swift
+++ b/Packages/Sources/Core/Core+ArchiveGuideCatalog.swift
@@ -27,7 +27,7 @@ extension Core {
 
         /// Essential guides with full info (URL + framework)
         /// Always reads from user-writable location (creates from bundled if missing)
-        public static var essentialGuidesWithInfo: [ArchiveGuideInfo] {
+        public static var essentialGuidesWithInfo: [AppleArchiveCrawler.GuideInfo] {
             // Ensure user selections file exists (creates from bundled if missing)
             ensureUserSelectionsFileExists()
 
@@ -35,14 +35,14 @@ extension Core {
             if let selectedGuides = loadUserSelectedGuides(), !selectedGuides.isEmpty {
                 return selectedGuides.compactMap { guide in
                     guard let url = URL(string: "\(baseURL)/\(guide.path)") else { return nil }
-                    return ArchiveGuideInfo(url: url, framework: guide.framework)
+                    return AppleArchiveCrawler.GuideInfo(url: url, framework: guide.framework)
                 }
             }
 
             // Fall back to hardcoded list if everything else fails (no framework info)
             return essentialGuidePaths.compactMap { path in
                 guard let url = URL(string: "\(baseURL)/\(path)") else { return nil }
-                return ArchiveGuideInfo(url: url, framework: "")
+                return AppleArchiveCrawler.GuideInfo(url: url, framework: "")
             }
         }
 

--- a/Packages/Sources/Core/Core+Crawler.swift
+++ b/Packages/Sources/Core/Core+Crawler.swift
@@ -39,7 +39,7 @@ extension Core {
         private var enqueued = Set<String>()
         private var stats: Shared.Models.CrawlStatistics
 
-        private var onProgress: (@Sendable (CrawlProgress) -> Void)?
+        private var onProgress: (@Sendable (Progress) -> Void)?
         private var logFileHandle: FileHandle?
 
         public init(configuration: Shared.Configuration) async {
@@ -64,7 +64,7 @@ extension Core {
         // MARK: - Public API
 
         /// Start crawling from the configured start URL
-        public func crawl(onProgress: (@Sendable (CrawlProgress) -> Void)? = nil) async throws -> Shared.Models.CrawlStatistics {
+        public func crawl(onProgress: (@Sendable (Progress) -> Void)? = nil) async throws -> Shared.Models.CrawlStatistics {
             self.onProgress = onProgress
 
             // Check for resumable session (must match current start URL)
@@ -219,7 +219,7 @@ extension Core {
         /// Crawl a page with retry mechanism for difficult pages (#25)
         /// On failure, recycles WKWebView and retries up to maxRetries times
         private func crawlPageWithRetry(url: URL, depth: Int, maxRetries: Int) async throws {
-            var lastError: Error?
+            var lastError: Swift.Error?
 
             for attempt in 0...maxRetries {
                 if attempt > 0 {
@@ -247,7 +247,7 @@ extension Core {
             }
 
             // All retries exhausted
-            throw lastError ?? CrawlerError.invalidState
+            throw lastError ?? Error.invalidState
         }
 
         private func crawlPage(url: URL, depth: Int) async throws {
@@ -443,7 +443,7 @@ extension Core {
 
             // Notify progress
             if let onProgress {
-                let progress = await CrawlProgress(
+                let progress = await Progress(
                     currentURL: url,
                     visitedCount: visited.count,
                     totalPages: configuration.maxPages,
@@ -462,7 +462,7 @@ extension Core {
             canonicalURL: URL
         ) {
             guard let jsonURL = AppleJSONToMarkdown.jsonAPIURL(from: url) else {
-                throw CrawlerError.invalidState
+                throw Error.invalidState
             }
 
             logInfo("   📡 Using JSON API: \(jsonURL.lastPathComponent)")
@@ -472,7 +472,7 @@ extension Core {
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200
             else {
-                throw CrawlerError.invalidHTML
+                throw Error.invalidHTML
             }
 
             // Derive the canonical documentation URL from the post-redirect JSON API response URL.
@@ -494,7 +494,7 @@ extension Core {
             return try autoreleasepool {
                 let structuredPage = AppleJSONToMarkdown.toStructuredPage(data, url: canonicalURL, depth: depth)
                 guard let markdown = AppleJSONToMarkdown.convert(data, url: canonicalURL) else {
-                    throw CrawlerError.invalidHTML
+                    throw Error.invalidHTML
                 }
                 let links = AppleJSONToMarkdown.extractLinks(from: data)
                 return (structuredPage, markdown, links, canonicalURL)
@@ -667,36 +667,40 @@ extension Core {
 
 // MARK: - Crawler Progress
 
-/// Progress information during crawling
-public struct CrawlProgress: Sendable {
-    public let currentURL: URL
-    public let visitedCount: Int
-    public let totalPages: Int
-    public let stats: Shared.Models.CrawlStatistics
+extension Core.Crawler {
+    /// Progress information during crawling
+    public struct Progress: Sendable {
+        public let currentURL: URL
+        public let visitedCount: Int
+        public let totalPages: Int
+        public let stats: Shared.Models.CrawlStatistics
 
-    public var percentage: Double {
-        Double(visitedCount) / Double(totalPages) * 100
+        public var percentage: Double {
+            Double(visitedCount) / Double(totalPages) * 100
+        }
     }
 }
 
 // MARK: - Crawler Errors
 
-public enum CrawlerError: Error, LocalizedError {
-    case timeout
-    case invalidState
-    case invalidHTML
-    case unsupportedPlatform
+extension Core.Crawler {
+    public enum Error: Swift.Error, LocalizedError, Sendable {
+        case timeout
+        case invalidState
+        case invalidHTML
+        case unsupportedPlatform
 
-    public var errorDescription: String? {
-        switch self {
-        case .timeout:
-            return "Page load timeout"
-        case .invalidState:
-            return "Invalid crawler state"
-        case .invalidHTML:
-            return "Invalid HTML received"
-        case .unsupportedPlatform:
-            return "WKWebView is not available on this platform"
+        public var errorDescription: String? {
+            switch self {
+            case .timeout:
+                return "Page load timeout"
+            case .invalidState:
+                return "Invalid crawler state"
+            case .invalidHTML:
+                return "Invalid HTML received"
+            case .unsupportedPlatform:
+                return "WKWebView is not available on this platform"
+            }
         }
     }
 }

--- a/Packages/Sources/Core/Core+EvolutionCrawler.swift
+++ b/Packages/Sources/Core/Core+EvolutionCrawler.swift
@@ -29,9 +29,9 @@ extension Core {
         /// Crawl Swift Evolution proposals
         public func crawl(
             limit: Int? = nil, // Internal use only - for testing
-            onProgress: (@Sendable (EvolutionProgress) -> Void)? = nil
-        ) async throws -> EvolutionStatistics {
-            var stats = EvolutionStatistics(startTime: Date())
+            onProgress: (@Sendable (Progress) -> Void)? = nil
+        ) async throws -> Statistics {
+            var stats = Statistics(startTime: Date())
 
             logInfo("🚀 Starting Swift Evolution crawler")
             logInfo("   Repository: \(repo)")
@@ -69,7 +69,7 @@ extension Core {
 
                     // Progress callback
                     if let onProgress {
-                        let progress = EvolutionProgress(
+                        let progress = Progress(
                             current: index + 1,
                             total: proposals.count,
                             proposalID: proposal.id,
@@ -127,7 +127,7 @@ extension Core {
             let (data, response) = try await URLSession.shared.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                throw EvolutionCrawlerError.invalidResponse
+                throw Error.invalidResponse
             }
 
             if httpResponse.statusCode != 200 {
@@ -136,7 +136,7 @@ extension Core {
                     logInfo("   Testing proposals directory (\(path)) not found, skipping")
                     return []
                 }
-                throw EvolutionCrawlerError.invalidResponse
+                throw Error.invalidResponse
             }
 
             let files = try JSONDecoder().decode([GitHubFile].self, from: data)
@@ -149,17 +149,17 @@ extension Core {
             }
         }
 
-        private func downloadProposal(_ proposal: ProposalMetadata, stats: inout EvolutionStatistics) async throws {
+        private func downloadProposal(_ proposal: ProposalMetadata, stats: inout Statistics) async throws {
             logInfo("📄 [\(stats.totalProposals + 1)] \(proposal.id)")
 
             // Download markdown content
             guard let url = URL(string: proposal.downloadURL) else {
-                throw EvolutionCrawlerError.invalidURL(proposal.downloadURL)
+                throw Error.invalidURL(proposal.downloadURL)
             }
 
             let (data, _) = try await URLSession.shared.data(from: url)
             guard let markdown = String(data: data, encoding: .utf8) else {
-                throw EvolutionCrawlerError.invalidEncoding
+                throw Error.invalidEncoding
             }
 
             // Check status if filtering for accepted only
@@ -247,7 +247,7 @@ extension Core {
             Logging.Log.error(errorMessage, category: .evolution)
         }
 
-        private func logStatistics(_ stats: EvolutionStatistics) {
+        private func logStatistics(_ stats: Statistics) {
             let messages = [
                 "📊 Statistics:",
                 "   Total proposals: \(stats.totalProposals)",
@@ -268,69 +268,73 @@ extension Core {
 
 // MARK: - Models
 
-struct GitHubFile: Codable {
-    let name: String
-    let downloadURL: String? // Optional - directories have null download_url
+extension Core.EvolutionCrawler {
+    struct GitHubFile: Codable {
+        let name: String
+        let downloadURL: String? // Optional - directories have null download_url
 
-    enum CodingKeys: String, CodingKey {
-        case name
-        case downloadURL = "download_url"
-    }
-}
-
-struct ProposalMetadata {
-    let id: String
-    let filename: String
-    let downloadURL: String
-}
-
-public struct EvolutionStatistics: Sendable {
-    public var totalProposals: Int = 0
-    public var newProposals: Int = 0
-    public var updatedProposals: Int = 0
-    public var errors: Int = 0
-    public var startTime: Date?
-    public var endTime: Date?
-
-    public init(
-        totalProposals: Int = 0,
-        newProposals: Int = 0,
-        updatedProposals: Int = 0,
-        errors: Int = 0,
-        startTime: Date? = nil,
-        endTime: Date? = nil
-    ) {
-        self.totalProposals = totalProposals
-        self.newProposals = newProposals
-        self.updatedProposals = updatedProposals
-        self.errors = errors
-        self.startTime = startTime
-        self.endTime = endTime
-    }
-
-    public var duration: TimeInterval? {
-        guard let start = startTime, let end = endTime else {
-            return nil
+        enum CodingKeys: String, CodingKey {
+            case name
+            case downloadURL = "download_url"
         }
-        return end.timeIntervalSince(start)
     }
-}
 
-public struct EvolutionProgress: Sendable {
-    public let current: Int
-    public let total: Int
-    public let proposalID: String
-    public let stats: EvolutionStatistics
+    struct ProposalMetadata {
+        let id: String
+        let filename: String
+        let downloadURL: String
+    }
 
-    public var percentage: Double {
-        Double(current) / Double(total) * 100
+    public struct Statistics: Sendable {
+        public var totalProposals: Int = 0
+        public var newProposals: Int = 0
+        public var updatedProposals: Int = 0
+        public var errors: Int = 0
+        public var startTime: Date?
+        public var endTime: Date?
+
+        public init(
+            totalProposals: Int = 0,
+            newProposals: Int = 0,
+            updatedProposals: Int = 0,
+            errors: Int = 0,
+            startTime: Date? = nil,
+            endTime: Date? = nil
+        ) {
+            self.totalProposals = totalProposals
+            self.newProposals = newProposals
+            self.updatedProposals = updatedProposals
+            self.errors = errors
+            self.startTime = startTime
+            self.endTime = endTime
+        }
+
+        public var duration: TimeInterval? {
+            guard let start = startTime, let end = endTime else {
+                return nil
+            }
+            return end.timeIntervalSince(start)
+        }
+    }
+
+    public struct Progress: Sendable {
+        public let current: Int
+        public let total: Int
+        public let proposalID: String
+        public let stats: Statistics
+
+        public var percentage: Double {
+            Double(current) / Double(total) * 100
+        }
     }
 }
 
 // MARK: - Errors
 
-enum EvolutionCrawlerError: Error {
-    case invalidResponse
-    case invalidURL(String)
-    case invalidEncoding
+extension Core.EvolutionCrawler {
+    enum Error: Swift.Error {
+        case invalidResponse
+        case invalidURL(String)
+        case invalidEncoding
+    }
 }

--- a/Packages/Sources/Core/Core+HIGCrawler.swift
+++ b/Packages/Sources/Core/Core+HIGCrawler.swift
@@ -43,9 +43,9 @@ extension Core {
 
         /// Crawl Human Interface Guidelines
         public func crawl(
-            onProgress: (@Sendable (HIGProgress) -> Void)? = nil
-        ) async throws -> HIGStatistics {
-            var stats = HIGStatistics(startTime: Date())
+            onProgress: (@Sendable (Progress) -> Void)? = nil
+        ) async throws -> Statistics {
+            var stats = Statistics(startTime: Date())
 
             logInfo("Starting Human Interface Guidelines crawler")
             logInfo("   Output: \(outputDirectory.path)")
@@ -79,7 +79,7 @@ extension Core {
 
                     // Progress callback
                     if let onProgress {
-                        let progress = HIGProgress(
+                        let progress = Progress(
                             currentPage: index + 1,
                             totalPages: min(pages.count, maxPages),
                             currentItem: page.title,
@@ -109,7 +109,7 @@ extension Core {
             fetcher = nil
             #else
             logError("WebKit not available - HIG crawler requires macOS")
-            throw HIGCrawlerError.webKitNotAvailable
+            throw Error.webKitNotAvailable
             #endif
 
             stats.endTime = Date()
@@ -125,9 +125,9 @@ extension Core {
         #if canImport(WebKit)
         private func discoverPages(
             from rootURL: URL,
-            stats: inout HIGStatistics
-        ) async throws -> [HIGPage] {
-            var pages: [HIGPage] = []
+            stats: inout Statistics
+        ) async throws -> [Page] {
+            var pages: [Page] = []
             var visited: Set<String> = []
             var queue: [URL] = [rootURL]
 
@@ -161,7 +161,7 @@ extension Core {
                 // Determine platforms from content
                 let platforms = extractPlatforms(from: html)
 
-                let page = HIGPage(
+                let page = Page(
                     url: url,
                     title: title,
                     category: category,
@@ -181,13 +181,13 @@ extension Core {
 
         private func loadPage(url: URL) async throws -> String {
             guard let fetcher else {
-                throw HIGCrawlerError.webViewNotInitialized
+                throw Error.webViewNotInitialized
             }
 
             return try await fetcher.fetch(url: url).content
         }
 
-        private func crawlPage(_ page: HIGPage, stats: inout HIGStatistics) async throws {
+        private func crawlPage(_ page: Page, stats: inout Statistics) async throws {
             // Determine output path
             let filename = sanitizeFilename(page.title) + ".md"
             let categoryDir = outputDirectory.appendingPathComponent(page.category.rawValue)
@@ -252,7 +252,7 @@ extension Core {
             return title.trimmingCharacters(in: .whitespacesAndNewlines)
         }
 
-        private func extractCategory(from url: URL) -> HIGCategory {
+        private func extractCategory(from url: URL) -> Category {
             let path = url.path.lowercased()
 
             if path.contains("/foundations") {
@@ -270,8 +270,8 @@ extension Core {
             }
         }
 
-        private func extractPlatforms(from html: String) -> [HIGPlatform] {
-            var platforms: [HIGPlatform] = []
+        private func extractPlatforms(from html: String) -> [Platform] {
+            var platforms: [Platform] = []
             let content = html.lowercased()
 
             if content.contains("ios") || content.contains("iphone") || content.contains("ipad") {
@@ -326,7 +326,7 @@ extension Core {
             return Array(Set(links))
         }
 
-        private func convertToMarkdown(_ html: String, page: HIGPage) -> String {
+        private func convertToMarkdown(_ html: String, page: Page) -> String {
             var lines: [String] = []
 
             // YAML front matter
@@ -531,7 +531,7 @@ extension Core {
             Logging.Log.error("Error: \(message)", category: .hig)
         }
 
-        private func logStatistics(_ stats: HIGStatistics) {
+        private func logStatistics(_ stats: Statistics) {
             let messages = [
                 "Statistics:",
                 "   Total pages: \(stats.totalPages)",
@@ -555,129 +555,137 @@ extension Core {
 
 // MARK: - Models
 
-/// Represents an HIG page to crawl
-public struct HIGPage: Sendable {
-    public let url: URL
-    public let title: String
-    public let category: HIGCategory
-    public let platforms: [HIGPlatform]
+extension Core.HIGCrawler {
+    /// Represents an HIG page to crawl
+    public struct Page: Sendable {
+        public let url: URL
+        public let title: String
+        public let category: Category
+        public let platforms: [Platform]
 
-    public init(url: URL, title: String, category: HIGCategory, platforms: [HIGPlatform]) {
-        self.url = url
-        self.title = title
-        self.category = category
-        self.platforms = platforms
-    }
-}
-
-/// HIG content categories
-public enum HIGCategory: String, Sendable, CaseIterable {
-    case foundations
-    case patterns
-    case components
-    case technologies
-    case inputs
-    case general
-
-    public var displayName: String {
-        switch self {
-        case .foundations: return "Foundations"
-        case .patterns: return "Patterns"
-        case .components: return "Components"
-        case .technologies: return "Technologies"
-        case .inputs: return "Inputs"
-        case .general: return "General"
+        public init(url: URL, title: String, category: Category, platforms: [Platform]) {
+            self.url = url
+            self.title = title
+            self.category = category
+            self.platforms = platforms
         }
     }
-}
 
-/// HIG platforms
-public enum HIGPlatform: String, Sendable, CaseIterable {
-    case iOS
-    case macOS
-    case watchOS
-    case visionOS
-    case tvOS
-    case all
+    /// HIG content categories
+    public enum Category: String, Sendable, CaseIterable {
+        case foundations
+        case patterns
+        case components
+        case technologies
+        case inputs
+        case general
 
-    public var displayName: String {
-        switch self {
-        case .iOS: return "iOS"
-        case .macOS: return "macOS"
-        case .watchOS: return "watchOS"
-        case .visionOS: return "visionOS"
-        case .tvOS: return "tvOS"
-        case .all: return "All Platforms"
+        public var displayName: String {
+            switch self {
+            case .foundations: return "Foundations"
+            case .patterns: return "Patterns"
+            case .components: return "Components"
+            case .technologies: return "Technologies"
+            case .inputs: return "Inputs"
+            case .general: return "General"
+            }
+        }
+    }
+
+    /// HIG platforms
+    public enum Platform: String, Sendable, CaseIterable {
+        case iOS
+        case macOS
+        case watchOS
+        case visionOS
+        case tvOS
+        case all
+
+        public var displayName: String {
+            switch self {
+            case .iOS: return "iOS"
+            case .macOS: return "macOS"
+            case .watchOS: return "watchOS"
+            case .visionOS: return "visionOS"
+            case .tvOS: return "tvOS"
+            case .all: return "All Platforms"
+            }
         }
     }
 }
 
 // MARK: - Statistics
 
-public struct HIGStatistics: Sendable {
-    public var totalPages: Int = 0
-    public var newPages: Int = 0
-    public var updatedPages: Int = 0
-    public var skippedPages: Int = 0
-    public var errors: Int = 0
-    public var startTime: Date?
-    public var endTime: Date?
+extension Core.HIGCrawler {
+    public struct Statistics: Sendable {
+        public var totalPages: Int = 0
+        public var newPages: Int = 0
+        public var updatedPages: Int = 0
+        public var skippedPages: Int = 0
+        public var errors: Int = 0
+        public var startTime: Date?
+        public var endTime: Date?
 
-    public init(
-        totalPages: Int = 0,
-        newPages: Int = 0,
-        updatedPages: Int = 0,
-        skippedPages: Int = 0,
-        errors: Int = 0,
-        startTime: Date? = nil,
-        endTime: Date? = nil
-    ) {
-        self.totalPages = totalPages
-        self.newPages = newPages
-        self.updatedPages = updatedPages
-        self.skippedPages = skippedPages
-        self.errors = errors
-        self.startTime = startTime
-        self.endTime = endTime
-    }
-
-    public var duration: TimeInterval? {
-        guard let start = startTime, let end = endTime else {
-            return nil
+        public init(
+            totalPages: Int = 0,
+            newPages: Int = 0,
+            updatedPages: Int = 0,
+            skippedPages: Int = 0,
+            errors: Int = 0,
+            startTime: Date? = nil,
+            endTime: Date? = nil
+        ) {
+            self.totalPages = totalPages
+            self.newPages = newPages
+            self.updatedPages = updatedPages
+            self.skippedPages = skippedPages
+            self.errors = errors
+            self.startTime = startTime
+            self.endTime = endTime
         }
-        return end.timeIntervalSince(start)
+
+        public var duration: TimeInterval? {
+            guard let start = startTime, let end = endTime else {
+                return nil
+            }
+            return end.timeIntervalSince(start)
+        }
     }
 }
 
 // MARK: - Progress
 
-public struct HIGProgress: Sendable {
-    public let currentPage: Int
-    public let totalPages: Int
-    public let currentItem: String
-    public let stats: HIGStatistics
+extension Core.HIGCrawler {
+    public struct Progress: Sendable {
+        public let currentPage: Int
+        public let totalPages: Int
+        public let currentItem: String
+        public let stats: Statistics
 
-    public var percentage: Double {
-        guard totalPages > 0 else { return 0 }
-        return Double(currentPage) / Double(totalPages) * 100
+        public var percentage: Double {
+            guard totalPages > 0 else { return 0 }
+            return Double(currentPage) / Double(totalPages) * 100
+        }
     }
 }
 
 // MARK: - Errors
 
-public enum HIGCrawlerError: Error, LocalizedError {
-    case invalidResponse(URL)
-    case webKitNotAvailable
-    case webViewNotInitialized
+extension Core.HIGCrawler {
+    public enum Error: Swift.Error, LocalizedError, Sendable {
+        case invalidResponse(URL)
+        case webKitNotAvailable
+        case webViewNotInitialized
 
-    public var errorDescription: String? {
-        switch self {
-        case .invalidResponse(let url):
-            return "Invalid response from \(url)"
-        case .webKitNotAvailable:
-            return "WebKit not available - HIG crawler requires macOS"
-        case .webViewNotInitialized:
-            return "WebView not initialized"
+        public var errorDescription: String? {
+            switch self {
+            case .invalidResponse(let url):
+                return "Invalid response from \(url)"
+            case .webKitNotAvailable:
+                return "WebKit not available - HIG crawler requires macOS"
+            case .webViewNotInitialized:
+                return "WebView not initialized"
+            }
         }
     }
 }

--- a/Packages/Tests/CoreTests/CrawlerTests.swift
+++ b/Packages/Tests/CoreTests/CrawlerTests.swift
@@ -282,12 +282,12 @@ struct CrawlerTests {
         #expect(decoded.errors == 5)
     }
 
-    // MARK: - CrawlProgress Tests
+    // MARK: - Core.Crawler.Progress Tests
 
-    @Test("CrawlProgress calculates percentage")
+    @Test("Core.Crawler.Progress calculates percentage")
     func progressCalculatesPercentage() throws {
         let stats = Shared.Models.CrawlStatistics()
-        let progress = try CrawlProgress(
+        let progress = try Core.Crawler.Progress(
             currentURL: #require(URL(string: "https://example.com")),
             visitedCount: 10,
             totalPages: 100,

--- a/Packages/Tests/CoreTests/SwiftEvolutionCrawlerTests.swift
+++ b/Packages/Tests/CoreTests/SwiftEvolutionCrawlerTests.swift
@@ -213,11 +213,11 @@ struct SwiftEvolutionCrawlerTests {
         #expect(isAccepted == false)
     }
 
-    // MARK: - EvolutionStatistics Tests
+    // MARK: - Core.EvolutionCrawler.Statistics Tests
 
-    @Test("EvolutionStatistics initializes with zeros")
+    @Test("Core.EvolutionCrawler.Statistics initializes with zeros")
     func statisticsInitializesWithZeros() {
-        let stats = EvolutionStatistics()
+        let stats = Core.EvolutionCrawler.Statistics()
 
         #expect(stats.totalProposals == 0)
         #expect(stats.newProposals == 0)
@@ -225,9 +225,9 @@ struct SwiftEvolutionCrawlerTests {
         #expect(stats.errors == 0)
     }
 
-    @Test("EvolutionStatistics tracks counts")
+    @Test("Core.EvolutionCrawler.Statistics tracks counts")
     func statisticsTracksCounts() {
-        var stats = EvolutionStatistics(startTime: Date())
+        var stats = Core.EvolutionCrawler.Statistics(startTime: Date())
         stats.totalProposals = 400
         stats.newProposals = 350
         stats.updatedProposals = 50
@@ -239,21 +239,21 @@ struct SwiftEvolutionCrawlerTests {
         #expect(stats.errors == 0)
     }
 
-    @Test("EvolutionStatistics calculates duration")
+    @Test("Core.EvolutionCrawler.Statistics calculates duration")
     func statisticsCalculatesDuration() {
-        var stats = EvolutionStatistics(startTime: Date())
+        var stats = Core.EvolutionCrawler.Statistics(startTime: Date())
         stats.endTime = stats.startTime?.addingTimeInterval(3600) // 1 hour
 
         let duration = stats.duration
         #expect(duration == 3600.0)
     }
 
-    // MARK: - EvolutionProgress Tests
+    // MARK: - Core.EvolutionCrawler.Progress Tests
 
-    @Test("EvolutionProgress tracks progress")
+    @Test("Core.EvolutionCrawler.Progress tracks progress")
     func progressTracksProgress() {
-        let stats = EvolutionStatistics()
-        let progress = EvolutionProgress(
+        let stats = Core.EvolutionCrawler.Statistics()
+        let progress = Core.EvolutionCrawler.Progress(
             current: 100,
             total: 400,
             proposalID: "SE-0100",
@@ -266,11 +266,11 @@ struct SwiftEvolutionCrawlerTests {
         #expect(progress.percentage == 25.0)
     }
 
-    // MARK: - ProposalMetadata Tests
+    // MARK: - Core.EvolutionCrawler.ProposalMetadata Tests
 
-    @Test("ProposalMetadata stores proposal info")
+    @Test("Core.EvolutionCrawler.ProposalMetadata stores proposal info")
     func proposalMetadataStoresInfo() {
-        let metadata = ProposalMetadata(
+        let metadata = Core.EvolutionCrawler.ProposalMetadata(
             id: "SE-0001",
             filename: "0001-keywords-as-argument-labels.md",
             downloadURL: "https://raw.githubusercontent.com/swiftlang/swift-evolution/main/proposals/0001-keywords-as-argument-labels.md"
@@ -281,14 +281,14 @@ struct SwiftEvolutionCrawlerTests {
         #expect(metadata.downloadURL.contains("raw.githubusercontent.com"))
     }
 
-    @Test("ProposalMetadata can be sorted by ID")
+    @Test("Core.EvolutionCrawler.ProposalMetadata can be sorted by ID")
     func proposalMetadataCanBeSorted() {
-        let proposal1 = ProposalMetadata(
+        let proposal1 = Core.EvolutionCrawler.ProposalMetadata(
             id: "SE-0001",
             filename: "0001-test.md",
             downloadURL: "https://example.com/1"
         )
-        let proposal2 = ProposalMetadata(
+        let proposal2 = Core.EvolutionCrawler.ProposalMetadata(
             id: "SE-0002",
             filename: "0002-test.md",
             downloadURL: "https://example.com/2"
@@ -322,9 +322,9 @@ struct SwiftEvolutionCrawlerTests {
         }
     }
 
-    @Test("ProposalMetadata stores ST proposal info")
+    @Test("Core.EvolutionCrawler.ProposalMetadata stores ST proposal info")
     func stProposalMetadataStoresInfo() {
-        let metadata = ProposalMetadata(
+        let metadata = Core.EvolutionCrawler.ProposalMetadata(
             id: "ST-0001",
             filename: "0001-refactor-bug-inits.md",
             downloadURL: "https://raw.githubusercontent.com/swiftlang/swift-evolution/main/proposals/testing/0001-refactor-bug-inits.md"
@@ -338,10 +338,10 @@ struct SwiftEvolutionCrawlerTests {
     @Test("Mixed SE and ST proposals sort correctly")
     func mixedSEAndSTProposalsSortCorrectly() {
         let proposals = [
-            ProposalMetadata(id: "ST-0001", filename: "0001-test.md", downloadURL: "https://example.com/st1"),
-            ProposalMetadata(id: "SE-0002", filename: "0002-test.md", downloadURL: "https://example.com/se2"),
-            ProposalMetadata(id: "SE-0001", filename: "0001-test.md", downloadURL: "https://example.com/se1"),
-            ProposalMetadata(id: "ST-0002", filename: "0002-test.md", downloadURL: "https://example.com/st2"),
+            Core.EvolutionCrawler.ProposalMetadata(id: "ST-0001", filename: "0001-test.md", downloadURL: "https://example.com/st1"),
+            Core.EvolutionCrawler.ProposalMetadata(id: "SE-0002", filename: "0002-test.md", downloadURL: "https://example.com/se2"),
+            Core.EvolutionCrawler.ProposalMetadata(id: "SE-0001", filename: "0001-test.md", downloadURL: "https://example.com/se1"),
+            Core.EvolutionCrawler.ProposalMetadata(id: "ST-0002", filename: "0002-test.md", downloadURL: "https://example.com/st2"),
         ]
 
         let sorted = proposals.sorted { $0.id < $1.id }
@@ -351,10 +351,10 @@ struct SwiftEvolutionCrawlerTests {
         #expect(sorted[3].id == "ST-0002")
     }
 
-    @Test("EvolutionProgress works with ST proposal ID")
+    @Test("Core.EvolutionCrawler.Progress works with ST proposal ID")
     func progressWithSTProposalID() {
-        let stats = EvolutionStatistics()
-        let progress = EvolutionProgress(
+        let stats = Core.EvolutionCrawler.Statistics()
+        let progress = Core.EvolutionCrawler.Progress(
             current: 1,
             total: 10,
             proposalID: "ST-0001",


### PR DESCRIPTION
## Summary

Continues the namespacing sweep into the Core layer. Wraps the file-scope companion types of all four Core crawlers under their respective \`extension Core.<Crawler> { ... }\` blocks and renames the files to \`Core+<Crawler>.swift\`.

This is the Infrastructure-layer continuation (task #12 in the layered task list, formally tracked by #183) after the Foundation-layer pass and the Search namespacing work in #378 / #379 / #380.

## Crawlers + companions

### \`Core.Crawler\` (Core+Crawler.swift)

- \`CrawlProgress\`         → \`Core.Crawler.Progress\`
- \`CrawlerError\`          → \`Core.Crawler.Error\` (conforms to \`Swift.Error\`)

\`lastError: Swift.Error?\` to keep the heterogeneous catch site working.

### \`Core.AppleArchiveCrawler\` (Core+AppleArchiveCrawler.swift)

- \`ArchiveGuideInfo\`      → \`Core.AppleArchiveCrawler.GuideInfo\`
- \`BookJSON\`              → \`Core.AppleArchiveCrawler.BookJSON\`
- \`BookSection\`           → \`Core.AppleArchiveCrawler.BookSection\`
- \`ArchivePage\`           → \`Core.AppleArchiveCrawler.Page\` (internal)
- \`ParsedArchivePage\`     → \`Core.AppleArchiveCrawler.ParsedPage\` (internal)
- \`ArchiveStatistics\`     → \`Core.AppleArchiveCrawler.Statistics\`
- \`ArchiveProgress\`       → \`Core.AppleArchiveCrawler.Progress\`
- \`ArchiveCrawlerError\`   → \`Core.AppleArchiveCrawler.Error\`

External callers swept:
- \`Core+ArchiveGuideCatalog.swift\` (parent-scope \`AppleArchiveCrawler.GuideInfo\`)
- \`CLI/Command+Fetch.swift\` (fully qualified \`Core.AppleArchiveCrawler.GuideInfo\`)

### \`Core.HIGCrawler\` (Core+HIGCrawler.swift)

- \`HIGPage\`               → \`Core.HIGCrawler.Page\`
- \`HIGCategory\`           → \`Core.HIGCrawler.Category\`
- \`HIGPlatform\`           → \`Core.HIGCrawler.Platform\`
- \`HIGStatistics\`         → \`Core.HIGCrawler.Statistics\`
- \`HIGProgress\`           → \`Core.HIGCrawler.Progress\`
- \`HIGCrawlerError\`       → \`Core.HIGCrawler.Error\`

All references internal; no external sweep needed.

### \`Core.EvolutionCrawler\` (Core+EvolutionCrawler.swift)

- \`GitHubFile\`            → \`Core.EvolutionCrawler.GitHubFile\` (internal)
- \`ProposalMetadata\`      → \`Core.EvolutionCrawler.ProposalMetadata\` (internal)
- \`EvolutionStatistics\`   → \`Core.EvolutionCrawler.Statistics\`
- \`EvolutionProgress\`     → \`Core.EvolutionCrawler.Progress\`
- \`EvolutionCrawlerError\` → \`Core.EvolutionCrawler.Error\` (internal)

Test refs in \`CoreTests/SwiftEvolutionCrawlerTests.swift\` qualified through \`Core.EvolutionCrawler.<type>\`.

## File renames

| Before | After |
|---|---|
| \`Core/Crawler.swift\` | \`Core/Core+Crawler.swift\` |
| \`Core/AppleArchiveCrawler.swift\` | \`Core/Core+AppleArchiveCrawler.swift\` |
| \`Core/HIGCrawler.swift\` | \`Core/Core+HIGCrawler.swift\` |
| \`Core/SwiftEvolutionCrawler.swift\` | \`Core/Core+EvolutionCrawler.swift\` |

## Verification

- \`xcrun swift build\` clean: **0 warnings, 0 errors**
- \`xcrun swift test\`: **1300/1300 pass**

## Follow-ups (still pending in #183)

- Core/JSONParser + Core/PackageIndexing stragglers
- Core/WKWebCrawler file/namespace alignment
- RemoteSync 10-type residue
- Availability / Distribution / Diagnostics audit
- Services Formatter singular restructure
- Shared.Configuration + Shared.Core finish
- TUI sweep