### PR TITLE
refactor(Services): #402 drop final import Search via ServiceContainer factory injection — closes #402

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.ListFrameworks.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.ListFrameworks.swift
@@ -29,7 +29,7 @@ extension CLI.Command {
 
         mutating func run() async throws {
             // Use Services.ServiceContainer for managed lifecycle
-            let (frameworks, totalDocs) = try await Services.ServiceContainer.withDocsService(dbPath: searchDb) { service in
+            let (frameworks, totalDocs) = try await Services.ServiceContainer.withDocsService(dbPath: searchDb, makeSearchDatabase: makeSearchDatabase) { service in
                 let frameworks = try await service.listFrameworks()
                 let totalDocs = try await service.documentCount()
                 return (frameworks, totalDocs)

--- a/Packages/Sources/CLI/Commands/CLI.Command.Read.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Read.swift
@@ -86,6 +86,7 @@ extension CLI.Command {
                     searchDB: searchDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
                     samplesDB: sampleDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
                     packagesDB: packagesDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
+                    makeSearchDatabase: makeSearchDatabase,
                     packageFileLookup: { dbURL, owner, repo, relpath in
                         // The Search.PackageQuery actor is the production
                         // packages.db reader. CLI wires it in here so

--- a/Packages/Sources/CLI/Commands/CLI.Command.Search.SourceRunners.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Search.SourceRunners.swift
@@ -16,7 +16,7 @@ import SearchModels
 /// `CLI.Command.Search+SmartReport.swift` (#239).
 extension CLI.Command.Search {
     func runDocsSearch() async throws {
-        let results = try await Services.ServiceContainer.withDocsService(dbPath: searchDb) { service in
+        let results = try await Services.ServiceContainer.withDocsService(dbPath: searchDb, makeSearchDatabase: makeSearchDatabase) { service in
             try await service.search(Services.SearchQuery(
                 text: query,
                 source: source,
@@ -34,7 +34,8 @@ extension CLI.Command.Search {
 
         let teasers = try await Services.ServiceContainer.withTeaserService(
             searchDbPath: searchDb,
-            sampleDbPath: resolveSampleDbPath()
+            sampleDbPath: resolveSampleDbPath(),
+            makeSearchDatabase: makeSearchDatabase,
         ) { service in
             await service.fetchAllTeasers(
                 query: query,
@@ -95,7 +96,8 @@ extension CLI.Command.Search {
         do {
             teasers = try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: searchDb,
-                sampleDbPath: resolveSampleDbPath()
+                sampleDbPath: resolveSampleDbPath(),
+                makeSearchDatabase: makeSearchDatabase,
             ) { service in
                 await service.fetchAllTeasers(
                     query: query,
@@ -174,7 +176,7 @@ extension CLI.Command.Search {
     }
 
     func runHIGSearch() async throws {
-        let results = try await Services.ServiceContainer.withDocsService(dbPath: searchDb) { service in
+        let results = try await Services.ServiceContainer.withDocsService(dbPath: searchDb, makeSearchDatabase: makeSearchDatabase) { service in
             try await service.search(Services.SearchQuery(
                 text: query,
                 source: Shared.Constants.SourcePrefix.hig,
@@ -187,7 +189,8 @@ extension CLI.Command.Search {
 
         let teasers = try await Services.ServiceContainer.withTeaserService(
             searchDbPath: searchDb,
-            sampleDbPath: resolveSampleDbPath()
+            sampleDbPath: resolveSampleDbPath(),
+            makeSearchDatabase: makeSearchDatabase,
         ) { service in
             await service.fetchAllTeasers(
                 query: query,

--- a/Packages/Sources/CLI/SearchModuleAlias.swift
+++ b/Packages/Sources/CLI/SearchModuleAlias.swift
@@ -1,5 +1,7 @@
+import Foundation
 import Search
 import SearchModels
+import Services
 
 // MARK: - Search Module Disambiguator
 
@@ -15,3 +17,14 @@ import SearchModels
 // in the CLI target.
 
 typealias SearchModule = Search
+
+// MARK: - Production Search.Database Factory
+
+// The factory closure CLI threads into every `Services.ServiceContainer.with*Service`
+// call. Production wiring: open a `SearchModule.Index` at the resolved path —
+// `Search.Index` conforms to `Search.Database` (the protocol in SearchModels) so
+// the concrete actor flows through Services' protocol-typed inits unchanged.
+// One declaration covers every with*Service call site in CLI.
+let makeSearchDatabase: Services.ServiceContainer.MakeSearchDatabase = { dbURL in
+    try await SearchModule.Index(dbPath: dbURL)
+}

--- a/Packages/Sources/Services/ReadCommands/Services.ReadService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.ReadService.swift
@@ -88,6 +88,7 @@ extension Services {
             searchDB: URL?,
             samplesDB: URL?,
             packagesDB: URL?,
+            makeSearchDatabase: Services.ServiceContainer.MakeSearchDatabase,
             packageFileLookup: PackageFileLookup,
         ) async throws -> Result {
             if let explicit {
@@ -99,6 +100,7 @@ extension Services {
                     samplesDB: samplesDB,
                     packagesDB: packagesDB,
                     allowFallback: false,
+                    makeSearchDatabase: makeSearchDatabase,
                     packageFileLookup: packageFileLookup,
                 )
             }
@@ -112,6 +114,7 @@ extension Services {
                     samplesDB: samplesDB,
                     packagesDB: packagesDB,
                     allowFallback: false,
+                    makeSearchDatabase: makeSearchDatabase,
                     packageFileLookup: packageFileLookup,
                 )
             }
@@ -125,6 +128,7 @@ extension Services {
                     samplesDB: samplesDB,
                     packagesDB: packagesDB,
                     allowFallback: true,
+                    makeSearchDatabase: makeSearchDatabase,
                     packageFileLookup: packageFileLookup,
                 )
             } catch ReadError.samplesNotFound, ReadError.packagesNotFound,
@@ -139,6 +143,7 @@ extension Services {
                 samplesDB: samplesDB,
                 packagesDB: packagesDB,
                 allowFallback: false,
+                makeSearchDatabase: makeSearchDatabase,
                 packageFileLookup: packageFileLookup,
             )
         }
@@ -153,6 +158,7 @@ extension Services {
             samplesDB: URL?,
             packagesDB: URL?,
             allowFallback: Bool,
+            makeSearchDatabase: Services.ServiceContainer.MakeSearchDatabase,
             packageFileLookup: PackageFileLookup,
         ) async throws -> Result {
             switch source {
@@ -160,7 +166,8 @@ extension Services {
                 return try await readFromDocs(
                     identifier: identifier,
                     format: format,
-                    searchDB: searchDB
+                    searchDB: searchDB,
+                    makeSearchDatabase: makeSearchDatabase,
                 )
             case .samples:
                 return try await readFromSamples(
@@ -182,10 +189,12 @@ extension Services {
         private static func readFromDocs(
             identifier: String,
             format: Search.DocumentFormat,
-            searchDB: URL?
+            searchDB: URL?,
+            makeSearchDatabase: Services.ServiceContainer.MakeSearchDatabase,
         ) async throws -> Result {
             let content = try await Services.ServiceContainer.withDocsService(
-                dbPath: searchDB?.path
+                dbPath: searchDB?.path,
+                makeSearchDatabase: makeSearchDatabase,
             ) { service in
                 try await service.read(uri: identifier, format: format)
             }

--- a/Packages/Sources/Services/Services.ServiceContainer.swift
+++ b/Packages/Sources/Services/Services.ServiceContainer.swift
@@ -1,100 +1,38 @@
 import Foundation
 import SampleIndex
-import Search
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - Service Container
 
-/// Container for managing service lifecycle and providing access to search services.
-/// Handles database connections and cleanup.
+/// Composition utility for the Services target's read-side services
+/// (`DocsSearchService`, `TeaserService`, `UnifiedSearchService`,
+/// `Sample.Search.Service`). Provides `with*Service` static methods that
+/// handle path resolution + existence checks + service disconnect, so
+/// CLI / MCP / TUI callers don't have to repeat that boilerplate per
+/// command.
+///
+/// The container does not import the Search target. Every search-side
+/// database (`Search.Index`) is constructed by an injected factory
+/// closure (`makeSearchDatabase`) that callers wire from the
+/// composition root — CLI typically passes
+/// `{ try await Search.Index(dbPath: $0) }`.
 extension Services {
-    public actor ServiceContainer {
-        private var docsService: Services.DocsSearchService?
-        private var higService: Services.HIGSearchService?
-        private var sampleService: Sample.Search.Service?
-
-        private let searchDbPath: URL
-        private let sampleDbPath: URL?
-
-        /// Initialize with database paths
-        public init(
-            searchDbPath: URL = Shared.Constants.defaultSearchDatabase,
-            sampleDbPath: URL? = nil
-        ) {
-            self.searchDbPath = searchDbPath
-            self.sampleDbPath = sampleDbPath
-        }
-
-        // MARK: - Service Access
-
-        /// Get or create the documentation search service
-        public func getDocsService() async throws -> Services.DocsSearchService {
-            if let service = docsService {
-                return service
-            }
-
-            let index = try await Search.Index(dbPath: searchDbPath)
-            let service = Services.DocsSearchService(database: index)
-            docsService = service
-            return service
-        }
-
-        /// Get or create the HIG search service
-        public func getHIGService() async throws -> Services.HIGSearchService {
-            if let service = higService {
-                return service
-            }
-
-            let docsService = try await getDocsService()
-            let service = Services.HIGSearchService(docsService: docsService)
-            higService = service
-            return service
-        }
-
-        /// Get or create the sample search service
-        public func getSampleService() async throws -> Sample.Search.Service {
-            if let service = sampleService {
-                return service
-            }
-
-            guard let dbPath = sampleDbPath else {
-                throw Shared.Core.ToolError.noData("Sample database path not configured")
-            }
-
-            let service = try await Sample.Search.Service(dbPath: dbPath)
-            sampleService = service
-            return service
-        }
-
-        // MARK: - Lifecycle
-
-        /// Disconnect all services
-        public func disconnectAll() async {
-            if let docs = docsService {
-                await docs.disconnect()
-                docsService = nil
-            }
-
-            if let hig = higService {
-                await hig.disconnect()
-                higService = nil
-            }
-
-            if let sample = sampleService {
-                await sample.disconnect()
-                sampleService = nil
-            }
-        }
+    public enum ServiceContainer {
+        /// Closure signature for opening a `Search.Database` from a URL.
+        /// CLI passes `{ try await Search.Index(dbPath: $0) }`; tests
+        /// can pass a fake.
+        public typealias MakeSearchDatabase = @Sendable (URL) async throws -> any Search.Database
 
         // MARK: - Convenience Factory Methods
 
-        /// Execute an operation with a docs service, handling lifecycle
+        /// Execute an operation with a docs service, handling lifecycle.
         public static func withDocsService<T>(
             dbPath: String? = nil,
-            operation: (Services.DocsSearchService) async throws -> T
+            makeSearchDatabase: MakeSearchDatabase,
+            operation: (Services.DocsSearchService) async throws -> T,
         ) async throws -> T {
             let resolvedPath = Shared.Utils.PathResolver.searchDatabase(dbPath)
 
@@ -102,8 +40,8 @@ extension Services {
                 throw Shared.Core.ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
             }
 
-            let index = try await Search.Index(dbPath: resolvedPath)
-            let service = Services.DocsSearchService(database: index)
+            let database = try await makeSearchDatabase(resolvedPath)
+            let service = Services.DocsSearchService(database: database)
             defer {
                 Task {
                     await service.disconnect()
@@ -113,32 +51,14 @@ extension Services {
             return try await operation(service)
         }
 
-        /// Execute an operation with a HIG service, handling lifecycle
-        public static func withHIGService<T>(
-            dbPath: String? = nil,
-            operation: (Services.HIGSearchService) async throws -> T
-        ) async throws -> T {
-            let resolvedPath = Shared.Utils.PathResolver.searchDatabase(dbPath)
-
-            guard Shared.Utils.PathResolver.exists(resolvedPath) else {
-                throw Shared.Core.ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
-            }
-
-            let index = try await Search.Index(dbPath: resolvedPath)
-            let service = Services.HIGSearchService(database: index)
-            defer {
-                Task {
-                    await service.disconnect()
-                }
-            }
-
-            return try await operation(service)
-        }
-
-        /// Execute an operation with a sample service, handling lifecycle
+        /// Execute an operation with a sample service, handling lifecycle.
+        /// No `makeSearchDatabase` here: the sample service is backed by
+        /// `Sample.Search.Service`, which constructs its own
+        /// `Sample.Index.Database` — that's a SampleIndex-target concern,
+        /// not Search.
         public static func withSampleService<T: Sendable>(
             dbPath: URL,
-            operation: (Sample.Search.Service) async throws -> T
+            operation: (Sample.Search.Service) async throws -> T,
         ) async throws -> T {
             guard Shared.Utils.PathResolver.exists(dbPath) else {
                 throw Shared.Core.ToolError.noData("Sample database not found at \(dbPath.path). Run 'cupertino save --samples' to build the index.")
@@ -150,14 +70,15 @@ extension Services {
             return result
         }
 
-        /// Execute an operation with a teaser service. The teaser service
-        /// reads from the search database (optional) and the sample
-        /// database (optional). If either path is missing or doesn't
-        /// resolve to a file, the service handles that source as empty
-        /// rather than failing.
+        /// Execute an operation with a teaser service.
+        ///
+        /// The teaser service reads from the search database (optional)
+        /// and the sample database (optional). Missing paths degrade
+        /// each source to empty rather than failing.
         public static func withTeaserService<T: Sendable>(
             searchDbPath: String? = nil,
             sampleDbPath: URL? = nil,
+            makeSearchDatabase: MakeSearchDatabase,
             operation: (Services.TeaserService) async throws -> T,
         ) async throws -> T {
             let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
@@ -165,7 +86,7 @@ extension Services {
 
             let searchIndex: (any Search.Database)?
             if Shared.Utils.PathResolver.exists(resolvedSearchPath) {
-                searchIndex = try await Search.Index(dbPath: resolvedSearchPath)
+                searchIndex = try await makeSearchDatabase(resolvedSearchPath)
             } else {
                 searchIndex = nil
             }
@@ -183,6 +104,7 @@ extension Services {
         public static func withUnifiedSearchService<T: Sendable>(
             searchDbPath: String? = nil,
             sampleDbPath: URL? = nil,
+            makeSearchDatabase: MakeSearchDatabase,
             operation: (Services.UnifiedSearchService) async throws -> T,
         ) async throws -> T {
             let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
@@ -190,7 +112,7 @@ extension Services {
 
             let searchIndex: (any Search.Database)?
             if Shared.Utils.PathResolver.exists(resolvedSearchPath) {
-                searchIndex = try await Search.Index(dbPath: resolvedSearchPath)
+                searchIndex = try await makeSearchDatabase(resolvedSearchPath)
             } else {
                 searchIndex = nil
             }

--- a/Packages/Tests/ServicesTests/ServicesTests.swift
+++ b/Packages/Tests/ServicesTests/ServicesTests.swift
@@ -210,10 +210,17 @@ struct TeaserResultsResilienceTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
+        // Stub factory: when withTeaserService finds a "path" that exists
+        // (here a directory rather than a real .db), it calls the factory.
+        // Our stub throws — the test verifies the outer call propagates it.
+        let throwingFactory: Services.ServiceContainer.MakeSearchDatabase = { _ in
+            throw NSError(domain: "ServicesTests.stub", code: 1)
+        }
         await #expect(throws: (any Error).self) {
             try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: tempDir.path,
-                sampleDbPath: nil
+                sampleDbPath: nil,
+                makeSearchDatabase: throwingFactory,
             ) { service in
                 _ = await service.fetchAllTeasers(
                     query: "swiftui",
@@ -231,11 +238,15 @@ struct TeaserResultsResilienceTests {
         // catch the throw, fall back to TeaserResults(). Verifies the
         // fallback contract (empty + iterable) so future changes don't
         // accidentally make the empty struct require parameters.
+        let throwingFactory: Services.ServiceContainer.MakeSearchDatabase = { _ in
+            throw NSError(domain: "ServicesTests.stub", code: 1)
+        }
         let teasers: Services.Formatter.TeaserResults
         do {
             teasers = try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: "/var/empty/intentionally-broken-search.db.\(UUID().uuidString)",
-                sampleDbPath: nil
+                sampleDbPath: nil,
+                makeSearchDatabase: throwingFactory,
             ) { service in
                 await service.fetchAllTeasers(
                     query: "swiftui",


### PR DESCRIPTION
**Closes #402.** Services target now imports zero behavioural Search surface — every \`Search.Database\` value comes through an injected factory closure (\`MakeSearchDatabase\`) wired from the composition root.

## Per-file changes

1. **\`Services/Services.ServiceContainer.swift\`**
   - Converts \`ServiceContainer\` from \`public actor\` with instance state to a \`public enum\` with only static factory methods. The instance state + init + \`getDocsService\` / \`getHIGService\` / \`getSampleService\` / \`disconnectAll\` were dead (\`grep -rn ServiceContainer(\` returned zero callers outside the file).
   - Drop the unused \`withHIGService\` static factory (no callers).
   - Add \`MakeSearchDatabase = @Sendable (URL) async throws -> any Search.Database\` typealias.
   - Add \`makeSearchDatabase:\` parameter to \`withDocsService\`, \`withTeaserService\`, \`withUnifiedSearchService\`. Each calls the closure with the resolved DB path to get a \`Search.Database\`, then passes it to the protocol-typed init on the underlying service.
   - **Drop \`import Search\`**.

2. **\`Services/ReadCommands/Services.ReadService.swift\`**
   - Add \`makeSearchDatabase:\` parameter to public \`read(...)\` entry. Thread through \`readFrom(...)\` → \`readFromDocs(...)\` to the \`withDocsService\` call.

3. **\`Sources/CLI/SearchModuleAlias.swift\`**
   - New module-level \`let makeSearchDatabase: Services.ServiceContainer.MakeSearchDatabase\` constant. Production wiring: \`{ try await SearchModule.Index(dbPath: \$0) }\`. One declaration covers every with*Service call site in CLI.

4. **CLI command files** (\`ListFrameworks\`, \`Search.SourceRunners\`, \`Read\`)
   - Every \`Services.ServiceContainer.with*Service\` callsite now passes \`makeSearchDatabase: makeSearchDatabase\`.

5. **\`Tests/ServicesTests/ServicesTests.swift\`**
   - Two \`withTeaserService\` test sites get a throwing stub factory.

## Acceptance

\`\`\`
grep -l "^import Search$" Packages/Sources/Services/**/*.swift Packages/Sources/Services/*.swift
\`\`\`

returns no matches. The Services target compiles against SharedConstants / SharedUtils / SharedModels / SharedCore / SharedConfiguration / SampleIndex / SearchModels / MCPCore / MCPSharedTools / Logging / Foundation only — zero behavioural dependency on the Search target.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

The Services package stands independently per the DI epic's acceptance criterion. Search.Index instantiation moved up to CLI / MCP / TUI composition roots, which is exactly where the DIP says it belongs.

Closes #402.