### PR TITLE
refactor(Crawler): add Crawler.Engine typealias; closes #425

### DIFF
--- a/Packages/Sources/Crawler/Crawler.Engine.swift
+++ b/Packages/Sources/Crawler/Crawler.Engine.swift
@@ -1,0 +1,19 @@
+import CoreProtocols
+import Foundation
+
+// MARK: - Crawler.Engine
+
+extension Crawler {
+    /// Protocol every concrete crawler conforms to. Combines content fetching
+    /// and transformation behind a single interface so a dispatcher can drive
+    /// any crawler (`Crawler.AppleDocs`, `Crawler.AppleArchive`, `Crawler.HIG`,
+    /// `Crawler.Evolution`, `Crawler.WebKit.Engine`, `Core.JSONParser.Engine`)
+    /// uniformly.
+    ///
+    /// The protocol itself lives in `CoreProtocols` as `Core.Protocols.CrawlerEngine`
+    /// because parser-side engines (`Core.JSONParser.Engine`) conform too, and
+    /// CoreProtocols is the lowest-leaf target everyone can see. This typealias
+    /// promotes the natural read site `Crawler.Engine` while keeping the
+    /// dependency graph honest.
+    public typealias Engine = Core.Protocols.CrawlerEngine
+}

--- a/Packages/Sources/Crawler/Crawler.WebKit.Engine.swift
+++ b/Packages/Sources/Crawler/Crawler.WebKit.Engine.swift
@@ -14,7 +14,7 @@ import WebKit
 extension Crawler.WebKit {
     #if canImport(WebKit)
     @MainActor
-    public final class Engine: @preconcurrency Core.Protocols.CrawlerEngine {
+    public final class Engine: @preconcurrency Crawler.Engine {
         private let fetcher: Crawler.WebKit.ContentFetcher
 
         public init(


### PR DESCRIPTION
## Summary

Closes the **Crawler.Engine protocol unification** half of #425. The protocol stays defined in CoreProtocols as \`Core.Protocols.CrawlerEngine\` (parser-side engines conform too, and CoreProtocols is the lowest-leaf target); a typealias in the Crawler target promotes the natural read name.

\`\`\`swift
// Sources/Crawler/Crawler.Engine.swift
extension Crawler {
    public typealias Engine = Core.Protocols.CrawlerEngine
}
\`\`\`

\`Crawler.WebKit.Engine\`'s conformance updated to use the new alias. Concrete crawler conformances elsewhere (\`Crawler.AppleDocs\`, \`Crawler.AppleArchive\`, \`Crawler.HIG\`, \`Crawler.Evolution\`) inherit through their existing class hierarchy.

## Why typealias, not move

Moving the protocol into the Crawler target would create a circular dep: Crawler → CoreJSONParser, but CoreJSONParser would need to see Crawler.Engine. Keeping the protocol where it is and aliasing is the dependency-graph-clean answer.

## Closes

- #425 (Crawler functionality extracted into its own SPM target + Crawler.Engine protocol)

## Verification

- \`xcrun swift build\` (clean): **0 warnings, 0 errors**
- \`xcrun swift test\` (clean): **1300/1300 pass**

## Remaining queue

- **#426** Namespace anchor placement (Core.swift to its own target, MCP→MCPCore, Sample.Core direction)
- **#381** DI epic + 27 children (#382-#408)
- **#329** v1.2.0 release once enough lands