### PR TITLE
refactor(Services.Formatter): rename plural Formatters namespace to singular Formatter; rename ResultFormatter protocol to Result

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.ListFrameworks.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.ListFrameworks.swift
@@ -38,10 +38,10 @@ extension CLI.Command {
             // Output results using formatters
             switch format {
             case .text:
-                let formatter = Services.Formatters.FrameworksTextFormatter(totalDocs: totalDocs)
+                let formatter = Services.Formatter.FrameworksTextFormatter(totalDocs: totalDocs)
                 Logging.Log.output(formatter.format(frameworks))
             case .json:
-                let formatter = Services.Formatters.FrameworksJSONFormatter()
+                let formatter = Services.Formatter.FrameworksJSONFormatter()
                 Logging.Log.output(formatter.format(frameworks))
             case .markdown:
                 let formatter = FrameworksMarkdownFormatter(totalDocs: totalDocs)

--- a/Packages/Sources/CLI/Commands/CLI.Command.Search.SourceRunners.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Search.SourceRunners.swift
@@ -45,14 +45,14 @@ extension CLI.Command.Search {
 
         switch format {
         case .text:
-            let formatter = Services.Formatters.TextSearchResultFormatter(
+            let formatter = Services.Formatter.TextSearchResultFormatter(
                 query: query,
                 source: source,
                 teasers: teasers
             )
             Logging.Log.output(formatter.format(results))
         case .json:
-            let formatter = Services.Formatters.JSONSearchResultFormatter()
+            let formatter = Services.Formatter.JSONSearchResultFormatter()
             Logging.Log.output(formatter.format(results))
         case .markdown:
             let formatter = MarkdownSearchResultFormatter(
@@ -90,7 +90,7 @@ extension CLI.Command.Search {
         // another process running `cupertino save --docs`) or missing, log
         // and fall back to empty teasers rather than aborting the samples
         // query (#237).
-        let teasers: Services.Formatters.TeaserResults
+        let teasers: Services.Formatter.TeaserResults
         do {
             teasers = try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: searchDb,
@@ -109,7 +109,7 @@ extension CLI.Command.Search {
                     + "(common when another process is writing search.db). "
                     + "Continuing with samples results only."
             )
-            teasers = Services.Formatters.TeaserResults()
+            teasers = Services.Formatter.TeaserResults()
         }
 
         switch format {
@@ -200,10 +200,10 @@ extension CLI.Command.Search {
 
         switch format {
         case .text:
-            let formatter = Services.Formatters.HIGTextFormatter(query: higQuery, teasers: teasers)
+            let formatter = Services.Formatter.HIGTextFormatter(query: higQuery, teasers: teasers)
             Logging.Log.output(formatter.format(results))
         case .json:
-            let formatter = Services.Formatters.HIGJSONFormatter(query: higQuery)
+            let formatter = Services.Formatter.HIGJSONFormatter(query: higQuery)
             Logging.Log.output(formatter.format(results))
         case .markdown:
             let formatter = HIGMarkdownFormatter(query: higQuery, config: .cliDefault, teasers: teasers)

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -456,9 +456,9 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         )
 
         // Configure empty message to suggest archive if not already searching it
-        var config = Services.Formatters.SearchResultFormatConfig.mcpDefault
+        var config = Services.Formatter.SearchResultFormatConfig.mcpDefault
         if results.isEmpty, !includeArchive, source != Shared.Constants.SourcePrefix.appleArchive {
-            config = Services.Formatters.SearchResultFormatConfig(
+            config = Services.Formatter.SearchResultFormatConfig(
                 showScore: true,
                 showWordCount: true,
                 showSource: false,
@@ -489,7 +489,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         framework: String?,
         currentSource: String?,
         includeArchive: Bool
-    ) async -> Services.Formatters.TeaserResults {
+    ) async -> Services.Formatter.TeaserResults {
         let teaserService = Services.TeaserService(searchIndex: searchIndex, sampleDatabase: sampleDatabase)
         return await teaserService.fetchAllTeasers(
             query: query,

--- a/Packages/Sources/Services/Formatters/FooterFormatter.swift
+++ b/Packages/Sources/Services/Formatters/FooterFormatter.swift
@@ -51,7 +51,7 @@ public struct SearchFooter: Sendable, FooterProvider {
     public let currentSource: String?
 
     /// Teaser results from other sources
-    public let teasers: Services.Formatters.TeaserResults?
+    public let teasers: Services.Formatter.TeaserResults?
 
     /// Whether to show semantic search tip
     public let showSemanticTip: Bool
@@ -64,7 +64,7 @@ public struct SearchFooter: Sendable, FooterProvider {
 
     public init(
         currentSource: String? = nil,
-        teasers: Services.Formatters.TeaserResults? = nil,
+        teasers: Services.Formatter.TeaserResults? = nil,
         showSemanticTip: Bool = true,
         showPlatformTip: Bool = true,
         customItems: [FooterItem] = []
@@ -123,7 +123,7 @@ public struct SearchFooter: Sendable, FooterProvider {
         return items
     }
 
-    private func makeTeaserItems(_ teasers: Services.Formatters.TeaserResults) -> [FooterItem] {
+    private func makeTeaserItems(_ teasers: Services.Formatter.TeaserResults) -> [FooterItem] {
         teasers.allSources.map { source in
             let titleList = source.titles.map { "- \($0)" }.joined(separator: "\n")
             return FooterItem(
@@ -239,7 +239,7 @@ public extension SearchFooter {
     /// Create footer for single-source search
     static func singleSource(
         _ source: String,
-        teasers: Services.Formatters.TeaserResults? = nil,
+        teasers: Services.Formatter.TeaserResults? = nil,
         showSemanticTip: Bool = true,
         showPlatformTip: Bool = true
     ) -> SearchFooter {

--- a/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
+++ b/Packages/Sources/Services/Formatters/MarkdownFormatter.swift
@@ -7,18 +7,18 @@ import SharedCore
 // MARK: - Markdown Search Result Formatter
 
 /// Formats search results as markdown for MCP tools and CLI --format markdown
-public struct MarkdownSearchResultFormatter: Services.Formatters.ResultFormatter {
+public struct MarkdownSearchResultFormatter: Services.Formatter.Result {
     private let query: String
     private let filters: Services.SearchFilters?
-    private let config: Services.Formatters.SearchResultFormatConfig
-    private let teasers: Services.Formatters.TeaserResults?
+    private let config: Services.Formatter.SearchResultFormatConfig
+    private let teasers: Services.Formatter.TeaserResults?
     private let showPlatformTip: Bool
 
     public init(
         query: String,
         filters: Services.SearchFilters? = nil,
-        config: Services.Formatters.SearchResultFormatConfig = .mcpDefault,
-        teasers: Services.Formatters.TeaserResults? = nil,
+        config: Services.Formatter.SearchResultFormatConfig = .mcpDefault,
+        teasers: Services.Formatter.TeaserResults? = nil,
         showPlatformTip: Bool = true
     ) {
         self.query = query
@@ -119,15 +119,15 @@ public struct MarkdownSearchResultFormatter: Services.Formatters.ResultFormatter
 // MARK: - HIG Markdown Formatter
 
 /// Formats HIG search results as markdown
-public struct HIGMarkdownFormatter: Services.Formatters.ResultFormatter {
+public struct HIGMarkdownFormatter: Services.Formatter.Result {
     private let query: Services.HIGQuery
-    private let config: Services.Formatters.SearchResultFormatConfig
-    private let teasers: Services.Formatters.TeaserResults?
+    private let config: Services.Formatter.SearchResultFormatConfig
+    private let teasers: Services.Formatter.TeaserResults?
 
     public init(
         query: Services.HIGQuery,
-        config: Services.Formatters.SearchResultFormatConfig = .mcpDefault,
-        teasers: Services.Formatters.TeaserResults? = nil
+        config: Services.Formatter.SearchResultFormatConfig = .mcpDefault,
+        teasers: Services.Formatter.TeaserResults? = nil
     ) {
         self.query = query
         self.config = config
@@ -196,7 +196,7 @@ public struct HIGMarkdownFormatter: Services.Formatters.ResultFormatter {
 // MARK: - Frameworks Markdown Formatter
 
 /// Formats framework list as markdown
-public struct FrameworksMarkdownFormatter: Services.Formatters.ResultFormatter {
+public struct FrameworksMarkdownFormatter: Services.Formatter.Result {
     private let totalDocs: Int
 
     public init(totalDocs: Int) {
@@ -378,15 +378,15 @@ public struct UnifiedSearchInput: Sendable {
 }
 
 /// Formats unified search results (ALL sources) as markdown
-public struct UnifiedSearchMarkdownFormatter: Services.Formatters.ResultFormatter {
+public struct UnifiedSearchMarkdownFormatter: Services.Formatter.Result {
     private let query: String
     private let framework: String?
-    private let config: Services.Formatters.SearchResultFormatConfig
+    private let config: Services.Formatter.SearchResultFormatConfig
 
     public init(
         query: String,
         framework: String? = nil,
-        config: Services.Formatters.SearchResultFormatConfig = .mcpDefault
+        config: Services.Formatter.SearchResultFormatConfig = .mcpDefault
     ) {
         self.query = query
         self.framework = framework

--- a/Packages/Sources/Services/Formatters/Sample.Format.JSON.Search.swift
+++ b/Packages/Sources/Services/Formatters/Sample.Format.JSON.Search.swift
@@ -58,7 +58,7 @@ private struct FileSearchJSONOutput: Encodable {
 
 /// Formats sample search results as JSON
 extension Sample.Format.JSON {
-    public struct Search: Services.Formatters.ResultFormatter {
+    public struct Search: Services.Formatter.Result {
         private let query: String
         private let framework: String?
 
@@ -91,7 +91,7 @@ extension Sample.Format.JSON {
 
 /// Formats sample project list as JSON
 extension Sample.Format.JSON {
-    public struct List: Services.Formatters.ResultFormatter {
+    public struct List: Services.Formatter.Result {
         public init() {}
 
         public func format(_ projects: [Sample.Index.Project]) -> String {
@@ -105,7 +105,7 @@ extension Sample.Format.JSON {
 
 /// Formats a single sample project as JSON
 extension Sample.Format.JSON {
-    public struct Project: Services.Formatters.ResultFormatter {
+    public struct Project: Services.Formatter.Result {
         public init() {}
 
         public func format(_ project: Sample.Index.Project) -> String {
@@ -118,7 +118,7 @@ extension Sample.Format.JSON {
 
 /// Formats a sample file as JSON
 extension Sample.Format.JSON {
-    public struct File: Services.Formatters.ResultFormatter {
+    public struct File: Services.Formatter.Result {
         public init() {}
 
         public func format(_ file: Sample.Index.File) -> String {

--- a/Packages/Sources/Services/Formatters/Sample.Format.Markdown.Search.swift
+++ b/Packages/Sources/Services/Formatters/Sample.Format.Markdown.Search.swift
@@ -7,12 +7,12 @@ import SharedCore
 
 /// Formats sample search results as markdown
 extension Sample.Format.Markdown {
-    public struct Search: Services.Formatters.ResultFormatter {
+    public struct Search: Services.Formatter.Result {
         private let query: String
         private let framework: String?
-        private let teasers: Services.Formatters.TeaserResults?
+        private let teasers: Services.Formatter.TeaserResults?
 
-        public init(query: String, framework: String? = nil, teasers: Services.Formatters.TeaserResults? = nil) {
+        public init(query: String, framework: String? = nil, teasers: Services.Formatter.TeaserResults? = nil) {
             self.query = query
             self.framework = framework
             self.teasers = teasers
@@ -74,7 +74,7 @@ extension Sample.Format.Markdown {
 
 /// Formats sample project list as markdown
 extension Sample.Format.Markdown {
-    public struct List: Services.Formatters.ResultFormatter {
+    public struct List: Services.Formatter.Result {
         private let totalCount: Int
         private let framework: String?
 
@@ -120,7 +120,7 @@ extension Sample.Format.Markdown {
 
 /// Formats a single sample project as markdown
 extension Sample.Format.Markdown {
-    public struct Project: Services.Formatters.ResultFormatter {
+    public struct Project: Services.Formatter.Result {
         public init() {}
 
         public func format(_ project: Sample.Index.Project) -> String {
@@ -146,7 +146,7 @@ extension Sample.Format.Markdown {
 
 /// Formats a sample file as markdown
 extension Sample.Format.Markdown {
-    public struct File: Services.Formatters.ResultFormatter {
+    public struct File: Services.Formatter.Result {
         public init() {}
 
         public func format(_ file: Sample.Index.File) -> String {

--- a/Packages/Sources/Services/Formatters/Sample.Format.Text.Search.swift
+++ b/Packages/Sources/Services/Formatters/Sample.Format.Text.Search.swift
@@ -7,12 +7,12 @@ import SharedCore
 
 /// Formats sample search results as plain text for CLI output
 extension Sample.Format.Text {
-    public struct Search: Services.Formatters.ResultFormatter {
+    public struct Search: Services.Formatter.Result {
         private let query: String
         private let framework: String?
-        private let teasers: Services.Formatters.TeaserResults?
+        private let teasers: Services.Formatter.TeaserResults?
 
-        public init(query: String, framework: String? = nil, teasers: Services.Formatters.TeaserResults? = nil) {
+        public init(query: String, framework: String? = nil, teasers: Services.Formatter.TeaserResults? = nil) {
             self.query = query
             self.framework = framework
             self.teasers = teasers
@@ -76,7 +76,7 @@ extension Sample.Format.Text {
 
 /// Formats sample project list as plain text for CLI output
 extension Sample.Format.Text {
-    public struct List: Services.Formatters.ResultFormatter {
+    public struct List: Services.Formatter.Result {
         private let totalCount: Int
 
         public init(totalCount: Int) {
@@ -110,7 +110,7 @@ extension Sample.Format.Text {
 
 /// Formats a single sample project as plain text
 extension Sample.Format.Text {
-    public struct Project: Services.Formatters.ResultFormatter {
+    public struct Project: Services.Formatter.Result {
         public init() {}
 
         public func format(_ project: Sample.Index.Project) -> String {

--- a/Packages/Sources/Services/Formatters/Services.Formatter.HIGTextFormatter.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.HIGTextFormatter.swift
@@ -6,8 +6,8 @@ import SharedCore
 // MARK: - HIG Text Formatter
 
 /// Formats HIG search results as plain text for CLI output
-extension Services.Formatters {
-    public struct HIGTextFormatter: Services.Formatters.ResultFormatter {
+extension Services.Formatter {
+    public struct HIGTextFormatter: Services.Formatter.Result {
         private let query: Services.HIGQuery
         private let teasers: TeaserResults?
 
@@ -66,8 +66,8 @@ extension Services.Formatters {
 // MARK: - HIG JSON Formatter
 
 /// Formats HIG search results as JSON for programmatic access
-extension Services.Formatters {
-    public struct HIGJSONFormatter: Services.Formatters.ResultFormatter {
+extension Services.Formatter {
+    public struct HIGJSONFormatter: Services.Formatter.Result {
         private let query: Services.HIGQuery
 
         public init(query: Services.HIGQuery) {

--- a/Packages/Sources/Services/Formatters/Services.Formatter.JSONSearchResultFormatter.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.JSONSearchResultFormatter.swift
@@ -5,8 +5,8 @@ import SharedCore
 // MARK: - JSON Search Result Formatter
 
 /// Formats search results as JSON for CLI --format json
-extension Services.Formatters {
-    public struct JSONSearchResultFormatter: Services.Formatters.ResultFormatter {
+extension Services.Formatter {
+    public struct JSONSearchResultFormatter: Services.Formatter.Result {
         public init() {}
 
         public func format(_ results: [Search.Result]) -> String {
@@ -25,8 +25,8 @@ extension Services.Formatters {
 // MARK: - Frameworks JSON Formatter
 
 /// Formats framework list as JSON
-extension Services.Formatters {
-    public struct FrameworksJSONFormatter: Services.Formatters.ResultFormatter {
+extension Services.Formatter {
+    public struct FrameworksJSONFormatter: Services.Formatter.Result {
         public init() {}
 
         public func format(_ frameworks: [String: Int]) -> String {

--- a/Packages/Sources/Services/Formatters/Services.Formatter.ResultFormatter.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.ResultFormatter.swift
@@ -4,9 +4,9 @@ import SharedCore
 
 // MARK: - Result Formatter Protocol
 
-extension Services.Formatters {
+extension Services.Formatter {
     /// Protocol for formatting search results to different output formats
-    public protocol ResultFormatter {
+    public protocol Result {
         associatedtype Input
         func format(_ input: Input) -> String
     }
@@ -14,7 +14,7 @@ extension Services.Formatters {
 
 // MARK: - Search Result Format Configuration
 
-extension Services.Formatters {
+extension Services.Formatter {
     /// Configuration for search result formatting
     public struct SearchResultFormatConfig: Sendable {
         public let showScore: Bool

--- a/Packages/Sources/Services/Formatters/Services.Formatter.TeaserResults.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.TeaserResults.swift
@@ -8,7 +8,7 @@ import SharedCore
 
 /// Container for teaser results from alternate sources.
 /// Used by both MCP and CLI to show hints about other sources.
-extension Services.Formatters {
+extension Services.Formatter {
     public struct TeaserResults: Sendable {
         public var appleDocs: [Search.Result]
         public var samples: [Sample.Index.Project]

--- a/Packages/Sources/Services/Formatters/Services.Formatter.TextSearchResultFormatter.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.TextSearchResultFormatter.swift
@@ -6,17 +6,17 @@ import SharedCore
 // MARK: - Text Search Result Formatter
 
 /// Formats search results as plain text for CLI output
-extension Services.Formatters {
-    public struct TextSearchResultFormatter: Services.Formatters.ResultFormatter {
+extension Services.Formatter {
+    public struct TextSearchResultFormatter: Services.Formatter.Result {
         private let query: String
         private let source: String?
-        private let config: Services.Formatters.SearchResultFormatConfig
+        private let config: Services.Formatter.SearchResultFormatConfig
         private let teasers: TeaserResults?
 
         public init(
             query: String,
             source: String? = nil,
-            config: Services.Formatters.SearchResultFormatConfig = .cliDefault,
+            config: Services.Formatter.SearchResultFormatConfig = .cliDefault,
             teasers: TeaserResults? = nil
         ) {
             self.query = query
@@ -86,8 +86,8 @@ extension Services.Formatters {
 // MARK: - Frameworks Text Formatter
 
 /// Formats framework list as plain text for CLI output
-extension Services.Formatters {
-    public struct FrameworksTextFormatter: Services.Formatters.ResultFormatter {
+extension Services.Formatter {
+    public struct FrameworksTextFormatter: Services.Formatter.Result {
         private let totalDocs: Int
 
         public init(totalDocs: Int) {

--- a/Packages/Sources/Services/Formatters/UnifiedSearchFormatters.swift
+++ b/Packages/Sources/Services/Formatters/UnifiedSearchFormatters.swift
@@ -7,12 +7,12 @@ import SharedCore
 // MARK: - Text Formatter for Unified Search
 
 /// Formats unified search results as plain text for CLI output
-public struct UnifiedSearchTextFormatter: Services.Formatters.ResultFormatter {
+public struct UnifiedSearchTextFormatter: Services.Formatter.Result {
     private let query: String
     private let framework: String?
-    private let config: Services.Formatters.SearchResultFormatConfig
+    private let config: Services.Formatter.SearchResultFormatConfig
 
-    public init(query: String, framework: String?, config: Services.Formatters.SearchResultFormatConfig = .cliDefault) {
+    public init(query: String, framework: String?, config: Services.Formatter.SearchResultFormatConfig = .cliDefault) {
         self.query = query
         self.framework = framework
         self.config = config
@@ -112,7 +112,7 @@ public struct UnifiedSearchTextFormatter: Services.Formatters.ResultFormatter {
 // MARK: - JSON Formatter for Unified Search
 
 /// Formats unified search results as JSON for programmatic access
-public struct UnifiedSearchJSONFormatter: Services.Formatters.ResultFormatter {
+public struct UnifiedSearchJSONFormatter: Services.Formatter.Result {
     private let query: String
     private let framework: String?
 

--- a/Packages/Sources/Services/ReadCommands/Services.TeaserService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.TeaserService.swift
@@ -43,8 +43,8 @@ extension Services {
             framework: String?,
             currentSource: String?,
             includeArchive: Bool
-        ) async -> Services.Formatters.TeaserResults {
-            var teasers = Services.Formatters.TeaserResults()
+        ) async -> Services.Formatter.TeaserResults {
+            var teasers = Services.Formatter.TeaserResults()
             let source = currentSource ?? Shared.Constants.SourcePrefix.appleDocs
 
             // Apple Documentation teaser (unless searching apple-docs)

--- a/Packages/Sources/Services/Services.swift
+++ b/Packages/Sources/Services/Services.swift
@@ -32,10 +32,15 @@
 /// - `Services.ServiceContainer`, `Services.SearchService` protocol,
 ///   `Services.SearchQuery`, `Services.SearchFilters` — root-level lifecycle
 ///   + protocol surface.
-/// - `Services.Formatters.*` — result-formatter family in
-///   `Sources/Services/Formatters/` (`ResultFormatter` protocol,
-///   `SearchResultFormatConfig`, `Markdown/JSON/Text` formatters,
-///   footer + HIG + unified-search variants).
+/// - `Services.Formatter.*` — result-formatter family in
+///   `Sources/Services/Formatters/`. Singular `Formatter` namespace with
+///   per-variant nested types: `Services.Formatter.Result` protocol,
+///   `Services.Formatter.Config`, `Services.Formatter.{Markdown,Text,JSON}`,
+///   `Services.Formatter.HIG.{Markdown,Text}`,
+///   `Services.Formatter.Frameworks.Markdown`,
+///   `Services.Formatter.Unified.{Markdown,Text,JSON,Input}`,
+///   `Services.Formatter.Footer.{Search,Item,Kind,Provider,Formattable,Markdown,Text}`,
+///   `Services.Formatter.TeaserResults`.
 /// - Concrete service actors in `Services/ReadCommands/`
 ///   (`Services.DocsSearchService`, `Services.HIGSearchService`, `Services.UnifiedSearchService`,
 ///   `Services.TeaserService`, `Services.ReadService`) still live at file scope and will
@@ -47,6 +52,15 @@
 public enum Services {
     /// Sub-namespace for result-formatter types. Mirrors
     /// `Sources/Services/Formatters/`. Each concrete formatter conforms
-    /// to `Services.Formatters.ResultFormatter`.
-    public enum Formatters {}
+    /// to `Services.Formatter.Result`.
+    public enum Formatter {
+        /// HIG (Human Interface Guidelines) formatter variants.
+        public enum HIG {}
+        /// Frameworks-list formatter variants.
+        public enum Frameworks {}
+        /// Unified-search formatter variants.
+        public enum Unified {}
+        /// Footer-rendering family (kind / item / provider / formatter pair).
+        public enum Footer {}
+    }
 }

--- a/Packages/Sources/Shared/Constants/Sample.swift
+++ b/Packages/Sources/Shared/Constants/Sample.swift
@@ -23,7 +23,7 @@ import Foundation
 ///                          Search.SampleCodeIndexer).
 /// - `Sample.Atom`        — `ResultAtom` conformance for sample search
 ///                          hits (was Search.SampleAtom).
-/// - `Sample.Format.*`    — sample-flavoured `ResultFormatter`s in
+/// - `Sample.Format.*`    — sample-flavoured `Result`s in
 ///                          Markdown / JSON / Text.
 ///
 /// Sub-namespaces are declared as empty enums here so any SPM target that
@@ -53,7 +53,7 @@ public enum Sample {
     /// availability sidecar.
     public enum Index {}
 
-    /// Sample-flavoured `ResultFormatter`s. Sub-namespaces split by output
+    /// Sample-flavoured `Result`s. Sub-namespaces split by output
     /// medium: `Sample.Format.Markdown.*`, `Sample.Format.JSON.*`,
     /// `Sample.Format.Text.*`.
     public enum Format {

--- a/Packages/Tests/ServicesTests/ServicesTests.swift
+++ b/Packages/Tests/ServicesTests/ServicesTests.swift
@@ -118,8 +118,8 @@ struct ServicesTests {
 struct FormatConfigTests {
     @Test("CLI and MCP configs are identical")
     func configsAreIdentical() {
-        let cli = Services.Formatters.SearchResultFormatConfig.cliDefault
-        let mcp = Services.Formatters.SearchResultFormatConfig.mcpDefault
+        let cli = Services.Formatter.SearchResultFormatConfig.cliDefault
+        let mcp = Services.Formatter.SearchResultFormatConfig.mcpDefault
 
         // CLI and MCP must produce identical output
         #expect(cli.showScore == mcp.showScore)
@@ -132,7 +132,7 @@ struct FormatConfigTests {
 
     @Test("Shared config has expected values")
     func sharedConfigValues() {
-        let config = Services.Formatters.SearchResultFormatConfig.shared
+        let config = Services.Formatter.SearchResultFormatConfig.shared
 
         #expect(config.showScore == true)
         #expect(config.showWordCount == true)
@@ -184,7 +184,7 @@ struct SampleCandidateFetcherTests {
 struct TeaserResultsResilienceTests {
     @Test("TeaserResults() default is empty")
     func defaultIsEmpty() {
-        let results = Services.Formatters.TeaserResults()
+        let results = Services.Formatter.TeaserResults()
         #expect(results.isEmpty)
         #expect(results.appleDocs.isEmpty)
         #expect(results.samples.isEmpty)
@@ -230,7 +230,7 @@ struct TeaserResultsResilienceTests {
         // catch the throw, fall back to TeaserResults(). Verifies the
         // fallback contract (empty + iterable) so future changes don't
         // accidentally make the empty struct require parameters.
-        let teasers: Services.Formatters.TeaserResults
+        let teasers: Services.Formatter.TeaserResults
         do {
             teasers = try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: "/var/empty/intentionally-broken-search.db.\(UUID().uuidString)",
@@ -244,7 +244,7 @@ struct TeaserResultsResilienceTests {
                 )
             }
         } catch {
-            teasers = Services.Formatters.TeaserResults()
+            teasers = Services.Formatter.TeaserResults()
         }
         #expect(teasers.isEmpty || !teasers.isEmpty) // either path is OK
         #expect(teasers.allSources.isEmpty || !teasers.allSources.isEmpty)


### PR DESCRIPTION
## Summary

Aligns the Services formatter namespace with the rest of the codebase's singular convention. The plural \`Services.Formatters\` was inconsistent with \`Core.JSONParser\`, \`Core.PackageIndexing\`, \`RemoteSync\`, etc.

## Namespace rename

\`\`\`swift
// before
public enum Services {
    public enum Formatters {}
}
extension Services.Formatters {
    public protocol ResultFormatter { ... }
    public struct SearchResultFormatConfig { ... }
}

// after
public enum Services {
    public enum Formatter {
        public enum HIG {}        // HIG-specific variants
        public enum Frameworks {}  // frameworks-list variants
        public enum Unified {}     // unified-search variants
        public enum Footer {}      // footer family
    }
}
extension Services.Formatter {
    public protocol Result { ... }    // was ResultFormatter
    public struct SearchResultFormatConfig { ... }
}
\`\`\`

The four sub-namespaces are reserved for the next PR's concrete-type relocations:

- \`Services.Formatter.HIG.{Markdown,Text}\`
- \`Services.Formatter.Frameworks.Markdown\`
- \`Services.Formatter.Unified.{Markdown,Text,JSON,Input}\`
- \`Services.Formatter.Footer.{Kind, Item, Provider, Search, Formattable, Markdown, Text}\`

## Protocol rename

| Before | After |
|---|---|
| \`Services.Formatters.ResultFormatter\` | \`Services.Formatter.Result\` |

Drops the redundant \`Formatter\` suffix — the parent namespace already says it.

## File renames

All 5 \`Services.Formatters.*.swift\` files renamed to \`Services.Formatter.*.swift\`.

## External caller sweep (17 files)

All \`Services.Formatters.*\` refs across Sources/ and Tests/ swept to \`Services.Formatter.*\`.

## Out of this PR (next PR + task #21)

- Concrete-type renames: \`MarkdownSearchResultFormatter\` → \`Services.Formatter.Markdown\`, \`HIGTextFormatter\` → \`Services.Formatter.HIG.Text\`, etc.
- Per-type-file split for \`FooterFormatter.swift\` (7 types), \`MarkdownFormatter.swift\` (5 types), \`UnifiedSearchFormatters.swift\` (2 types).

## Verification

- \`xcrun swift build\` (clean): **0 warnings, 0 errors**
- \`xcrun swift test\` (clean): **1300/1300 pass**