### PR TITLE
refactor(SearchModels): #402c-prime lift CandidateFetcher + SmartCandidate + AvailabilityFilter

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.PackageSearch.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.PackageSearch.swift
@@ -78,10 +78,10 @@ extension CLI.Command {
             // to calling `PackageQuery.answer` directly — but it goes through the
             // exact same code path as `cupertino ask`, which means future ranking
             // tweaks land in one place.
-            let availabilityFilter: SearchModule.PackageQuery.AvailabilityFilter?
+            let availabilityFilter: SearchModels.Search.AvailabilityFilter?
             switch (platform, minVersion) {
             case let (platform?, minVersion?):
-                availabilityFilter = SearchModule.PackageQuery.AvailabilityFilter(
+                availabilityFilter = SearchModels.Search.AvailabilityFilter(
                     platform: platform,
                     minVersion: minVersion
                 )

--- a/Packages/Sources/CLI/Commands/CLI.Command.Search.SmartReport.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Search.SmartReport.swift
@@ -51,10 +51,10 @@ extension CLI.Command.Search {
     /// Validate the `--platform` / `--min-version` pair into an
     /// `AvailabilityFilter`. Either both flags or neither — anything else
     /// errors out with `ExitCode.failure` so the user sees a clean message.
-    func resolveAvailabilityFilter() throws -> SearchModule.PackageQuery.AvailabilityFilter? {
+    func resolveAvailabilityFilter() throws -> SearchModels.Search.AvailabilityFilter? {
         switch (platform, minVersion) {
         case let (platform?, minVersion?):
-            return SearchModule.PackageQuery.AvailabilityFilter(
+            return SearchModels.Search.AvailabilityFilter(
                 platform: platform,
                 minVersion: minVersion
             )
@@ -72,7 +72,7 @@ extension CLI.Command.Search {
     /// or unopenable DBs log a one-line info note and are silently dropped
     /// from the fan-out (mirrors the resilience that `cupertino ask` had).
     func buildFetchers(
-        availabilityFilter: SearchModule.PackageQuery.AvailabilityFilter?
+        availabilityFilter: SearchModels.Search.AvailabilityFilter?
     ) async -> FetcherPlan {
         var fetchers: [any Search.CandidateFetcher] = []
 
@@ -107,7 +107,7 @@ extension CLI.Command.Search {
     private static func openDocsFetchers(
         override: String?,
         skip: Bool,
-        availability: SearchModule.PackageQuery.AvailabilityFilter?,
+        availability: SearchModels.Search.AvailabilityFilter?,
         into fetchers: inout [any Search.CandidateFetcher]
     ) async -> SearchModule.Index? {
         guard !skip else { return nil }
@@ -141,7 +141,7 @@ extension CLI.Command.Search {
     private static func openPackagesFetcher(
         override: String?,
         skip: Bool,
-        availability: SearchModule.PackageQuery.AvailabilityFilter?,
+        availability: SearchModels.Search.AvailabilityFilter?,
         into fetchers: inout [any Search.CandidateFetcher]
     ) {
         guard !skip else { return }
@@ -162,7 +162,7 @@ extension CLI.Command.Search {
     private static func openSamplesFetcher(
         override: String?,
         skip: Bool,
-        availability: SearchModule.PackageQuery.AvailabilityFilter?,
+        availability: SearchModels.Search.AvailabilityFilter?,
         into fetchers: inout [any Search.CandidateFetcher]
     ) async -> Sample.Search.Service? {
         guard !skip else { return nil }

--- a/Packages/Sources/Search/CandidateFetcher.swift
+++ b/Packages/Sources/Search/CandidateFetcher.swift
@@ -18,64 +18,6 @@ import SearchModels
 // the ranker's job, not the fetcher's — this keeps implementations trivial
 // to add for new sources (WWDC transcripts #58, Swift Forums #89, etc.).
 
-extension Search {
-    /// A single candidate surfaced by a `CandidateFetcher`. Scores are
-    /// source-local and not comparable across fetchers — `SmartQuery` does the
-    /// cross-source ranking via rank fusion.
-    public struct SmartCandidate: Sendable, Hashable {
-        /// Source identifier, e.g. `"packages"`, `"apple-docs"`, `"swift-evolution"`.
-        public let source: String
-        /// Canonical identifier for the candidate. Format is source-dependent:
-        /// `owner/repo/relpath` for packages, the URI for docs rows.
-        public let identifier: String
-        /// Display title — what a UI should surface as the heading.
-        public let title: String
-        /// Excerpt to show the user. Expected to be already chunked/truncated.
-        public let chunk: String
-        /// Source-local score. Higher is better, but scales differ between
-        /// fetchers; only useful for within-source ordering.
-        public let rawScore: Double
-        /// Optional tag — DocKind raw value for docs, PackageFileKind raw value
-        /// for packages. Nil for sources without a kind taxonomy.
-        public let kind: String?
-        /// Free-form attribution metadata (framework, owner/repo, language, etc.).
-        public let metadata: [String: String]
-
-        public init(
-            source: String,
-            identifier: String,
-            title: String,
-            chunk: String,
-            rawScore: Double,
-            kind: String? = nil,
-            metadata: [String: String] = [:]
-        ) {
-            self.source = source
-            self.identifier = identifier
-            self.title = title
-            self.chunk = chunk
-            self.rawScore = rawScore
-            self.kind = kind
-            self.metadata = metadata
-        }
-    }
-
-    /// Produce ranked candidates for a free-text question.
-    ///
-    /// Implementations should return candidates already ordered best-first.
-    /// `limit` is an advisory cap; fetchers may return fewer results but
-    /// should not exceed it. Network/DB-missing conditions should surface as
-    /// thrown errors so `SmartQuery` can attribute failures; returning an
-    /// empty array signals "query ran, nothing matched".
-    public protocol CandidateFetcher: Sendable {
-        /// Short human-readable name, used for logs + attribution headers.
-        var sourceName: String { get }
-
-        /// Fetch candidates for the given question, capped at `limit`.
-        func fetch(question: String, limit: Int) async throws -> [SmartCandidate]
-    }
-}
-
 // MARK: - Package FTS fetcher (wraps Search.PackageQuery)
 
 extension Search {
@@ -87,11 +29,11 @@ extension Search {
         public let sourceName = Shared.Constants.SourcePrefix.packages
 
         private let dbPath: URL
-        private let availability: Search.PackageQuery.AvailabilityFilter?
+        private let availability: Search.AvailabilityFilter?
 
         public init(
             dbPath: URL = Shared.Constants.defaultPackagesDatabase,
-            availability: Search.PackageQuery.AvailabilityFilter? = nil
+            availability: Search.AvailabilityFilter? = nil
         ) {
             self.dbPath = dbPath
             self.availability = availability
@@ -140,7 +82,7 @@ extension Search {
 
         private let searchIndex: Search.Index
         private let includeArchive: Bool
-        private let availability: Search.PackageQuery.AvailabilityFilter?
+        private let availability: Search.AvailabilityFilter?
 
         /// Sources whose content uses a different availability axis from
         /// iOS / macOS / etc. — Swift language version (#225). When the
@@ -169,7 +111,7 @@ extension Search {
             searchIndex: Search.Index,
             source: String,
             includeArchive: Bool = false,
-            availability: Search.PackageQuery.AvailabilityFilter? = nil
+            availability: Search.AvailabilityFilter? = nil
         ) {
             self.searchIndex = searchIndex
             sourceName = source

--- a/Packages/Sources/Search/Search.PackageQuery.swift
+++ b/Packages/Sources/Search/Search.PackageQuery.swift
@@ -91,22 +91,6 @@ extension Search {
             return String(cString: ptr)
         }
 
-        /// Optional platform-availability filter (#220).
-        /// `platform` is one of `iOS`, `macOS`, `tvOS`, `watchOS`, `visionOS`
-        /// (case-insensitive). `minVersion` is a dotted decimal like
-        /// `"16.0"` or `"10.15"`. Both must be set to filter; otherwise the
-        /// flag is ignored. NULL `min_<platform>` rows in `package_metadata`
-        /// are dropped when a filter is active (no annotation = unknown =
-        /// excluded from a platform-specific query).
-        public struct AvailabilityFilter: Sendable {
-            public let platform: String
-            public let minVersion: String
-            public init(platform: String, minVersion: String) {
-                self.platform = platform
-                self.minVersion = minVersion
-            }
-        }
-
         public func answer(
             _ question: String,
             maxResults: Int = 3,

--- a/Packages/Sources/SearchModels/Search.AvailabilityFilter.swift
+++ b/Packages/Sources/SearchModels/Search.AvailabilityFilter.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Platform-version availability filter applied to package search.
+///
+/// Lifted out of `Search.PackageQuery.AvailabilityFilter` (nested
+/// inside the PackageQuery actor in the Search target) to top-level
+/// `Search.AvailabilityFilter` in SearchModels so consumers can
+/// construct and pass it without taking a behavioural dependency on
+/// the Search target.
+///
+/// `platform` is one of `iOS`, `macOS`, `tvOS`, `watchOS`, `visionOS`
+/// (case-insensitive). `minVersion` is a dotted decimal like `"16.0"`
+/// or `"10.15"`. Both must be set to filter; otherwise the flag is
+/// ignored. NULL `min_<platform>` rows in `package_metadata` are
+/// dropped when a filter is active (no annotation = unknown =
+/// excluded from a platform-specific query).
+extension Search {
+    public struct AvailabilityFilter: Sendable {
+        public let platform: String
+        public let minVersion: String
+
+        public init(platform: String, minVersion: String) {
+            self.platform = platform
+            self.minVersion = minVersion
+        }
+    }
+}

--- a/Packages/Sources/SearchModels/Search.CandidateFetcher.swift
+++ b/Packages/Sources/SearchModels/Search.CandidateFetcher.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// A `CandidateFetcher` turns a natural-language question into a ranked
+/// list of `Search.SmartCandidate` results pulled from one data source
+/// (packages.db, the apple-docs half of search.db, swift-evolution,
+/// swift-org, etc.).
+///
+/// `Search.SmartQuery` fans several fetchers out in parallel and cross-
+/// ranks their candidates via reciprocal rank fusion so the final
+/// ordering is source-agnostic.
+///
+/// The protocol lives in SearchModels (not in Search) so consumers
+/// outside the Search target — Services-side adapters that bridge
+/// cupertino-internal stores into the smart-query fan-out — can
+/// conform without taking a behavioural dependency on the Search
+/// target.
+///
+/// Implementations should return candidates already ordered best-first.
+/// `limit` is an advisory cap; fetchers may return fewer results but
+/// should not exceed it. Network / DB-missing conditions should
+/// surface as thrown errors so `SmartQuery` can attribute failures;
+/// returning an empty array signals "query ran, nothing matched".
+extension Search {
+    public protocol CandidateFetcher: Sendable {
+        /// Short human-readable name, used for logs + attribution headers.
+        var sourceName: String { get }
+
+        /// Fetch candidates for the given question, capped at `limit`.
+        func fetch(question: String, limit: Int) async throws -> [SmartCandidate]
+    }
+}

--- a/Packages/Sources/SearchModels/Search.SmartCandidate.swift
+++ b/Packages/Sources/SearchModels/Search.SmartCandidate.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// A single candidate surfaced by a `Search.CandidateFetcher`.
+///
+/// Lifted out of the Search target into SearchModels so consumers
+/// (Services-side adapters that bridge the cupertino-internal stores
+/// into the smart-query fan-out) can construct + return candidates
+/// without taking a behavioural dependency on the Search target.
+///
+/// Scores are source-local and not comparable across fetchers —
+/// `Search.SmartQuery` does the cross-source ranking via rank fusion
+/// (#192 section E).
+extension Search {
+    public struct SmartCandidate: Sendable, Hashable {
+        /// Source identifier, e.g. `"packages"`, `"apple-docs"`, `"swift-evolution"`.
+        public let source: String
+        /// Canonical identifier for the candidate. Format is source-dependent:
+        /// `owner/repo/relpath` for packages, the URI for docs rows.
+        public let identifier: String
+        /// Display title — what a UI should surface as the heading.
+        public let title: String
+        /// Excerpt to show the user. Expected to be already chunked / truncated.
+        public let chunk: String
+        /// Source-local score. Higher is better, but scales differ between
+        /// fetchers; only useful for within-source ordering.
+        public let rawScore: Double
+        /// Optional tag — DocKind raw value for docs, PackageFileKind raw value
+        /// for packages. Nil for sources without a kind taxonomy.
+        public let kind: String?
+        /// Free-form attribution metadata (framework, owner/repo, language, etc.).
+        public let metadata: [String: String]
+
+        public init(
+            source: String,
+            identifier: String,
+            title: String,
+            chunk: String,
+            rawScore: Double,
+            kind: String? = nil,
+            metadata: [String: String] = [:],
+        ) {
+            self.source = source
+            self.identifier = identifier
+            self.title = title
+            self.chunk = chunk
+            self.rawScore = rawScore
+            self.kind = kind
+            self.metadata = metadata
+        }
+    }
+}

--- a/Packages/Sources/Services/Sample.Services.CandidateFetcher.swift
+++ b/Packages/Sources/Services/Sample.Services.CandidateFetcher.swift
@@ -1,9 +1,8 @@
 import Foundation
 import SampleIndex
-import Search
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - Sample candidate fetcher (#230)
 
@@ -26,11 +25,11 @@ extension Sample.Services {
         public let sourceName: String = Shared.Constants.SourcePrefix.samples
 
         private let service: Sample.Search.Service
-        private let availability: Search.PackageQuery.AvailabilityFilter?
+        private let availability: Search.AvailabilityFilter?
 
         public init(
             service: Sample.Search.Service,
-            availability: Search.PackageQuery.AvailabilityFilter? = nil
+            availability: Search.AvailabilityFilter? = nil
         ) {
             self.service = service
             self.availability = availability


### PR DESCRIPTION
Slice C-prime of #402. Lifts three more types into SearchModels so \`Sample.Services.CandidateFetcher\` — the last value-type / protocol-only consumer in Services — can drop \`import Search\` entirely.

## What

Three types lifted from Search target to SearchModels:

1. **\`Search.CandidateFetcher\`** (protocol). Pure narrow protocol — \`sourceName: String { get }\` + one method. The concrete fetchers (PackageFTSCandidateFetcher, AppleDocsCandidateFetcher, …) stay in the Search target and conform via their existing extensions.

2. **\`Search.SmartCandidate\`** (value type). Pure data: source / identifier / title / chunk / rawScore / kind / metadata, all Sendable + Hashable.

3. **\`Search.AvailabilityFilter\`** (value type). Lifted out of \`Search.PackageQuery.AvailabilityFilter\` — was nested inside the PackageQuery actor, inaccessible to consumers that can't import the Search target. Now top-level under the Search namespace. In CLI, the local \`CLI.Command.Search\` subcommand shadows \`Search\`, so the fully-qualified \`SearchModels.Search.AvailabilityFilter\` form is used at 7 callsites.

## Source-target changes

- \`Search/CandidateFetcher.swift\`: delete the \`extension Search { ... SmartCandidate ... CandidateFetcher ... }\` block. The PackageFTSCandidateFetcher + AppleDocsCandidateFetcher extensions stay; they reach the lifted types via the existing \`import SearchModels\`.
- \`Search/Search.PackageQuery.swift\`: delete the nested \`AvailabilityFilter\` declaration. The bare-name reference inside the actor compiles via the same import.

## Services side

\`Sample.Services.CandidateFetcher.swift\` drops \`import Search\`. Its only Search.* references — \`Search.CandidateFetcher\` (protocol), \`Search.SmartCandidate\` (value), \`Search.AvailabilityFilter\` (filter) — now live in SearchModels.

## Status

After this PR, Services' production \`import Search\` count drops from 8 files to 7 (just the actor-adjacent ReadCommands/* services + ServiceContainer). The remaining 7 require the \`Search.Index\` protocol seam — slice C2.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Part 3 of #402.