### PR TITLE
refactor(Services.SearchService): #402c2 drop import Search — uses only SearchModels value types

### DIFF
--- a/Packages/Sources/Services/Services.SearchService.swift
+++ b/Packages/Sources/Services/Services.SearchService.swift
@@ -1,8 +1,7 @@
 import Foundation
-import Search
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - Search Service Protocol
 


### PR DESCRIPTION
Tiny incremental slice of #402. \`Services.SearchService.swift\` declares the cross-CLI/MCP search-service protocol. Its only \`Search.*\` references are \`Search.Result\` and \`Search.DocumentFormat\` — both live in SearchModels after the #402a / #402c-prime lifts. The \`import Search\` line was dead.

## Acceptance check

\`\`\`bash
grep -oE "Search\\.[A-Z][a-zA-Z]+" Packages/Sources/Services/Services.SearchService.swift \\
    | grep -vE "Search\\.(Result|MatchedSymbol|PlatformAvailability|DocumentFormat|FrameworkAvailability|Database|CandidateFetcher|SmartCandidate|AvailabilityFilter)"
\`\`\`

Returns empty. Safe to drop.

## Status

After this PR, Services' \`import Search\` count drops from 9 to 8. The remaining importers are the actor-adjacent files: \`DocsSearchService\` / \`HIGSearchService\` / \`TeaserService\` / \`UnifiedSearchService\` / \`ServiceContainer\` / \`ReadService\`. Each either instantiates \`Search.Index\` directly or contains an init that does. Dropping those imports requires factory injection at the composition root (CLI), which is the next slice's scope.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Part 6 of #402.