### PR TITLE
refactor(Services.HIGSearchService): #402c2 drop import Search via init(database:)

### DIFF
--- a/Packages/Sources/Services/ReadCommands/Services.HIGSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.HIGSearchService.swift
@@ -1,8 +1,7 @@
 import Foundation
-import Search
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - HIG Search Query
 
@@ -36,25 +35,15 @@ extension Services {
     public actor HIGSearchService {
         private let docsService: Services.DocsSearchService
 
-        /// Initialize with an existing docs service
+        /// Initialize with an existing docs service.
         public init(docsService: Services.DocsSearchService) {
             self.docsService = docsService
         }
 
-        /// Initialize with a search index.
-        public init(index: Search.Index) {
-            docsService = Services.DocsSearchService(index: index)
-        }
-
         /// Initialize with any `Search.Database` conformer.
+        /// Production: pass a `Search.Index`; tests pass a mock.
         public init(database: any Search.Database) {
             docsService = Services.DocsSearchService(database: database)
-        }
-
-        /// Initialize with a database path.
-        public init(dbPath: URL) async throws {
-            let index = try await Search.Index(dbPath: dbPath)
-            docsService = Services.DocsSearchService(index: index)
         }
 
         // MARK: - Search Methods

--- a/Packages/Sources/Services/Services.ServiceContainer.swift
+++ b/Packages/Sources/Services/Services.ServiceContainer.swift
@@ -123,7 +123,7 @@ extension Services {
             }
 
             let index = try await Search.Index(dbPath: resolvedPath)
-            let service = Services.HIGSearchService(index: index)
+            let service = Services.HIGSearchService(database: index)
             defer {
                 Task {
                     await service.disconnect()


### PR DESCRIPTION
Drops \`import Search\` from \`Services.HIGSearchService.swift\` by removing the two Search.Index-coupled inits the file no longer needs:

1. **\`init(index: Search.Index)\`** — superseded by \`init(database: any Search.Database)\` from PR #458. The one external caller (\`ServiceContainer.withHIGService\`, line 126) was renaming-only: \`Services.HIGSearchService(index: index)\` → \`Services.HIGSearchService(database: index)\`. \`Search.Index\` conforms to \`Search.Database\`, so the call passes the concrete actor through the protocol-typed init without any behavioural change.

2. **\`init(dbPath: URL)\`** — zero callers anywhere. Removed entirely.

After this PR, \`HIGSearchService.swift\` no longer references the Search target's symbols. It still uses \`Search.Result\` and \`Search.DocumentFormat\` (both in SearchModels) plus the new \`Search.Database\` protocol. \`import Search\` dropped.

\`ServiceContainer.swift\` still constructs \`Search.Index(dbPath:)\` directly, so it keeps its \`import Search\`. The factory-injection move at the ServiceContainer level is the next slice.

Services' import-Search file count drops from 8 to 7.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Part 7 of #402.