### PR TITLE
refactor(Services): #402c2 widen Services field types from Search.Index to any Search.Database

### DIFF
--- a/Packages/Sources/Services/ReadCommands/Services.DocsSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.DocsSearchService.swift
@@ -1,23 +1,34 @@
 import Foundation
 import Search
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - Documentation Search Service
 
-/// Service for searching Apple documentation, Swift Evolution, and other indexed sources.
-/// Wraps Search.Index with a clean interface for both CLI and MCP consumers.
+/// Service for searching Apple documentation, Swift Evolution, and other
+/// indexed sources. Internally holds an `any Search.Database` so the
+/// service can be driven by the production `Search.Index` actor or by a
+/// test stub conforming to `Search.Database`.
 extension Services {
     public actor DocsSearchService: Services.SearchService {
-        private let index: Search.Index
+        private let index: any Search.Database
 
-        /// Initialize with an existing search index
+        /// Initialize with an existing search index. Callers passing a
+        /// concrete `Search.Index` continue to compile unchanged because
+        /// `Search.Index` conforms to `Search.Database`.
         public init(index: Search.Index) {
             self.index = index
         }
 
-        /// Initialize with a database path, creating a new index connection
+        /// Initialize with any `Search.Database` conformer. Tests pass a
+        /// mock; CLI / MCP composition roots can opt into this overload
+        /// to avoid threading the concrete actor type through their wiring.
+        public init(database: any Search.Database) {
+            self.index = database
+        }
+
+        /// Initialize with a database path, creating a new index connection.
         public init(dbPath: URL) async throws {
             index = try await Search.Index(dbPath: dbPath)
         }

--- a/Packages/Sources/Services/ReadCommands/Services.HIGSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.HIGSearchService.swift
@@ -41,12 +41,17 @@ extension Services {
             self.docsService = docsService
         }
 
-        /// Initialize with a search index
+        /// Initialize with a search index.
         public init(index: Search.Index) {
             docsService = Services.DocsSearchService(index: index)
         }
 
-        /// Initialize with a database path
+        /// Initialize with any `Search.Database` conformer.
+        public init(database: any Search.Database) {
+            docsService = Services.DocsSearchService(database: database)
+        }
+
+        /// Initialize with a database path.
         public init(dbPath: URL) async throws {
             let index = try await Search.Index(dbPath: dbPath)
             docsService = Services.DocsSearchService(index: index)

--- a/Packages/Sources/Services/ReadCommands/Services.TeaserService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.TeaserService.swift
@@ -12,11 +12,13 @@ import SearchModels
 /// Consolidates teaser logic previously duplicated between CLI and MCP.
 extension Services {
     public actor TeaserService {
-        private let searchIndex: Search.Index?
+        private let searchIndex: (any Search.Database)?
         private let sampleDatabase: Sample.Index.Database?
 
-        /// Initialize with existing database connections
-        public init(searchIndex: Search.Index?, sampleDatabase: Sample.Index.Database?) {
+        /// Initialize with existing database connections. The concrete
+        /// `Search.Index?` form continues to compile because `Search.Index`
+        /// conforms to `Search.Database`.
+        public init(searchIndex: (any Search.Database)?, sampleDatabase: Sample.Index.Database?) {
             self.searchIndex = searchIndex
             self.sampleDatabase = sampleDatabase
         }

--- a/Packages/Sources/Services/ReadCommands/Services.UnifiedSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.UnifiedSearchService.swift
@@ -12,11 +12,13 @@ import SearchModels
 /// Consolidates search logic previously duplicated between CLI and MCP.
 extension Services {
     public actor UnifiedSearchService {
-        private let searchIndex: Search.Index?
+        private let searchIndex: (any Search.Database)?
         private let sampleDatabase: Sample.Index.Database?
 
-        /// Initialize with existing database connections
-        public init(searchIndex: Search.Index?, sampleDatabase: Sample.Index.Database?) {
+        /// Initialize with existing database connections. The concrete
+        /// `Search.Index?` form continues to compile because `Search.Index`
+        /// conforms to `Search.Database`.
+        public init(searchIndex: (any Search.Database)?, sampleDatabase: Sample.Index.Database?) {
             self.searchIndex = searchIndex
             self.sampleDatabase = sampleDatabase
         }


### PR DESCRIPTION
Additive slice of #402. Widens the internal field types in Services' search-adjacent actors from the concrete \`Search.Index\` to the protocol \`any Search.Database\`. Existing inits keep accepting \`Search.Index\` so every caller compiles unchanged — \`Search.Index\` conforms to \`Search.Database\`, so concrete values flow into the protocol-typed storage.

## Files touched

- **\`Services.DocsSearchService.swift\`**
  - \`private let index: Search.Index\` → \`private let index: any Search.Database\`
  - New \`init(database: any Search.Database)\` overload alongside \`init(index: Search.Index)\`. Tests / production wiring can inject a fake without naming \`Search.Index\` at the call site.

- **\`Services.HIGSearchService.swift\`**
  - New \`init(database: any Search.Database)\` overload that builds a \`DocsSearchService\` internally via the new path.

- **\`Services.TeaserService.swift\`**
  - \`private let searchIndex: Search.Index?\` → \`private let searchIndex: (any Search.Database)?\`
  - Init parameter accepts \`(any Search.Database)?\`. Existing callers passing \`Search.Index?\` continue to compile via the conformance.

- **\`Services.UnifiedSearchService.swift\`**
  - Same field + init parameter widening as TeaserService.

## Out of scope (next slices)

- \`Services.ServiceContainer.swift\` still instantiates \`Search.Index(dbPath:)\` directly. Moving that up to CLI requires factory injection on every \`with*Service\` static method + every CLI call site + test fanout — substantial refactor that doesn't pair with the field widening done here.
- \`Services.ReadService.swift\` internally calls \`ServiceContainer.withDocsService\`, which still instantiates \`Search.Index\`.
- \`Sample.Search.Service.swift\` uses Sample.Index; separate seam.

After this PR, Services still imports Search in the actor-adjacent paths above. The protocol-typed field is the architectural ground truth; the remaining imports are wiring that follows.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Part 5 of #402.