### PR TITLE
refactor(Services.DocsSearchService): #402c2 drop import Search via init(database:)

### DIFF
--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -28,7 +28,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
         // Wrap databases with services for search operations
         if let searchIndex {
-            docsService = Services.DocsSearchService(index: searchIndex)
+            docsService = Services.DocsSearchService(database: searchIndex)
         } else {
             docsService = nil
         }

--- a/Packages/Sources/Services/ReadCommands/Services.DocsSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.DocsSearchService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Search
 import SearchModels
 import SharedConstants
 import SharedCore
@@ -9,28 +8,20 @@ import SharedCore
 /// Service for searching Apple documentation, Swift Evolution, and other
 /// indexed sources. Internally holds an `any Search.Database` so the
 /// service can be driven by the production `Search.Index` actor or by a
-/// test stub conforming to `Search.Database`.
+/// test stub conforming to `Search.Database`. The composition root
+/// (CLI / MCP / TUI) constructs the database and passes it in via
+/// `init(database:)`; this file no longer takes a behavioural dependency
+/// on the Search target.
 extension Services {
     public actor DocsSearchService: Services.SearchService {
         private let index: any Search.Database
 
-        /// Initialize with an existing search index. Callers passing a
-        /// concrete `Search.Index` continue to compile unchanged because
-        /// `Search.Index` conforms to `Search.Database`.
-        public init(index: Search.Index) {
-            self.index = index
-        }
-
-        /// Initialize with any `Search.Database` conformer. Tests pass a
-        /// mock; CLI / MCP composition roots can opt into this overload
-        /// to avoid threading the concrete actor type through their wiring.
+        /// Initialize with any `Search.Database` conformer. Production:
+        /// pass a `Search.Index` from the Search target — it conforms to
+        /// `Search.Database`, so the actor flows through this protocol-
+        /// typed init unchanged. Tests pass a mock.
         public init(database: any Search.Database) {
             self.index = database
-        }
-
-        /// Initialize with a database path, creating a new index connection.
-        public init(dbPath: URL) async throws {
-            index = try await Search.Index(dbPath: dbPath)
         }
 
         // MARK: - Services.SearchService Protocol

--- a/Packages/Sources/Services/Services.ServiceContainer.swift
+++ b/Packages/Sources/Services/Services.ServiceContainer.swift
@@ -36,7 +36,8 @@ extension Services {
                 return service
             }
 
-            let service = try await Services.DocsSearchService(dbPath: searchDbPath)
+            let index = try await Search.Index(dbPath: searchDbPath)
+            let service = Services.DocsSearchService(database: index)
             docsService = service
             return service
         }
@@ -101,7 +102,8 @@ extension Services {
                 throw Shared.Core.ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
             }
 
-            let service = try await Services.DocsSearchService(dbPath: resolvedPath)
+            let index = try await Search.Index(dbPath: resolvedPath)
+            let service = Services.DocsSearchService(database: index)
             defer {
                 Task {
                     await service.disconnect()


### PR DESCRIPTION
Drops \`import Search\` from \`Services.DocsSearchService.swift\` by removing the two Search.Index-coupled inits:

1. **\`init(index: Search.Index)\`** — superseded by \`init(database:)\` from PR #458. One external caller in \`SearchToolProvider/CompositeToolProvider.swift\` updated to use the new label: \`Services.DocsSearchService(database: searchIndex)\`.

2. **\`init(dbPath: URL)\`** — was the path-taking factory. Internal callers (\`ServiceContainer.getDocsService\` + \`ServiceContainer.withDocsService\`) now construct Search.Index inline and pass it to \`init(database:)\`:

\`\`\`swift
let index = try await Search.Index(dbPath: searchDbPath)
let service = Services.DocsSearchService(database: index)
\`\`\`

This keeps the Search.Index instantiation inside \`ServiceContainer\` (which still imports Search) but lifts it out of \`DocsSearchService\`.

After this PR, DocsSearchService.swift's only \`Search.*\` references are \`Search.Result\`, \`Search.DocumentFormat\`, and the \`Search.Database\` protocol — all in SearchModels. \`import Search\` dropped.

**Services' import-Search file count: 7 → 6.**

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Part 8 of #402.