### PR TITLE
refactor(Services.Formatter): #402b drop import Search from all 12 formatters

### DIFF
--- a/Packages/Sources/Services/Formatters/Services.Formatter.HIG.JSON.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.HIG.JSON.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Search
 import SharedCore
 import SearchModels
 

--- a/Packages/Sources/Services/Formatters/Services.Formatter.HIG.Markdown.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.HIG.Markdown.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Search
 import SharedConstants
 import SharedCore
 import SearchModels

--- a/Packages/Sources/Services/Formatters/Services.Formatter.HIG.Text.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.HIG.Text.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Search
 import SharedConstants
 import SharedCore
 import SearchModels

--- a/Packages/Sources/Services/Formatters/Services.Formatter.JSON.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.JSON.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Search
 import SharedCore
 import SearchModels
 

--- a/Packages/Sources/Services/Formatters/Services.Formatter.Markdown.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.Markdown.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Search
 import SharedConstants
 import SharedCore
 import SearchModels

--- a/Packages/Sources/Services/Formatters/Services.Formatter.Result.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.Result.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Search
 import SharedCore
 import SearchModels
 

--- a/Packages/Sources/Services/Formatters/Services.Formatter.TeaserResults.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.TeaserResults.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SampleIndex
-import Search
 import SharedConstants
 import SharedCore
 import SearchModels

--- a/Packages/Sources/Services/Formatters/Services.Formatter.Text.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.Text.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Search
 import SharedConstants
 import SharedCore
 import SearchModels

--- a/Packages/Sources/Services/Formatters/Services.Formatter.Unified.Input.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.Unified.Input.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SampleIndex
-import Search
 import SharedConstants
 import SharedCore
 import SearchModels

--- a/Packages/Sources/Services/Formatters/Services.Formatter.Unified.JSON.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.Unified.JSON.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SampleIndex
-import Search
 import SharedConstants
 import SharedCore
 import SearchModels

--- a/Packages/Sources/Services/Formatters/Services.Formatter.Unified.Markdown.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.Unified.Markdown.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SampleIndex
-import Search
 import SharedConstants
 import SharedCore
 import SearchModels

--- a/Packages/Sources/Services/Formatters/Services.Formatter.Unified.Text.swift
+++ b/Packages/Sources/Services/Formatters/Services.Formatter.Unified.Text.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SampleIndex
-import Search
 import SharedConstants
 import SharedCore
 import SearchModels


### PR DESCRIPTION
Slice B of #402.

After #402a lifted \`Search.Result\` / \`Search.MatchedSymbol\` / \`Search.PlatformAvailability\` / \`Search.DocumentFormat\` into the new SearchModels target, every Services formatter became a pure value-type consumer. The \`import Search\` line in each formatter was dead weight: zero references to any Search-target behavioural symbol remained.

## Audit

\`\`\`bash
for f in Packages/Sources/Services/Formatters/*.swift; do
    uses=\$(grep -oE "Search\\.[A-Z][a-zA-Z]+" "\$f" \\
        | grep -vE "Search\\.(Result|MatchedSymbol|PlatformAvailability|DocumentFormat|FrameworkAvailability)" \\
        | sort -u)
    [ -n "\$uses" ] && echo "\$f: \$uses"
done
\`\`\`

Empty for all 12 formatter files. Safe to drop.

## What

\`import Search\` removed from:
- \`Services.Formatter.HIG.JSON.swift\` / \`HIG.Text.swift\` / \`HIG.Markdown.swift\`
- \`Services.Formatter.Markdown.swift\` / \`JSON.swift\` / \`Text.swift\`
- \`Services.Formatter.Result.swift\`
- \`Services.Formatter.TeaserResults.swift\`
- \`Services.Formatter.Unified.Markdown.swift\` / \`Unified.Text.swift\` / \`Unified.JSON.swift\` / \`Unified.Input.swift\`

The remaining \`import SearchModels\` is the right one — formatters declare per-type conformances on the qualified value-type paths, and SearchModels owns those types.

## Out of scope (slice C)

The Services target as a whole still imports Search in its actor-adjacent files: \`ServiceContainer\`, \`SearchService\`, and every \`ReadCommands/*\` service. Those need protocol seams; that's the next slice.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass (no regressions; same total as #402a).

Part 2 of #402.