### PR TITLE
chore: merge main into develop — port #432 SPA no-content gate to new Crawler target

### DIFF
--- a/Packages/Sources/Core/Crawler.swift
+++ b/Packages/Sources/Core/Crawler.swift
@@ -315,6 +315,24 @@ extension Core {
                     let html = try await loadPage(url: url)
                     if HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) {
                         logInfo("   ⛔ HTTP error template detected, skipping (#284)")
+                        await state.recordRejection(
+                            url: url,
+                            framework: framework,
+                            reason: .httpErrorTemplate,
+                            outputDirectory: configuration.outputDirectory
+                        )
+                        await state.updateStatistics { $0.errors += 1 }
+                        await state.updateStatistics { $0.totalPages += 1 }
+                        return
+                    }
+                    if HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) {
+                        logInfo("   ⛔ Apple SPA no-content sub-view detected, skipping (#284)")
+                        await state.recordRejection(
+                            url: url,
+                            framework: framework,
+                            reason: .javaScriptFallback,
+                            outputDirectory: configuration.outputDirectory
+                        )
                         await state.updateStatistics { $0.errors += 1 }
                         await state.updateStatistics { $0.totalPages += 1 }
                         return
@@ -332,6 +350,24 @@ extension Core {
                 let html = try await loadPage(url: url)
                 if HTMLToMarkdown.looksLikeHTTPErrorPage(html: html) {
                     logInfo("   ⛔ HTTP error template detected, skipping (#284)")
+                    await state.recordRejection(
+                        url: url,
+                        framework: framework,
+                        reason: .httpErrorTemplate,
+                        outputDirectory: configuration.outputDirectory
+                    )
+                    await state.updateStatistics { $0.errors += 1 }
+                    await state.updateStatistics { $0.totalPages += 1 }
+                    return
+                }
+                if HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) {
+                    logInfo("   ⛔ Apple SPA no-content sub-view detected, skipping (#284)")
+                    await state.recordRejection(
+                        url: url,
+                        framework: framework,
+                        reason: .javaScriptFallback,
+                        outputDirectory: configuration.outputDirectory
+                    )
                     await state.updateStatistics { $0.errors += 1 }
                     await state.updateStatistics { $0.totalPages += 1 }
                     return

--- a/Packages/Sources/Core/CrawlerState.swift
+++ b/Packages/Sources/Core/CrawlerState.swift
@@ -276,6 +276,73 @@ public actor CrawlerState {
         metadata.lastCrawl
     }
 
+    // MARK: - Rejected URL Tracking (#284)
+
+    /// Why a URL was rejected by one of the crawler's content-quality gates.
+    /// String raw values so the on-disk JSONL file stays human-greppable.
+    public enum RejectionReason: String, Codable, Sendable {
+        /// `HTMLToMarkdown.looksLikeHTTPErrorPage` tripped — Apple's CDN
+        /// served a styled 403/404/502 page at HTTP 200.
+        case httpErrorTemplate = "http_error_template"
+        /// `HTMLToMarkdown.looksLikeJavaScriptFallback` tripped — Apple's
+        /// React SPA rendered its "page can't be found" / "unknown error"
+        /// sub-view at HTTP 200 (the internal doc-loader returned 404).
+        case javaScriptFallback = "js_fallback"
+    }
+
+    /// One row of the rejected-URLs log. Append-only JSONL so an interrupted
+    /// crawl preserves every prior write.
+    public struct RejectedURLRecord: Codable, Sendable {
+        public let url: String
+        public let framework: String
+        public let reason: RejectionReason
+        public let timestamp: Date
+    }
+
+    /// Append a single rejection record to the session's rejected-URLs log
+    /// at `<outputDirectory>/.cupertino-rejected-urls.jsonl`. Each call writes
+    /// one JSON line + a `\n` terminator so a crash mid-write loses at most
+    /// the in-flight record. The file is plain text + line-delimited so
+    /// operators can `grep` / `jq` / `wc -l` it without parsing the metadata.
+    ///
+    /// Failure to append is logged but does not propagate — a missing log
+    /// row must never block a crawl that is otherwise making progress.
+    public func recordRejection(
+        url: URL,
+        framework: String,
+        reason: RejectionReason,
+        outputDirectory: URL
+    ) {
+        let record = RejectedURLRecord(
+            url: url.absoluteString,
+            framework: framework,
+            reason: reason,
+            timestamp: Date()
+        )
+        let logFile = outputDirectory.appendingPathComponent(".cupertino-rejected-urls.jsonl")
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let line = try encoder.encode(record) + Data("\n".utf8)
+            if FileManager.default.fileExists(atPath: logFile.path) {
+                let handle = try FileHandle(forWritingTo: logFile)
+                defer { try? handle.close() }
+                try handle.seekToEnd()
+                try handle.write(contentsOf: line)
+            } else {
+                try FileManager.default.createDirectory(
+                    at: outputDirectory,
+                    withIntermediateDirectories: true
+                )
+                try line.write(to: logFile)
+            }
+        } catch {
+            Logging.Logger.crawler.warning(
+                "⚠️ Failed to record rejected URL \(url.absoluteString): \(error.localizedDescription)"
+            )
+        }
+    }
+
     // MARK: - Session State Management
 
     /// Save current crawl session state

--- a/Packages/Sources/Core/Transformers/HTMLToMarkdown.swift
+++ b/Packages/Sources/Core/Transformers/HTMLToMarkdown.swift
@@ -129,6 +129,35 @@ public struct HTMLToMarkdown: ContentTransformer, @unchecked Sendable {
         return looksLikeHTTPErrorPage(title: title, html: html)
     }
 
+    /// Returns true if `html` is Apple's React SPA shell served without a
+    /// rendered page body. Apple's developer-docs site is a client-rendered
+    /// React app; when its internal doc-loader endpoint returns 404 (or
+    /// some other failure) for a given URL, the page returns HTTP 200 OK
+    /// with the shell HTML and one of two sub-view templates as the visible
+    /// body: "The page you're looking for can't be found." (Apple's 404
+    /// sub-view) or "An unknown error occurred." (generic error sub-view).
+    /// Neither is an HTTP error, so `looksLikeHTTPErrorPage` lets them
+    /// through; without this gate, ~1,300 such files landed on disk during
+    /// the v1.0.0–v1.0.2 crawls and propagated into every bundle.
+    ///
+    /// The indexer-side `pageLooksLikeJavaScriptFallback` (#284) catches
+    /// the same shape post-conversion, but only on the apple-docs index
+    /// path — and even then, the poison files still sit in the source
+    /// corpus. This crawler-side gate stops them at write time so neither
+    /// the corpus nor the indexer's other code paths see them.
+    public static func looksLikeJavaScriptFallback(html: String) -> Bool {
+        // Apple's specific React sub-view phrases. Pinned literals because
+        // they are unique to the React app's no-content states; real Apple
+        // documentation pages do not quote either sentence.
+        if html.contains("The page you're looking for can't be found") {
+            return true
+        }
+        if html.contains("An unknown error occurred") {
+            return true
+        }
+        return false
+    }
+
     /// Pure decision over a pre-extracted `title` + the surrounding `html`.
     /// Split out so unit tests can exercise the rule against synthetic
     /// inputs without round-tripping through the full HTML title-extractor.

--- a/Packages/Sources/Shared/Models.swift
+++ b/Packages/Sources/Shared/Models.swift
@@ -842,23 +842,46 @@ public enum HashUtilities {
 
 /// Utilities for URL manipulation
 public enum URLUtilities {
-    /// Normalize a URL: strip fragment and query, lowercase the path.
-    /// Apple's docs server is case-insensitive on the path
-    /// (`/documentation/Cinematic/CNAssetInfo-2ata2` and the all-lowercase
-    /// form return the same content), so dedup logic must treat them as one
-    /// page (#200). Dash-vs-underscore framework variants
-    /// (`professional-video-applications` ↔ `professional_video_applications`)
-    /// are NOT collapsed here because at least one Apple framework
-    /// (`installer_js`) legitimately uses underscore in its path; that axis
-    /// is handled at the search-index save layer instead.
+    /// Returns a normalized copy of `url` with fragment and query stripped,
+    /// path lowercased, and underscores replaced with dashes in sub-page
+    /// segments within `/documentation/` paths.
+    ///
+    /// Applies underscore-to-dash replacement only to path segments at depth
+    /// ≥ 3 (sub-page level). Framework slugs at depth 2 are preserved because
+    /// at least two Apple frameworks (`installer_js`,
+    /// `professional_video_applications`) use underscores canonically and
+    /// their dash forms return 404. This resolves the 31 duplicate URI
+    /// clusters in search.db (#285).
+    ///
+    /// - Parameter url: The URL to normalize.
+    /// - Returns: The normalized URL, or `nil` if `url` cannot be decomposed
+    ///   into URL components.
     public static func normalize(_ url: URL) -> URL? {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         components?.fragment = nil
         components?.query = nil
         if let path = components?.path {
-            components?.path = path.lowercased()
+            components?.path = normalizeDocPath(path.lowercased())
         }
         return components?.url
+    }
+
+    // Replace underscores with dashes in sub-page path segments only.
+    // Framework slugs at depth 2 after /documentation/ use underscores
+    // canonically (installer_js, professional_video_applications) and must
+    // be left untouched.
+    private static func normalizeDocPath(_ path: String) -> String {
+        var parts = path.components(separatedBy: "/")
+        guard let docIdx = parts.firstIndex(of: "documentation"),
+              docIdx + 2 < parts.count else { return path }
+
+        let normalizeFromIdx = docIdx + 2
+        return parts
+            .enumerated()
+            .map { index, part in
+                index >= normalizeFromIdx ? String(part.map { $0 == "_" ? "-" : $0 }) : part
+            }
+            .joined(separator: "/")
     }
 
     /// Extract framework name from documentation URL (Apple or Swift.org)

--- a/Packages/Tests/CoreTests/CrawlerTests.swift
+++ b/Packages/Tests/CoreTests/CrawlerTests.swift
@@ -99,6 +99,69 @@ struct CrawlerTests {
         #expect(try !#require(normalized?.absoluteString.contains("installer-js")))
     }
 
+    @Test("URLUtilities normalize converts underscore sub-page slug to dash")
+    func urlNormalizeConvertsUnderscoreSubpageToDash() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/corelocation/getting_heading_and_course_information")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/corelocation/getting-heading-and-course-information")
+    }
+
+    @Test("URLUtilities normalize preserves framework slug at depth 2 and normalizes sub-page underscore")
+    func urlNormalizePreservesFrameworkSlugNormalizesSubpage() throws {
+        // driverkit/driverkit_constants is one of the 31 duplicate-cluster pairs from #285.
+        // The framework slug "driverkit" at depth 2 must be left untouched;
+        // only "driverkit_constants" at depth 3 is collapsed to dashes.
+        let url = URL(string: "https://developer.apple.com/documentation/driverkit/driverkit_constants")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/driverkit/driverkit-constants")
+    }
+
+    @Test("URLUtilities normalize converts underscores at multiple sub-page depths")
+    func urlNormalizeConvertsUnderscoresAtMultipleDepths() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/swiftui/some_class/some_method")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/swiftui/some-class/some-method")
+    }
+
+    @Test("URLUtilities normalize does not touch non-documentation URL underscores")
+    func urlNormalizeDoesNotTouchNonDocsPaths() throws {
+        let url = URL(string: "https://developer.apple.com/videos/play/wwdc2023/10_video")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/videos/play/wwdc2023/10_video")
+    }
+
+    @Test("URLUtilities normalize strips fragment and query and collapses sub-page underscore")
+    func urlNormalizeStripsFragmentQueryAndNormalizesUnderscore() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/swiftui/some_method?foo=1#bar")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/swiftui/some-method")
+        #expect(normalized?.query == nil)
+        #expect(normalized?.fragment == nil)
+    }
+
+    @Test("URLUtilities normalize lowercases before collapsing underscore to dash")
+    func urlNormalizeLowercasesBeforeCollapsingUnderscore() throws {
+        let url = URL(string: "https://developer.apple.com/documentation/SwiftUI/Some_Method")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation/swiftui/some-method")
+    }
+
+    @Test("URLUtilities normalize does not crash on /documentation with no framework slug")
+    func urlNormalizeHandlesDocumentationOnlyPath() throws {
+        // Regression: normalizeDocPath used to trap with "Range requires lowerBound <= upperBound"
+        // when documentation was found but had fewer than 2 following path segments.
+        let url = URL(string: "https://developer.apple.com/documentation")!
+        let normalized = URLUtilities.normalize(url)
+
+        #expect(normalized?.path == "/documentation")
+    }
+
     // MARK: - Framework Extraction Tests
 
     @Test("URLUtilities extracts framework from Apple docs URL")

--- a/Packages/Tests/CoreTests/HTMLToMarkdownJavaScriptFallbackTests.swift
+++ b/Packages/Tests/CoreTests/HTMLToMarkdownJavaScriptFallbackTests.swift
@@ -1,0 +1,126 @@
+@testable import Core
+import Foundation
+import Testing
+
+// Coverage for `HTMLToMarkdown.looksLikeJavaScriptFallback(...)` — the
+// crawler-side gate added on top of #284 to catch Apple's React SPA
+// "no-content" sub-views. Apple's developer-docs site is a client-rendered
+// React app; when its internal doc-loader endpoint returns 404 (or some
+// other failure) for a given URL, the page itself returns HTTP 200 OK
+// with the shell HTML and one of two sub-view templates as the body.
+//
+// Neither sub-view is an HTTP error, so `looksLikeHTTPErrorPage` lets
+// them through. The indexer-side `pageLooksLikeJavaScriptFallback`
+// (#284, in SearchIndexBuilder) catches the same shape post-conversion,
+// but only on the apple-docs index path AND only after the poison file
+// has already landed in the source corpus. This crawler-side gate stops
+// them at write time so neither the corpus nor any downstream code sees
+// them.
+
+@Suite("HTMLToMarkdown.looksLikeJavaScriptFallback (#284 crawler-side)")
+struct HTMLToMarkdownJavaScriptFallbackTests {
+    // MARK: 404 sub-view ("page can't be found")
+
+    @Test("Apple's React 404 sub-view trips the gate")
+    func reactNotFoundSubView() {
+        // Sample captured from a v1.0.2-era poison file: HTTP 200, JS ran,
+        // React app booted, doc-loader returned 404, sub-view rendered.
+        let html = """
+        <html><head><title>Apple Developer Documentation</title></head>
+        <body>
+        <h1>Apple Developer Documentation</h1>
+        <a href="#app-main">Skip Navigation</a>
+        <h1>The page you're looking for can't be found.</h1>
+        <input placeholder="Search developer.apple.com">
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == true)
+    }
+
+    @Test("Sub-view phrase embedded in a paragraph still trips")
+    func subViewInParagraph() {
+        let html = """
+        <html><body><p>The page you're looking for can't be found.</p></body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == true)
+    }
+
+    // MARK: generic error sub-view
+
+    @Test("Apple's React 'unknown error' sub-view trips the gate")
+    func reactUnknownErrorSubView() {
+        let html = """
+        <html><head><title>Apple Developer Documentation</title></head>
+        <body>
+        <h1>Apple Developer Documentation</h1>
+        <a href="#app-main">Skip Navigation</a>
+        <h1>An unknown error occurred.</h1>
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == true)
+    }
+
+    // MARK: real Apple pages must NOT trip
+
+    @Test("Real Apple symbol page is not flagged")
+    func realPageNotFlagged() {
+        let html = """
+        <html><head><title>AVCustomMediaSelectionScheme | Apple Developer Documentation</title></head>
+        <body>
+        <h1>AVCustomMediaSelectionScheme</h1>
+        <p>A media selection scheme provides custom settings for controlling
+        media presentation in playback and authoring workflows. Use this type
+        when the built-in audio and subtitle selection options don't meet
+        your app's needs.</p>
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == false)
+    }
+
+    @Test("Real page legitimately discussing JavaScript APIs is not flagged")
+    func realJavaScriptPageNotFlagged() {
+        // The gate must not trip on Apple's WebKit / WKWebView pages that
+        // legitimately discuss the word "JavaScript" in normal prose.
+        // We pin literal phrases unique to React's no-content sub-views,
+        // not the substring "JavaScript", to avoid this class of false
+        // positive.
+        let html = """
+        <html><head><title>WKWebView.evaluateJavaScript | Apple Developer Documentation</title></head>
+        <body>
+        <h1>evaluateJavaScript(_:completionHandler:)</h1>
+        <p>Use this method to execute JavaScript code in the context of the
+        currently loaded page. Real Apple documentation routinely mentions
+        JavaScript without the SPA's no-content sub-view markers; this
+        page must therefore not be flagged.</p>
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == false)
+    }
+
+    @Test("Real page that mentions a similar phrase mid-prose is not flagged")
+    func similarPhraseInProseNotFlagged() {
+        // Defensively confirm that nearby English phrasing ("can't find
+        // the page", "could not be located") doesn't trip the gate —
+        // only the literal Apple sub-view sentence does.
+        let html = """
+        <html><body>
+        <p>If a page can't be located the routing layer should surface
+        a NotFoundError, not silently drop the request.</p>
+        </body></html>
+        """
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == false)
+    }
+
+    // MARK: degenerate inputs
+
+    @Test("Empty HTML returns false")
+    func emptyHTMLReturnsFalse() {
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: "") == false)
+    }
+
+    @Test("HTML with only a title returns false")
+    func titleOnlyReturnsFalse() {
+        let html = "<html><head><title>Apple Developer Documentation</title></head></html>"
+        #expect(HTMLToMarkdown.looksLikeJavaScriptFallback(html: html) == false)
+    }
+}


### PR DESCRIPTION
## Summary

Pulls main into develop. Main has 2 commits develop was missing:

- **#286** (\`6b6d58b\`) — search URL underscore→dash normalization. **Logically already on develop** via parallel PR #343.
- **#432** (\`0fcd246\`) — Apple SPA no-content sub-view gate (#284 follow-up). **NEW work, ported here.**

## Port: #432 SPA no-content gate

Main's commit touched 4 files. After the Crawler extract (#430), those locations no longer exist; the equivalent logic was ported as follows:

| Main location | Develop location after port |
|---|---|
| \`Core/Crawler.swift\` (gate calls in fallback paths) | \`Crawler/Crawler.AppleDocs.swift\` (auto-merged) |
| \`Core/CrawlerState.swift\` (recordRejection + types) | \`Crawler/Crawler.AppleDocs.State.swift\` + new \`State.RejectionReason.swift\` + \`State.RejectedURLRecord.swift\` (per task #21) |
| \`Core/Transformers/HTMLToMarkdown.swift\` (looksLikeJavaScriptFallback) | \`Core/HTMLParser/Core.Parser.HTML.swift\` (added next to looksLikeHTTPErrorPage) |
| \`Tests/CoreTests/HTMLToMarkdownJavaScriptFallbackTests.swift\` (new, 8 tests) | Kept; \`HTMLToMarkdown\` references rewritten to \`Core.Parser.HTML\` |

## Conflict resolutions

- \`Sources/Shared/Models.swift\` — kept develop's deletion (already split into \`Shared.Models.*.swift\` files).
- \`Sources/Core/Transformers/HTMLToMarkdown.swift\` — deleted; functionality moved to \`Core/HTMLParser/Core.Parser.HTML.swift\` during Phase 1.
- \`Sources/Core/CrawlerState.swift\` — deleted; moved to \`Crawler/Crawler.AppleDocs.State.swift\` during #430.
- \`Tests/CoreTests/CrawlerTests.swift\` — kept develop's idiomatic version (\`try #require(URL(...))\` + qualified \`Shared.Models.URLUtilities\`).

## New types (one-per-file per task #21)

- \`Crawler.AppleDocs.State.RejectionReason\` — `.httpErrorTemplate`, `.javaScriptFallback`
- \`Crawler.AppleDocs.State.RejectedURLRecord\` — JSONL-serialized row of the rejected-URLs log

## Verification

- Develop history now contains main as ancestor: \`git log HEAD..origin/main\` → 0 commits.
- Future develop → main merges are now fast-forward (no more divergence).
- \`xcrun swift build\` (clean): **0 warnings, 0 errors**
- \`xcrun swift test\` (clean): **1308/1308 pass** (+8 new tests from #432)