### PR TITLE
refactor(task-21): mark file-scope helper types private; closes the multi-type-file stragglers

### DIFF
--- a/Packages/Sources/Core/HTMLParser/Core.Parser.XML.swift
+++ b/Packages/Sources/Core/HTMLParser/Core.Parser.XML.swift
@@ -48,7 +48,7 @@ extension Core.Parser {
 // MARK: - XML to Markdown Parser
 
 /// Parses XML and converts to Markdown format
-final class XMLToMarkdownParser: NSObject, XMLParserDelegate {
+private final class XMLToMarkdownParser: NSObject, XMLParserDelegate {
     private let parser: XMLParser
     private let sourceURL: URL
 
@@ -180,7 +180,7 @@ final class XMLToMarkdownParser: NSObject, XMLParserDelegate {
 // MARK: - XML Link Extractor
 
 /// Extracts links from XML content (sitemaps, RSS feeds, etc.)
-final class XMLLinkExtractor: NSObject, XMLParserDelegate {
+private final class XMLLinkExtractor: NSObject, XMLParserDelegate {
     private let parser: XMLParser
     private var links: [URL] = []
     private var currentElement: String = ""

--- a/Packages/Sources/Core/JSONParser/Core.JSONParser.AppleJSONToMarkdown.swift
+++ b/Packages/Sources/Core/JSONParser/Core.JSONParser.AppleJSONToMarkdown.swift
@@ -436,7 +436,7 @@ extension Core.JSONParser {
 
 // MARK: - JSON Models for Apple Documentation API
 
-struct AppleDocumentation: Codable {
+private struct AppleDocumentation: Codable {
     let identifier: Identifier?
     let metadata: Metadata
     let abstract: [InlineContent]?
@@ -469,7 +469,7 @@ struct AppleDocumentation: Codable {
     }
 }
 
-struct InlineContent: Codable {
+private struct InlineContent: Codable {
     let type: String
     let text: String?
     let code: String?
@@ -478,7 +478,7 @@ struct InlineContent: Codable {
     let inlineContent: [InlineContent]?
 }
 
-struct PrimaryContentSection: Codable {
+private struct PrimaryContentSection: Codable {
     let kind: String
     let declarations: [Declaration]?
     let parameters: [Parameter]?
@@ -500,7 +500,7 @@ struct PrimaryContentSection: Codable {
     }
 }
 
-struct ContentBlock: Codable {
+private struct ContentBlock: Codable {
     let type: String
     let inlineContent: [InlineContent]?
     let code: [String]?
@@ -514,18 +514,18 @@ struct ContentBlock: Codable {
     }
 }
 
-struct TopicSection: Codable {
+private struct TopicSection: Codable {
     let title: String
     let identifiers: [String]
 }
 
-struct RelationshipSection: Codable {
+private struct RelationshipSection: Codable {
     let title: String
     let identifiers: [String]
     let kind: String?
 }
 
-struct Reference: Codable {
+private struct Reference: Codable {
     let title: String?
     let abstract: [InlineContent]?
     let role: String?

--- a/Packages/Sources/MockAIAgent/main.swift
+++ b/Packages/Sources/MockAIAgent/main.swift
@@ -665,11 +665,11 @@ actor MCPClient {
 
 // MARK: - Helper Types
 
-struct EmptyParams: Codable {}
+private struct EmptyParams: Codable {}
 
 // MARK: - Errors
 
-enum MCPClientError: Error, CustomStringConvertible {
+private enum MCPClientError: Error, CustomStringConvertible {
     case notConnected
     case encodingFailed
     case decodingFailed


### PR DESCRIPTION
## Summary

Closes issue #424 (every non-private type in its own file). The remaining multi-type files all had file-scope helper types that are exclusively used inside their host file but happened to default to internal access (no access modifier). Marking them \`private\` shrinks the \"multi-type per file\" metric to zero without producing useless single-type files.

## Changes

### \`Core.JSONParser.AppleJSONToMarkdown.swift\`

Seven Codable JSON model structs marked \`private\`:

\`AppleDocumentation\`, \`InlineContent\`, \`PrimaryContentSection\`, \`ContentBlock\`, \`TopicSection\`, \`RelationshipSection\`, \`Reference\`

All are internal-only decode shapes for the converter — never used outside the file.

### \`Core.Parser.XML.swift\`

\`XMLToMarkdownParser\` and \`XMLLinkExtractor\` are NSObject XML delegates instantiated and consumed only inside \`Core.Parser.XML\`'s static methods. Marked \`private final class\`.

### \`MockAIAgent/main.swift\`

\`EmptyParams\` (Codable) and \`MCPClientError\` (Error enum) are MockAIAgent-local helpers — the agent's own protocol surface, never imported by anything else. Marked \`private\`.

## Why private, not split

Issue #424 is about navigation. Splitting these into 13 new single-type files would create 13 navigable files for types that nobody should navigate to — they're internal decode glue. Marking them \`private\` encodes the same fact (file-only scope) without the file-count cost.

**The rule stays:** every non-private type in its own file. File-scope helpers that should never escape get \`private\`.

## Verification

- \`xcrun swift build\` (clean): **0 warnings, 0 errors**
- \`xcrun swift test\` (clean): **1300/1300 pass**

## Closes

- #424 (task #21 — every non-private type in its own file)

## Remaining queue

- **#425** Crawler target extract
- **#426** Anchor placement (Core/MCP/Sample anchors at target root + MCP→MCPCore rename)
- **#381** DI epic — blocked on #425 and #426