### PR TITLE
refactor(MCPSupport): #406 drop Search dep via injected MarkdownLookup closure

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -322,12 +322,12 @@ let targets: [Target] = {
 
     let mcpSupportTarget = Target.target(
         name: "MCPSupport",
-        dependencies: ["MCPCore", "MCPSharedTools", "SharedCore", "SharedConfiguration", "SharedConstants", "SharedModels", "SharedUtils", "Logging", "Search"],
+        dependencies: ["MCPCore", "MCPSharedTools", "SharedCore", "SharedConfiguration", "SharedConstants", "SharedModels", "SharedUtils", "Logging"],
         path: "Sources/MCP/Support"
     )
     let mcpSupportTestsTarget = Target.testTarget(
         name: "MCPSupportTests",
-        dependencies: ["MCPSupport", "MCPCore", "MCPSharedTools", "SharedCore", "SharedConfiguration", "SharedConstants", "SharedModels", "Search", "TestSupport"],
+        dependencies: ["MCPSupport", "MCPCore", "MCPSharedTools", "SharedCore", "SharedConfiguration", "SharedConstants", "SharedModels", "TestSupport"],
         path: "Tests/MCP/SupportTests"
     )
 

--- a/Packages/Sources/CLI/Commands/CLI.Command.Serve.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Serve.swift
@@ -123,11 +123,23 @@ extension CLI.Command {
             // Initialize search index if available
             let searchIndex: SearchModule.Index? = await loadSearchIndex(searchDBURL: searchDBURL)
 
-            // Register resource provider with optional search index
+            // Register resource provider with optional search-index markdown
+            // lookup. The provider doesn't see the Search target — it just
+            // gets a closure that returns markdown for a URI, or nil if the
+            // URI isn't indexed. This keeps MCPSupport free of the Search
+            // import per the DI epic (#406).
+            let markdownLookup: MCP.Support.DocsResourceProvider.MarkdownLookup?
+            if let searchIndex {
+                markdownLookup = { uri in
+                    try await searchIndex.getDocumentContent(uri: uri, format: .markdown)
+                }
+            } else {
+                markdownLookup = nil
+            }
             let resourceProvider = MCP.Support.DocsResourceProvider(
                 configuration: config,
                 evolutionDirectory: evolutionURL,
-                searchIndex: searchIndex
+                markdownLookup: markdownLookup
             )
             await server.registerResourceProvider(resourceProvider)
 

--- a/Packages/Sources/MCP/Support/MCP.Support.DocsResourceProvider.swift
+++ b/Packages/Sources/MCP/Support/MCP.Support.DocsResourceProvider.swift
@@ -2,7 +2,6 @@ import Foundation
 import Logging
 import MCPCore
 import MCPSharedTools
-import Search
 import SharedConfiguration
 import SharedConstants
 import SharedCore
@@ -12,24 +11,37 @@ import SharedUtils
 // MARK: - Documentation Resource Provider
 
 extension MCP.Support {
-    /// Provides crawled documentation as MCP resources
+    /// Provides crawled documentation as MCP resources.
+    ///
+    /// The provider's database lookup is injected as a closure rather than a
+    /// concrete `Search.Index` value, so this target stays free of any
+    /// behavioural dependency on Search. Consumers wire the closure at the
+    /// call site (CLI/MCP entrypoint) — typically a small adapter around
+    /// `Search.Index.getDocumentContent(uri:format:)`.
     public actor DocsResourceProvider: MCP.Core.ResourceProvider {
+        /// Closure signature for resolving a resource URI to pre-rendered
+        /// markdown out of a search-index database (or any other source).
+        /// Returns `nil` if the URI is not present; throws if the lookup
+        /// itself fails. The provider treats either as a fall-back trigger
+        /// to read from the filesystem.
+        public typealias MarkdownLookup = @Sendable (String) async throws -> String?
+
         private let configuration: Shared.Configuration
         private var metadata: Shared.Models.CrawlMetadata?
         private let evolutionDirectory: URL
         private let archiveDirectory: URL
-        private let searchIndex: Search.Index?
+        private let markdownLookup: MarkdownLookup?
 
         public init(
             configuration: Shared.Configuration,
             evolutionDirectory: URL? = nil,
             archiveDirectory: URL? = nil,
-            searchIndex: Search.Index? = nil
+            markdownLookup: MarkdownLookup? = nil
         ) {
             self.configuration = configuration
             self.evolutionDirectory = evolutionDirectory ?? Shared.Constants.defaultSwiftEvolutionDirectory
             self.archiveDirectory = archiveDirectory ?? Shared.Constants.defaultArchiveDirectory
-            self.searchIndex = searchIndex
+            self.markdownLookup = markdownLookup
             // Metadata will be loaded lazily on first access
         }
 
@@ -114,9 +126,9 @@ extension MCP.Support {
         public func readResource(uri: String) async throws -> MCP.Core.Protocols.ReadResourceResult {
             let markdown: String
 
-            // Try database first if search index is available
-            if let searchIndex {
-                if let dbContent = try await searchIndex.getDocumentContent(uri: uri, format: .markdown) {
+            // Try database first if a markdown lookup was injected
+            if let markdownLookup {
+                if let dbContent = try await markdownLookup(uri) {
                     // Found in database - return markdown
                     let contents = MCP.Core.Protocols.ResourceContents.text(
                         MCP.Core.Protocols.TextResourceContents(

--- a/Packages/Tests/MCP/SupportTests/DocsResourceProviderMalformedURLSkipTests.swift
+++ b/Packages/Tests/MCP/SupportTests/DocsResourceProviderMalformedURLSkipTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import MCPCore
 @testable import MCPSupport
-import Search
 import SharedConfiguration
 import SharedConstants
 import SharedCore
@@ -31,7 +30,7 @@ struct DocsResourceProviderMalformedURLSkipTests {
             configuration: Shared.Configuration(),
             evolutionDirectory: evolutionDir,
             archiveDirectory: archiveDir,
-            searchIndex: nil
+            markdownLookup: nil
         )
     }
 


### PR DESCRIPTION
First heavy-tier DI cut that actually moves a production import. MCPSupport's only behavioural cross-package dependency was \`Search\`, through one field on \`DocsResourceProvider\`:

\`\`\`swift
private let searchIndex: Search.Index?
...
if let searchIndex {
    if let dbContent = try await searchIndex.getDocumentContent(
        uri: uri, format: .markdown
    ) { ... }
}
\`\`\`

Single method call, narrow surface. The cleanest seam is a closure on the consumer side: MCPSupport defines a typealias for the markdown-lookup shape and stores an optional value of that closure type; production consumers wrap \`searchIndex.getDocumentContent(...)\` in a closure at the call site.

## Changes

1. \`Sources/MCP/Support/MCP.Support.DocsResourceProvider.swift\`
   - Drop \`import Search\`.
   - Add \`public typealias MarkdownLookup = @Sendable (String) async throws -> String?\`.
   - Replace \`searchIndex: Search.Index?\` field + init parameter with \`markdownLookup: MarkdownLookup?\`.
   - Replace the readResource call with \`try await markdownLookup(uri)\`.

2. \`Sources/CLI/Commands/CLI.Command.Serve.swift\`
   - Wrap \`searchIndex.getDocumentContent(uri:, format: .markdown)\` in a \`markdownLookup\` closure and pass it to the provider.

3. \`Tests/MCP/SupportTests/DocsResourceProviderMalformedURLSkipTests.swift\`
   - Drop \`import Search\`.
   - Update \`searchIndex: nil\` to \`markdownLookup: nil\` in the test factory.

4. \`Packages/Package.swift\`
   - Drop \`\"Search\"\` from \`mcpSupportTarget.dependencies\`.
   - Drop \`\"Search\"\` from \`mcpSupportTestsTarget.dependencies\`.

## Acceptance

\`\`\`
grep -rln '^import Search\b' Packages/Sources/MCP/Support/ Packages/Tests/MCP/SupportTests/
\`\`\`

returns no matches. MCPSupport now compiles + tests in isolation with zero behavioural dependency on Search — the production consumer in CLI holds the wiring.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1404 tests in 156 suites pass (no regressions; the existing malformed-URL skip test in DocsResourceProviderMalformedURLSkipTests passes against the new closure shape).

Closes #406.