### PR TITLE
refactor(MCP): #319 dedupe EmptyParams into MCP.Core.Protocols.EmptyParams

### DIFF
--- a/Packages/Sources/MCP/Client/MCP.Client.swift
+++ b/Packages/Sources/MCP/Client/MCP.Client.swift
@@ -184,7 +184,7 @@ extension MCP {
                 jsonrpc: "2.0",
                 id: .int(nextMessageID()),
                 method: "tools/list",
-                params: EmptyParams()
+                params: MCP.Core.Protocols.EmptyParams()
             )
 
             let response: MCP.Core.Protocols.ListToolsResult = try await sendRequest(request)
@@ -213,7 +213,7 @@ extension MCP {
                 jsonrpc: "2.0",
                 id: .int(nextMessageID()),
                 method: "resources/list",
-                params: EmptyParams()
+                params: MCP.Core.Protocols.EmptyParams()
             )
 
             let response: MCP.Core.Protocols.ListResourcesResult = try await sendRequest(request)
@@ -315,7 +315,7 @@ extension MCP {
 
 // MARK: - Helper Types
 
-struct EmptyParams: Codable {}
+// EmptyParams moved to MCP.Core.Protocols.EmptyParams in MCPCore (#319).
 
 // MARK: - Errors
 

--- a/Packages/Sources/MCP/Core/Protocol/MCP.Core.Protocols.EmptyParams.swift
+++ b/Packages/Sources/MCP/Core/Protocol/MCP.Core.Protocols.EmptyParams.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Empty parameter bundle for MCP JSON-RPC requests that don't carry any
+/// arguments (e.g. `initialize`, `tools/list`, `resources/list`,
+/// `ping`). Equivalent to `{}` on the wire.
+///
+/// Used as the generic `Params` argument to
+/// `MCP.Core.Protocols.Request<Params>` for the no-args methods.
+/// Declared once here so MCPClient, MCPSupport, MockAIAgent and any
+/// future MCP consumer share the same wire shape.
+extension MCP.Core.Protocols {
+    public struct EmptyParams: Codable, Sendable {
+        public init() {}
+    }
+}

--- a/Packages/Sources/MockAIAgent/main.swift
+++ b/Packages/Sources/MockAIAgent/main.swift
@@ -289,7 +289,7 @@ private actor MCPClient {
             jsonrpc: "2.0",
             id: .int(nextMessageID()),
             method: "tools/list",
-            params: EmptyParams()
+            params: MCP.Core.Protocols.EmptyParams()
         )
 
         let response: MCP.Core.Protocols.ListToolsResult = try await sendRequest(request)
@@ -423,7 +423,7 @@ private actor MCPClient {
             jsonrpc: "2.0",
             id: .int(nextMessageID()),
             method: "resources/list",
-            params: EmptyParams()
+            params: MCP.Core.Protocols.EmptyParams()
         )
 
         let response: MCP.Core.Protocols.ListResourcesResult = try await sendRequest(request)
@@ -665,7 +665,7 @@ private actor MCPClient {
 
 // MARK: - Helper Types
 
-private struct EmptyParams: Codable {}
+// EmptyParams moved to MCP.Core.Protocols.EmptyParams in MCPCore (#319).
 
 // MARK: - Errors
 

--- a/Packages/Tests/MockAIAgentTests/MockAIAgentTests.swift
+++ b/Packages/Tests/MockAIAgentTests/MockAIAgentTests.swift
@@ -73,7 +73,7 @@ struct MCPMessageEncodingTests {
             jsonrpc: "2.0",
             id: .int(42),
             method: "tools/list",
-            params: EmptyParams()
+            params: MCP.Core.Protocols.EmptyParams()
         )
 
         let encoder = JSONEncoder()
@@ -384,4 +384,4 @@ struct MCPToolCallTests {
 
 // MARK: - Helper Types
 
-struct EmptyParams: Codable {}
+// EmptyParams moved to MCP.Core.Protocols.EmptyParams in MCPCore (#319).


### PR DESCRIPTION
\`struct EmptyParams: Codable {}\` was declared three times across the MCP-touching targets:

- \`Packages/Sources/MCP/Client/MCP.Client.swift:318\` (internal)
- \`Packages/Sources/MockAIAgent/main.swift:668\` (private)
- \`Packages/Tests/MockAIAgentTests/MockAIAgentTests.swift:387\` (internal)

Each lived next to the MCP request type it parameterized, with the same shape (empty Codable struct serializing to \`{}\` on the wire) but no shared declaration.

## What

Single source of truth lands in MCPCore as \`MCP.Core.Protocols.EmptyParams: Codable, Sendable\`. New file \`MCP.Core.Protocols.EmptyParams.swift\` under the existing MCP.Core.Protocols namespace.

\`Sendable\` conformance added explicitly — the previous local definitions inherited Sendable from their actor-local context, but the shared declaration is explicit so concurrent JSON-RPC paths cross actor boundaries cleanly.

## Callsites updated

- 2 sites in MCP.Client.swift
- 2 sites in MockAIAgent/main.swift
- 1 site in MockAIAgentTests.swift

## Verification

\`\`\`
xcrun swift build
make test-clean
\`\`\`

Result: 1414 tests in 157 suites pass.

Closes #319.