### PR TITLE
refactor(Search): #400 drop import Core via stale-import cleanup

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -372,7 +372,7 @@ let targets: [Target] = {
         // the Strategies/ folder moves to Sources/SearchStrategies/ and gets its own
         // SPM target with deps: [SearchIndexCore, CoreJSONParser, CorePackageIndexing,
         // Core, SharedModels, SharedConstants, Resources, Logging].
-        dependencies: ["SearchModels", "SharedCore", "SharedConstants", "SharedModels", "Logging", "CoreProtocols", "CoreJSONParser", "CorePackageIndexingModels", "CoreSampleCode", "Core", "ASTIndexer"]
+        dependencies: ["SearchModels", "SharedCore", "SharedConstants", "SharedModels", "Logging", "CoreProtocols", "CoreJSONParser", "CorePackageIndexingModels", "CoreSampleCode", "ASTIndexer"]
     )
     let searchTestsTarget = Target.testTarget(
         name: "SearchTests",

--- a/Packages/Sources/Search/Strategies/Search.Strategies.SampleCode.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.SampleCode.swift
@@ -1,4 +1,3 @@
-import Core
 import CoreSampleCode
 import Foundation
 import Logging

--- a/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
@@ -1,5 +1,4 @@
 import SearchModels
-import Core
 import CoreProtocols
 import Foundation
 import Logging

--- a/Packages/Tests/SearchTests/PackageIndexTests.swift
+++ b/Packages/Tests/SearchTests/PackageIndexTests.swift
@@ -1,7 +1,6 @@
 import SearchModels
 
 // swiftlint:disable identifier_name
-@testable import Core
 import CorePackageIndexingModels
 import CoreProtocols
 import Foundation


### PR DESCRIPTION
After #305 (\`Sample.Core.*\` → \`CoreSampleCode\`), #479 / #480 (\`Core.PackageIndexing\` value types + \`AnnotationResult\` → \`CorePackageIndexingModels\`), the Search target had no real \`Core\` dependency left — just three stale imports.

## Drops

- \`Sources/Search/Strategies/Search.Strategies.SampleCode.swift\`: drops \`import Core\` — file uses \`Sample.Core.Catalog\` only, which comes via \`CoreSampleCode\`
- \`Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift\`: drops stale \`import Core\` — no \`Core.*\` type referenced
- \`Tests/SearchTests/PackageIndexTests.swift\`: drops stale \`@testable import Core\` — all \`Core.PackageIndexing.*\` references resolve through \`CorePackageIndexingModels\`

## Package.swift

Search target deps drop \`Core\`. New deps list:

\`SearchModels, SharedCore, SharedConstants, SharedModels, Logging, CoreProtocols, CoreJSONParser, CorePackageIndexingModels, CoreSampleCode, ASTIndexer\`

## Acceptance grep

\`\`\`
\$ grep -rln '^import Core\$\\|@testable import Core\$' Packages/Sources/Search Packages/Tests/SearchTests
(empty)
\`\`\`

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #400 remaining

\`import CoreJSONParser\` still in 2 strategy files (\`Search.Strategies.AppleDocs.swift\`, \`Search.Strategies.SwiftOrg.swift\`) for \`Core.JSONParser.MarkdownToStructuredPage\`. That one needs a protocol seam — bigger refactor for the next slice.