### PR TITLE
refactor(SharedUtils): #323 add Shared.Utils.SQL.countRows helper + replace 11 inline SQL literals

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Doctor.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Doctor.swift
@@ -299,9 +299,9 @@ extension CLI.Command {
             Logging.Log.output("   ✓ Database: \(samplesDBURL.path)")
             Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
 
-            let projectCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM projects;")
-            let fileCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM files;")
-            let symbolCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: "SELECT COUNT(*) FROM file_symbols;")
+            let projectCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: Shared.Utils.SQL.countRows(in: "projects"))
+            let fileCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: Shared.Utils.SQL.countRows(in: "files"))
+            let symbolCount = Diagnostics.Probes.rowCount(at: samplesDBURL, sql: Shared.Utils.SQL.countRows(in: "file_symbols"))
             if let projectCount { Logging.Log.output("   ✓ Projects: \(projectCount)") }
             if let fileCount { Logging.Log.output("   ✓ Indexed files: \(fileCount)") }
             if let symbolCount { Logging.Log.output("   ✓ Indexed symbols: \(symbolCount)") }
@@ -331,8 +331,8 @@ extension CLI.Command {
             Logging.Log.output("   ✓ Database: \(packagesDBURL.path)")
             Logging.Log.output("   ✓ Size: \(Shared.Utils.Formatting.formatBytes(Int64(fileSize)))")
 
-            let packageCount = Diagnostics.Probes.rowCount(at: packagesDBURL, sql: "SELECT COUNT(*) FROM packages;")
-            let fileCount = Diagnostics.Probes.rowCount(at: packagesDBURL, sql: "SELECT COUNT(*) FROM package_files;")
+            let packageCount = Diagnostics.Probes.rowCount(at: packagesDBURL, sql: Shared.Utils.SQL.countRows(in: "packages"))
+            let fileCount = Diagnostics.Probes.rowCount(at: packagesDBURL, sql: Shared.Utils.SQL.countRows(in: "package_files"))
             if let packageCount { Logging.Log.output("   ✓ Packages: \(packageCount)") }
             if let fileCount { Logging.Log.output("   ✓ Indexed files: \(fileCount)") }
             Logging.Log.output("   ℹ  Bundled version: \(Shared.Constants.App.databaseVersion)")

--- a/Packages/Sources/SampleIndex/Sample.Index.Database.swift
+++ b/Packages/Sources/SampleIndex/Sample.Index.Database.swift
@@ -1028,7 +1028,7 @@ extension Sample.Index {
                 throw Sample.Index.Error.databaseNotInitialized
             }
 
-            let sql = "SELECT COUNT(*) FROM projects;"
+            let sql = Shared.Utils.SQL.countRows(in: "projects")
 
             var statement: OpaquePointer?
             defer { sqlite3_finalize(statement) }
@@ -1047,7 +1047,7 @@ extension Sample.Index {
                 throw Sample.Index.Error.databaseNotInitialized
             }
 
-            let sql = "SELECT COUNT(*) FROM files;"
+            let sql = Shared.Utils.SQL.countRows(in: "files")
 
             var statement: OpaquePointer?
             defer { sqlite3_finalize(statement) }
@@ -1066,7 +1066,7 @@ extension Sample.Index {
                 throw Sample.Index.Error.databaseNotInitialized
             }
 
-            let sql = "SELECT COUNT(*) FROM file_symbols;"
+            let sql = Shared.Utils.SQL.countRows(in: "file_symbols")
 
             var statement: OpaquePointer?
             defer { sqlite3_finalize(statement) }
@@ -1085,7 +1085,7 @@ extension Sample.Index {
                 throw Sample.Index.Error.databaseNotInitialized
             }
 
-            let sql = "SELECT COUNT(*) FROM file_imports;"
+            let sql = Shared.Utils.SQL.countRows(in: "file_imports")
 
             var statement: OpaquePointer?
             defer { sqlite3_finalize(statement) }

--- a/Packages/Sources/Search/PackageIndex.swift
+++ b/Packages/Sources/Search/PackageIndex.swift
@@ -2,6 +2,7 @@ import Core
 import CorePackageIndexing
 import CoreProtocols
 import Foundation
+import SharedUtils
 import SharedConstants
 import SharedCore
 import SQLite3
@@ -158,8 +159,8 @@ extension Search {
             guard let database else {
                 throw PackageIndexError.databaseNotInitialized
             }
-            let packages = try Int(selectScalar("SELECT COUNT(*) FROM package_metadata"))
-            let files = try Int(selectScalar("SELECT COUNT(*) FROM package_files"))
+            let packages = try Int(selectScalar(Shared.Utils.SQL.countRows(in: "package_metadata")))
+            let files = try Int(selectScalar(Shared.Utils.SQL.countRows(in: "package_files")))
             let bytes = try selectScalar("SELECT IFNULL(SUM(size_bytes), 0) FROM package_files")
             _ = database
             return Summary(packageCount: packages, fileCount: files, bytesIndexed: bytes)

--- a/Packages/Sources/Search/Search.Index.CodeExamples.swift
+++ b/Packages/Sources/Search/Search.Index.CodeExamples.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SharedUtils
 import SharedConstants
 import SharedCore
 import SQLite3
@@ -54,7 +55,7 @@ extension Search.Index {
             throw Search.Error.databaseNotInitialized
         }
 
-        let sql = "SELECT COUNT(*) FROM doc_code_examples;"
+        let sql = Shared.Utils.SQL.countRows(in: "doc_code_examples")
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
 

--- a/Packages/Sources/Search/Search.Index.CountsAndAliases.swift
+++ b/Packages/Sources/Search/Search.Index.CountsAndAliases.swift
@@ -1,4 +1,6 @@
 import Foundation
+import SharedConstants
+import SharedUtils
 import SharedCore
 import SQLite3
 import SearchModels
@@ -9,7 +11,7 @@ extension Search.Index {
             throw Search.Error.databaseNotInitialized
         }
 
-        let sql = "SELECT COUNT(*) FROM doc_symbols;"
+        let sql = Shared.Utils.SQL.countRows(in: "doc_symbols")
 
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -253,7 +255,7 @@ extension Search.Index {
             throw Search.Error.databaseNotInitialized
         }
 
-        let sql = "SELECT COUNT(*) FROM docs_metadata;"
+        let sql = Shared.Utils.SQL.countRows(in: "docs_metadata")
 
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -275,7 +277,7 @@ extension Search.Index {
             throw Search.Error.databaseNotInitialized
         }
 
-        let sql = "SELECT COUNT(*) FROM sample_code_metadata;"
+        let sql = Shared.Utils.SQL.countRows(in: "sample_code_metadata")
 
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
@@ -297,7 +299,7 @@ extension Search.Index {
             throw Search.Error.databaseNotInitialized
         }
 
-        let sql = "SELECT COUNT(*) FROM packages;"
+        let sql = Shared.Utils.SQL.countRows(in: "packages")
 
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }

--- a/Packages/Sources/Shared/Utils/Shared.Utils.SQL.swift
+++ b/Packages/Sources/Shared/Utils/Shared.Utils.SQL.swift
@@ -1,0 +1,29 @@
+import Foundation
+import SharedConstants
+
+// MARK: - Shared.Utils.SQL
+
+/// SQL string builders shared across Search and SampleIndex.
+///
+/// This namespace deliberately does NOT execute SQL — each call site
+/// continues to prepare / step / finalize through its own SQLite3
+/// handle. The helpers just centralize the canonical wording of
+/// frequently-typed queries so the project doesn't accumulate ten
+/// near-identical literal strings.
+extension Shared.Utils {
+    public enum SQL {
+        /// Returns the canonical `SELECT COUNT(*) FROM <table>;` query.
+        ///
+        /// Used by `Search.Index.documentCount()`, `Sample.Index.Database.projectCount()`,
+        /// and the half-dozen other row-count fetches across the search-
+        /// and sample-index targets. Single-source-of-truth wording means
+        /// any future change (e.g. `SELECT COUNT(1)` for SQLite3 query-
+        /// planner reasons) is a one-line edit.
+        ///
+        /// `table` is interpolated raw — callers are responsible for
+        /// passing a fixed table-name literal, not user input.
+        public static func countRows(in table: String) -> String {
+            "SELECT COUNT(*) FROM \(table);"
+        }
+    }
+}


### PR DESCRIPTION
The pattern \`let sql = "SELECT COUNT(*) FROM <table>;"\` followed by prepare-step-finalize lived in 11 call sites across Search, SampleIndex, and CLI/Doctor. Each restated the same SQL literal, trivially typo-prone (a missing semicolon or accidental space would have silently broken one site).

## What

Adds **\`Shared.Utils.SQL.countRows(in: String) -> String\`** in a new \`Packages/Sources/Shared/Utils/Shared.Utils.SQL.swift\` file. The helper returns the canonical query string; each call site still prepares + steps + finalizes through its own SQLite3 handle. The helper deliberately doesn't take an \`OpaquePointer\` to keep SharedUtils free of the SQLite3 import — that stays a per-database concern.

## Replacements (11 sites)

- **\`Search.Index.CountsAndAliases.swift\`**: \`doc_symbols\` / \`docs_metadata\` / \`sample_code_metadata\` / \`packages\`
- **\`Search.Index.CodeExamples.swift\`**: \`doc_code_examples\`
- **\`Search/PackageIndex.swift\`**: \`package_metadata\` / \`package_files\`
- **\`Sample.Index.Database.swift\`**: \`projects\` / \`files\` / \`file_symbols\` / \`file_imports\`
- **\`CLI.Command.Doctor.swift\`**: 5 doctor probe sites (\`projects\` / \`files\` / \`file_symbols\` / \`packages\` / \`package_files\`)

Drive-by imports added where files didn't already pull in SharedUtils + SharedConstants.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Closes #323.