### PR TITLE
refactor(Search): #321 wrap 18-param indexDocument into IndexDocumentParams struct

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.swift
@@ -239,7 +239,7 @@ extension CLI.Command.Save {
         Logging.ConsoleLogger.output("")
         try await indexer.run(
             indexDocument: { uri, source, framework, title, content, jsonData in
-                try await searchIndex.indexDocument(
+                try await searchIndex.indexDocument(Search.Index.IndexDocumentParams(
                     uri: uri,
                     source: source,
                     framework: framework,
@@ -251,8 +251,8 @@ extension CLI.Command.Save {
                     lastCrawled: Date(),
                     sourceType: source,
                     packageId: nil,
-                    jsonData: jsonData
-                )
+                    jsonData: jsonData,
+                ))
             },
             onProgress: { progress in
                 reporter.update(progress)

--- a/Packages/Sources/Search/Search.Index.IndexDocumentParams.swift
+++ b/Packages/Sources/Search/Search.Index.IndexDocumentParams.swift
@@ -1,0 +1,78 @@
+import Foundation
+import SearchModels
+import SharedConstants
+
+// MARK: - Search.Index.IndexDocumentParams
+
+extension Search.Index {
+    /// Parameter bundle for `Search.Index.indexDocument(_:)`.
+    ///
+    /// The original signature accepted 18 parameters — most of them with
+    /// defaults, several added incrementally as the indexer learned new
+    /// sources (`minIOS` / `minMacOS` / …) and new database layouts
+    /// (`packageId`, `jsonData`, `availabilitySource`). 18-arg call sites
+    /// were unreadable and any new field meant re-touching every caller.
+    ///
+    /// `IndexDocumentParams` groups the fields so call sites can name
+    /// only what's specific to the page; defaults flow through.
+    public struct IndexDocumentParams: Sendable {
+        public let uri: String
+        public let source: String
+        public let framework: String?
+        public let language: String?
+        public let title: String
+        public let content: String
+        public let filePath: String
+        public let contentHash: String
+        public let lastCrawled: Date
+        public let sourceType: String
+        public let packageId: Int?
+        public let jsonData: String?
+        public let minIOS: String?
+        public let minMacOS: String?
+        public let minTvOS: String?
+        public let minWatchOS: String?
+        public let minVisionOS: String?
+        public let availabilitySource: String?
+
+        public init(
+            uri: String,
+            source: String,
+            framework: String?,
+            language: String? = nil,
+            title: String,
+            content: String,
+            filePath: String,
+            contentHash: String,
+            lastCrawled: Date,
+            sourceType: String = Shared.Constants.Database.defaultSourceTypeApple,
+            packageId: Int? = nil,
+            jsonData: String? = nil,
+            minIOS: String? = nil,
+            minMacOS: String? = nil,
+            minTvOS: String? = nil,
+            minWatchOS: String? = nil,
+            minVisionOS: String? = nil,
+            availabilitySource: String? = nil,
+        ) {
+            self.uri = uri
+            self.source = source
+            self.framework = framework
+            self.language = language
+            self.title = title
+            self.content = content
+            self.filePath = filePath
+            self.contentHash = contentHash
+            self.lastCrawled = lastCrawled
+            self.sourceType = sourceType
+            self.packageId = packageId
+            self.jsonData = jsonData
+            self.minIOS = minIOS
+            self.minMacOS = minMacOS
+            self.minTvOS = minTvOS
+            self.minWatchOS = minWatchOS
+            self.minVisionOS = minVisionOS
+            self.availabilitySource = availabilitySource
+        }
+    }
+}

--- a/Packages/Sources/Search/Search.Index.IndexingDocs.swift
+++ b/Packages/Sources/Search/Search.Index.IndexingDocs.swift
@@ -12,30 +12,38 @@ import SearchModels
 // rationale carries forward to the per-concern slices.
 
 extension Search.Index {
-    ///   - jsonData: Optional JSON representation of document
-    public func indexDocument(
-        uri: String,
-        source: String,
-        framework: String?,
-        language: String? = nil,
-        title: String,
-        content: String,
-        filePath: String,
-        contentHash: String,
-        lastCrawled: Date,
-        sourceType: String = Shared.Constants.Database.defaultSourceTypeApple,
-        packageId: Int? = nil,
-        jsonData: String? = nil,
-        minIOS: String? = nil,
-        minMacOS: String? = nil,
-        minTvOS: String? = nil,
-        minWatchOS: String? = nil,
-        minVisionOS: String? = nil,
-        availabilitySource: String? = nil
-    ) async throws {
+    /// Index a document for searching.
+    ///
+    /// All per-page values flow through `Search.Index.IndexDocumentParams`
+    /// so adding a new column (the indexer learns new sources / metadata
+    /// over time) doesn't touch every call site — the struct's init
+    /// gains a defaulted parameter and existing callers compile unchanged.
+    public func indexDocument(_ params: IndexDocumentParams) async throws {
         guard let database else {
             throw Search.Error.databaseNotInitialized
         }
+
+        // Unpack params once at the top so the function body reads as it
+        // did before the bundling. Avoids `params.` prefixing every site
+        // in the ~130-line body below.
+        let uri = params.uri
+        let source = params.source
+        let framework = params.framework
+        let language = params.language
+        let title = params.title
+        let content = params.content
+        let filePath = params.filePath
+        let contentHash = params.contentHash
+        let lastCrawled = params.lastCrawled
+        let sourceType = params.sourceType
+        let packageId = params.packageId
+        let jsonData = params.jsonData
+        let minIOS = params.minIOS
+        let minMacOS = params.minMacOS
+        let minTvOS = params.minTvOS
+        let minWatchOS = params.minWatchOS
+        let minVisionOS = params.minVisionOS
+        let availabilitySource = params.availabilitySource
 
         // Extract summary (first 500 chars, stop at sentence)
         let summary = extractSummary(from: content)
@@ -156,7 +164,7 @@ extension Search.Index {
         // Get the indexer for this source
         guard let indexer = Search.IndexerRegistry.indexer(for: item.source) else {
             // Fall back to generic indexing if no specific indexer
-            try await indexDocument(
+            try await indexDocument(IndexDocumentParams(
                 uri: item.uri,
                 source: item.source,
                 framework: item.framework,
@@ -174,8 +182,8 @@ extension Search.Index {
                 minTvOS: item.minTvOS,
                 minWatchOS: item.minWatchOS,
                 minVisionOS: item.minVisionOS,
-                availabilitySource: item.availabilitySource
-            )
+                availabilitySource: item.availabilitySource,
+            ))
             return
         }
 
@@ -188,7 +196,7 @@ extension Search.Index {
         let processedItem = indexer.preprocess(item)
 
         // Index the document
-        try await indexDocument(
+        try await indexDocument(IndexDocumentParams(
             uri: processedItem.uri,
             source: processedItem.source,
             framework: processedItem.framework,
@@ -206,8 +214,8 @@ extension Search.Index {
             minTvOS: processedItem.minTvOS,
             minWatchOS: processedItem.minWatchOS,
             minVisionOS: processedItem.minVisionOS,
-            availabilitySource: processedItem.availabilitySource
-        )
+            availabilitySource: processedItem.availabilitySource,
+        ))
 
         // Extract and index AST symbols if enabled
         if extractSymbols {

--- a/Packages/Sources/Search/Search.IndexBuilder.swift
+++ b/Packages/Sources/Search/Search.IndexBuilder.swift
@@ -195,7 +195,7 @@ extension Search {
 
                 // Index document (Apple docs from /docs folder)
                 do {
-                    try await searchIndex.indexDocument(
+                    try await searchIndex.indexDocument(Search.Index.IndexDocumentParams(
                         uri: uri,
                         source: Shared.Constants.SourcePrefix.appleDocs,
                         framework: pageMetadata.framework,
@@ -203,8 +203,8 @@ extension Search {
                         content: content,
                         filePath: pageMetadata.filePath,
                         contentHash: pageMetadata.contentHash,
-                        lastCrawled: pageMetadata.lastCrawled
-                    )
+                        lastCrawled: pageMetadata.lastCrawled,
+                    ))
                     indexed += 1
                 } catch {
                     logError("Failed to index \(uri): \(error)")
@@ -617,7 +617,7 @@ extension Search {
             let availability = mapSwiftVersionToAvailability(status)
 
             // Swift Evolution source - no framework, just source
-            try await searchIndex.indexDocument(
+            try await searchIndex.indexDocument(Search.Index.IndexDocumentParams(
                 uri: uri,
                 source: Shared.Constants.SourcePrefix.swiftEvolution,
                 framework: nil,
@@ -628,8 +628,8 @@ extension Search {
                 lastCrawled: modDate,
                 minIOS: availability.iOS,
                 minMacOS: availability.macOS,
-                availabilitySource: availability.iOS != nil ? "swift-version" : nil
-            )
+                availabilitySource: availability.iOS != nil ? "swift-version" : nil,
+            ))
         }
 
         /// Map Swift version to iOS/macOS availability
@@ -946,7 +946,7 @@ extension Search {
 
                 do {
                     // Apple Archive source with framework (or book title as fallback)
-                    try await searchIndex.indexDocument(
+                    try await searchIndex.indexDocument(Search.Index.IndexDocumentParams(
                         uri: uri,
                         source: "apple-archive",
                         framework: framework,
@@ -960,8 +960,8 @@ extension Search {
                         minTvOS: availability.minTvOS,
                         minWatchOS: availability.minWatchOS,
                         minVisionOS: availability.minVisionOS,
-                        availabilitySource: availability.minIOS != nil ? "framework" : nil
-                    )
+                        availabilitySource: availability.minIOS != nil ? "framework" : nil,
+                    ))
                     indexed += 1
                 } catch {
                     logError("Failed to index \(uri): \(error)")
@@ -1027,7 +1027,7 @@ extension Search {
                 do {
                     // HIG source with category as framework
                     // HIG is universal - applies to all Apple platforms
-                    try await searchIndex.indexDocument(
+                    try await searchIndex.indexDocument(Search.Index.IndexDocumentParams(
                         uri: uri,
                         source: Shared.Constants.SourcePrefix.hig,
                         framework: category,
@@ -1041,8 +1041,8 @@ extension Search {
                         minTvOS: "9.0",
                         minWatchOS: "2.0",
                         minVisionOS: "1.0",
-                        availabilitySource: "universal"
-                    )
+                        availabilitySource: "universal",
+                    ))
                     indexed += 1
                 } catch {
                     logError("Failed to index \(uri): \(error)")

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -147,7 +147,7 @@ struct MCPCommandTests {
         let searchIndex = try await Search.Index(dbPath: searchDbPath)
 
         // Index a test document
-        try await searchIndex.indexDocument(
+        try await searchIndex.indexDocument(Search.Index.IndexDocumentParams(
             uri: "https://developer.apple.com/documentation/swift",
             source: "apple-docs",
             framework: "swift",
@@ -155,8 +155,8 @@ struct MCPCommandTests {
             content: "Swift is a powerful programming language for iOS, macOS, and more.",
             filePath: "/test/swift.md",
             contentHash: "test-hash",
-            lastCrawled: Date()
-        )
+            lastCrawled: Date(),
+            ))
 
         let server = MCP.Core.Server(name: "test-server", version: "1.0.0")
         let provider = CompositeToolProvider(searchIndex: searchIndex, sampleDatabase: nil)
@@ -192,7 +192,7 @@ struct MCPCommandTests {
         let searchDbPath = tempDir.appendingPathComponent("search.db")
         let searchIndex = try await Search.Index(dbPath: searchDbPath)
 
-        try await searchIndex.indexDocument(
+        try await searchIndex.indexDocument(Search.Index.IndexDocumentParams(
             uri: "https://developer.apple.com/documentation/swift/array",
             source: "apple-docs",
             framework: "swift",
@@ -200,8 +200,8 @@ struct MCPCommandTests {
             content: "An ordered, random-access collection of elements.",
             filePath: "/test/array.md",
             contentHash: "test-hash-array",
-            lastCrawled: Date()
-        )
+            lastCrawled: Date(),
+            ))
 
         let provider = CompositeToolProvider(searchIndex: searchIndex, sampleDatabase: nil)
 

--- a/Packages/Tests/SearchTests/BM25TitleWeightingTests.swift
+++ b/Packages/Tests/SearchTests/BM25TitleWeightingTests.swift
@@ -71,7 +71,7 @@ struct BM25TitleWeightingTests {
         let idx = try await Search.Index(dbPath: dbPath)
 
         // A: query term lives in the title, body is unrelated.
-        try await idx.indexDocument(
+        try await idx.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://swift/task",
             source: "apple-docs",
             framework: "Swift",
@@ -79,11 +79,11 @@ struct BM25TitleWeightingTests {
             content: "An asynchronous unit of work without the query term repeated.",
             filePath: "/tmp/a",
             contentHash: "a",
-            lastCrawled: Date()
-        )
+            lastCrawled: Date(),
+            ))
 
         // B: query term appears only in the body, title is unrelated.
-        try await idx.indexDocument(
+        try await idx.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://kernel/task-info",
             source: "apple-docs",
             framework: "Kernel",
@@ -91,8 +91,8 @@ struct BM25TitleWeightingTests {
             content: "A mach task contains threads and memory regions. Task accounting is reported here.",
             filePath: "/tmp/b",
             contentHash: "b",
-            lastCrawled: Date()
-        )
+            lastCrawled: Date(),
+            ))
 
         await idx.disconnect()
 
@@ -115,7 +115,7 @@ struct BM25TitleWeightingTests {
         let idx = try await Search.Index(dbPath: dbPath)
 
         // A: query term appears in the first sentence (becomes the summary).
-        try await idx.indexDocument(
+        try await idx.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://foundation/bundle",
             source: "apple-docs",
             framework: "Foundation",
@@ -123,12 +123,12 @@ struct BM25TitleWeightingTests {
             content: "Bundle is the entry point for resource lookup. " + String(repeating: "Filler sentence. ", count: 40),
             filePath: "/tmp/s1",
             contentHash: "s1",
-            lastCrawled: Date()
-        )
+            lastCrawled: Date(),
+            ))
 
         // B: query term only appears deep in the body, past the summary cut.
         let bodyB = String(repeating: "Unrelated padding text. ", count: 60) + " Bundle is mentioned only here at the end."
-        try await idx.indexDocument(
+        try await idx.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://misc/other",
             source: "apple-docs",
             framework: "Misc",
@@ -136,8 +136,8 @@ struct BM25TitleWeightingTests {
             content: bodyB,
             filePath: "/tmp/s2",
             contentHash: "s2",
-            lastCrawled: Date()
-        )
+            lastCrawled: Date(),
+            ))
 
         await idx.disconnect()
 

--- a/Packages/Tests/SearchTests/CanonicalTypeRankingTests.swift
+++ b/Packages/Tests/SearchTests/CanonicalTypeRankingTests.swift
@@ -30,7 +30,7 @@ private func indexPage(
     title: String,
     content: String
 ) async throws {
-    try await idx.indexDocument(
+    try await idx.indexDocument(Search.Index.IndexDocumentParams(
         uri: uri,
         source: "apple-docs",
         framework: framework,
@@ -38,8 +38,8 @@ private func indexPage(
         content: content,
         filePath: "/tmp/\(framework)-\(UUID().uuidString)",
         contentHash: UUID().uuidString,
-        lastCrawled: Date()
-    )
+        lastCrawled: Date(),
+        ))
 }
 
 @Suite("Canonical type ranking (#254 + #256)")

--- a/Packages/Tests/SearchTests/CodeExampleSymbolsTests.swift
+++ b/Packages/Tests/SearchTests/CodeExampleSymbolsTests.swift
@@ -76,7 +76,7 @@ private func countImportRows(at dbPath: URL, uri: String) throws -> Int {
 }
 
 private func seedDoc(index: Search.Index, uri: String) async throws {
-    try await index.indexDocument(
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: uri,
         source: "apple-docs",
         framework: "swiftui",
@@ -84,8 +84,8 @@ private func seedDoc(index: Search.Index, uri: String) async throws {
         content: "placeholder body",
         filePath: "/tmp/x",
         contentHash: "h",
-        lastCrawled: Date()
-    )
+        lastCrawled: Date(),
+    ))
 }
 
 @Suite("Search.Index.extractCodeExampleSymbols (#192 D)")

--- a/Packages/Tests/SearchTests/CupertinoSearchTests.swift
+++ b/Packages/Tests/SearchTests/CupertinoSearchTests.swift
@@ -38,7 +38,7 @@ func createTestSearchIndexWithDocument(
 ) async throws -> (index: Search.Index, cleanup: () throws -> Void) {
     let (index, cleanup) = try await createTestSearchIndex()
 
-    try await index.indexDocument(
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: uri,
         source: source,
         framework: framework,
@@ -47,8 +47,8 @@ func createTestSearchIndexWithDocument(
         filePath: "/test.md",
         contentHash: "test-hash",
         lastCrawled: Date(),
-        sourceType: "test"
-    )
+        sourceType: "test",
+        ))
 
     return (index, cleanup)
 }
@@ -150,7 +150,7 @@ struct CupertinoSearchTests {
         defer { try? cleanup() }
 
         // Index documents in different frameworks
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "swift://array",
             source: "apple-docs",
             framework: "swift",
@@ -159,10 +159,10 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "uikit://array",
             source: "apple-docs",
             framework: "uikit",
@@ -171,8 +171,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         // Search with framework filter
         let swiftResults = try await index.search(query: "array", framework: "swift", limit: 10)
@@ -198,7 +198,7 @@ struct CupertinoSearchTests {
 
         // Index multiple documents
         for docNumber in 1...10 {
-            try await index.indexDocument(
+            try await index.indexDocument(Search.Index.IndexDocumentParams(
                 uri: "test://doc\(docNumber)",
                 source: "apple-docs",
                 framework: "swift",
@@ -207,8 +207,8 @@ struct CupertinoSearchTests {
                 filePath: "/test.md",
                 contentHash: "test-hash",
                 lastCrawled: Date(),
-                sourceType: "apple"
-            )
+                sourceType: "apple",
+                ))
         }
 
         // Search with limit
@@ -242,7 +242,7 @@ struct CupertinoSearchTests {
         let uri = "test://doc"
 
         // Index original document
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: uri,
             source: "apple-docs",
             framework: "swift",
@@ -251,11 +251,11 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "hash1",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         // Update document
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: uri,
             source: "apple-docs",
             framework: "swift",
@@ -264,8 +264,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "hash2",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         // Search for new content
         let results = try await index.search(query: "dictionaries", framework: nil, limit: 10)
@@ -314,7 +314,7 @@ struct CupertinoSearchTests {
 
         // Index documents with different relevance
         // Doc 1: Title match + multiple content matches (highest relevance)
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "doc1",
             source: "apple-docs",
             framework: "swift",
@@ -323,11 +323,11 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         // Doc 2: Content match only (lower relevance)
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "doc2",
             source: "apple-docs",
             framework: "uikit",
@@ -336,11 +336,11 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         // Doc 3: Single content match (lowest relevance)
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "doc3",
             source: "apple-docs",
             framework: "foundation",
@@ -349,8 +349,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         let results = try await index.search(query: "SwiftUI", framework: nil, limit: 10)
 
@@ -382,7 +382,7 @@ struct CupertinoSearchTests {
         let index = try await Search.Index(dbPath: tempDB)
 
         // Index documents from different sources
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple://doc",
             source: "apple-docs",
             framework: "swift",
@@ -391,10 +391,10 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "evolution://SE-0001",
             source: "swift-evolution",
             framework: nil,
@@ -403,8 +403,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "swift-evolution"
-        )
+            sourceType: "swift-evolution",
+            ))
 
         let results = try await index.search(query: "documentation", framework: nil, limit: 10)
         #expect(results.count == 2)
@@ -420,7 +420,7 @@ struct CupertinoSearchTests {
         let index = try await Search.Index(dbPath: tempDB)
 
         // Index documents from different sources with common keyword "swift"
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://swiftui/view",
             source: "apple-docs",
             framework: "swiftui",
@@ -429,10 +429,10 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "swift-evolution://SE-0302",
             source: "swift-evolution",
             framework: nil,
@@ -441,10 +441,10 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "swift-evolution"
-        )
+            sourceType: "swift-evolution",
+            ))
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "swift-book://concurrency",
             source: "swift-book",
             framework: nil,
@@ -453,8 +453,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "swift-book"
-        )
+            sourceType: "swift-book",
+            ))
 
         // Search all sources with common keyword
         let allResults = try await index.search(query: "swift", source: nil, framework: nil, limit: 10)
@@ -491,7 +491,7 @@ struct CupertinoSearchTests {
         let uri = "swift-book://concurrency"
         let ftsContent = "# Concurrency\n\nSwift has built-in support for async/await."
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: uri,
             source: "swift-book",
             framework: nil,
@@ -501,8 +501,8 @@ struct CupertinoSearchTests {
             contentHash: "test-hash",
             lastCrawled: Date(),
             sourceType: "swift-book",
-            jsonData: "{\"title\":\"Concurrency\",\"rawMarkdown\":null,\"url\":\"\(uri)\"}"
-        )
+            jsonData: "{\"title\":\"Concurrency\",\"rawMarkdown\":null,\"url\":\"\(uri)\"}",
+            ))
 
         // Get content as markdown - should fall back to FTS content
         let content = try await index.getDocumentContent(uri: uri, format: .markdown)
@@ -535,7 +535,7 @@ struct CupertinoSearchTests {
         let uri = "apple-docs://swift/string"
         let jsonData = "{\"title\":\"String\",\"kind\":\"struct\",\"rawMarkdown\":\"# String\"}"
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: uri,
             source: "apple-docs",
             framework: "swift",
@@ -545,8 +545,8 @@ struct CupertinoSearchTests {
             contentHash: "test-hash",
             lastCrawled: Date(),
             sourceType: "apple",
-            jsonData: jsonData
-        )
+            jsonData: jsonData,
+            ))
 
         // Get content as JSON
         let content = try await index.getDocumentContent(uri: uri, format: .json)
@@ -565,7 +565,7 @@ struct CupertinoSearchTests {
         defer { try? cleanup() }
 
         // Index an ST proposal
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "swift-evolution://ST-0001",
             source: "swift-evolution",
             framework: nil,
@@ -574,8 +574,8 @@ struct CupertinoSearchTests {
             filePath: "/test/ST-0001.md",
             contentHash: "st-hash",
             lastCrawled: Date(),
-            sourceType: "swift-evolution"
-        )
+            sourceType: "swift-evolution",
+            ))
 
         // Search should find it
         let results = try await index.search(query: "refactor bug", source: "swift-evolution", framework: nil, limit: 10)
@@ -593,7 +593,7 @@ struct CupertinoSearchTests {
         defer { try? cleanup() }
 
         // Index an SE proposal (accepted)
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "swift-evolution://SE-0302",
             source: "swift-evolution",
             framework: nil,
@@ -602,11 +602,11 @@ struct CupertinoSearchTests {
             filePath: "/test/SE-0302.md",
             contentHash: "se-hash",
             lastCrawled: Date(),
-            sourceType: "swift-evolution"
-        )
+            sourceType: "swift-evolution",
+            ))
 
         // Index an ST proposal (accepted)
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "swift-evolution://ST-0001",
             source: "swift-evolution",
             framework: nil,
@@ -615,8 +615,8 @@ struct CupertinoSearchTests {
             filePath: "/test/ST-0001.md",
             contentHash: "st-hash",
             lastCrawled: Date(),
-            sourceType: "swift-evolution"
-        )
+            sourceType: "swift-evolution",
+            ))
 
         // Both should be findable under swift-evolution source
         let allResults = try await index.search(query: "swift", source: "swift-evolution", framework: nil, limit: 10)
@@ -780,7 +780,7 @@ struct CupertinoSearchTests {
         let uri = "swift-book://basics"
         let ftsContent = "# The Basics\n\nSwift is a type-safe language."
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: uri,
             source: "swift-book",
             framework: nil,
@@ -790,8 +790,8 @@ struct CupertinoSearchTests {
             contentHash: "test-hash",
             lastCrawled: Date(),
             sourceType: "swift-book",
-            jsonData: "{\"title\":\"The Basics\",\"rawMarkdown\":null}"
-        )
+            jsonData: "{\"title\":\"The Basics\",\"rawMarkdown\":null}",
+            ))
 
         // Get content as JSON - should return the original JSON (since it exists in metadata)
         // Note: FTS fallback only happens when metadata doesn't exist or can't be decoded

--- a/Packages/Tests/SearchTests/DocKindIntegrationTests.swift
+++ b/Packages/Tests/SearchTests/DocKindIntegrationTests.swift
@@ -140,7 +140,7 @@ struct IndexDocumentKindTests {
         defer { try? FileManager.default.removeItem(at: dbPath) }
 
         let idx = try await Search.Index(dbPath: dbPath)
-        try await idx.indexDocument(
+        try await idx.indexDocument(Search.Index.IndexDocumentParams(
             uri: uri,
             source: source,
             framework: framework,
@@ -148,8 +148,8 @@ struct IndexDocumentKindTests {
             content: "Some content for the test.",
             filePath: "/tmp/x",
             contentHash: "h",
-            lastCrawled: Date()
-        )
+            lastCrawled: Date(),
+            ))
         await idx.disconnect()
 
         return try readColumn(at: dbPath, column: "kind", forURI: uri)
@@ -208,7 +208,7 @@ struct SymbolsColumnTests {
         defer { try? FileManager.default.removeItem(at: dbPath) }
 
         let idx = try await Search.Index(dbPath: dbPath)
-        try await idx.indexDocument(
+        try await idx.indexDocument(Search.Index.IndexDocumentParams(
             uri: "test://nosym",
             source: "swift-book",
             framework: nil,
@@ -216,8 +216,8 @@ struct SymbolsColumnTests {
             content: "Body",
             filePath: "/tmp/x",
             contentHash: "h",
-            lastCrawled: Date()
-        )
+            lastCrawled: Date(),
+            ))
         await idx.disconnect()
 
         // Column exists, value is NULL — readColumn returns nil for NULL.

--- a/Packages/Tests/SearchTests/DocsSourceCandidateFetcherTests.swift
+++ b/Packages/Tests/SearchTests/DocsSourceCandidateFetcherTests.swift
@@ -15,7 +15,7 @@ private func seedIndex() async throws -> (Search.Index, URL) {
 
     // Two docs in apple-docs source, plus one in swift-evolution so we can
     // verify source scoping.
-    try await index.indexDocument(
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "apple-docs://swiftui/view",
         source: "apple-docs",
         framework: "swiftui",
@@ -23,9 +23,9 @@ private func seedIndex() async throws -> (Search.Index, URL) {
         content: "A SwiftUI view protocol.",
         filePath: "/tmp/view.md",
         contentHash: "h1",
-        lastCrawled: Date()
-    )
-    try await index.indexDocument(
+        lastCrawled: Date(),
+        ))
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "apple-docs://swiftui/animation",
         source: "apple-docs",
         framework: "swiftui",
@@ -33,9 +33,9 @@ private func seedIndex() async throws -> (Search.Index, URL) {
         content: "SwiftUI animation APIs.",
         filePath: "/tmp/anim.md",
         contentHash: "h2",
-        lastCrawled: Date()
-    )
-    try await index.indexDocument(
+        lastCrawled: Date(),
+        ))
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "swift-evolution://SE-0306",
         source: "swift-evolution",
         framework: nil,
@@ -43,8 +43,8 @@ private func seedIndex() async throws -> (Search.Index, URL) {
         content: "Swift actors proposal.",
         filePath: "/tmp/se306.md",
         contentHash: "h3",
-        lastCrawled: Date()
-    )
+        lastCrawled: Date(),
+        ))
     return (index, dbPath)
 }
 

--- a/Packages/Tests/SearchTests/ExactTitlePeerTiebreakTests.swift
+++ b/Packages/Tests/SearchTests/ExactTitlePeerTiebreakTests.swift
@@ -35,7 +35,7 @@ private func indexPage(
     title: String,
     content: String
 ) async throws {
-    try await idx.indexDocument(
+    try await idx.indexDocument(Search.Index.IndexDocumentParams(
         uri: uri,
         source: "apple-docs",
         framework: framework,
@@ -43,8 +43,8 @@ private func indexPage(
         content: content,
         filePath: "/tmp/\(framework)",
         contentHash: framework,
-        lastCrawled: Date()
-    )
+        lastCrawled: Date(),
+        ))
 }
 
 @Suite("Exact title peer tiebreak (#256)")

--- a/Packages/Tests/SearchTests/VersionFilterTests.swift
+++ b/Packages/Tests/SearchTests/VersionFilterTests.swift
@@ -238,7 +238,7 @@ struct VersionFilterTests {
         }
 
         // Index document WITHOUT availability data
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "test://noavail",
             source: "apple-docs",
             framework: "test",
@@ -247,8 +247,8 @@ struct VersionFilterTests {
             filePath: "/test.md",
             contentHash: "hash",
             lastCrawled: Date(),
-            sourceType: "test"
-        )
+            sourceType: "test",
+            ))
 
         // Without availability, should not appear in filtered results
         let filtered = try await index.search(query: "Availability", minIOS: "15.0")
@@ -371,7 +371,7 @@ struct VersionFilterTests {
             .appendingPathComponent("test-\(UUID().uuidString).db")
         let index = try await Search.Index(dbPath: tempDB)
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: uri,
             source: "apple-docs",
             framework: "test",
@@ -385,8 +385,8 @@ struct VersionFilterTests {
             minMacOS: minMacOS,
             minTvOS: minTvOS,
             minWatchOS: minWatchOS,
-            minVisionOS: minVisionOS
-        )
+            minVisionOS: minVisionOS,
+            ))
 
         let cleanup: @Sendable () -> Void = {
             Task { await index.disconnect() }

--- a/Packages/Tests/SearchToolProviderTests/CupertinoSearchToolProviderTests.swift
+++ b/Packages/Tests/SearchToolProviderTests/CupertinoSearchToolProviderTests.swift
@@ -31,7 +31,7 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
     let (index, cleanup) = try await createTestSearchIndex()
 
     // Apple docs
-    try await index.indexDocument(
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "apple-docs://swiftui/animation",
         source: Shared.Constants.SourcePrefix.appleDocs,
         framework: "swiftui",
@@ -40,11 +40,11 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/animation.md",
         contentHash: "hash1",
         lastCrawled: Date(),
-        sourceType: "apple"
-    )
+        sourceType: "apple",
+        ))
 
     // Apple archive
-    try await index.indexDocument(
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "apple-archive://coreanim/animation",
         source: Shared.Constants.SourcePrefix.appleArchive,
         framework: "coreanimation",
@@ -53,11 +53,11 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/coreanimation.md",
         contentHash: "hash2",
         lastCrawled: Date(),
-        sourceType: "archive"
-    )
+        sourceType: "archive",
+        ))
 
     // HIG
-    try await index.indexDocument(
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "hig://motion/animation",
         source: Shared.Constants.SourcePrefix.hig,
         framework: nil,
@@ -66,11 +66,11 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/hig-motion.md",
         contentHash: "hash3",
         lastCrawled: Date(),
-        sourceType: "hig"
-    )
+        sourceType: "hig",
+        ))
 
     // Swift Evolution
-    try await index.indexDocument(
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "swift-evolution://SE-0392",
         source: Shared.Constants.SourcePrefix.swiftEvolution,
         framework: nil,
@@ -79,11 +79,11 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/se-0392.md",
         contentHash: "hash4",
         lastCrawled: Date(),
-        sourceType: "swift-evolution"
-    )
+        sourceType: "swift-evolution",
+        ))
 
     // Swift.org
-    try await index.indexDocument(
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "swift-org://docs/animation",
         source: Shared.Constants.SourcePrefix.swiftOrg,
         framework: nil,
@@ -92,11 +92,11 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/swift-org-animation.md",
         contentHash: "hash5",
         lastCrawled: Date(),
-        sourceType: "swift-org"
-    )
+        sourceType: "swift-org",
+        ))
 
     // Swift Book
-    try await index.indexDocument(
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "swift-book://chapter/animation",
         source: Shared.Constants.SourcePrefix.swiftBook,
         framework: nil,
@@ -105,11 +105,11 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/swift-book-animation.md",
         contentHash: "hash6",
         lastCrawled: Date(),
-        sourceType: "swift-book"
-    )
+        sourceType: "swift-book",
+        ))
 
     // Packages
-    try await index.indexDocument(
+    try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "packages://swift-animations",
         source: Shared.Constants.SourcePrefix.packages,
         framework: nil,
@@ -118,8 +118,8 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/packages-animation.md",
         contentHash: "hash7",
         lastCrawled: Date(),
-        sourceType: "packages"
-    )
+        sourceType: "packages",
+        ))
 
     return (index, cleanup)
 }
@@ -477,7 +477,7 @@ struct UnifiedSearchTests {
         defer { try? cleanup() }
 
         // Only index apple-docs
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://swift/string",
             source: Shared.Constants.SourcePrefix.appleDocs,
             framework: "swift",
@@ -486,8 +486,8 @@ struct UnifiedSearchTests {
             filePath: "/test/string.md",
             contentHash: "hash",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
@@ -545,7 +545,7 @@ struct TeaserResultsTests {
 
         // Add multiple archive docs
         for docNumber in 1...5 {
-            try await index.indexDocument(
+            try await index.indexDocument(Search.Index.IndexDocumentParams(
                 uri: "apple-archive://doc\(docNumber)",
                 source: Shared.Constants.SourcePrefix.appleArchive,
                 framework: nil,
@@ -554,12 +554,12 @@ struct TeaserResultsTests {
                 filePath: "/test/archive\(docNumber).md",
                 contentHash: "hash\(docNumber)",
                 lastCrawled: Date(),
-                sourceType: "archive"
-            )
+                sourceType: "archive",
+                ))
         }
 
         // Add apple-docs to search
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://animation",
             source: Shared.Constants.SourcePrefix.appleDocs,
             framework: "swiftui",
@@ -568,8 +568,8 @@ struct TeaserResultsTests {
             filePath: "/test/swiftui.md",
             contentHash: "hashMain",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
@@ -600,7 +600,7 @@ struct TeaserResultsTests {
         defer { try? cleanup() }
 
         // Add docs for "networking" query
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://networking",
             source: Shared.Constants.SourcePrefix.appleDocs,
             framework: "foundation",
@@ -609,11 +609,11 @@ struct TeaserResultsTests {
             filePath: "/test/networking.md",
             contentHash: "hash1",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         // Add archive doc that matches "networking"
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-archive://network-guide",
             source: Shared.Constants.SourcePrefix.appleArchive,
             framework: nil,
@@ -622,11 +622,11 @@ struct TeaserResultsTests {
             filePath: "/test/archive-network.md",
             contentHash: "hash2",
             lastCrawled: Date(),
-            sourceType: "archive"
-        )
+            sourceType: "archive",
+            ))
 
         // Add archive doc about "graphics" - completely different topic
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-archive://graphics-guide",
             source: Shared.Constants.SourcePrefix.appleArchive,
             framework: nil,
@@ -635,8 +635,8 @@ struct TeaserResultsTests {
             filePath: "/test/archive-graphics.md",
             contentHash: "hash3",
             lastCrawled: Date(),
-            sourceType: "archive"
-        )
+            sourceType: "archive",
+            ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
 
@@ -688,7 +688,7 @@ struct TeaserResultsTests {
         defer { try? cleanup() }
 
         // Only add apple-docs
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://unique-topic",
             source: Shared.Constants.SourcePrefix.appleDocs,
             framework: "foundation",
@@ -697,8 +697,8 @@ struct TeaserResultsTests {
             filePath: "/test/unique.md",
             contentHash: "hash",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
@@ -725,7 +725,7 @@ struct SearchFilteringTests {
         let (index, cleanup) = try await createTestSearchIndex()
         defer { try? cleanup() }
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://swiftui/view",
             source: Shared.Constants.SourcePrefix.appleDocs,
             framework: "swiftui",
@@ -734,10 +734,10 @@ struct SearchFilteringTests {
             filePath: "/test/view.md",
             contentHash: "hash1",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://uikit/view",
             source: Shared.Constants.SourcePrefix.appleDocs,
             framework: "uikit",
@@ -746,8 +746,8 @@ struct SearchFilteringTests {
             filePath: "/test/uiview.md",
             contentHash: "hash2",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
@@ -772,7 +772,7 @@ struct SearchFilteringTests {
 
         // Add multiple docs
         for docNumber in 1...10 {
-            try await index.indexDocument(
+            try await index.indexDocument(Search.Index.IndexDocumentParams(
                 uri: "apple-docs://swift\(docNumber)",
                 source: Shared.Constants.SourcePrefix.appleDocs,
                 framework: "swift",
@@ -781,8 +781,8 @@ struct SearchFilteringTests {
                 filePath: "/test/swift\(docNumber).md",
                 contentHash: "hash\(docNumber)",
                 lastCrawled: Date(),
-                sourceType: "apple"
-            )
+                sourceType: "apple",
+                ))
         }
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
@@ -810,7 +810,7 @@ struct SearchFilteringTests {
         let (index, cleanup) = try await createTestSearchIndex()
         defer { try? cleanup() }
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://swift/string",
             source: Shared.Constants.SourcePrefix.appleDocs,
             framework: "swift",
@@ -819,10 +819,10 @@ struct SearchFilteringTests {
             filePath: "/test/string.md",
             contentHash: "hash1",
             lastCrawled: Date(),
-            sourceType: "apple"
-        )
+            sourceType: "apple",
+            ))
 
-        try await index.indexDocument(
+        try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-archive://string-guide",
             source: Shared.Constants.SourcePrefix.appleArchive,
             framework: nil,
@@ -831,8 +831,8 @@ struct SearchFilteringTests {
             filePath: "/test/archive-string.md",
             contentHash: "hash2",
             lastCrawled: Date(),
-            sourceType: "archive"
-        )
+            sourceType: "archive",
+            ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
 


### PR DESCRIPTION
The \`Search.Index.indexDocument(...)\` signature accepted 18 parameters, most defaulted, several added incrementally as the indexer learned new sources (\`minIOS\` / \`minMacOS\` / \`minTvOS\` / \`minWatchOS\` / \`minVisionOS\`) and new database layouts (\`packageId\`, \`jsonData\`, \`availabilitySource\`). 18-arg call sites were unreadable and any new field meant re-touching every caller.

## What

1. **New \`Search.Index.IndexDocumentParams.swift\`** — \`public struct IndexDocumentParams: Sendable\` nested under \`Search.Index\` with the same 18 fields and matching defaults. Sendable so it crosses actor boundaries cleanly.

2. **Signature collapses** from 18 named parameters to one positional \`IndexDocumentParams\`:
   \`\`\`swift
   public func indexDocument(_ params: IndexDocumentParams) async throws
   \`\`\`

3. **Function body unpacks \`params\` into local lets at the top** so the ~130-line implementation keeps reading as it did before the bundling — no \`params.x\` prefixing throughout the SQL bind sites.

4. **Call sites updated to wrap their args** (~30+ sites total, all mechanical):
   - Search.Index.IndexingDocs.swift internal recursion (2)
   - Search.IndexBuilder.swift (4)
   - CLI.Command.Save.swift (1)
   - Tests: CodeExampleSymbolsTests, VersionFilterTests, DocKindIntegrationTests, BM25TitleWeightingTests, CupertinoSearchTests, DocsSourceCandidateFetcherTests, CanonicalTypeRankingTests, ExactTitlePeerTiebreakTests, SearchToolProviderTests, ServeTests

## Future

The next time the indexer learns a new column, the \`IndexDocumentParams\` init gains a defaulted parameter and existing callers compile unchanged.

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Closes #321.