### PR TITLE
refactor(Search): #400 drop import CorePackageIndexing via AnnotationResult lift

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -233,11 +233,11 @@ let targets: [Target] = {
     //   PackageAvailabilityAnnotator.outputFilename)
     let corePackageIndexingModelsTarget = Target.target(
         name: "CorePackageIndexingModels",
-        dependencies: ["CoreProtocols", "SharedConstants", "SharedModels"]
+        dependencies: ["ASTIndexer", "CoreProtocols", "SharedConstants", "SharedModels"]
     )
     let corePackageIndexingModelsTestsTarget = Target.testTarget(
         name: "CorePackageIndexingModelsTests",
-        dependencies: ["CorePackageIndexingModels", "CoreProtocols", "SharedConstants", "SharedModels", "TestSupport"]
+        dependencies: ["CorePackageIndexingModels", "ASTIndexer", "CoreProtocols", "SharedConstants", "SharedModels", "TestSupport"]
     )
 
     // ---------- CorePackageIndexing (v1.2 refactor 2.4: Resolver + Fetcher + Archive Extractor + Annotator + ManifestCache + Store + DocDownloader) ----------
@@ -372,11 +372,11 @@ let targets: [Target] = {
         // the Strategies/ folder moves to Sources/SearchStrategies/ and gets its own
         // SPM target with deps: [SearchIndexCore, CoreJSONParser, CorePackageIndexing,
         // Core, SharedModels, SharedConstants, Resources, Logging].
-        dependencies: ["SearchModels", "SharedCore", "SharedConstants", "SharedModels", "Logging", "CoreProtocols", "CoreJSONParser", "CorePackageIndexing", "CorePackageIndexingModels", "CoreSampleCode", "Core", "ASTIndexer"]
+        dependencies: ["SearchModels", "SharedCore", "SharedConstants", "SharedModels", "Logging", "CoreProtocols", "CoreJSONParser", "CorePackageIndexingModels", "CoreSampleCode", "Core", "ASTIndexer"]
     )
     let searchTestsTarget = Target.testTarget(
         name: "SearchTests",
-        dependencies: ["Search", "SearchModels", "SharedCore", "SharedConstants", "SharedModels", "SharedUtils", "TestSupport", "CorePackageIndexing", "CorePackageIndexingModels", "ASTIndexer", "SampleIndex"]
+        dependencies: ["Search", "SearchModels", "SharedCore", "SharedConstants", "SharedModels", "SharedUtils", "TestSupport", "CorePackageIndexingModels", "ASTIndexer", "SampleIndex"]
     )
 
     let sampleIndexTarget = Target.target(

--- a/Packages/Sources/Core/PackageIndexing/Core.PackageIndexing.PackageAvailabilityAnnotator.swift
+++ b/Packages/Sources/Core/PackageIndexing/Core.PackageIndexing.PackageAvailabilityAnnotator.swift
@@ -25,28 +25,11 @@ extension Core.PackageIndexing {
         // `CorePackageIndexingModels`. Internally reference the same
         // value via the lifted constant to keep one source of truth.
 
-        public struct AnnotationResult: Codable, Sendable, Equatable {
-            public let version: String
-            public let annotatedAt: Date
-            public let deploymentTargets: [String: String]
-            public let fileAvailability: [FileAvailability]
-            public let stats: Stats
-
-            public struct Stats: Codable, Sendable, Equatable {
-                public let filesScanned: Int
-                public let filesWithAvailability: Int
-                public let totalAttributes: Int
-            }
-        }
-
-        public struct FileAvailability: Codable, Sendable, Equatable {
-            public let relpath: String
-            public let attributes: [Attribute]
-        }
-
-        /// Re-exported under the original public name for source/binary
-        /// stability after the parser helpers moved to ASTIndexer (#228).
-        public typealias Attribute = ASTIndexer.AvailabilityParsers.Attribute
+        // `AnnotationResult` / `FileAvailability` / `Attribute` lifted to
+        // top-level under `Core.PackageIndexing.*` in
+        // `CorePackageIndexingModels` so `Search.PackageIndexer` can hold
+        // them without depending on the full `CorePackageIndexing`
+        // target.
 
         public enum AnnotationError: Error, Sendable, Equatable {
             case missingPackageDirectory(URL)

--- a/Packages/Sources/CorePackageIndexingModels/Core.PackageIndexing.AnnotationResult.swift
+++ b/Packages/Sources/CorePackageIndexingModels/Core.PackageIndexing.AnnotationResult.swift
@@ -1,0 +1,78 @@
+import ASTIndexer
+import CoreProtocols
+import Foundation
+
+// MARK: - Core.PackageIndexing.AnnotationResult
+
+/// The output of a single `PackageAvailabilityAnnotator.annotate(...)`
+/// call. Lifted to a top-level value type under `Core.PackageIndexing.*`
+/// so consumers (`Search.PackageIndexer`) can hold it without pulling in
+/// the full `CorePackageIndexing` target.
+///
+/// Previously nested as
+/// `Core.PackageIndexing.PackageAvailabilityAnnotator.AnnotationResult`.
+/// Callers that wrote that fully-qualified name now write
+/// `Core.PackageIndexing.AnnotationResult`. Same renaming pattern as
+/// `PackageArchiveExtractor.Result → PackageExtractionResult` and
+/// `Sample.Index.Database.FileSearchResult → Sample.Index.FileSearchResult`.
+extension Core.PackageIndexing {
+    public struct AnnotationResult: Codable, Sendable, Equatable {
+        public let version: String
+        public let annotatedAt: Date
+        public let deploymentTargets: [String: String]
+        public let fileAvailability: [FileAvailability]
+        public let stats: Stats
+
+        public init(
+            version: String,
+            annotatedAt: Date,
+            deploymentTargets: [String: String],
+            fileAvailability: [FileAvailability],
+            stats: Stats
+        ) {
+            self.version = version
+            self.annotatedAt = annotatedAt
+            self.deploymentTargets = deploymentTargets
+            self.fileAvailability = fileAvailability
+            self.stats = stats
+        }
+
+        /// Run-summary numbers attached to every annotation pass.
+        public struct Stats: Codable, Sendable, Equatable {
+            public let filesScanned: Int
+            public let filesWithAvailability: Int
+            public let totalAttributes: Int
+
+            public init(
+                filesScanned: Int,
+                filesWithAvailability: Int,
+                totalAttributes: Int
+            ) {
+                self.filesScanned = filesScanned
+                self.filesWithAvailability = filesWithAvailability
+                self.totalAttributes = totalAttributes
+            }
+        }
+    }
+
+    /// Per-source-file availability annotation. Lifted alongside
+    /// `AnnotationResult` so the `[FileAvailability]` field on the result
+    /// resolves cleanly from this Models target.
+    public struct FileAvailability: Codable, Sendable, Equatable {
+        public let relpath: String
+        public let attributes: [Attribute]
+
+        public init(relpath: String, attributes: [Attribute]) {
+            self.relpath = relpath
+            self.attributes = attributes
+        }
+    }
+
+    /// Re-exported under the original public name for source / binary
+    /// stability. The underlying value type comes from `ASTIndexer.AvailabilityParsers`
+    /// (the parser helpers that emit one of these per matched `@available(...)`
+    /// occurrence). The typealias sits under `Core.PackageIndexing.*` so
+    /// `FileAvailability.attributes: [Core.PackageIndexing.Attribute]` reads
+    /// naturally at the call site.
+    public typealias Attribute = ASTIndexer.AvailabilityParsers.Attribute
+}

--- a/Packages/Sources/Search/PackageIndexer.swift
+++ b/Packages/Sources/Search/PackageIndexer.swift
@@ -1,4 +1,3 @@
-import CorePackageIndexing
 import CorePackageIndexingModels
 import CoreProtocols
 import Foundation
@@ -183,7 +182,7 @@ extension Search {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
             guard let result = try? decoder.decode(
-                Core.PackageIndexing.PackageAvailabilityAnnotator.AnnotationResult.self,
+                Core.PackageIndexing.AnnotationResult.self,
                 from: data
             ) else { return nil }
 

--- a/Packages/Tests/CoreTests/CupertinoCoreTests.swift
+++ b/Packages/Tests/CoreTests/CupertinoCoreTests.swift
@@ -642,7 +642,7 @@ struct PackageAvailabilityAnnotatorTests {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let reloaded = try decoder.decode(
-            Core.PackageIndexing.PackageAvailabilityAnnotator.AnnotationResult.self,
+            Core.PackageIndexing.AnnotationResult.self,
             from: Data(contentsOf: outURL)
         )
         #expect(reloaded.deploymentTargets == result.deploymentTargets)

--- a/Packages/Tests/SearchTests/PackageIndexTests.swift
+++ b/Packages/Tests/SearchTests/PackageIndexTests.swift
@@ -2,7 +2,6 @@ import SearchModels
 
 // swiftlint:disable identifier_name
 @testable import Core
-@testable import CorePackageIndexing
 import CorePackageIndexingModels
 import CoreProtocols
 import Foundation


### PR DESCRIPTION
Search target's last reach into \`CorePackageIndexing\` was \`PackageIndexer.swift\` decoding \`Core.PackageIndexing.PackageAvailabilityAnnotator.AnnotationResult\` to parse the availability sidecar JSON. Lifts the result types so the decode resolves through \`CorePackageIndexingModels\`, then drops the dep at both source and Package.swift level.

Progress toward #400.

## What moved

Three types lifted from nested-in-actor → top-level under \`Core.PackageIndexing.*\` in \`CorePackageIndexingModels\`:

- \`AnnotationResult\` (was \`PackageAvailabilityAnnotator.AnnotationResult\`) with nested \`Stats\`
- \`FileAvailability\` (was \`PackageAvailabilityAnnotator.FileAvailability\`)
- \`Attribute\` typealias (was \`PackageAvailabilityAnnotator.Attribute\` — re-exports \`ASTIndexer.AvailabilityParsers.Attribute\` under the old public name for source-compat)

The lift required \`CorePackageIndexingModels\` to gain \`ASTIndexer\` as a dep (so the \`Attribute\` typealias resolves). ASTIndexer is foundation-only (SwiftSyntax + Foundation), so no behavioural surface sneaks in.

## Consumer + actor updates

- \`Sources/Core/PackageIndexing/Core.PackageIndexing.PackageAvailabilityAnnotator.swift\`: drops the three nested type declarations. Internal references (\`-> AnnotationResult\`, \`FileAvailability(...)\`, \`AnnotationResult.Stats(...)\`) now resolve to the lifted versions via the file's existing \`import CorePackageIndexingModels\`.
- \`Sources/Search/PackageIndexer.swift\`: rename \`Core.PackageIndexing.PackageAvailabilityAnnotator.AnnotationResult\` → \`Core.PackageIndexing.AnnotationResult\` at the one call site. **Drops \`import CorePackageIndexing\` entirely** — file now imports only \`CorePackageIndexingModels\`.
- \`Tests/SearchTests/PackageIndexTests.swift\`: drops \`@testable import CorePackageIndexing\` (no Search test reaches into CorePackageIndexing types after the lift).
- \`Tests/CoreTests/CupertinoCoreTests.swift\`: same rename at the one test call site decoding the sidecar.

## Package.swift

- \`CorePackageIndexingModels\` target deps gain \`ASTIndexer\`.
- **\`Search\` target deps drop \`CorePackageIndexing\`** — the only files that used it (\`PackageIndex.swift\`, \`PackageIndexer.swift\`) now resolve everything through \`CorePackageIndexingModels\`.
- \`SearchTests\` target deps drop \`CorePackageIndexing\` — same reason.

## Acceptance grep

\`\`\`
\$ grep -rln '^import CorePackageIndexing\$\\|@testable import CorePackageIndexing' Packages/Sources/Search Packages/Tests/SearchTests
(empty)
\`\`\`

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #400 progress

Search target deps after this PR: \`SearchModels, SharedCore, SharedConstants, SharedModels, Logging, CoreProtocols, CoreJSONParser, CorePackageIndexingModels, CoreSampleCode, Core, ASTIndexer\`.

Heavy-tier remaining for #400:
- \`import Core\` — \`Search.Strategies.SampleCode.swift\` uses \`Sample.Core.*\` but only via \`CoreSampleCode\` now; the \`Core\` dep is actually likely stale (verify + drop in a follow-up).
- \`import CoreJSONParser\` — \`Search.Strategies.{AppleDocs, SwiftOrg}.swift\` use \`Core.JSONParser.MarkdownToStructuredPage\`. Needs a protocol seam (parser as injected dep) — bigger refactor.