### PR TITLE
refactor(MCPCore): rename SPM target MCP → MCPCore

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -10,7 +10,7 @@ import PackageDescription
 
 let baseProducts: [Product] = [
     // MCP Framework (cross-platform, consolidated from MCPShared + MCPTransport + MCPServer)
-    .singleTargetLibrary("MCP"),
+    .singleTargetLibrary("MCPCore"),
 ]
 
 // Cupertino products (macOS only - uses FileManager.homeDirectoryForCurrentUser)
@@ -74,20 +74,20 @@ let deps: [Package.Dependency] = [
 
 let targets: [Target] = {
     // ---------- MCP Framework (Consolidated from MCPShared + MCPTransport + MCPServer) ----------
-    let mcpTarget = Target.target(
-        name: "MCP",
+    let mcpCoreTarget = Target.target(
+        name: "MCPCore",
         dependencies: [],
         path: "Sources/MCP/Core"
     )
-    let mcpTestsTarget = Target.testTarget(
+    let mcpCoreTestsTarget = Target.testTarget(
         name: "MCPTests",
-        dependencies: ["MCP"],
+        dependencies: ["MCPCore"],
         path: "Tests/MCP/CoreTests"
     )
 
     let mcpTargets = [
-        mcpTarget,
-        mcpTestsTarget,
+        mcpCoreTarget,
+        mcpCoreTestsTarget,
     ]
 
     // ---------- Cupertino (Apple Docs Crawler → MCP Server - macOS only) ----------
@@ -144,7 +144,7 @@ let targets: [Target] = {
     // ---------- MCPSharedTools (v1.1 refactor 1.1: extracts MCP.SharedTools.ArgumentExtractor + MCP-protocol-output constants from Shared) ----------
     let mcpSharedToolsTarget = Target.target(
         name: "MCPSharedTools",
-        dependencies: ["MCP", "SharedCore", "SharedConstants"],
+        dependencies: ["MCPCore", "SharedCore", "SharedConstants"],
         path: "Sources/MCP/SharedTools"
     )
     let mcpSharedToolsTestsTarget = Target.testTarget(
@@ -283,18 +283,18 @@ let targets: [Target] = {
 
     let mcpSupportTarget = Target.target(
         name: "MCPSupport",
-        dependencies: ["MCP", "MCPSharedTools", "SharedCore", "SharedConfiguration", "SharedConstants", "SharedModels", "SharedUtils", "Logging", "Search"],
+        dependencies: ["MCPCore", "MCPSharedTools", "SharedCore", "SharedConfiguration", "SharedConstants", "SharedModels", "SharedUtils", "Logging", "Search"],
         path: "Sources/MCP/Support"
     )
     let mcpSupportTestsTarget = Target.testTarget(
         name: "MCPSupportTests",
-        dependencies: ["MCPSupport", "MCP", "MCPSharedTools", "SharedCore", "SharedConfiguration", "SharedConstants", "SharedModels", "Search", "TestSupport"],
+        dependencies: ["MCPSupport", "MCPCore", "MCPSharedTools", "SharedCore", "SharedConfiguration", "SharedConstants", "SharedModels", "Search", "TestSupport"],
         path: "Tests/MCP/SupportTests"
     )
 
     let searchToolProviderTarget = Target.target(
         name: "SearchToolProvider",
-        dependencies: ["MCP", "MCPSharedTools", "SharedCore", "SharedConstants", "SharedUtils", "Search", "SampleIndex", "Services"]
+        dependencies: ["MCPCore", "MCPSharedTools", "SharedCore", "SharedConstants", "SharedUtils", "Search", "SampleIndex", "Services"]
     )
     let searchToolProviderTestsTarget = Target.testTarget(
         name: "SearchToolProviderTests",
@@ -303,7 +303,7 @@ let targets: [Target] = {
 
     let mcpClientTarget = Target.target(
         name: "MCPClient",
-        dependencies: ["MCP"],
+        dependencies: ["MCPCore"],
         path: "Sources/MCP/Client"
     )
     let mcpClientTestsTarget = Target.testTarget(
@@ -406,7 +406,7 @@ let targets: [Target] = {
             "RemoteSync",
             "Availability",
             // MCP dependencies (for mcp serve command)
-            "MCP",
+            "MCPCore",
             "MCPSupport",
             "SearchToolProvider",
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
@@ -430,7 +430,7 @@ let targets: [Target] = {
     let mockAIAgentTarget = Target.executableTarget(
         name: "MockAIAgent",
         dependencies: [
-            "MCP",
+            "MCPCore",
             "SharedCore",
             "SharedConstants",
             "Logging",
@@ -460,13 +460,13 @@ let targets: [Target] = {
     // CLI Command Test Targets
     let serveTestsTarget = Target.testTarget(
         name: "ServeTests",
-        dependencies: ["CLI", "Crawler", "MCP", "MCPSupport", "Search", "SearchToolProvider", "SharedCore", "TestSupport"],
+        dependencies: ["CLI", "Crawler", "MCPCore", "MCPSupport", "Search", "SearchToolProvider", "SharedCore", "TestSupport"],
         path: "Tests/CLICommandTests/ServeTests"
     )
 
     let doctorTestsTarget = Target.testTarget(
         name: "DoctorTests",
-        dependencies: ["CLI", "Diagnostics", "MCP", "MCPSupport", "Search", "SharedCore", "TestSupport"],
+        dependencies: ["CLI", "Diagnostics", "MCPCore", "MCPSupport", "Search", "SharedCore", "TestSupport"],
         path: "Tests/CLICommandTests/DoctorTests"
     )
 
@@ -497,7 +497,7 @@ let targets: [Target] = {
     )
     let mockAIAgentTestsTarget = Target.testTarget(
         name: "MockAIAgentTests",
-        dependencies: ["MCP", "SampleIndex", "SharedCore", "TestSupport"]
+        dependencies: ["MCPCore", "SampleIndex", "SharedCore", "TestSupport"]
     )
 
     let cupertinoTargets: [Target] = [

--- a/Packages/Sources/CLI/Commands/CLI.Command.Doctor.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Doctor.swift
@@ -6,7 +6,7 @@ import Diagnostics
 import Foundation
 import Indexer
 import Logging
-import MCP
+import MCPCore
 import MCPSupport
 import SampleIndex
 import Search

--- a/Packages/Sources/CLI/Commands/CLI.Command.Serve.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Serve.swift
@@ -4,7 +4,7 @@ import CoreProtocols
 import Darwin
 import Foundation
 import Logging
-import MCP
+import MCPCore
 import MCPSupport
 import SampleIndex
 import Search

--- a/Packages/Sources/MCP/Client/MCP.Client.Cupertino.swift
+++ b/Packages/Sources/MCP/Client/MCP.Client.Cupertino.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MCP
+import MCPCore
 
 // MARK: - Cupertino Convenience Methods
 

--- a/Packages/Sources/MCP/Client/MCP.Client.swift
+++ b/Packages/Sources/MCP/Client/MCP.Client.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MCP
+import MCPCore
 
 // MARK: - MCP Client
 

--- a/Packages/Sources/MCP/SharedTools/MCP.SharedTools.ArgumentExtractor.swift
+++ b/Packages/Sources/MCP/SharedTools/MCP.SharedTools.ArgumentExtractor.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MCP
+import MCPCore
 import SharedConstants
 import SharedCore
 

--- a/Packages/Sources/MCP/SharedTools/MCP.SharedTools.Copy.swift
+++ b/Packages/Sources/MCP/SharedTools/MCP.SharedTools.Copy.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MCP
+import MCPCore
 import SharedConstants
 
 // MARK: - MCP.SharedTools.Copy

--- a/Packages/Sources/MCP/SharedTools/MCP.SharedTools.swift
+++ b/Packages/Sources/MCP/SharedTools/MCP.SharedTools.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MCP
+import MCPCore
 
 // MARK: - MCP.SharedTools Namespace
 

--- a/Packages/Sources/MCP/Support/MCP.Support.DocsResourceProvider.swift
+++ b/Packages/Sources/MCP/Support/MCP.Support.DocsResourceProvider.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Logging
-import MCP
+import MCPCore
 import MCPSharedTools
 import Search
 import SharedConfiguration

--- a/Packages/Sources/MCP/Support/MCP.Support.swift
+++ b/Packages/Sources/MCP/Support/MCP.Support.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MCP
+import MCPCore
 
 // MARK: - MCP.Support Namespace
 

--- a/Packages/Sources/MockAIAgent/main.swift
+++ b/Packages/Sources/MockAIAgent/main.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MCP
+import MCPCore
 import SharedConstants
 import SharedCore
 

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MCP
+import MCPCore
 import MCPSharedTools
 import SampleIndex
 import Search

--- a/Packages/Tests/CLICommandTests/DoctorTests/DoctorTests.swift
+++ b/Packages/Tests/CLICommandTests/DoctorTests/DoctorTests.swift
@@ -3,7 +3,7 @@ import Core
 import CoreProtocols
 import Diagnostics
 import Foundation
-import MCP
+import MCPCore
 import MCPSupport
 import Search
 import SharedCore

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -3,7 +3,7 @@ import AppKit
 import CoreProtocols
 import Crawler
 import Foundation
-@testable import MCP
+@testable import MCPCore
 @testable import MCPSupport
 @testable import Search
 @testable import SearchToolProvider

--- a/Packages/Tests/MCP/ClientTests/MCPClientTests.swift
+++ b/Packages/Tests/MCP/ClientTests/MCPClientTests.swift
@@ -1,5 +1,5 @@
-import MCP
 @testable import MCPClient
+import MCPCore
 import Testing
 
 @Suite("MCPClient Tests")

--- a/Packages/Tests/MCP/CoreTests/MCPTests.swift
+++ b/Packages/Tests/MCP/CoreTests/MCPTests.swift
@@ -1,6 +1,6 @@
 // swiftlint:disable use_data_constructor_over_string_member non_optional_string_data_conversion
 import Foundation
-@testable import MCP
+@testable import MCPCore
 import Testing
 
 // MARK: - MCP Framework Tests

--- a/Packages/Tests/MCP/SharedToolsTests/ArgumentExtractorTests.swift
+++ b/Packages/Tests/MCP/SharedToolsTests/ArgumentExtractorTests.swift
@@ -1,4 +1,4 @@
-import MCP
+import MCPCore
 import MCPSharedTools
 import SharedConstants
 import SharedCore

--- a/Packages/Tests/MCP/SupportTests/DocsResourceProviderMalformedURLSkipTests.swift
+++ b/Packages/Tests/MCP/SupportTests/DocsResourceProviderMalformedURLSkipTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MCP
+import MCPCore
 @testable import MCPSupport
 import Search
 import SharedConfiguration

--- a/Packages/Tests/MockAIAgentTests/MCPIntegrationTests.swift
+++ b/Packages/Tests/MockAIAgentTests/MCPIntegrationTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import MCP
+@testable import MCPCore
 @testable import SampleIndex
 import SharedConstants
 @testable import SharedCore

--- a/Packages/Tests/MockAIAgentTests/MockAIAgentTests.swift
+++ b/Packages/Tests/MockAIAgentTests/MockAIAgentTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import MCP
+@testable import MCPCore
 import Testing
 
 // MARK: - Mock AI Agent Tests

--- a/Packages/Tests/SearchToolProviderTests/CupertinoSearchToolProviderTests.swift
+++ b/Packages/Tests/SearchToolProviderTests/CupertinoSearchToolProviderTests.swift
@@ -1,6 +1,6 @@
 // swiftlint:disable file_length
 import Foundation
-import MCP
+import MCPCore
 @testable import SampleIndex
 @testable import Search
 @testable import SearchToolProvider


### PR DESCRIPTION
## Summary

Closes **item 4** of [#426](https://github.com/mihaelamj/cupertino/issues/426). Renames the SPM target \`MCP\` → \`MCPCore\` to mirror the \`CorePackageIndexing\` / \`CoreJSONParser\` pattern where \"Core\" suffix indicates \"the foundation of this family.\"

Types stay under the \`MCP.*\` namespace — only the SPM target name changes.

## Changes

### Package.swift
- \`name: "MCP"\` → \`name: "MCPCore"\` (path unchanged: \`Sources/MCP/Core\`)
- \`mcpTarget\` → \`mcpCoreTarget\` / \`mcpTestsTarget\` → \`mcpCoreTestsTarget\`
- Every \`"MCP"\` dependency string across sibling targets → \`"MCPCore"\`

### External caller sweep
- \`import MCP\` → \`import MCPCore\` across Sources + Tests
- \`@testable import MCP\` → \`@testable import MCPCore\`

## Item 3 of #426 (MCP.swift at folder root)

Visual root would be \`Sources/MCP/MCP.swift\`, but the MCPCore target's path is \`Sources/MCP/Core\`. The anchor IS at the root of its target's folder, just not the visual root of the parent \`Sources/MCP/\` folder. Moving the anchor up requires restructuring the SPM target boundary (changing path + adding excludes for sibling targets like MCPSharedTools, MCPSupport, MCPClient). That's a separate decision; if you want it, I'll do it in a follow-up PR.

## Verification

- \`xcrun swift build\` (clean): **0 warnings, 0 errors**
- \`xcrun swift test\` (clean): **1308/1308 pass**

## Remaining items in #426

- **Item 1** Core.swift to its own zero-dep CoreNamespace target (architectural decision — option A/B/C)
- **Item 2** Other namespace anchors at folder root (mostly satisfied; just \`Core/JSONParser/\`, \`Core/PackageIndexing/\`, \`Core/WKWebCrawler/\` anchors which are at their target roots)
- **Item 3** MCP.swift visual root (see above — needs SPM target path restructure)
- **Item 5** Sample namespace declared in SharedConstants
- **Item 6** Sample.Core vs Core.Sample direction