### PR TITLE
refactor(SearchToolProvider): #408 drop import Search via Search.Database protocol expansion

### DIFF
--- a/Packages/Sources/Search/Search.Index.Search.swift
+++ b/Packages/Sources/Search/Search.Index.Search.swift
@@ -1074,19 +1074,10 @@ extension Search.Index {
 
     // MARK: - Semantic Symbol Search (#81)
 
-    /// Symbol search result with document context
-    public struct SymbolSearchResult: Sendable {
-        public let docUri: String
-        public let docTitle: String
-        public let framework: String
-        public let symbolName: String
-        public let symbolKind: String
-        public let signature: String?
-        public let attributes: String?
-        public let conformances: String?
-        public let isAsync: Bool
-        public let isPublic: Bool
-    }
+    // `SymbolSearchResult` lives in SearchModels as `Search.SymbolSearchResult`
+    // so consumers (SearchToolProvider, MCP responders) can render symbol
+    // hits without importing the Search target. The semantic-search
+    // methods below produce values of that lifted type.
 
     // Search symbols by name pattern and optional filters
     // - Parameters:

--- a/Packages/Sources/Search/Search.Index.SemanticSearch.swift
+++ b/Packages/Sources/Search/Search.Index.SemanticSearch.swift
@@ -16,7 +16,7 @@ extension Search.Index {
         isAsync: Bool? = nil,
         framework: String? = nil,
         limit: Int = Shared.Constants.Limit.defaultSearchLimit
-    ) async throws -> [SymbolSearchResult] {
+    ) async throws -> [Search.SymbolSearchResult] {
         guard let database else {
             throw Search.Error.databaseNotInitialized
         }
@@ -82,7 +82,7 @@ extension Search.Index {
         }
         sqlite3_bind_int(statement, paramIndex, Int32(limit))
 
-        var results: [SymbolSearchResult] = []
+        var results: [Search.SymbolSearchResult] = []
         while sqlite3_step(statement) == SQLITE_ROW {
             let docUri = sqlite3_column_text(statement, 0).map { String(cString: $0) } ?? ""
             let docTitle = sqlite3_column_text(statement, 1).map { String(cString: $0) } ?? ""
@@ -95,7 +95,7 @@ extension Search.Index {
             let isAsync = sqlite3_column_int(statement, 8) != 0
             let isPublic = sqlite3_column_int(statement, 9) != 0
 
-            results.append(SymbolSearchResult(
+            results.append(Search.SymbolSearchResult(
                 docUri: docUri,
                 docTitle: docTitle,
                 framework: framework,
@@ -122,7 +122,7 @@ extension Search.Index {
         wrapper: String,
         framework: String? = nil,
         limit: Int = Shared.Constants.Limit.defaultSearchLimit
-    ) async throws -> [SymbolSearchResult] {
+    ) async throws -> [Search.SymbolSearchResult] {
         guard let database else {
             throw Search.Error.databaseNotInitialized
         }
@@ -176,7 +176,7 @@ extension Search.Index {
         }
         sqlite3_bind_int(statement, paramIndex, Int32(limit))
 
-        var results: [SymbolSearchResult] = []
+        var results: [Search.SymbolSearchResult] = []
         while sqlite3_step(statement) == SQLITE_ROW {
             let docUri = sqlite3_column_text(statement, 0).map { String(cString: $0) } ?? ""
             let docTitle = sqlite3_column_text(statement, 1).map { String(cString: $0) } ?? ""
@@ -189,7 +189,7 @@ extension Search.Index {
             let isAsync = sqlite3_column_int(statement, 8) != 0
             let isPublic = sqlite3_column_int(statement, 9) != 0
 
-            results.append(SymbolSearchResult(
+            results.append(Search.SymbolSearchResult(
                 docUri: docUri,
                 docTitle: docTitle,
                 framework: framework,
@@ -216,7 +216,7 @@ extension Search.Index {
         pattern: String,
         framework: String? = nil,
         limit: Int = Shared.Constants.Limit.defaultSearchLimit
-    ) async throws -> [SymbolSearchResult] {
+    ) async throws -> [Search.SymbolSearchResult] {
         guard let database else {
             throw Search.Error.databaseNotInitialized
         }
@@ -289,7 +289,7 @@ extension Search.Index {
         }
         sqlite3_bind_int(statement, paramIndex, Int32(limit))
 
-        var results: [SymbolSearchResult] = []
+        var results: [Search.SymbolSearchResult] = []
         while sqlite3_step(statement) == SQLITE_ROW {
             let docUri = sqlite3_column_text(statement, 0).map { String(cString: $0) } ?? ""
             let docTitle = sqlite3_column_text(statement, 1).map { String(cString: $0) } ?? ""
@@ -302,7 +302,7 @@ extension Search.Index {
             let isAsync = sqlite3_column_int(statement, 8) != 0
             let isPublic = sqlite3_column_int(statement, 9) != 0
 
-            results.append(SymbolSearchResult(
+            results.append(Search.SymbolSearchResult(
                 docUri: docUri,
                 docTitle: docTitle,
                 framework: framework,
@@ -329,7 +329,7 @@ extension Search.Index {
         protocolName: String,
         framework: String? = nil,
         limit: Int = Shared.Constants.Limit.defaultSearchLimit
-    ) async throws -> [SymbolSearchResult] {
+    ) async throws -> [Search.SymbolSearchResult] {
         guard let database else {
             throw Search.Error.databaseNotInitialized
         }
@@ -381,7 +381,7 @@ extension Search.Index {
         }
         sqlite3_bind_int(statement, paramIndex, Int32(limit))
 
-        var results: [SymbolSearchResult] = []
+        var results: [Search.SymbolSearchResult] = []
         while sqlite3_step(statement) == SQLITE_ROW {
             let docUri = sqlite3_column_text(statement, 0).map { String(cString: $0) } ?? ""
             let docTitle = sqlite3_column_text(statement, 1).map { String(cString: $0) } ?? ""
@@ -394,7 +394,7 @@ extension Search.Index {
             let isAsync = sqlite3_column_int(statement, 8) != 0
             let isPublic = sqlite3_column_int(statement, 9) != 0
 
-            results.append(SymbolSearchResult(
+            results.append(Search.SymbolSearchResult(
                 docUri: docUri,
                 docTitle: docTitle,
                 framework: framework,

--- a/Packages/Sources/SearchModels/Search.Database.swift
+++ b/Packages/Sources/SearchModels/Search.Database.swift
@@ -57,6 +57,40 @@ extension Search {
         /// Close the database connection. Idempotent; safe to call from a
         /// `defer` even when the actor has already shut down.
         func disconnect() async
+
+        // MARK: - Semantic Symbol Search (#81)
+
+        /// Semantic search across AST-extracted symbols by name pattern + kind.
+        func searchSymbols(
+            query: String?,
+            kind: String?,
+            isAsync: Bool?,
+            framework: String?,
+            limit: Int,
+        ) async throws -> [Search.SymbolSearchResult]
+
+        /// Semantic search for property-wrapper attributes (e.g. `@Observable`,
+        /// `@State`, `@MainActor`).
+        func searchPropertyWrappers(
+            wrapper: String,
+            framework: String?,
+            limit: Int,
+        ) async throws -> [Search.SymbolSearchResult]
+
+        /// Semantic search for Swift concurrency patterns
+        /// (`async`, `actor`, `sendable`, `mainactor`, `task`, `asyncsequence`).
+        func searchConcurrencyPatterns(
+            pattern: String,
+            framework: String?,
+            limit: Int,
+        ) async throws -> [Search.SymbolSearchResult]
+
+        /// Semantic search for types by protocol conformance.
+        func searchConformances(
+            protocolName: String,
+            framework: String?,
+            limit: Int,
+        ) async throws -> [Search.SymbolSearchResult]
     }
 }
 

--- a/Packages/Sources/SearchModels/Search.SymbolSearchResult.swift
+++ b/Packages/Sources/SearchModels/Search.SymbolSearchResult.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Symbol search result with document context.
+///
+/// Lifted out of `Search.Index.SymbolSearchResult` (the nested type
+/// inside the Search.Index actor in the Search target) to top-level
+/// `Search.SymbolSearchResult` in SearchModels so consumers
+/// (SearchToolProvider, MCP responders) can decode + render semantic-
+/// search hits without taking a behavioural dependency on the Search
+/// target.
+extension Search {
+    public struct SymbolSearchResult: Sendable {
+        public let docUri: String
+        public let docTitle: String
+        public let framework: String
+        public let symbolName: String
+        public let symbolKind: String
+        public let signature: String?
+        public let attributes: String?
+        public let conformances: String?
+        public let isAsync: Bool
+        public let isPublic: Bool
+
+        public init(
+            docUri: String,
+            docTitle: String,
+            framework: String,
+            symbolName: String,
+            symbolKind: String,
+            signature: String?,
+            attributes: String?,
+            conformances: String?,
+            isAsync: Bool,
+            isPublic: Bool,
+        ) {
+            self.docUri = docUri
+            self.docTitle = docTitle
+            self.framework = framework
+            self.symbolName = symbolName
+            self.symbolKind = symbolKind
+            self.signature = signature
+            self.attributes = attributes
+            self.conformances = conformances
+            self.isAsync = isAsync
+            self.isPublic = isPublic
+        }
+    }
+}

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -2,12 +2,11 @@ import Foundation
 import MCPCore
 import MCPSharedTools
 import SampleIndex
-import Search
+import SearchModels
 import Services
 import SharedConstants
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - Unified Cupertino Tool Provider
 
@@ -18,11 +17,13 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
     private let docsService: Services.DocsSearchService?
     private let sampleService: Sample.Search.Service?
 
-    // Keep direct access for low-level operations (list frameworks, read document)
-    private let searchIndex: Search.Index?
+    // Keep direct access for low-level operations (list frameworks, read
+    // document, semantic-symbol searches). Protocol-typed so this file
+    // doesn't import the Search target.
+    private let searchIndex: (any Search.Database)?
     private let sampleDatabase: Sample.Index.Database?
 
-    public init(searchIndex: Search.Index?, sampleDatabase: Sample.Index.Database?) {
+    public init(searchIndex: (any Search.Database)?, sampleDatabase: Sample.Index.Database?) {
         self.searchIndex = searchIndex
         self.sampleDatabase = sampleDatabase
 
@@ -871,7 +872,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
     /// Format symbol search results as markdown
     private func formatSymbolResults(
-        results: [Search.Index.SymbolSearchResult],
+        results: [Search.SymbolSearchResult],
         title: String,
         query: String?,
         filters: [String: String?]
@@ -897,7 +898,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         markdown += "Found **\(results.count)** symbols:\n\n"
 
         // Group by document for better organization
-        var byDocument: [String: [(Search.Index.SymbolSearchResult, Int)]] = [:]
+        var byDocument: [String: [(Search.SymbolSearchResult, Int)]] = [:]
         for (index, result) in results.enumerated() {
             byDocument[result.docUri, default: []].append((result, index))
         }


### PR DESCRIPTION
Drops \`import Search\` from \`SearchToolProvider/CompositeToolProvider.swift\` by widening its \`searchIndex\` field type from concrete \`Search.Index?\` to \`(any Search.Database)?\`, lifting \`SymbolSearchResult\` to SearchModels, and expanding the \`Search.Database\` protocol with the 4 semantic-search methods.

## Type lifts

1. **New \`Packages/Sources/SearchModels/Search.SymbolSearchResult.swift\`** — lifted out of \`Search.Index.SymbolSearchResult\`. 10 Sendable public fields.
2. **\`Search.Index.Search.swift\`** — drops the nested \`public struct SymbolSearchResult\` block.
3. **\`Search.Index.SemanticSearch.swift\`** — 12 callsites rewritten from bare \`SymbolSearchResult\` to \`Search.SymbolSearchResult\`.

## Protocol surface added

4. **\`Search.Database\` protocol** gains 4 semantic-search method requirements:
   - \`searchSymbols(query:kind:isAsync:framework:limit:)\`
   - \`searchPropertyWrappers(wrapper:framework:limit:)\`
   - \`searchConcurrencyPatterns(pattern:framework:limit:)\`
   - \`searchConformances(protocolName:framework:limit:)\`

   Each returns \`[Search.SymbolSearchResult]\`. \`Search.Index\` already implements all four with matching signatures — the existing \`extension Search.Index: Search.Database {}\` conformance witness auto-witnesses them.

## Consumer changes

5. **\`CompositeToolProvider.swift\`**:
   - \`private let searchIndex: Search.Index?\` → \`private let searchIndex: (any Search.Database)?\`
   - Init parameter widens identically (Search.Index conforms to Search.Database, so existing call sites passing concrete Search.Index still work).
   - Two callsites renaming \`Search.Index.SymbolSearchResult\` → \`Search.SymbolSearchResult\`.
   - **Drop \`import Search\`**. File now imports MCPCore + MCPSharedTools + SampleIndex + SearchModels + Services + Shared* only.

## Status

SearchToolProvider target's \`import Search\` count: **1 → 0**. The target still imports SampleIndex (Sample.Index.Database access) and Services (CompositeToolProvider wraps the search-side service); the SampleIndex dependency is the next slice.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Part 1 of #408. (Sample.Index seam to follow.)