### PR TITLE
fix(crawler): catch Apple's SPA no-content sub-views + log rejected URLs (#284)

### DIFF
--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -315,6 +315,24 @@ extension Core {
                     let html = try await loadPage(url: url)
                     if HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) {
                         logInfo("   ⛔ HTTP error template detected, skipping (#284)")
+                        await state.recordRejection(
+                            url: url,
+                            framework: framework,
+                            reason: .httpErrorTemplate,
+                            outputDirectory: configuration.outputDirectory
+                        )
+                        await state.updateStatistics { $0.errors += 1 }
+                        await state.updateStatistics { $0.totalPages += 1 }
+                        return
+                    }
+                    if HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) {
+                        logInfo("   ⛔ Apple SPA no-content sub-view detected, skipping (#284)")
+                        await state.recordRejection(
+                            url: url,
+                            framework: framework,
+                            reason: .javaScriptFallback,
+                            outputDirectory: configuration.outputDirectory
+                        )
                         await state.updateStatistics { $0.errors += 1 }
                         await state.updateStatistics { $0.totalPages += 1 }
                         return
@@ -332,6 +350,24 @@ extension Core {
                 let html = try await loadPage(url: url)
                 if HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) {
                     logInfo("   ⛔ HTTP error template detected, skipping (#284)")
+                    await state.recordRejection(
+                        url: url,
+                        framework: framework,
+                        reason: .httpErrorTemplate,
+                        outputDirectory: configuration.outputDirectory
+                    )
+                    await state.updateStatistics { $0.errors += 1 }
+                    await state.updateStatistics { $0.totalPages += 1 }
+                    return
+                }
+                if HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) {
+                    logInfo("   ⛔ Apple SPA no-content sub-view detected, skipping (#284)")
+                    await state.recordRejection(
+                        url: url,
+                        framework: framework,
+                        reason: .javaScriptFallback,
+                        outputDirectory: configuration.outputDirectory
+                    )
                     await state.updateStatistics { $0.errors += 1 }
                     await state.updateStatistics { $0.totalPages += 1 }
                     return

--- a/Packages/Sources/Core/CrawlerState.swift
+++ b/Packages/Sources/Core/CrawlerState.swift
@@ -276,6 +276,73 @@ public actor CrawlerState {
         metadata.lastCrawl
     }
 
+    // MARK: - Rejected URL Tracking (#284)
+
+    /// Why a URL was rejected by one of the crawler's content-quality gates.
+    /// String raw values so the on-disk JSONL file stays human-greppable.
+    public enum RejectionReason: String, Codable, Sendable {
+        /// `HTMLToMarkdown.looksLikeHTTPErrorPage` tripped — Apple's CDN
+        /// served a styled 403/404/502 page at HTTP 200.
+        case httpErrorTemplate = "http_error_template"
+        /// `HTMLToMarkdown.looksLikeJavaScriptFallback` tripped — Apple's
+        /// React SPA rendered its "page can't be found" / "unknown error"
+        /// sub-view at HTTP 200 (the internal doc-loader returned 404).
+        case javaScriptFallback = "js_fallback"
+    }
+
+    /// One row of the rejected-URLs log. Append-only JSONL so an interrupted
+    /// crawl preserves every prior write.
+    public struct RejectedURLRecord: Codable, Sendable {
+        public let url: String
+        public let framework: String
+        public let reason: RejectionReason
+        public let timestamp: Date
+    }
+
+    /// Append a single rejection record to the session's rejected-URLs log
+    /// at `<outputDirectory>/.cupertino-rejected-urls.jsonl`. Each call writes
+    /// one JSON line + a `\n` terminator so a crash mid-write loses at most
+    /// the in-flight record. The file is plain text + line-delimited so
+    /// operators can `grep` / `jq` / `wc -l` it without parsing the metadata.
+    ///
+    /// Failure to append is logged but does not propagate — a missing log
+    /// row must never block a crawl that is otherwise making progress.
+    public func recordRejection(
+        url: URL,
+        framework: String,
+        reason: RejectionReason,
+        outputDirectory: URL
+    ) {
+        let record = RejectedURLRecord(
+            url: url.absoluteString,
+            framework: framework,
+            reason: reason,
+            timestamp: Date()
+        )
+        let logFile = outputDirectory.appendingPathComponent(".cupertino-rejected-urls.jsonl")
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let line = try encoder.encode(record) + Data("\n".utf8)
+            if FileManager.default.fileExists(atPath: logFile.path) {
+                let handle = try FileHandle(forWritingTo: logFile)
+                defer { try? handle.close() }
+                try handle.seekToEnd()
+                try handle.write(contentsOf: line)
+            } else {
+                try FileManager.default.createDirectory(
+                    at: outputDirectory,
+                    withIntermediateDirectories: true
+                )
+                try line.write(to: logFile)
+            }
+        } catch {
+            Logging.Logger.crawler.warning(
+                "⚠️ Failed to record rejected URL \(url.absoluteString): \(error.localizedDescription)"
+            )
+        }
+    }
+
     // MARK: - Session State Management
 
     /// Save current crawl session state

--- a/Packages/Sources/Core/Transformers/HTMLToMarkdown.swift
+++ b/Packages/Sources/Core/Transformers/HTMLToMarkdown.swift
@@ -129,6 +129,35 @@ public struct HTMLToMarkdown: ContentTransformer, @unchecked Sendable {
         return looksLikeHTTPErrorPage(title: title, html: html)
     }
 
+    /// Returns true if `html` is Apple's React SPA shell served without a
+    /// rendered page body. Apple's developer-docs site is a client-rendered
+    /// React app; when its internal doc-loader endpoint returns 404 (or
+    /// some other failure) for a given URL, the page returns HTTP 200 OK
+    /// with the shell HTML and one of two sub-view templates as the visible
+    /// body: "The page you're looking for can't be found." (Apple's 404
+    /// sub-view) or "An unknown error occurred." (generic error sub-view).
+    /// Neither is an HTTP error, so `looksLikeHTTPErrorPage` lets them
+    /// through; without this gate, ~1,300 such files landed on disk during
+    /// the v1.0.0–v1.0.2 crawls and propagated into every bundle.
+    ///
+    /// The indexer-side `pageLooksLikeJavaScriptFallback` (#284) catches
+    /// the same shape post-conversion, but only on the apple-docs index
+    /// path — and even then, the poison files still sit in the source
+    /// corpus. This crawler-side gate stops them at write time so neither
+    /// the corpus nor the indexer's other code paths see them.
+    public static func looksLikeJavaScriptFallback(html: String) -> Bool {
+        // Apple's specific React sub-view phrases. Pinned literals because
+        // they are unique to the React app's no-content states; real Apple
+        // documentation pages do not quote either sentence.
+        if html.contains("The page you're looking for can't be found") {
+            return true
+        }
+        if html.contains("An unknown error occurred") {
+            return true
+        }
+        return false
+    }
+
     /// Pure decision over a pre-extracted `title` + the surrounding `html`.
     /// Split out so unit tests can exercise the rule against synthetic
     /// inputs without round-tripping through the full HTML title-extractor.

--- a/Packages/Tests/CoreTests/HTMLToMarkdownJavaScriptFallbackTests.swift
+++ b/Packages/Tests/CoreTests/HTMLToMarkdownJavaScriptFallbackTests.swift
@@ -1,0 +1,126 @@
+@testable import Core
+import Foundation
+import Testing
+
+// Coverage for `HTMLToMarkdown.looksLikeJavaScriptFallback(...)` — the
+// crawler-side gate added on top of #284 to catch Apple's React SPA
+// "no-content" sub-views. Apple's developer-docs site is a client-rendered
+// React app; when its internal doc-loader endpoint returns 404 (or some
+// other failure) for a given URL, the page itself returns HTTP 200 OK
+// with the shell HTML and one of two sub-view templates as the body.
+//
+// Neither sub-view is an HTTP error, so `looksLikeHTTPErrorPage` lets
+// them through. The indexer-side `pageLooksLikeJavaScriptFallback`
+// (#284, in SearchIndexBuilder) catches the same shape post-conversion,
+// but only on the apple-docs index path AND only after the poison file
+// has already landed in the source corpus. This crawler-side gate stops
+// them at write time so neither the corpus nor any downstream code sees
+// them.
+
+@Suite("HTMLToMarkdown.looksLikeJavaScriptFallback (#284 crawler-side)")
+struct HTMLToMarkdownJavaScriptFallbackTests {
+    // MARK: 404 sub-view ("page can't be found")
+
+    @Test("Apple's React 404 sub-view trips the gate")
+    func reactNotFoundSubView() {
+        // Sample captured from a v1.0.2-era poison file: HTTP 200, JS ran,
+        // React app booted, doc-loader returned 404, sub-view rendered.
+        let html = """
+        <html><head><title>Apple Developer Documentation</title></head>
+        <body>
+        <h1>Apple Developer Documentation</h1>
+        <a href="#app-main">Skip Navigation</a>
+        <h1>The page you're looking for can't be found.</h1>
+        <input placeholder="Search developer.apple.com">
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == true)
+    }
+
+    @Test("Sub-view phrase embedded in a paragraph still trips")
+    func subViewInParagraph() {
+        let html = """
+        <html><body><p>The page you're looking for can't be found.</p></body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == true)
+    }
+
+    // MARK: generic error sub-view
+
+    @Test("Apple's React 'unknown error' sub-view trips the gate")
+    func reactUnknownErrorSubView() {
+        let html = """
+        <html><head><title>Apple Developer Documentation</title></head>
+        <body>
+        <h1>Apple Developer Documentation</h1>
+        <a href="#app-main">Skip Navigation</a>
+        <h1>An unknown error occurred.</h1>
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == true)
+    }
+
+    // MARK: real Apple pages must NOT trip
+
+    @Test("Real Apple symbol page is not flagged")
+    func realPageNotFlagged() {
+        let html = """
+        <html><head><title>AVCustomMediaSelectionScheme | Apple Developer Documentation</title></head>
+        <body>
+        <h1>AVCustomMediaSelectionScheme</h1>
+        <p>A media selection scheme provides custom settings for controlling
+        media presentation in playback and authoring workflows. Use this type
+        when the built-in audio and subtitle selection options don't meet
+        your app's needs.</p>
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == false)
+    }
+
+    @Test("Real page legitimately discussing JavaScript APIs is not flagged")
+    func realJavaScriptPageNotFlagged() {
+        // The gate must not trip on Apple's WebKit / WKWebView pages that
+        // legitimately discuss the word "JavaScript" in normal prose.
+        // We pin literal phrases unique to React's no-content sub-views,
+        // not the substring "JavaScript", to avoid this class of false
+        // positive.
+        let html = """
+        <html><head><title>WKWebView.evaluateJavaScript | Apple Developer Documentation</title></head>
+        <body>
+        <h1>evaluateJavaScript(_:completionHandler:)</h1>
+        <p>Use this method to execute JavaScript code in the context of the
+        currently loaded page. Real Apple documentation routinely mentions
+        JavaScript without the SPA's no-content sub-view markers; this
+        page must therefore not be flagged.</p>
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == false)
+    }
+
+    @Test("Real page that mentions a similar phrase mid-prose is not flagged")
+    func similarPhraseInProseNotFlagged() {
+        // Defensively confirm that nearby English phrasing ("can't find
+        // the page", "could not be located") doesn't trip the gate —
+        // only the literal Apple sub-view sentence does.
+        let html = """
+        <html><body>
+        <p>If a page can't be located the routing layer should surface
+        a NotFoundError, not silently drop the request.</p>
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == false)
+    }
+
+    // MARK: degenerate inputs
+
+    @Test("Empty HTML returns false")
+    func emptyHTMLReturnsFalse() {
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: "") == false)
+    }
+
+    @Test("HTML with only a title returns false")
+    func titleOnlyReturnsFalse() {
+        let html = "<html><head><title>Apple Developer Documentation</title></head></html>"
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == false)
+    }
+}


### PR DESCRIPTION
## Summary

PR #289's `looksLikeHTTPErrorPage` caught HTTP-status-error templates (`403`, `502`, etc.) at the crawler's HTML fallback path. It missed a second class of poison: Apple's React SPA renders its own sub-views as HTTP 200 OK with the SPA shell HTML when its internal doc-loader returns 404 for a URL:

- `"The page you're looking for can't be found"` (Apple's 404 sub-view)
- `"An unknown error occurred"` (generic error sub-view)

Neither is an HTTP error, so PR #289 let them through. PR #291's indexer-side check caught the same shape post-conversion but only on the apple-docs index path, and even then the poison file sat in the source corpus.

## What this adds

- `HTMLToMarkdown.looksLikeJavaScriptFallback(html:)` — pinned-literal check for either Apple-specific sub-view marker. Real Apple docs don't quote either sentence, so false-positive risk is low.
- Both `Crawler.swift` HTML-fallback paths now call the new gate alongside `looksLikeHTTPErrorPage`.
- `CrawlerState.recordRejection(...)` writes one JSONL row per skipped URL to `<output>/.cupertino-rejected-urls.jsonl` (append-only, framework + reason + URL + ISO-8601 timestamp). Write failure logs but never blocks the crawl.
- 9 truth-table tests for the new gate (positive: both sub-view markers; negative: real Apple symbol pages, WebKit pages legitimately discussing JavaScript, English prose with similar phrasing).

## Evidence

51-URL re-crawl of URLs that produced poison in the v1.0.2-era bundle:

| State | Saves | Defense trips | New poison files |
|---|---|---|---|
| Pre-fix (binary 1.0.2) | 9 | 0 | 9 |
| Post-fix (this branch) | 0 | 48 | 0 |

The 48 rejections came back as `.cupertino-rejected-urls.jsonl` rows:

```json
{"url":"https://developer.apple.com/documentation/accountorganizationaldatasharing/fetch-apple","framework":"accountorganizationaldatasharing","reason":"js_fallback","timestamp":"2026-05-13T..."}
```

## Tests

- `HTMLToMarkdownErrorPageDetectionTests` (existing) — 8 tests, all green
- `HTMLToMarkdownJavaScriptFallbackTests` (new) — 9 tests, all green
- `CoreTests` full pass — 76 tests, 3 suites, green
- `swiftformat` + `swiftlint` pre-commit hooks — green

## Related

- #284 — defense work tracking issue
- #429 — corpus → DB reconciliation tests (this PR enables their evidence trail)
- PR #289 — crawler HTTP-error gate
- PR #291 — indexer-side JS-fallback gate (apple-docs only; gap remains for non-apple-docs index paths)