### PR TITLE
fix(Availability): #317 replace URL force-unwrap in buildAPIURL

### DIFF
--- a/Packages/Sources/Availability/Availability.Fetcher.swift
+++ b/Packages/Sources/Availability/Availability.Fetcher.swift
@@ -376,10 +376,18 @@ extension Availability {
             // Build API URL from doc URL
             // https://developer.apple.com/documentation/SwiftUI/View
             // -> https://developer.apple.com/tutorials/data/documentation/swiftui/view.json
+            //
+            // If URL construction fails (malformed apiBaseURL or weird
+            // path characters), skip the network fetch entirely — the
+            // local-content fallback below handles availability extraction
+            // from the embedded JSON.
             let apiURL = buildAPIURL(from: docURL)
 
             // Fetch availability from API
-            var availability = await fetchAvailability(from: apiURL)
+            var availability: Availability.Info?
+            if let apiURL {
+                availability = await fetchAvailability(from: apiURL)
+            }
             var inherited = false
             var derivedFromRefs = false
 
@@ -554,8 +562,8 @@ extension Availability {
             return false // Equal versions
         }
 
-        private func buildAPIURL(from docURL: URL) -> URL {
-            // Extract path after /documentation/
+        private func buildAPIURL(from docURL: URL) -> URL? {
+            // Extract path after /documentation/.
             let path = docURL.path.lowercased()
             let apiPath: String
 
@@ -565,13 +573,15 @@ extension Availability {
                 apiPath = path
             }
 
-            // Availability target deliberately has no `Shared` dependency, so the
-            // `URL.knownGood` helper used elsewhere in the codebase isn't
-            // available here. The single site, with a known-good base + sanitized
-            // path, gets a localized swiftlint exemption rather than dragging a
-            // whole package dependency in just for one URL constructor.
-            // swiftlint:disable:next force_unwrapping
-            return URL(string: "\(configuration.apiBaseURL)/\(apiPath).json")!
+            // `Availability` deliberately has no `Shared` dependency, so the
+            // `URL.knownGood`-style helpers used elsewhere in the codebase
+            // aren't available here. Use the throwing `URL(string:)` and
+            // let the caller skip the network fetch when construction fails
+            // (mis-configured apiBaseURL, exotic path characters Apple
+            // hasn't shipped yet). The caller falls back to local-content
+            // availability extraction, so a nil here just degrades
+            // gracefully instead of trapping the process.
+            return URL(string: "\(configuration.apiBaseURL)/\(apiPath).json")
         }
 
         private func fetchAvailability(from url: URL) async -> Availability.Info? {


### PR DESCRIPTION
\`Availability.Fetcher.Implementation.buildAPIURL(from:)\` used a swiftlint-disabled force-unwrap on \`URL(string:)\` because the Availability target doesn't depend on \`Shared\` (so the \`URL.knownGood\` helper used elsewhere wasn't available). The justification comment claimed a "known-good base + sanitized path", but that's brittle: a mis-configured \`configuration.apiBaseURL\` (typo, missing scheme, missing host) or an exotic path character Apple ships in a future framework slug would trap the process.

## Fix

\`buildAPIURL\` now returns \`URL?\` and uses non-trapping \`URL(string:)\`. The single caller (\`processFile\`) handles the nil case by skipping the network fetch — local-content availability extraction (the existing fallback path) handles the page either way, so the function degrades gracefully instead of crashing.

## Behavioural change

Zero. The fallback path was already exercised whenever the network fetch returned empty data; a nil API URL now takes the same path one step earlier.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Closes #317.