### PR TITLE
test(SharedUtils): #383 add standalone SharedUtilsTests target

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -118,6 +118,10 @@ let targets: [Target] = {
         dependencies: ["SharedConstants"],
         path: "Sources/Shared/Utils"
     )
+    let sharedUtilsTestsTarget = Target.testTarget(
+        name: "SharedUtilsTests",
+        dependencies: ["SharedUtils", "SharedConstants"]
+    )
 
     // ---------- SharedModels (v1.1 refactor 1.5: extracts the Models/ folder from Shared) ----------
     let sharedModelsTarget = Target.target(
@@ -510,6 +514,7 @@ let targets: [Target] = {
         sharedConstantsTarget,
         sharedConstantsTestsTarget,
         sharedUtilsTarget,
+        sharedUtilsTestsTarget,
         sharedModelsTarget,
         sharedCoreTarget,
         sharedCoreTestsTarget,

--- a/Packages/Tests/SharedUtilsTests/SharedUtilsTests.swift
+++ b/Packages/Tests/SharedUtilsTests/SharedUtilsTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import SharedConstants
+@testable import SharedUtils
+import Testing
+
+// MARK: - SharedUtils Public API Smoke Tests
+
+// SharedUtils sits one rung above SharedConstants — it imports Foundation +
+// SharedConstants (data-only) and provides stateless utility functions:
+// JSON coding presets, path-resolver helpers, formatting, FTS-query
+// escaping, schema-version arithmetic, URL extensions.
+//
+// Per #383 independence acceptance: SharedUtils imports only Foundation +
+// SharedConstants. No behavioural cross-package import.
+// `grep -rln "^import " Packages/Sources/Shared/Utils/` returns exactly
+// `Foundation` and `SharedConstants`.
+//
+// These tests guard the public surface against accidental renames during
+// refactor passes; behavioural tests live alongside the producers that
+// drive the utilities (the existing SharedCoreTests suite covers
+// JSONCoding round-trips, PathResolver behaviour, etc. through the
+// SharedCore integration path).
+
+@Suite("SharedUtils public surface")
+struct SharedUtilsPublicSurfaceTests {
+    @Test("JSONCoding namespace reachable")
+    func jsonCodingNamespace() {
+        _ = Shared.Utils.JSONCoding.encoder()
+        _ = Shared.Utils.JSONCoding.decoder()
+        _ = Shared.Utils.JSONCoding.prettyEncoder()
+    }
+
+    @Test("JSONCoding round-trips simple Codable values")
+    func jsonCodingRoundTrip() throws {
+        struct Probe: Codable, Equatable {
+            let name: String
+            let value: Int
+        }
+        let original = Probe(name: "leaf-382", value: 42)
+        let data = try Shared.Utils.JSONCoding.encode(original)
+        let decoded = try Shared.Utils.JSONCoding.decode(Probe.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test("PathResolver namespace reachable")
+    func pathResolverNamespace() {
+        // Just verify the static surface compiles; behavioural tests against
+        // real disk paths live in SharedCoreTests, where filesystem fixtures
+        // are wired up.
+        _ = Shared.Utils.PathResolver.self
+    }
+
+    @Test("Formatting namespace reachable")
+    func formattingNamespace() {
+        _ = Shared.Utils.Formatting.self
+    }
+
+    @Test("FTSQuery namespace reachable")
+    func ftsQueryNamespace() {
+        _ = Shared.Utils.FTSQuery.self
+    }
+
+    @Test("SchemaVersion namespace reachable")
+    func schemaVersionNamespace() {
+        _ = Shared.Utils.SchemaVersion.self
+    }
+
+    @Test("URL.knownGood produces a usable URL")
+    func urlKnownGoodExtension() {
+        // The URL.knownGood extension is the canonical Cupertino way to
+        // assert a literal URL is valid — used wherever a string literal
+        // is known to parse. Crash here would mean the extension is gone.
+        let url = URL.knownGood("https://developer.apple.com/documentation/")
+        #expect(url.scheme == "https")
+    }
+}


### PR DESCRIPTION
Second leaf of the DI epic (#381). Mirrors the SharedConstants leaf shipped in #435.

## What

- Add `Packages/Tests/SharedUtilsTests/SharedUtilsTests.swift` with 7 smoke tests guarding the public surface against accidental renames during refactor passes:
  - `Shared.Utils.JSONCoding` (encoder / decoder / pretty + round-trip)
  - `Shared.Utils.PathResolver`
  - `Shared.Utils.Formatting`
  - `Shared.Utils.FTSQuery`
  - `Shared.Utils.SchemaVersion`
  - `URL.knownGood` extension
- `Package.swift`: declare `sharedUtilsTestsTarget` with deps `["SharedUtils", "SharedConstants"]` and register it in `cupertinoTargets` directly after `sharedUtilsTarget`.

## Why

SharedUtils already imports only `Foundation` and `SharedConstants` (`grep -rln '^import ' Packages/Sources/Shared/Utils/` returns exactly those two). Adding a standalone test target pins that contract: anything that drags in a heavier dep will fail to build the test target before reaching any consumer.

Behavioural coverage stays in `SharedCoreTests` where the filesystem fixtures and JSON-coding round-trips through real disk paths are already wired up. This target only proves the symbols compile and the namespace surface is reachable from a consumer that imports nothing but `SharedConstants` + `SharedUtils`.

## Verification

```
xcrun swift build
make test-clean
```

Result: 1319 tests in 147 suites pass (was 1312, +7 SharedUtils smoke tests).

Closes #383.