### PR TITLE
refactor(Services.Teaser+Unified): #402c2 drop import Search via factory move to ServiceContainer

### DIFF
--- a/Packages/Sources/Services/ReadCommands/Services.TeaserService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.TeaserService.swift
@@ -1,10 +1,9 @@
 import Foundation
 import SampleIndex
-import Search
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - Teaser Service
 
@@ -23,13 +22,13 @@ extension Services {
             self.sampleDatabase = sampleDatabase
         }
 
-        /// Initialize with database paths (creates connections)
-        public init(searchDbPath: URL?, sampleDbPath: URL?) async throws {
-            if let searchDbPath, Shared.Utils.PathResolver.exists(searchDbPath) {
-                searchIndex = try await Search.Index(dbPath: searchDbPath)
-            } else {
-                searchIndex = nil
-            }
+        /// Initialize with a sample-database path. The search-side database
+        /// is injected via `searchIndex:` because constructing a
+        /// `Search.Index` requires the Search target — which Services no
+        /// longer imports. The composition root (`withTeaserService` in
+        /// `Services.ServiceContainer`) wires both sides.
+        public init(searchIndex: (any Search.Database)?, sampleDbPath: URL?) async throws {
+            self.searchIndex = searchIndex
 
             if let sampleDbPath, Shared.Utils.PathResolver.exists(sampleDbPath) {
                 sampleDatabase = try await Sample.Index.Database(dbPath: sampleDbPath)
@@ -159,23 +158,10 @@ extension Services {
     }
 }
 
-// MARK: - Services.ServiceContainer Extension
-
-extension Services.ServiceContainer {
-    /// Execute an operation with a teaser service
-    public static func withTeaserService<T: Sendable>(
-        searchDbPath: String? = nil,
-        sampleDbPath: URL? = nil,
-        operation: (Services.TeaserService) async throws -> T
-    ) async throws -> T {
-        let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
-        let resolvedSamplePath = sampleDbPath ?? Sample.Index.defaultDatabasePath
-
-        let service = try await Services.TeaserService(
-            searchDbPath: Shared.Utils.PathResolver.exists(resolvedSearchPath) ? resolvedSearchPath : nil,
-            sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil
-        )
-
-        return try await operation(service)
-    }
-}
+// The `withTeaserService` factory used to live here, but it needed to
+// construct a `Search.Index` (which lives in the Search target) and so
+// dragged `import Search` into this file. The factory now lives in
+// `Services.ServiceContainer.swift`, alongside the other
+// `with*Service` factories — that file keeps its `import Search` for
+// the same Search.Index-instantiation responsibility, but this file no
+// longer needs it.

--- a/Packages/Sources/Services/ReadCommands/Services.UnifiedSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.UnifiedSearchService.swift
@@ -1,10 +1,9 @@
 import Foundation
 import SampleIndex
-import Search
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - Unified Search Service
 
@@ -23,13 +22,14 @@ extension Services {
             self.sampleDatabase = sampleDatabase
         }
 
-        /// Initialize with database paths (creates connections)
-        public init(searchDbPath: URL?, sampleDbPath: URL?) async throws {
-            if let searchDbPath, Shared.Utils.PathResolver.exists(searchDbPath) {
-                searchIndex = try await Search.Index(dbPath: searchDbPath)
-            } else {
-                searchIndex = nil
-            }
+        /// Initialize with a sample-database path. The search-side
+        /// database is injected via `searchIndex:` because constructing
+        /// a `Search.Index` requires the Search target — which Services
+        /// no longer imports. The composition root
+        /// (`withUnifiedSearchService` in `Services.ServiceContainer`)
+        /// wires both sides.
+        public init(searchIndex: (any Search.Database)?, sampleDbPath: URL?) async throws {
+            self.searchIndex = searchIndex
 
             if let sampleDbPath, Shared.Utils.PathResolver.exists(sampleDbPath) {
                 sampleDatabase = try await Sample.Index.Database(dbPath: sampleDbPath)
@@ -170,23 +170,7 @@ extension Services {
     }
 }
 
-// MARK: - Services.ServiceContainer Extension
-
-extension Services.ServiceContainer {
-    /// Execute an operation with a unified search service
-    public static func withUnifiedSearchService<T: Sendable>(
-        searchDbPath: String? = nil,
-        sampleDbPath: URL? = nil,
-        operation: (Services.UnifiedSearchService) async throws -> T
-    ) async throws -> T {
-        let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
-        let resolvedSamplePath = sampleDbPath ?? Sample.Index.defaultDatabasePath
-
-        let service = try await Services.UnifiedSearchService(
-            searchDbPath: Shared.Utils.PathResolver.exists(resolvedSearchPath) ? resolvedSearchPath : nil,
-            sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil
-        )
-
-        return try await operation(service)
-    }
-}
+// The `withUnifiedSearchService` factory lives in
+// `Services.ServiceContainer.swift` alongside the other `with*Service`
+// factories — that file keeps `import Search` for the Search.Index
+// instantiation; this file no longer needs it.

--- a/Packages/Sources/Services/Services.ServiceContainer.swift
+++ b/Packages/Sources/Services/Services.ServiceContainer.swift
@@ -149,5 +149,58 @@ extension Services {
             await service.disconnect()
             return result
         }
+
+        /// Execute an operation with a teaser service. The teaser service
+        /// reads from the search database (optional) and the sample
+        /// database (optional). If either path is missing or doesn't
+        /// resolve to a file, the service handles that source as empty
+        /// rather than failing.
+        public static func withTeaserService<T: Sendable>(
+            searchDbPath: String? = nil,
+            sampleDbPath: URL? = nil,
+            operation: (Services.TeaserService) async throws -> T,
+        ) async throws -> T {
+            let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
+            let resolvedSamplePath = sampleDbPath ?? Sample.Index.defaultDatabasePath
+
+            let searchIndex: (any Search.Database)?
+            if Shared.Utils.PathResolver.exists(resolvedSearchPath) {
+                searchIndex = try await Search.Index(dbPath: resolvedSearchPath)
+            } else {
+                searchIndex = nil
+            }
+
+            let service = try await Services.TeaserService(
+                searchIndex: searchIndex,
+                sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil,
+            )
+
+            return try await operation(service)
+        }
+
+        /// Execute an operation with a unified search service. Same
+        /// composition pattern as `withTeaserService`.
+        public static func withUnifiedSearchService<T: Sendable>(
+            searchDbPath: String? = nil,
+            sampleDbPath: URL? = nil,
+            operation: (Services.UnifiedSearchService) async throws -> T,
+        ) async throws -> T {
+            let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
+            let resolvedSamplePath = sampleDbPath ?? Sample.Index.defaultDatabasePath
+
+            let searchIndex: (any Search.Database)?
+            if Shared.Utils.PathResolver.exists(resolvedSearchPath) {
+                searchIndex = try await Search.Index(dbPath: resolvedSearchPath)
+            } else {
+                searchIndex = nil
+            }
+
+            let service = try await Services.UnifiedSearchService(
+                searchIndex: searchIndex,
+                sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil,
+            )
+
+            return try await operation(service)
+        }
     }
 }


### PR DESCRIPTION
Drops \`import Search\` from \`Services.TeaserService.swift\` and \`Services.UnifiedSearchService.swift\` by moving their static \`with*Service\` factories into \`Services.ServiceContainer.swift\` — ServiceContainer keeps its \`import Search\` for the Search.Index instantiation responsibility, but the two service files become Search-free.

## Per-file changes

1. **\`Services.TeaserService.swift\`**
   - Replace \`init(searchDbPath: URL?, sampleDbPath: URL?)\` with \`init(searchIndex: (any Search.Database)?, sampleDbPath: URL?)\`. The caller passes the already-constructed database directly; this file no longer touches \`Search.Index(dbPath:)\`.
   - Remove the \`extension Services.ServiceContainer { withTeaserService }\` block at the bottom of the file.
   - Drop \`import Search\`.

2. **\`Services.UnifiedSearchService.swift\`**
   - Same pattern: replace \`init(searchDbPath:, sampleDbPath:)\` with \`init(searchIndex:, sampleDbPath:)\`.
   - Remove the \`withUnifiedSearchService\` extension block.
   - Drop \`import Search\`.

3. **\`Services.ServiceContainer.swift\`** gains two new factory methods (lifted from the per-service files):

\`\`\`swift
public static func withTeaserService<T: Sendable>(
    searchDbPath: String? = nil,
    sampleDbPath: URL? = nil,
    operation: (Services.TeaserService) async throws -> T,
) async throws -> T { ... }

public static func withUnifiedSearchService<T: Sendable>(
    searchDbPath: String? = nil,
    sampleDbPath: URL? = nil,
    operation: (Services.UnifiedSearchService) async throws -> T,
) async throws -> T { ... }
\`\`\`

Both resolve the search-DB + sample-DB paths via the existing \`Shared.Utils.PathResolver\` helpers, optionally instantiate \`Search.Index(dbPath:)\`, and pass the resulting \`any Search.Database?\` to the protocol-typed init. CLI / MCP / TUI callers using these \`with*Service\` static methods continue to compile unchanged — the API surface seen by consumers is identical.

## Status

**Services' import-Search file count: 4 → 2.** The remaining importers are:
- \`ServiceContainer.swift\` — the composition root inside Services that still constructs \`Search.Index\` directly.
- \`ReadService.swift\` — uses \`Search.PackageQuery\` (separate seam, future slice).

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Part 9 of #402.