### PR TITLE
test(CoreProtocols): #386 add standalone CoreProtocolsTests target

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -182,6 +182,10 @@ let targets: [Target] = {
         name: "CoreProtocols",
         dependencies: ["SharedCore", "SharedConstants", "SharedModels", "Resources"]
     )
+    let coreProtocolsTestsTarget = Target.testTarget(
+        name: "CoreProtocolsTests",
+        dependencies: ["CoreProtocols", "SharedCore", "SharedConstants", "SharedModels", "Resources"]
+    )
 
     // CoreHTMLParser merged back into Core (HTMLToMarkdown -> Core.Parser.HTML,
     // XMLTransformer -> Core.Parser.XML). The Sources/Core/HTMLParser/ folder
@@ -527,6 +531,7 @@ let targets: [Target] = {
         mcpSharedToolsTarget,
         mcpSharedToolsTestsTarget,
         coreProtocolsTarget,
+        coreProtocolsTestsTarget,
         coreJSONParserTarget,
         corePackageIndexingTarget,
         resourcesTarget,

--- a/Packages/Tests/CoreProtocolsTests/CoreProtocolsTests.swift
+++ b/Packages/Tests/CoreProtocolsTests/CoreProtocolsTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+@testable import CoreProtocols
+import Resources
+import SharedConstants
+import SharedCore
+import SharedModels
+import Testing
+
+// MARK: - CoreProtocols Public API Smoke Tests
+
+// CoreProtocols sits at the bottom of the protocols + Core-namespace
+// tier. It owns the `Core` and `Core.Protocols` namespace anchors plus
+// every protocol the crawl/fetch/transform layers conform to:
+// ContentFetcher, ContentTransformer, CrawlerEngine, plus the
+// ExclusionList loader, GitHubCanonicalizer actor, and the
+// SwiftPackagesCatalog data shape.
+//
+// Per #386 independence acceptance: CoreProtocols imports only
+// Foundation + Resources + SharedConstants + SharedCore + SharedModels.
+// No behavioural cross-package import.
+// `grep -rln "^import " Packages/Sources/CoreProtocols/` returns
+// exactly those five imports.
+//
+// These tests guard the public surface against accidental renames
+// during refactor passes. Conformance tests live alongside concrete
+// implementers (Crawler, Core.Parser.HTML, Core.JSONParser, …) where
+// the producers can be wired up against fixtures.
+
+@Suite("CoreProtocols public surface")
+struct CoreProtocolsPublicSurfaceTests {
+    // MARK: Namespace anchors
+
+    @Test("Core and Core.Protocols namespaces reachable")
+    func coreAndProtocolsNamespaces() {
+        _ = Core.self
+        _ = Core.Protocols.self
+    }
+
+    // MARK: ContentFetcher
+
+    @Test("Core.Protocols.FetchResult round-trips its inputs")
+    func contentFetcherFetchResult() throws {
+        // FetchResult is the post-redirect URL carrier added in #277 and
+        // consumed by every crawler engine. Pin the field shape so a
+        // refactor doesn't drop responseHeaders or break the init.
+        let url = try #require(URL(string: "https://developer.apple.com/documentation/swiftui"))
+        let result = Core.Protocols.FetchResult(
+            content: "hello",
+            url: url,
+            responseHeaders: ["Content-Type": "text/html"],
+        )
+        #expect(result.content == "hello")
+        #expect(result.url == url)
+        #expect(result.responseHeaders?["Content-Type"] == "text/html")
+    }
+
+    @Test("Core.Protocols.FetchResult allows nil response headers")
+    func contentFetcherFetchResultNilHeaders() throws {
+        let url = try #require(URL(string: "https://example.com"))
+        let result = Core.Protocols.FetchResult(content: 42, url: url)
+        #expect(result.content == 42)
+        #expect(result.responseHeaders == nil)
+    }
+
+    // MARK: ContentTransformer
+
+    @Test("Core.Protocols.TransformResult exposes markdown/links/metadata/structuredPage")
+    func contentTransformerTransformResult() throws {
+        let metadata = Core.Protocols.TransformMetadata(
+            title: "Title",
+            description: "Description",
+            framework: "SwiftUI",
+            platforms: ["iOS"],
+            isDeprecated: false,
+        )
+        let url = try #require(URL(string: "https://developer.apple.com/documentation/swiftui/view"))
+        let result = Core.Protocols.TransformResult(
+            markdown: "# View",
+            links: [url],
+            metadata: metadata,
+            structuredPage: nil,
+        )
+        #expect(result.markdown == "# View")
+        #expect(result.links == [url])
+        #expect(result.metadata?.title == "Title")
+        #expect(result.metadata?.framework == "SwiftUI")
+        #expect(result.metadata?.platforms == ["iOS"])
+        #expect(result.metadata?.isDeprecated == false)
+        #expect(result.structuredPage == nil)
+    }
+
+    // MARK: ExclusionList
+
+    @Test("Core.Protocols.ExclusionList.normalise strips whitespace and lowercases")
+    func exclusionListNormalise() {
+        // The exclusion-list format is a plain text file of one slug per
+        // line; entries can carry stray whitespace or differ in case
+        // across hand-curated files. Pin the normalisation contract so
+        // a consumer comparing against it doesn't go off-rails.
+        #expect(Core.Protocols.ExclusionList.normalise("  SwiftUI  ") == "swiftui")
+        #expect(Core.Protocols.ExclusionList.normalise("UIKit") == "uikit")
+        #expect(Core.Protocols.ExclusionList.normalise("") == "")
+    }
+
+    // MARK: GitHubCanonicalizer
+
+    @Test("Core.Protocols.GitHubCanonicalizer.CanonicalName round-trips owner + repo")
+    func gitHubCanonicalizerCanonicalName() {
+        let name = Core.Protocols.GitHubCanonicalizer.CanonicalName(owner: "apple", repo: "swift")
+        #expect(name.owner == "apple")
+        #expect(name.repo == "swift")
+        // Equatable is part of the contract; conform-by-rename would
+        // silently break dedup logic downstream.
+        #expect(name == Core.Protocols.GitHubCanonicalizer.CanonicalName(owner: "apple", repo: "swift"))
+    }
+
+    @Test("Core.Protocols.GitHubCanonicalizer primes and snapshots its cache")
+    func gitHubCanonicalizerCachePrimeAndSnapshot() async throws {
+        // Don't write to disk for a smoke test; the actor accepts any
+        // cache URL and only persists on demand.
+        let cacheURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cupertino-leaf386-\(UUID().uuidString).json")
+        let canonicalizer = Core.Protocols.GitHubCanonicalizer(cacheURL: cacheURL)
+        await canonicalizer.primeCache(
+            inputOwner: "Mihaela",
+            inputRepo: "Cupertino",
+            canonicalOwner: "mihaelamj",
+            canonicalRepo: "cupertino",
+        )
+        let snapshot = await canonicalizer.cacheSnapshot()
+        // The snapshot key shape (input owner+repo lowercased) is an
+        // implementation detail of the actor; instead of pinning the
+        // exact key, just verify at least one entry now exists.
+        #expect(!snapshot.isEmpty)
+    }
+
+    // MARK: SwiftPackagesCatalog
+
+    @Test("Core.Protocols.SwiftPackageEntry decodes from canonical JSON")
+    func swiftPackageEntryDecodes() throws {
+        // Post-#161 the catalog is slimmed to URL-only, but the on-disk
+        // entry schema preserves the rich shape (owner / repo / url /
+        // description / stars / language / license / fork / archived /
+        // updatedAt) so legacy JSON archives still decode. Pin the
+        // required-key set so a refactor doesn't drop one.
+        let json = """
+        {
+            "owner": "apple",
+            "repo": "swift-collections",
+            "url": "https://github.com/apple/swift-collections",
+            "stars": 3000,
+            "fork": false,
+            "archived": false
+        }
+        """.data(using: .utf8)!
+        let entry = try JSONDecoder().decode(Core.Protocols.SwiftPackageEntry.self, from: json)
+        #expect(entry.owner == "apple")
+        #expect(entry.repo == "swift-collections")
+        #expect(entry.url == "https://github.com/apple/swift-collections")
+        #expect(entry.stars == 3000)
+        #expect(entry.fork == false)
+        #expect(entry.archived == false)
+        #expect(entry.description == nil)
+    }
+
+    @Test("Core.Protocols.SwiftPackagesCatalog reads from the embedded URL list")
+    func swiftPackagesCatalogLoads() async {
+        // Post-#161 the catalog is materialised lazily out of
+        // Resources.Embedded.SwiftPackagesCatalog.urls. Pin that the
+        // loaded count matches the embedded count and the version /
+        // source markers are non-empty.
+        let count = await Core.Protocols.SwiftPackagesCatalog.count
+        let version = await Core.Protocols.SwiftPackagesCatalog.version
+        let source = await Core.Protocols.SwiftPackagesCatalog.source
+        #expect(count > 0)
+        #expect(count == Resources.Embedded.SwiftPackagesCatalog.urls.count)
+        #expect(!version.isEmpty)
+        #expect(!source.isEmpty)
+    }
+}


### PR DESCRIPTION
Fourth leaf of the DI epic (#381). Mirrors the SharedConstants (#435), SharedUtils (#436), and SharedModels (#439) leaves.

## What

- Add \`Packages/Tests/CoreProtocolsTests/CoreProtocolsTests.swift\` with 9 smoke tests guarding the public surface:
  - \`Core\` + \`Core.Protocols\` namespace anchors reachable
  - \`Core.Protocols.FetchResult\` round-trips \`content\` / \`url\` / \`responseHeaders\` (the post-redirect URL carrier added in #277)
  - \`Core.Protocols.FetchResult\` allows nil response headers
  - \`Core.Protocols.TransformResult\` exposes \`markdown\` / \`links\` / \`metadata\` / \`structuredPage\` with all \`TransformMetadata\` fields
  - \`Core.Protocols.ExclusionList.normalise\` lowercases + strips whitespace
  - \`Core.Protocols.GitHubCanonicalizer.CanonicalName\` Equatable
  - \`Core.Protocols.GitHubCanonicalizer\` primes cache + snapshot returns the entry
  - \`Core.Protocols.SwiftPackageEntry\` decodes canonical legacy JSON (required keys pinned)
  - \`Core.Protocols.SwiftPackagesCatalog.count\` matches \`Resources.Embedded.SwiftPackagesCatalog.urls.count\` post-#161 slim
- \`Package.swift\`: declare \`coreProtocolsTestsTarget\` with deps \`["CoreProtocols", "SharedCore", "SharedConstants", "SharedModels", "Resources"]\` and register it in \`cupertinoTargets\`.

## Why

CoreProtocols imports only \`Foundation\`, \`Resources\`, \`SharedConstants\`, \`SharedCore\`, \`SharedModels\` (\`grep -rln '^import ' Packages/Sources/CoreProtocols/\`). Three of those four internal deps are themselves DI-leaf-pinned (#385, #382, #384); SharedCore is foundation-tier. Adding a standalone test target pins that the package can compile and run against exactly those deps.

Behavioural conformance tests stay alongside concrete implementers (Crawler.AppleDocs uses CrawlerEngine, Core.Parser.HTML implements ContentTransformer, JSONContentFetcher implements ContentFetcher). This target only proves the symbols compile and the namespace surface is reachable.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1338 tests in 149 suites pass (was 1329, +9 CoreProtocols smoke tests).

Closes #386.