### PR TITLE
release(v1.1.0): bump CLI 1.0.2 -> 1.1.0; refactor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,21 @@ _On #199: empirical investigation against the post-merge corpus shows `id` is de
 
 ---
 
+## 1.1.0 — 2026-05-13
+
+_Refactor release. No new user-visible features, no schema change. `databaseVersion` stays at `1.0.2` — `cupertino setup` from a v1.1.0 binary downloads the same `cupertino-databases-v1.0.2.zip` bundle. The work folds in the namespacing / per-type-file pass across every SPM target, the `Crawler` extract into its own target, the `MCP` → `MCPCore` target rename, and the first two leaves of the DI epic (`SharedConstants` + `SharedUtils` standalone test targets). Two prior `main` fixes are also captured at their new file locations: SPA no-content gate (#432) at `Core.Parser.HTML.looksLikeJavaScriptFallback` + `Crawler.AppleDocs.State.RejectionReason`, and search URL sub-page dash/underscore normalisation (#286) at `Shared.Models.URLUtilities.normalizeDocPath`._
+
+### Changed
+
+- **Structural refactor across every SPM target**: one non-private type per file, every file named `<Namespace>.<Type>.swift`, every cross-cutting type nested under a Swift `enum` namespace. `Core` types moved into `Core.<Sub>` (`Core.Parser.HTML`, `Core.Parser.XML`, `Core.JSONParser.*`, `Core.PackageIndexing.*`, `Core.WKWebCrawler`). `Shared` split into 5 targets (`SharedConstants`, `SharedUtils`, `SharedModels`, `SharedCore`, `SharedConfiguration`) with the same naming. `Services`, `RemoteSync`, `TUI`, `ReleaseTool`, `CLI.Command`, `Sample.Core` all folded the same way. `<Namespace>+<Type>.swift` files were renamed to `<Namespace>.<Type>.swift` to make the dot-separated form the single convention.
+- **`Crawler` extracted into its own SPM target** (#425, #430, #431): every web-crawling concern now lives in `Packages/Sources/Crawler/` as `Crawler.AppleDocs`, `Crawler.AppleArchive`, `Crawler.HIG`, `Crawler.Evolution`, `Crawler.WebKit.{Engine, ContentFetcher}`, `Crawler.TechnologiesIndex`, and `Crawler.ArchiveGuideCatalog`. Concrete crawlers conform to `Core.Protocols.CrawlerEngine` via a `Crawler.Engine` typealias so a higher-level dispatcher can drive any of them through the same interface.
+- **`MCP` SPM target renamed to `MCPCore`** (#426, #434): the bare `MCP` name was confusable with the `MCP` namespace; the target is now `MCPCore` with no behavioural change.
+- **DI leaf-first epic kicked off** (#381): `SharedConstants` (#382) and `SharedUtils` (#383) each gained a standalone test target with deps `["SharedConstants"]` and `["SharedUtils", "SharedConstants"]` respectively. Smoke tests pin the public namespace surface against accidental renames. The acceptance criterion is zero internal-cupertino behavioural imports per leaf, verified by `grep -rln '^import ' Packages/Sources/<Target>/`.
+
+### Fixed
+
+- **`cupertino-rel` constants path was stale** (release-time chore): six call sites in `Packages/Sources/ReleaseTool/` pointed at the pre-split `Packages/Sources/Shared/Constants.swift` and would fail every bump / tag / homebrew / docs-update flow with "no such file". Repointed at `Packages/Sources/Shared/Constants/Shared.Constants.swift`. The README/DEPLOYMENT version-badge regex literal `\*\*Version:\*\*` had also been incorrectly rewritten to `\*\*Release.Version:\*\*` during the namespacing sweep, so the bump succeeded silently against the markdown files but didn't actually patch them. Both regex literals restored.
+
 ## 1.0.1 — 2026-05-08
 
 _Binary-only bug-fix release on top of v1.0.0 "First Light". `databaseVersion` stays at `1.0.0`: `cupertino setup` from a v1.0.1 binary downloads the same `cupertino-databases-v1.0.0.zip` bundle. The #200 fix is preventive going forward — verified that the shipped v1.0.0 `search.db` has zero case-axis duplicate pairs (a `GROUP BY LOWER(uri) HAVING variants > 1` returned empty across 405,782 docs); Apple's JSON references during the v1.0.0 crawl happened to be uniformly lowercase, so the bug was dodged. Re-index would be ~12 h locally with no observable benefit on the existing corpus; future crawls would have hit the bug and v1.0.1 prevents that going forward. If a refreshed bundle is wanted later, ship as v1.0.1.1._

--- a/Packages/Sources/ReleaseTool/README.md
+++ b/Packages/Sources/ReleaseTool/README.md
@@ -82,7 +82,7 @@ The `bump` command updates:
 
 | File | Field |
 |------|-------|
-| `Packages/Sources/Shared/Constants.swift` | `version = "X.Y.Z"` |
+| `Packages/Sources/Shared/Constants/Shared.Constants.swift` | `version = "X.Y.Z"` |
 | `README.md` | `**Version:** X.Y.Z` |
 | `CHANGELOG.md` | Adds `## X.Y.Z` section |
 | `docs/DEPLOYMENT.md` | `**Version:** X.Y.Z` |

--- a/Packages/Sources/ReleaseTool/Release.Command.Bump.swift
+++ b/Packages/Sources/ReleaseTool/Release.Command.Bump.swift
@@ -28,7 +28,7 @@ extension Release.Command {
             let deployment: URL
 
             init(root: URL) {
-                constants = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+                constants = root.appendingPathComponent("Packages/Sources/Shared/Constants/Shared.Constants.swift")
                 readme = root.appendingPathComponent("README.md")
                 changelog = root.appendingPathComponent("CHANGELOG.md")
                 deployment = root.appendingPathComponent("docs/DEPLOYMENT.md")
@@ -149,8 +149,8 @@ extension Release.Command {
         private func updateReadme(at url: URL, to version: Release.Version) throws {
             var content = try String(contentsOf: url, encoding: .utf8)
 
-            // Update **Release.Version:** X.Y.Z
-            let pattern = #"(\*\*Release.Version:\*\*\s*)\d+\.\d+\.\d+"#
+            // Update **Version:** X.Y.Z
+            let pattern = #"(\*\*Version:\*\*\s*)\d+\.\d+\.\d+"#
             guard let regex = try? NSRegularExpression(pattern: pattern) else {
                 throw BumpError.updateFailed(url.path)
             }
@@ -208,8 +208,8 @@ extension Release.Command {
         private func updateDeployment(at url: URL, to version: Release.Version) throws {
             var content = try String(contentsOf: url, encoding: .utf8)
 
-            // Update **Release.Version:** X.Y.Z
-            let pattern = #"(\*\*Release.Version:\*\*\s*)\d+\.\d+\.\d+"#
+            // Update **Version:** X.Y.Z
+            let pattern = #"(\*\*Version:\*\*\s*)\d+\.\d+\.\d+"#
             guard let regex = try? NSRegularExpression(pattern: pattern) else {
                 throw BumpError.updateFailed(url.path)
             }

--- a/Packages/Sources/ReleaseTool/Release.Command.DocsUpdate.swift
+++ b/Packages/Sources/ReleaseTool/Release.Command.DocsUpdate.swift
@@ -36,7 +36,7 @@ extension Release.Command {
 
         mutating func run() async throws {
             let root = try findRepoRoot()
-            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants/Shared.Constants.swift")
             let readmePath = root.appendingPathComponent("README.md")
 
             Release.Console.info("📚 Documentation Update Workflow")

--- a/Packages/Sources/ReleaseTool/Release.Command.Full.swift
+++ b/Packages/Sources/ReleaseTool/Release.Command.Full.swift
@@ -32,7 +32,7 @@ extension Release.Command {
 
         mutating func run() async throws {
             let root = try findRepoRoot()
-            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants/Shared.Constants.swift")
 
             // Get current version
             let currentVersion = try readCurrentVersion(from: constantsPath)

--- a/Packages/Sources/ReleaseTool/Release.Command.Homebrew.swift
+++ b/Packages/Sources/ReleaseTool/Release.Command.Homebrew.swift
@@ -110,7 +110,7 @@ extension Release.Command {
         }
 
         private func readCurrentVersion(from root: URL) throws -> Release.Version {
-            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants/Shared.Constants.swift")
             let content = try String(contentsOf: constantsPath, encoding: .utf8)
             let pattern = #"public\s+static\s+let\s+version\s*=\s*"(\d+\.\d+\.\d+)""#
             guard let regex = try? NSRegularExpression(pattern: pattern),

--- a/Packages/Sources/ReleaseTool/Release.Command.Tag.swift
+++ b/Packages/Sources/ReleaseTool/Release.Command.Tag.swift
@@ -26,7 +26,7 @@ extension Release.Command {
 
         mutating func run() async throws {
             let root = try findRepoRoot()
-            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants/Shared.Constants.swift")
 
             // Get version from Constants.swift or argument
             let tagVersion: Release.Version

--- a/Packages/Sources/ReleaseTool/Release.Publishing.swift
+++ b/Packages/Sources/ReleaseTool/Release.Publishing.swift
@@ -24,7 +24,7 @@ extension Release {
         }
 
         static func readCurrentVersion(from root: URL) throws -> Release.Version {
-            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants.swift")
+            let constantsPath = root.appendingPathComponent("Packages/Sources/Shared/Constants/Shared.Constants.swift")
             let content = try String(contentsOf: constantsPath, encoding: .utf8)
             // Read databaseVersion, not CLI version — the two are decoupled and
             // database releases follow the database axis.

--- a/Packages/Sources/Shared/Constants/Shared.Constants.swift
+++ b/Packages/Sources/Shared/Constants/Shared.Constants.swift
@@ -181,7 +181,7 @@ extension Shared.Constants {
         public static let userAgent = "CupertinoCrawler/1.0"
 
         /// Current version
-        public static let version = "1.0.2"
+        public static let version = "1.1.0"
 
         /// Database version - separate from CLI version, only bump when schema/content changes.
         /// Controls the cupertino-docs release tag that `cupertino setup` downloads from.

--- a/README.md
+++ b/README.md
@@ -738,8 +738,8 @@ For development setup, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Project Status
 
-**Version:** 1.0.2
-**Status:** ✅ Released 2026-05-11 (re-indexed bundle on top of v1.0.0 "First Light")
+**Version:** 1.1.0
+**Status:** ✅ Released 2026-05-13 (refactor release: namespacing + Crawler extract + DI epic kickoff; bundle stays at v1.0.2)
 
 - ✅ All core functionality working
 - ✅ 1,234 tests across 135 suites passing (100% pass rate)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Cupertino Deployment Guide
 
-**Version:** 0.10.0
+**Version:** 1.1.0
 **Last Updated:** 2025-12-12
 
 This guide covers the complete release process for Cupertino.


### PR DESCRIPTION
Refactor release. No new user-visible features, no schema change.

## Versions

- CLI: `1.0.2` → `1.1.0`
- Database: stays at `1.0.2` (no schema or content change; `cupertino setup` continues to download `cupertino-databases-v1.0.2.zip`)

## What this release captures

- One non-private type per file, every file named `<Namespace>.<Type>.swift`, every cross-cutting type nested under a Swift `enum` namespace, across every SPM target.
- `Crawler` extracted into its own SPM target (#425 / #430 / #431).
- `MCP` target renamed to `MCPCore` (#426 / #434).
- DI epic kickoff: `SharedConstants` (#382) and `SharedUtils` (#383) each gained a standalone test target. Acceptance: zero internal behavioural imports per target.
- main fixes captured at the new file locations:
  - #432 SPA no-content gate → `Core.Parser.HTML.looksLikeJavaScriptFallback` + `Crawler.AppleDocs.State.RejectionReason`
  - #286 sub-page dash/underscore normalisation → `Shared.Models.URLUtilities.normalizeDocPath`

## Drive-by fixes

- Six call sites in `Packages/Sources/ReleaseTool/` pointed at the pre-split `Packages/Sources/Shared/Constants.swift` and would fail every bump/tag/homebrew/docs-update flow with "no such file". Repointed at `Packages/Sources/Shared/Constants/Shared.Constants.swift`.
- The README/DEPLOYMENT version-badge regex literal `\*\*Version:\*\*` had been incorrectly rewritten to `\*\*Release.Version:\*\*` during the namespacing sweep. The bump succeeded silently against the markdown files but didn't actually patch them. Both regex literals restored.

## Verification

`xcrun swift build` clean; `make test-clean` → 1319 tests in 147 suites pass.

## After this merges

1. Merge develop → main via a follow-up PR.
2. Tag `v1.1.0` on main.
3. No `cupertino release databases` step needed (bundle stays at v1.0.2).
4. Homebrew formula update points at the v1.1.0 binary tarball.