### PR TITLE
fix(Availability): replace URL force-unwrap in AvailabilityFetcher.swift:572 (#317)

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -331,7 +331,7 @@ let targets: [Target] = {
 
     let availabilityTarget = Target.target(
         name: "Availability",
-        dependencies: ["SharedConstants"]
+        dependencies: ["SharedConstants", "SharedUtils"]
     )
     let availabilityTestsTarget = Target.testTarget(
         name: "AvailabilityTests",

--- a/Packages/Sources/Availability/Availability.Fetcher.swift
+++ b/Packages/Sources/Availability/Availability.Fetcher.swift
@@ -555,7 +555,7 @@ extension Availability {
             return false // Equal versions
         }
 
-        private func buildAPIURL(from docURL: URL) -> URL {
+        func buildAPIURL(from docURL: URL) -> URL {
             // Extract path after /documentation/
             let path = docURL.path.lowercased()
             let apiPath: String

--- a/Packages/Sources/Availability/Availability.Fetcher.swift
+++ b/Packages/Sources/Availability/Availability.Fetcher.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SharedConstants
+import SharedUtils
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -565,13 +566,7 @@ extension Availability {
                 apiPath = path
             }
 
-            // Availability target deliberately has no `Shared` dependency, so the
-            // `URL.knownGood` helper used elsewhere in the codebase isn't
-            // available here. The single site, with a known-good base + sanitized
-            // path, gets a localized swiftlint exemption rather than dragging a
-            // whole package dependency in just for one URL constructor.
-            // swiftlint:disable:next force_unwrapping
-            return URL(string: "\(configuration.apiBaseURL)/\(apiPath).json")!
+            return URL.knownGood("\(configuration.apiBaseURL)/\(apiPath).json")
         }
 
         private func fetchAvailability(from url: URL) async -> Availability.Info? {

--- a/Packages/Tests/AvailabilityTests/AvailabilityTests.swift
+++ b/Packages/Tests/AvailabilityTests/AvailabilityTests.swift
@@ -1,4 +1,4 @@
-import Availability
+@testable import Availability
 import Foundation
 import Testing
 
@@ -571,5 +571,49 @@ struct AvailabilityAnnotationParserTests {
         #expect(result != nil)
         #expect(result?.minimumiOS == "17.0")
         #expect(result?.minimumMacOS == "14.0")
+    }
+}
+
+// MARK: - Availability.Fetcher.buildAPIURL Tests
+
+@Suite("Availability.Fetcher.buildAPIURL Tests")
+struct FetcherBuildAPIURLTests {
+    private let defaultFetcher = Availability.Fetcher(
+        docsDirectory: URL(fileURLWithPath: "/tmp")
+    )
+
+    @Test("strips /documentation/ prefix, lowercases path, and appends .json")
+    func stripsDocumentationPrefix() async {
+        let docURL = URL(string: "https://developer.apple.com/documentation/SwiftUI/View")!
+        let result = await defaultFetcher.buildAPIURL(from: docURL)
+        #expect(result.absoluteString == "https://developer.apple.com/tutorials/data/documentation/swiftui/view.json")
+    }
+
+    @Test("handles mixed-case framework and symbol names")
+    func mixedCasePath() async {
+        let docURL = URL(string: "https://developer.apple.com/documentation/Foundation/URL")!
+        let result = await defaultFetcher.buildAPIURL(from: docURL)
+        #expect(result.absoluteString == "https://developer.apple.com/tutorials/data/documentation/foundation/url.json")
+    }
+
+    @Test("custom apiBaseURL is used in constructed URL")
+    func customBaseURL() async {
+        let config = Availability.Fetcher.Configuration(
+            apiBaseURL: "https://custom.example.com/data/documentation"
+        )
+        let fetcher = Availability.Fetcher(
+            docsDirectory: URL(fileURLWithPath: "/tmp"),
+            configuration: config
+        )
+        let docURL = URL(string: "https://developer.apple.com/documentation/Combine/Publisher")!
+        let result = await fetcher.buildAPIURL(from: docURL)
+        #expect(result.absoluteString == "https://custom.example.com/data/documentation/combine/publisher.json")
+    }
+
+    @Test("always produces a URL ending in .json")
+    func alwaysEndsInJSON() async {
+        let docURL = URL(string: "https://developer.apple.com/documentation/SwiftUI")!
+        let result = await defaultFetcher.buildAPIURL(from: docURL)
+        #expect(result.absoluteString.hasSuffix(".json"))
     }
 }


### PR DESCRIPTION
Fixes the last remaining production force-unwrap in the `Availability` package.

## What

`Availability.Fetcher.buildAPIURL(from:)` constructed its return URL with `URL(string:)!` guarded by a `// swiftlint:disable:next force_unwrapping` comment. An inline comment justified this by claiming `SharedUtils` (which defines `URL.knownGood`) could not be added without pulling in a large dependency chain. That claim does not hold: `SharedUtils` depends only on `SharedConstants`, which `Availability` already declared as a dependency — so there are no new transitive deps.

Changes:

1. **`Packages/Package.swift`**: add `"SharedUtils"` to `availabilityTarget.dependencies` alongside the existing `"SharedConstants"`.

2. **`Packages/Sources/Availability/Availability.Fetcher.swift`**:
   - Add `import SharedUtils`
   - Replace the 6-line explanatory comment block and `URL(string:)!` with a single `URL.knownGood(...)` call — consistent with every other fixed-URL construction site in the codebase
   - Widen `buildAPIURL` visibility from `private` to `internal` to allow `@testable` access from `AvailabilityTests`

3. **`Packages/Tests/AvailabilityTests/AvailabilityTests.swift`**:
   - Switch to `@testable import Availability`
   - Add `Availability.Fetcher.buildAPIURL Tests` suite with 4 focused tests:
     - strips `/documentation/` prefix, lowercases path, appends `.json`
     - handles mixed-case framework and symbol names
     - custom `apiBaseURL` in `Configuration` is reflected in the constructed URL
     - result always ends in `.json`

## Verification

```
xcrun swift build
swift test --filter AvailabilityTests
```

Result: 52 tests in 9 suites pass (was 48, +4 `buildAPIURL` tests). No regressions.

Closes #317.