### PR TITLE
refactor(SharedConstants): add standalone test target; closes #382 (DI epic first leaf)

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -107,6 +107,10 @@ let targets: [Target] = {
         dependencies: [],
         path: "Sources/Shared/Constants"
     )
+    let sharedConstantsTestsTarget = Target.testTarget(
+        name: "SharedConstantsTests",
+        dependencies: ["SharedConstants"]
+    )
 
     // ---------- SharedUtils (v1.1 refactor 1.4: extracts Shared.Utils.JSONCoding, Shared.Utils.PathResolver, Formatting, FTSQuery, SchemaVersion) ----------
     let sharedUtilsTarget = Target.target(
@@ -504,6 +508,7 @@ let targets: [Target] = {
         loggingTarget,
         loggingTestsTarget,
         sharedConstantsTarget,
+        sharedConstantsTestsTarget,
         sharedUtilsTarget,
         sharedModelsTarget,
         sharedCoreTarget,

--- a/Packages/Tests/SharedConstantsTests/SharedConstantsTests.swift
+++ b/Packages/Tests/SharedConstantsTests/SharedConstantsTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+@testable import SharedConstants
+import Testing
+
+// MARK: - SharedConstants Public API Smoke Tests
+
+// SharedConstants is a zero-dependency leaf SPM target whose only role is to
+// expose stable named values: paths, URLs, base directories, source-prefix
+// metadata, and the cross-cutting `Sample` namespace shell. These tests
+// guard the public surface against accidental renames or deletions during
+// refactor passes; they do NOT verify the values themselves (those are
+// implementation choices that can drift). They verify that every public
+// path callers depend on still resolves at the qualified namespace path
+// after a rebuild.
+//
+// Independence check (#382 acceptance): SharedConstants imports only
+// `Foundation`. No other internal cupertino package is imported anywhere
+// in this target. Verified by `grep -rln "^import " Packages/Sources/Shared/Constants/`.
+
+@Suite("SharedConstants public surface")
+struct SharedConstantsPublicSurfaceTests {
+    @Test("Root Shared namespace anchor is reachable")
+    func sharedNamespaceAnchor() {
+        // The Shared namespace enum is declared here; types in every other
+        // cupertino target extend it. If this lookup fails the entire
+        // namespace tree under Shared.* breaks at compile time.
+        _ = Shared.Constants.baseDirectoryName
+    }
+
+    @Test("Sample namespace shell exists")
+    func sampleNamespaceAnchor() {
+        // The cross-cutting Sample namespace lives in this target because
+        // every consumer (Core, SampleIndex, Services, Search) imports
+        // SharedConstants. Verify the anchor is in place.
+        _ = Sample.self
+    }
+
+    @Test("Directory string constants are populated")
+    func directoryConstants() {
+        #expect(!Shared.Constants.Directory.docs.isEmpty)
+        #expect(!Shared.Constants.Directory.swiftEvolution.isEmpty)
+        #expect(!Shared.Constants.Directory.swiftOrg.isEmpty)
+        #expect(!Shared.Constants.Directory.swiftBook.isEmpty)
+        #expect(!Shared.Constants.Directory.packages.isEmpty)
+        #expect(!Shared.Constants.Directory.sampleCode.isEmpty)
+        #expect(!Shared.Constants.Directory.archive.isEmpty)
+        #expect(!Shared.Constants.Directory.hig.isEmpty)
+    }
+
+    @Test("BaseURL constants are populated")
+    func baseURLConstants() {
+        #expect(Shared.Constants.BaseURL.appleDeveloper.hasPrefix("https://"))
+        #expect(Shared.Constants.BaseURL.appleDeveloperDocs.hasPrefix("https://"))
+        #expect(Shared.Constants.BaseURL.appleArchive.hasPrefix("https://"))
+        #expect(Shared.Constants.BaseURL.appleArchiveDocs.hasPrefix("https://"))
+        #expect(Shared.Constants.BaseURL.appleHIG.hasPrefix("https://"))
+        #expect(Shared.Constants.BaseURL.appleSampleCode.hasPrefix("https://"))
+        #expect(Shared.Constants.BaseURL.appleTutorialsData.hasPrefix("https://"))
+        #expect(Shared.Constants.BaseURL.appleTutorialsDocs.hasPrefix("https://"))
+    }
+}


### PR DESCRIPTION
## Summary

**First child of the DI epic #381.** SharedConstants is the zero-dep leaf — already imports only Foundation, so no cross-cupertino imports to drop. The only acceptance gap was a dedicated test target.

## Acceptance per #382

- ✅ \`grep -rln '^import ' Packages/Sources/Shared/Constants/\` returns only \`Foundation\` — zero internal-cupertino imports.
- ✅ \`Packages/Tests/SharedConstantsTests/\` exists. (SharedConstants has no injected protocols — pure constants module — so no mocks needed.)
- ✅ New \`testTarget\` in \`Package.swift\` declares \`SharedConstants\` as its only dep. No \`TestSupport\` dep either (nothing to support).
- ✅ \`xcrun swift build\` clean; \`xcrun swift test\` green; no behaviour change.

## Tests added (4)

Smoke-level only — guard the public surface against accidental renames during refactor passes:

- \`sharedNamespaceAnchor\` — root \`Shared\` namespace anchor reachable
- \`sampleNamespaceAnchor\` — cross-cutting \`Sample\` namespace shell exists
- \`directoryConstants\` — \`Shared.Constants.Directory.*\` populated
- \`baseURLConstants\` — \`Shared.Constants.BaseURL.*\` populated

## Verification

- \`xcrun swift build\` (clean): **0 warnings, 0 errors**
- \`xcrun swift test\` (clean): **1312/1312 pass** (+4 new from this target)

## Closes

- #382 — Refactor(SharedConstants): stand independently — drop cross-package imports, own test target

## Next in queue

- #383 SharedUtils (depends on SharedConstants)
- #384 SharedModels
- #385 Resources
- #386 CoreProtocols
- #387 Logging

The leaf-first order from #381's sequencing section.