### PR TITLE
refactor(Services.ReadService): #402c2 drop import Search via packageFileLookup closure injection

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Read.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Read.swift
@@ -85,7 +85,16 @@ extension CLI.Command {
                     format: documentFormat,
                     searchDB: searchDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
                     samplesDB: sampleDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
-                    packagesDB: packagesDb.map { URL(fileURLWithPath: $0).expandingTildeInPath }
+                    packagesDB: packagesDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
+                    packageFileLookup: { dbURL, owner, repo, relpath in
+                        // The Search.PackageQuery actor is the production
+                        // packages.db reader. CLI wires it in here so
+                        // Services.ReadService doesn't need to import the
+                        // Search target.
+                        let query = try await SearchModule.PackageQuery(dbPath: dbURL)
+                        defer { Task { await query.disconnect() } }
+                        return try await query.fileContent(owner: owner, repo: repo, relpath: relpath)
+                    }
                 )
             } catch Services.ReadService.ReadError.docsNotFound(let id) {
                 Logging.Log.error("Document not found in search.db: \(id)")

--- a/Packages/Sources/Services/ReadCommands/Services.ReadService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.ReadService.swift
@@ -1,9 +1,8 @@
 import Foundation
 import SampleIndex
-import Search
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - Unified read service
 
@@ -71,6 +70,13 @@ extension Services {
             }
         }
 
+        /// Closure that resolves a file inside `packages.db` to its raw
+        /// content. Production composition root (CLI) wires this as a
+        /// thin wrapper around `Search.PackageQuery(dbPath:).fileContent(...)`,
+        /// then `disconnect()`. ReadService doesn't import the Search
+        /// target, so the actor stays opaque behind this seam.
+        public typealias PackageFileLookup = @Sendable (_ dbURL: URL, _ owner: String, _ repo: String, _ relpath: String) async throws -> String?
+
         /// Read a document by identifier. When `explicit` is provided the
         /// matching backend is used; otherwise we infer:
         /// 1. URI scheme present → docs.
@@ -81,7 +87,8 @@ extension Services {
             format: Search.DocumentFormat,
             searchDB: URL?,
             samplesDB: URL?,
-            packagesDB: URL?
+            packagesDB: URL?,
+            packageFileLookup: PackageFileLookup,
         ) async throws -> Result {
             if let explicit {
                 return try await readFrom(
@@ -91,7 +98,8 @@ extension Services {
                     searchDB: searchDB,
                     samplesDB: samplesDB,
                     packagesDB: packagesDB,
-                    allowFallback: false
+                    allowFallback: false,
+                    packageFileLookup: packageFileLookup,
                 )
             }
 
@@ -103,7 +111,8 @@ extension Services {
                     searchDB: searchDB,
                     samplesDB: samplesDB,
                     packagesDB: packagesDB,
-                    allowFallback: false
+                    allowFallback: false,
+                    packageFileLookup: packageFileLookup,
                 )
             }
 
@@ -115,7 +124,8 @@ extension Services {
                     searchDB: searchDB,
                     samplesDB: samplesDB,
                     packagesDB: packagesDB,
-                    allowFallback: true
+                    allowFallback: true,
+                    packageFileLookup: packageFileLookup,
                 )
             } catch ReadError.samplesNotFound, ReadError.packagesNotFound,
                 ReadError.packagesIdentifierInvalid {
@@ -128,7 +138,8 @@ extension Services {
                 searchDB: searchDB,
                 samplesDB: samplesDB,
                 packagesDB: packagesDB,
-                allowFallback: false
+                allowFallback: false,
+                packageFileLookup: packageFileLookup,
             )
         }
 
@@ -141,7 +152,8 @@ extension Services {
             searchDB: URL?,
             samplesDB: URL?,
             packagesDB: URL?,
-            allowFallback: Bool
+            allowFallback: Bool,
+            packageFileLookup: PackageFileLookup,
         ) async throws -> Result {
             switch source {
             case .docs:
@@ -155,12 +167,14 @@ extension Services {
                     identifier: identifier,
                     samplesDB: samplesDB,
                     allowFallback: allowFallback,
-                    packagesDB: packagesDB
+                    packagesDB: packagesDB,
+                    packageFileLookup: packageFileLookup,
                 )
             case .packages:
                 return try await readFromPackages(
                     identifier: identifier,
-                    packagesDB: packagesDB
+                    packagesDB: packagesDB,
+                    packageFileLookup: packageFileLookup,
                 )
             }
         }
@@ -185,14 +199,16 @@ extension Services {
             identifier: String,
             samplesDB: URL?,
             allowFallback: Bool,
-            packagesDB: URL?
+            packagesDB: URL?,
+            packageFileLookup: PackageFileLookup,
         ) async throws -> Result {
             let dbURL = samplesDB ?? Sample.Index.defaultDatabasePath
             guard FileManager.default.fileExists(atPath: dbURL.path) else {
                 if allowFallback {
                     return try await readFromPackages(
                         identifier: identifier,
-                        packagesDB: packagesDB
+                        packagesDB: packagesDB,
+                        packageFileLookup: packageFileLookup,
                     )
                 }
                 throw ReadError.samplesNotFound(identifier: identifier)
@@ -222,7 +238,8 @@ extension Services {
             if allowFallback {
                 return try await readFromPackages(
                     identifier: identifier,
-                    packagesDB: packagesDB
+                    packagesDB: packagesDB,
+                    packageFileLookup: packageFileLookup,
                 )
             }
             throw ReadError.samplesNotFound(identifier: identifier)
@@ -230,7 +247,8 @@ extension Services {
 
         private static func readFromPackages(
             identifier: String,
-            packagesDB: URL?
+            packagesDB: URL?,
+            packageFileLookup: PackageFileLookup,
         ) async throws -> Result {
             // Identifier shape: `<owner>/<repo>/<relpath>`. Anything else is
             // not a valid package identifier — auto-source mode bails here.
@@ -247,17 +265,9 @@ extension Services {
                 throw ReadError.packagesNotFound(identifier: identifier)
             }
 
-            let query: Search.PackageQuery
-            do {
-                query = try await Search.PackageQuery(dbPath: dbURL)
-            } catch {
-                throw ReadError.backendFailed("Could not open packages.db: \(error.localizedDescription)")
-            }
-            defer { Task { await query.disconnect() } }
-
             let content: String?
             do {
-                content = try await query.fileContent(owner: owner, repo: repo, relpath: relpath)
+                content = try await packageFileLookup(dbURL, owner, repo, relpath)
             } catch {
                 throw ReadError.backendFailed("packages.db query failed: \(error.localizedDescription)")
             }


### PR DESCRIPTION
Drops \`import Search\` from \`Services.ReadService.swift\` by extracting the single \`Search.PackageQuery\` operation it performed (\`fileContent(owner:repo:relpath:)\`) into an injected closure.

## Surface added

\`\`\`swift
public typealias PackageFileLookup = @Sendable (
    _ dbURL: URL,
    _ owner: String,
    _ repo: String,
    _ relpath: String,
) async throws -> String?
\`\`\`

Threaded through \`Services.ReadService.read\` → \`readFrom\` → \`readFromPackages\` (and the \`readFromSamples\` fall-through into \`readFromPackages\`). The \`read\` entry takes the closure as a required parameter.

## Production wiring

The single call site in CLI:

\`\`\`swift
try await Services.ReadService.read(
    identifier: identifier,
    ...,
    packageFileLookup: { dbURL, owner, repo, relpath in
        let query = try await SearchModule.PackageQuery(dbPath: dbURL)
        defer { Task { await query.disconnect() } }
        return try await query.fileContent(owner: owner, repo: repo, relpath: relpath)
    }
)
\`\`\`

CLI is the right home — it's the composition root, and it already imports Search (via the \`SearchModule\` typealias that disambiguates from the local \`CLI.Command.Search\` subcommand). \`Services.ReadService\` now operates purely on the closure; \`Search.PackageQuery\` becomes a producer detail invisible to Services.

## Status

**Services target's import-Search count: 2 → 1.** The only remaining importer is \`Services.ServiceContainer.swift\`, which instantiates \`Search.Index(dbPath:)\` directly. Dropping that final import requires factory injection on every \`with*Service\` static method + the \`getDocsService\` / \`getHIGService\` / \`getSampleService\` instance methods — a wider CLI fanout that lands as a separate slice.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Part 10 of #402.