### PR TITLE
test(SharedCore): #388 add focused public-surface tests for Shared.Core + ToolError

### DIFF
--- a/Packages/Tests/Shared/CoreTests/SharedCorePublicSurfaceTests.swift
+++ b/Packages/Tests/Shared/CoreTests/SharedCorePublicSurfaceTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import SharedConstants
+@testable import SharedCore
+import Testing
+
+// MARK: - SharedCore Public API Smoke Tests
+
+// SharedCore is the umbrella residue of the legacy Shared target. Post-
+// dissection (refactor 1.6) it owns three concerns only:
+// - `Shared.Core` namespace anchor under the top-level `Shared` enum
+// - `Shared.Core.ToolError` — the unified error type used by every MCP
+//   tool/resource provider and by the `Services.*` actors
+// - `CupertinoShared.swift` — `@_exported import Foundation` +
+//   `@_exported import CryptoKit` so consumers that `import Shared` (a
+//   path that may resurface in dependents) see the symbols transitively.
+//
+// Per #388 independence acceptance: SharedCore imports only Foundation
+// + SharedConstants. No behavioural cross-package import.
+// `grep -rln "^import " Packages/Sources/Shared/Core/` returns exactly
+// those two imports.
+//
+// The legacy SharedCoreTests folder also hosts test files that
+// historically covered SharedModels / SharedUtils / SharedConfiguration
+// before the dissection — those keep running in this target as the
+// canonical integration layer. This suite adds focused coverage for
+// what actually lives in SharedCore today, so a refactor that drops
+// the namespace anchor or breaks ToolError will fail at the leaf.
+
+@Suite("SharedCore public surface")
+struct SharedCorePublicSurfaceTests {
+    // MARK: Namespace
+
+    @Test("Shared.Core namespace reachable")
+    func sharedCoreNamespace() {
+        _ = Shared.Core.self
+    }
+
+    // MARK: ToolError cases
+
+    @Test("Shared.Core.ToolError.unknownTool has the expected localized description")
+    func toolErrorUnknownTool() {
+        let error = Shared.Core.ToolError.unknownTool("search_widgets")
+        #expect(error.errorDescription == "Unknown tool: search_widgets")
+    }
+
+    @Test("Shared.Core.ToolError.missingArgument has the expected localized description")
+    func toolErrorMissingArgument() {
+        let error = Shared.Core.ToolError.missingArgument("framework")
+        #expect(error.errorDescription == "Missing required argument: framework")
+    }
+
+    @Test("Shared.Core.ToolError.invalidArgument carries the arg name and reason")
+    func toolErrorInvalidArgument() {
+        let error = Shared.Core.ToolError.invalidArgument("limit", "must be > 0")
+        // The wire format here is shown back to MCP clients (Claude
+        // Desktop, Cursor); changing the punctuation would visibly
+        // change every error message they render. Pin it.
+        #expect(error.errorDescription == "Invalid argument 'limit': must be > 0")
+    }
+
+    @Test("Shared.Core.ToolError.notFound has the expected localized description")
+    func toolErrorNotFound() {
+        let error = Shared.Core.ToolError.notFound("apple-docs://SwiftUI/View")
+        #expect(error.errorDescription == "Not found: apple-docs://SwiftUI/View")
+    }
+
+    @Test("Shared.Core.ToolError.invalidURI has the expected localized description")
+    func toolErrorInvalidURI() {
+        let error = Shared.Core.ToolError.invalidURI("garbage://?")
+        #expect(error.errorDescription == "Invalid resource URI: garbage://?")
+    }
+
+    @Test("Shared.Core.ToolError.noData echoes the supplied message verbatim")
+    func toolErrorNoData() {
+        // noData is the catch-all for "we have no rows / no crawled
+        // pages / no DB"; the message goes straight through. Renaming
+        // or auto-prefixing would silently rewrap every consumer's
+        // human-written message.
+        let message = "No documentation has been crawled yet. Run cupertino fetch first."
+        let error = Shared.Core.ToolError.noData(message)
+        #expect(error.errorDescription == message)
+    }
+
+    // MARK: Error / LocalizedError conformance
+
+    @Test("Shared.Core.ToolError conforms to Error and LocalizedError")
+    func toolErrorConformances() {
+        // Compile-time check via existential casts. If a refactor
+        // ever drops LocalizedError, the MCP tool-error path stops
+        // rendering descriptions in error responses.
+        let error = Shared.Core.ToolError.unknownTool("x")
+        let asError: Error = error
+        let asLocalized: LocalizedError? = error
+        _ = asError
+        #expect(asLocalized?.errorDescription != nil)
+    }
+}


### PR DESCRIPTION
Sixth leaf of the DI epic (#381). Mirrors the SharedConstants (#435), SharedUtils (#436), SharedModels (#439), CoreProtocols (#440), and Logging (#441) leaves.

## What

SharedCore is the umbrella residue of the legacy \`Shared\` target. Post-dissection it owns three concerns only:

- \`Shared.Core\` namespace anchor under the top-level \`Shared\` enum
- \`Shared.Core.ToolError\` — unified error type used by every MCP tool/resource provider and by the \`Services.*\` actors
- \`CupertinoShared.swift\` — \`@_exported\` re-exports of \`Foundation\` and \`CryptoKit\`

Imports verified by \`grep -rln '^import ' Packages/Sources/Shared/Core/\`: only \`Foundation\` + \`SharedConstants\`. The standalone test target \`sharedCoreTestsTarget\` already exists; #388 acceptance is met.

The coverage gap: the legacy \`SharedCoreTests\` folder hosts test files (ModelsTests / URLUtilitiesFilenameTests / SchemaVersionTests / JSONCodingTests / …) that cover SharedModels / SharedUtils / SharedConfiguration concerns from before the dissection. None of them cover the three things actually living in SharedCore today.

Adds \`Packages/Tests/Shared/CoreTests/SharedCorePublicSurfaceTests.swift\` with 8 focused tests:

- \`Shared.Core\` namespace reachable
- Each of the 6 \`Shared.Core.ToolError\` cases pinned to its \`errorDescription\`:
  - \`unknownTool\` → \`"Unknown tool: <name>"\`
  - \`missingArgument\` → \`"Missing required argument: <arg>"\`
  - \`invalidArgument\` → \`"Invalid argument '<arg>': <reason>"\`
  - \`notFound\` → \`"Not found: <resource>"\`
  - \`invalidURI\` → \`"Invalid resource URI: <uri>"\`
  - \`noData\` → echoes the supplied message verbatim (catch-all)
- \`Shared.Core.ToolError\` conforms to both \`Error\` and \`LocalizedError\` (dropping \`LocalizedError\` would silently stop MCP error responses rendering descriptions)

## Out of scope

The legacy \`SharedCoreTests\` files are unchanged. Re-distributing those tests into per-target test files (SharedModels' tests into SharedModelsTests, etc.) is a separate refactor outside #388's scope and risks losing real behavioural coverage if done in a single sweep.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1354 tests in 151 suites pass (was 1346, +8 SharedCore public-surface smoke tests).

Closes #388.