### PR TITLE
fix(CorePackageIndexing): #322 replace stray print() with Logging.ConsoleLogger

### DIFF
--- a/Packages/Sources/Core/PackageIndexing/Core.PackageIndexing.PriorityPackagesCatalog.swift
+++ b/Packages/Sources/Core/PackageIndexing/Core.PackageIndexing.PriorityPackagesCatalog.swift
@@ -4,6 +4,7 @@
 
 import CoreProtocols
 import Foundation
+import Logging
 import Resources
 import SharedConstants
 import SharedCore
@@ -298,7 +299,7 @@ extension Core.PackageIndexing {
 
             do {
                 try mergedData.write(to: selectedURL)
-                print("📥 selected-packages.json: added \(totalNew) new priority entries from embedded list (#218)")
+                Logging.ConsoleLogger.info("📥 selected-packages.json: added \(totalNew) new priority entries from embedded list (#218)")
             } catch {
                 // Silently fail - we already have the user file from before
             }


### PR DESCRIPTION
The last \`print()\` in production code outside of doc-comment blocks was in \`Core.PackageIndexing.PriorityPackagesCatalog.mergeUserSelectedWithEmbedded\`, emitting an info-level message when the embedded-list merge writes new entries to \`~/.cupertino/selected-packages.json\`. Replaces with \`Logging.ConsoleLogger.info(...)\` to match every other user-facing message in this target.

Drive-by: \`import Logging\` added to the file (was missing because the file had no logger calls before).

## Verification

\`\`\`bash
grep -rn "^\\s*print(" Packages/Sources/Core/ Packages/Sources/Crawler/
\`\`\`

Returns zero hits in production code. (The earlier hits in \`CupertinoCore.swift\` are inside a \`/* ... */\` doc-comment block — not production code.)

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Closes #322.