### PR TITLE
feat(SearchModels): #402c2-foundation add Search.Database protocol + Search.Index conformance

### DIFF
--- a/Packages/Sources/Search/Search.Index.Database.swift
+++ b/Packages/Sources/Search/Search.Index.Database.swift
@@ -1,0 +1,14 @@
+import SearchModels
+
+// MARK: - Search.Index ↔ Search.Database
+
+// `Search.Index` already implements every method on `Search.Database`:
+// `search`, `getDocumentContent`, `listFrameworks`, `documentCount`, and
+// `disconnect`. The declaration below witnesses the conformance so
+// Services / MCPSupport / CLI consumers can accept `any Search.Database`
+// and have a production `Search.Index` flow through unchanged.
+//
+// The protocol itself lives in SearchModels; this conformance lives in
+// the Search target because it touches the actor.
+
+extension Search.Index: Search.Database {}

--- a/Packages/Sources/SearchModels/Search.Database.swift
+++ b/Packages/Sources/SearchModels/Search.Database.swift
@@ -1,0 +1,91 @@
+import Foundation
+import SharedConstants
+
+/// Behavioural contract for the search-index database.
+///
+/// Production implementation: `Search.Index` (the actor in the Search SPM
+/// target). Consumers — Services read commands, MCPSupport responders,
+/// CLI runners — accept this protocol instead of taking a behavioural
+/// dependency on the Search target.
+///
+/// The protocol surfaces every method Services calls on `Search.Index`:
+/// `search`, `getDocumentContent`, `listFrameworks`, `documentCount`,
+/// and `disconnect`. The full-parameter `search` lives on the protocol
+/// itself; a convenience overload with `nil`-defaulted platform filters
+/// is provided as a protocol extension so existing call sites with
+/// fewer arguments compile unchanged.
+extension Search {
+    public protocol Database: Sendable {
+        /// Run a full search across the index.
+        ///
+        /// - Parameters:
+        ///   - query: Free-text query (FTS5 syntax).
+        ///   - source: Filter by source prefix (`apple-docs`, `samples`, …).
+        ///   - framework: Filter by framework slug.
+        ///   - language: Filter by primary language (`swift`, `objc`, `c`).
+        ///   - limit: Maximum number of results.
+        ///   - includeArchive: Include archive results when `source` is nil.
+        ///   - minIOS / minMacOS / minTvOS / minWatchOS / minVisionOS:
+        ///     Filter rows whose minimum-version annotation falls below the
+        ///     dotted-decimal threshold. Pass `nil` to skip a platform.
+        func search(
+            query: String,
+            source: String?,
+            framework: String?,
+            language: String?,
+            limit: Int,
+            includeArchive: Bool,
+            minIOS: String?,
+            minMacOS: String?,
+            minTvOS: String?,
+            minWatchOS: String?,
+            minVisionOS: String?,
+        ) async throws -> [Search.Result]
+
+        /// Fetch the pre-rendered document content for a URI.
+        ///
+        /// Returns `nil` when the URI is not present in the index. Throws
+        /// only on real database failures.
+        func getDocumentContent(uri: String, format: Search.DocumentFormat) async throws -> String?
+
+        /// All frameworks present in the index with their document counts.
+        func listFrameworks() async throws -> [String: Int]
+
+        /// Total document count across every source in the index.
+        func documentCount() async throws -> Int
+
+        /// Close the database connection. Idempotent; safe to call from a
+        /// `defer` even when the actor has already shut down.
+        func disconnect() async
+    }
+}
+
+// MARK: - Convenience overload with defaulted platform filters
+
+extension Search.Database {
+    /// Convenience overload that defaults every platform-availability
+    /// filter to `nil`. Callers who don't restrict by minimum OS version
+    /// stay one line.
+    public func search(
+        query: String,
+        source: String? = nil,
+        framework: String? = nil,
+        language: String? = nil,
+        limit: Int = Shared.Constants.Limit.defaultSearchLimit,
+        includeArchive: Bool = false,
+    ) async throws -> [Search.Result] {
+        try await search(
+            query: query,
+            source: source,
+            framework: framework,
+            language: language,
+            limit: limit,
+            includeArchive: includeArchive,
+            minIOS: nil,
+            minMacOS: nil,
+            minTvOS: nil,
+            minWatchOS: nil,
+            minVisionOS: nil,
+        )
+    }
+}


### PR DESCRIPTION
Foundation for slice C2 of #402. Lays the protocol seam so subsequent PRs can switch Services read-services from \`Search.Index\` (the actor in the Search target) to \`any Search.Database\` (the protocol in SearchModels) — the last blocker to Services fully dropping its \`import Search\`.

## What this PR adds

1. **\`Packages/Sources/SearchModels/Search.Database.swift\`** — new protocol covering every method Services calls on \`Search.Index\`:
   - \`search(query:source:framework:language:limit:includeArchive:minIOS:minMacOS:minTvOS:minWatchOS:minVisionOS:) async throws -> [Search.Result]\`
   - \`getDocumentContent(uri:format:) async throws -> String?\`
   - \`listFrameworks() async throws -> [String: Int]\`
   - \`documentCount() async throws -> Int\`
   - \`disconnect() async\`

   Plus a protocol-extension convenience overload of \`search\` that defaults the five platform-availability filters to \`nil\`, so call sites that don't restrict by platform version compile unchanged when they switch from concrete \`Search.Index\` to \`any Search.Database\`.

2. **\`Packages/Sources/Search/Search.Index.Database.swift\`** — one-line conformance witness. \`Search.Index\` already implements every method on \`Search.Database\` with matching signatures, so no method bodies move.

## What this PR does NOT do (deliberate)

- Switch Services read-services from \`Search.Index?\` to \`(any Search.Database)?\`. That touches DocsSearchService, HIGSearchService, TeaserService, UnifiedSearchService, ReadService, and ServiceContainer in Services, plus 5 CLI command files that pass-through the value, plus the test fanout. Each service migrates in its own PR so the individual reviews stay manageable.
- Drop \`import Search\` from Services. That can't happen until every service is migrated AND ServiceContainer's \`Search.Index(dbPath:)\` instantiation moves up to CLI via factory injection.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass (no behavioural change; only adds the protocol + conformance).

Part 4 of #402.