### PR TITLE
refactor(Search): #400 drop import CoreJSONParser via MarkdownToStructuredPage closure seam

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -372,7 +372,7 @@ let targets: [Target] = {
         // the Strategies/ folder moves to Sources/SearchStrategies/ and gets its own
         // SPM target with deps: [SearchIndexCore, CoreJSONParser, CorePackageIndexing,
         // Core, SharedModels, SharedConstants, Resources, Logging].
-        dependencies: ["SearchModels", "SharedCore", "SharedConstants", "SharedModels", "Logging", "CoreProtocols", "CoreJSONParser", "CorePackageIndexingModels", "CoreSampleCode", "ASTIndexer"]
+        dependencies: ["SearchModels", "SharedCore", "SharedConstants", "SharedModels", "Logging", "CoreProtocols", "CorePackageIndexingModels", "CoreSampleCode", "ASTIndexer"]
     )
     let searchTestsTarget = Target.testTarget(
         name: "SearchTests",

--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
@@ -1,3 +1,5 @@
+import CoreJSONParser
+import CoreProtocols
 import Foundation
 import Indexer
 import Logging
@@ -31,7 +33,10 @@ extension CLI.Command.Save {
         )
 
         let tracker = ProgressTracker()
-        let outcome = try await Indexer.DocsService.run(request) { event in
+        let outcome = try await Indexer.DocsService.run(
+            request,
+            markdownToStructuredPage: Core.JSONParser.MarkdownToStructuredPage.convert
+        ) { event in
             Self.handleDocsEvent(event, tracker: tracker)
         }
         Self.printDocsSummary(outcome: outcome)

--- a/Packages/Sources/Indexer/Indexer.DocsService.swift
+++ b/Packages/Sources/Indexer/Indexer.DocsService.swift
@@ -58,6 +58,7 @@ extension Indexer {
 
         public static func run(
             _ request: Request,
+            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage,
             handler: @escaping @Sendable (Event) -> Void = { _ in }
         ) async throws -> Outcome {
             let docsURL = request.docsDir
@@ -99,7 +100,8 @@ extension Indexer {
                 evolutionDirectory: evolutionDirToUse,
                 swiftOrgDirectory: swiftOrgDirToUse,
                 archiveDirectory: archiveDirToUse,
-                higDirectory: higDirToUse
+                higDirectory: higDirToUse,
+                markdownToStructuredPage: markdownToStructuredPage
             )
 
             try await builder.buildIndex(clearExisting: request.clear) { processed, total in

--- a/Packages/Sources/Search/Search.IndexBuilder.swift
+++ b/Packages/Sources/Search/Search.IndexBuilder.swift
@@ -94,7 +94,8 @@ extension Search {
             swiftOrgDirectory: URL? = nil,
             archiveDirectory: URL? = nil,
             higDirectory: URL? = nil,
-            indexSampleCode: Bool = true
+            indexSampleCode: Bool = true,
+            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage
         ) {
             self.init(
                 searchIndex: searchIndex,
@@ -105,7 +106,8 @@ extension Search {
                     swiftOrgDirectory: swiftOrgDirectory,
                     archiveDirectory: archiveDirectory,
                     higDirectory: higDirectory,
-                    indexSampleCode: indexSampleCode
+                    indexSampleCode: indexSampleCode,
+                    markdownToStructuredPage: markdownToStructuredPage
                 )
             )
         }
@@ -177,16 +179,23 @@ extension Search {
             swiftOrgDirectory: URL? = nil,
             archiveDirectory: URL? = nil,
             higDirectory: URL? = nil,
-            indexSampleCode: Bool = true
+            indexSampleCode: Bool = true,
+            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage
         ) -> [any Search.SourceIndexingStrategy] {
             var strategies: [any Search.SourceIndexingStrategy] = [
-                Search.AppleDocsStrategy(docsDirectory: docsDirectory),
+                Search.AppleDocsStrategy(
+                    docsDirectory: docsDirectory,
+                    markdownToStructuredPage: markdownToStructuredPage
+                ),
             ]
             if let dir = evolutionDirectory {
                 strategies.append(Search.SwiftEvolutionStrategy(evolutionDirectory: dir))
             }
             if let dir = swiftOrgDirectory {
-                strategies.append(Search.SwiftOrgStrategy(swiftOrgDirectory: dir))
+                strategies.append(Search.SwiftOrgStrategy(
+                    swiftOrgDirectory: dir,
+                    markdownToStructuredPage: markdownToStructuredPage
+                ))
             }
             if let dir = archiveDirectory {
                 strategies.append(Search.AppleArchiveStrategy(archiveDirectory: dir))

--- a/Packages/Sources/Search/Strategies/Search.Strategies.AppleDocs.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.AppleDocs.swift
@@ -1,10 +1,9 @@
-import CoreJSONParser
 import CoreProtocols
 import Foundation
 import Logging
+import SearchModels
 import SharedConstants
 import SharedModels
-import SearchModels
 
 // MARK: - AppleDocsStrategy
 
@@ -43,11 +42,26 @@ extension Search {
         /// Root directory containing the crawled Apple documentation files.
         public let docsDirectory: URL
 
+        /// Closure that converts raw markdown to a structured page.
+        /// Injected so this target doesn't depend on `CoreJSONParser`;
+        /// the composition root supplies
+        /// `Core.JSONParser.MarkdownToStructuredPage.convert`.
+        private let markdownToStructuredPage: Search.MarkdownToStructuredPage
+
         /// Create a strategy for indexing Apple Developer Documentation.
         ///
-        /// - Parameter docsDirectory: Root directory of the crawled documentation.
-        public init(docsDirectory: URL) {
+        /// - Parameters:
+        ///   - docsDirectory: Root directory of the crawled documentation.
+        ///   - markdownToStructuredPage: Closure that converts raw markdown into a
+        ///     `Shared.Models.StructuredDocumentationPage`. Injected at the
+        ///     composition root so the strategy can parse `.md` pages without
+        ///     depending on the `CoreJSONParser` target directly.
+        public init(
+            docsDirectory: URL,
+            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage
+        ) {
             self.docsDirectory = docsDirectory
+            self.markdownToStructuredPage = markdownToStructuredPage
         }
 
         /// Index all Apple documentation pages by scanning ``docsDirectory``.
@@ -160,9 +174,7 @@ extension Search {
                         string: "\(Shared.Constants.BaseURL.appleDeveloperDocs)\(framework)/" +
                                 "\(file.deletingPathExtension().lastPathComponent)"
                     )
-                    guard let converted = Core.JSONParser.MarkdownToStructuredPage.convert(
-                        mdContent, url: pageURL
-                    ) else {
+                    guard let converted = markdownToStructuredPage(mdContent, pageURL) else {
                         Logging.Log.error(
                             "❌ Failed to convert \(file.lastPathComponent) to structured page",
                             category: .search

--- a/Packages/Sources/Search/Strategies/Search.Strategies.SwiftOrg.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.SwiftOrg.swift
@@ -1,10 +1,9 @@
-import CoreJSONParser
 import CoreProtocols
 import Foundation
 import Logging
+import SearchModels
 import SharedConstants
 import SharedModels
-import SearchModels
 
 // MARK: - SwiftOrgStrategy
 
@@ -38,11 +37,26 @@ extension Search {
         /// Root directory containing the Swift.org documentation files.
         public let swiftOrgDirectory: URL
 
+        /// Closure that converts raw markdown to a structured page.
+        /// Injected so this target doesn't depend on `CoreJSONParser`;
+        /// the composition root supplies
+        /// `Core.JSONParser.MarkdownToStructuredPage.convert`.
+        private let markdownToStructuredPage: Search.MarkdownToStructuredPage
+
         /// Create a strategy for indexing Swift.org documentation.
         ///
-        /// - Parameter swiftOrgDirectory: Root directory of the Swift.org corpus.
-        public init(swiftOrgDirectory: URL) {
+        /// - Parameters:
+        ///   - swiftOrgDirectory: Root directory of the Swift.org corpus.
+        ///   - markdownToStructuredPage: Closure that converts raw markdown into a
+        ///     `Shared.Models.StructuredDocumentationPage`. Injected at the
+        ///     composition root so the strategy can parse `.md` pages without
+        ///     depending on the `CoreJSONParser` target directly.
+        public init(
+            swiftOrgDirectory: URL,
+            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage
+        ) {
             self.swiftOrgDirectory = swiftOrgDirectory
+            self.markdownToStructuredPage = markdownToStructuredPage
         }
 
         /// Index all Swift.org documentation pages found under ``swiftOrgDirectory``.
@@ -115,9 +129,7 @@ extension Search {
                         string: "https://www.swift.org/documentation/" +
                                 "\(file.deletingPathExtension().lastPathComponent)"
                     )
-                    guard let converted = Core.JSONParser.MarkdownToStructuredPage.convert(
-                        mdContent, url: pageURL
-                    ) else {
+                    guard let converted = markdownToStructuredPage(mdContent, pageURL) else {
                         Logging.Log.error(
                             "❌ Failed to convert \(file.lastPathComponent) to structured page",
                             category: .search

--- a/Packages/Sources/SearchModels/Search.MarkdownToStructuredPage.swift
+++ b/Packages/Sources/SearchModels/Search.MarkdownToStructuredPage.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SharedConstants
+import SharedModels
+
+// MARK: - Search.MarkdownToStructuredPage
+
+/// Closure shape for converting raw markdown (with optional YAML / TOML
+/// front-matter) into a `Shared.Models.StructuredDocumentationPage`.
+///
+/// The Search target's strategies (`AppleDocsStrategy`, `SwiftOrgStrategy`)
+/// take one of these at init so they can parse markdown pages without
+/// directly depending on the `CoreJSONParser` target where the concrete
+/// `Core.JSONParser.MarkdownToStructuredPage.convert(_:url:)` lives.
+///
+/// The composition root (the CLI binary, the Indexer service entry
+/// point, or a test harness) supplies the concrete function. Indexing
+/// callers that don't need markdown→structured conversion can pass a
+/// stub that always returns `nil`; the strategies that don't call the
+/// closure (HIG, Archive, SampleCode, SwiftPackages) won't invoke it.
+///
+/// Mirrors the `Search.Database` / `Sample.Index.Reader` / `MakeSearchDatabase`
+/// pattern: the abstraction lives in a value-types target, the
+/// implementation lives in the producer target, the wiring lives at the
+/// composition root.
+public extension Search {
+    typealias MarkdownToStructuredPage = @Sendable (
+        _ markdown: String,
+        _ url: URL?
+    ) -> Shared.Models.StructuredDocumentationPage?
+}

--- a/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
+++ b/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
@@ -56,7 +56,8 @@ struct SaveCommandTests {
             searchIndex: searchIndex,
             metadata: metadata,
             docsDirectory: tempDir,
-            evolutionDirectory: nil
+            evolutionDirectory: nil,
+            markdownToStructuredPage: { _, _ in nil }
         )
 
         try await builder.buildIndex()
@@ -110,7 +111,8 @@ struct SaveCommandTests {
             searchIndex: searchIndex,
             metadata: metadata,
             docsDirectory: tempDir,
-            evolutionDirectory: nil
+            evolutionDirectory: nil,
+            markdownToStructuredPage: { _, _ in nil }
         )
         try await builder.buildIndex()
 
@@ -152,7 +154,8 @@ struct SaveCommandTests {
             searchIndex: searchIndex,
             metadata: emptyMetadata,
             docsDirectory: tempDir,
-            evolutionDirectory: nil
+            evolutionDirectory: nil,
+            markdownToStructuredPage: { _, _ in nil }
         )
 
         // Should not throw, just save 0 documents
@@ -211,7 +214,8 @@ struct SaveCommandTests {
             searchIndex: searchIndex,
             metadata: metadata,
             docsDirectory: docsDir,
-            evolutionDirectory: evolutionDir
+            evolutionDirectory: evolutionDir,
+            markdownToStructuredPage: { _, _ in nil }
         )
 
         try await builder.buildIndex()
@@ -281,7 +285,8 @@ struct SaveCommandTests {
             searchIndex: searchIndex,
             metadata: nil, // No metadata!
             docsDirectory: tempDir.appendingPathComponent("docs"),
-            evolutionDirectory: nil
+            evolutionDirectory: nil,
+            markdownToStructuredPage: { _, _ in nil }
         )
 
         try await builder.buildIndex()
@@ -335,7 +340,8 @@ struct SaveCommandTests {
             searchIndex: searchIndex,
             metadata: nil,
             docsDirectory: tempDir.appendingPathComponent("docs"),
-            evolutionDirectory: nil
+            evolutionDirectory: nil,
+            markdownToStructuredPage: { _, _ in nil }
         )
 
         try await builder.buildIndex()
@@ -384,7 +390,8 @@ struct SaveCommandTests {
             searchIndex: searchIndex,
             metadata: nil,
             docsDirectory: tempDir,
-            evolutionDirectory: nil
+            evolutionDirectory: nil,
+            markdownToStructuredPage: { _, _ in nil }
         )
 
         try await builder.buildIndex()
@@ -416,7 +423,8 @@ struct SaveCommandTests {
             searchIndex: searchIndex,
             metadata: nil,
             docsDirectory: tempDir,
-            evolutionDirectory: nil
+            evolutionDirectory: nil,
+            markdownToStructuredPage: { _, _ in nil }
         )
 
         try await builder.buildIndex()

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -392,7 +392,8 @@ struct MCPServerIntegrationTests {
             searchIndex: searchIndex,
             metadata: metadata,
             docsDirectory: tempDir,
-            evolutionDirectory: nil
+            evolutionDirectory: nil,
+            markdownToStructuredPage: { _, _ in nil }
         )
         try await builder.buildIndex()
         print("   ✅ Index built")

--- a/Packages/Tests/SearchTests/IndexBuilderMalformedURLSkipTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderMalformedURLSkipTests.swift
@@ -66,7 +66,10 @@ struct IndexBuilderMalformedURLSkipTests {
 
         let dbPath = tempRoot.appendingPathComponent("search.db")
         let index = try await Search.Index(dbPath: dbPath)
-        let strategy = Search.AppleDocsStrategy(docsDirectory: docsDir)
+        let strategy = Search.AppleDocsStrategy(
+            docsDirectory: docsDir,
+            markdownToStructuredPage: { _, _ in nil }
+        )
 
         let stats = try await strategy.indexFromMetadata(
             into: index, metadata: crawlMetadata, progress: nil
@@ -104,7 +107,10 @@ struct IndexBuilderMalformedURLSkipTests {
 
         let dbPath = tempRoot.appendingPathComponent("search.db")
         let index = try await Search.Index(dbPath: dbPath)
-        let strategy = Search.AppleDocsStrategy(docsDirectory: docsDir)
+        let strategy = Search.AppleDocsStrategy(
+            docsDirectory: docsDir,
+            markdownToStructuredPage: { _, _ in nil }
+        )
 
         let stats = try await strategy.indexFromMetadata(
             into: index, metadata: crawlMetadata, progress: nil

--- a/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
@@ -134,7 +134,8 @@ struct IndexBuilderSymbolsIntegrationTests {
             searchIndex: index,
             metadata: nil,
             docsDirectory: docsDir,
-            indexSampleCode: false
+            indexSampleCode: false,
+            markdownToStructuredPage: { _, _ in nil }
         )
 
         try await builder.buildIndex(clearExisting: true)

--- a/Packages/Tests/SearchTests/StrategyMissingDirectoryTests.swift
+++ b/Packages/Tests/SearchTests/StrategyMissingDirectoryTests.swift
@@ -39,7 +39,10 @@ struct StrategyMissingDirectoryTests {
 
         let missingDir = tempRoot.appendingPathComponent("docs")
         let index = try await makeIndex(in: tempRoot)
-        let strategy = Search.AppleDocsStrategy(docsDirectory: missingDir)
+        let strategy = Search.AppleDocsStrategy(
+            docsDirectory: missingDir,
+            markdownToStructuredPage: { _, _ in nil }
+        )
 
         let stats = try await strategy.indexItems(into: index, progress: nil)
 
@@ -56,7 +59,10 @@ struct StrategyMissingDirectoryTests {
         let emptyDir = tempRoot.appendingPathComponent("docs")
         try FileManager.default.createDirectory(at: emptyDir, withIntermediateDirectories: true)
         let index = try await makeIndex(in: tempRoot)
-        let strategy = Search.AppleDocsStrategy(docsDirectory: emptyDir)
+        let strategy = Search.AppleDocsStrategy(
+            docsDirectory: emptyDir,
+            markdownToStructuredPage: { _, _ in nil }
+        )
 
         let stats = try await strategy.indexItems(into: index, progress: nil)
 
@@ -151,7 +157,10 @@ struct StrategyMissingDirectoryTests {
 
         let missingDir = tempRoot.appendingPathComponent("swift-org")
         let index = try await makeIndex(in: tempRoot)
-        let strategy = Search.SwiftOrgStrategy(swiftOrgDirectory: missingDir)
+        let strategy = Search.SwiftOrgStrategy(
+            swiftOrgDirectory: missingDir,
+            markdownToStructuredPage: { _, _ in nil }
+        )
 
         let stats = try await strategy.indexItems(into: index, progress: nil)
 


### PR DESCRIPTION
Search target's last remaining behavioural cross-package import was \`CoreJSONParser\`, used by \`AppleDocsStrategy\` + \`SwiftOrgStrategy\` to parse \`.md\` pages into \`Shared.Models.StructuredDocumentationPage\`. This PR introduces an injected closure seam so the strategies hold a function, not a CoreJSONParser dep.

Progress toward #400.

## New typealias in SearchModels

\`\`\`swift
public extension Search {
    typealias MarkdownToStructuredPage = @Sendable (
        _ markdown: String,
        _ url: URL?
    ) -> Shared.Models.StructuredDocumentationPage?
}
\`\`\`

Foundation-only deps. Mirrors the \`MakeSearchDatabase\` / \`MarkdownLookup\` / \`PackageFileLookup\` closure-typealias pattern already in SearchModels.

## Strategy updates

- \`Search.AppleDocsStrategy\` + \`Search.SwiftOrgStrategy\` both gain a required \`markdownToStructuredPage:\` closure parameter on init. Drop \`import CoreJSONParser\`; the call site at the inner markdown conversion now invokes the closure instead of \`Core.JSONParser.MarkdownToStructuredPage.convert\`.
- \`Search.IndexBuilder\` threads the closure: its convenience init + static \`makeDefaultStrategies\` factory both take the closure and pass it to the two strategies that need it (the other 5 strategies don't touch markdown so they ignore it).
- \`Search.IndexBuilder\` strict-init form unchanged (callers can still pass a hand-built strategy array).

## Indexer.DocsService threads through

\`Indexer.DocsService.run(_:handler:)\` gains a \`markdownToStructuredPage:\` parameter sitting between the request and the handler. Indexer doesn't import CoreJSONParser; it just forwards the closure into \`Search.IndexBuilder\`.

## CLI composition root

\`CLI.Command.Save.Indexers.swift\` gains \`import CoreJSONParser\` + \`import CoreProtocols\` and passes \`Core.JSONParser.MarkdownToStructuredPage.convert\` into \`Indexer.DocsService.run\`.

## Package.swift

**Search target deps drop \`CoreJSONParser\`.** New deps list: \`SearchModels, SharedCore, SharedConstants, SharedModels, Logging, CoreProtocols, CorePackageIndexingModels, CoreSampleCode, ASTIndexer\`.

## Test updates

Tests that constructed strategies / IndexBuilder directly get the trivial no-op closure passed as the closure value:
- \`Tests/SearchTests/StrategyMissingDirectoryTests.swift\` (AppleDocs + SwiftOrg constructions)
- \`Tests/SearchTests/IndexBuilderMalformedURLSkipTests.swift\`
- \`Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift\`
- \`Tests/CLICommandTests/SaveTests/SaveTests.swift\` (8 callsites)
- \`Tests/CLICommandTests/ServeTests/ServeTests.swift\` (1 callsite)

The no-op closure \`{ _, _ in nil }\` is acceptable for these tests because none of them index \`.md\` content; they all test indexer plumbing with \`.json\` fixtures or empty / missing directories.

## Acceptance grep

\`\`\`
\$ grep -rln '^import CoreJSONParser\$' Packages/Sources/Search Packages/Tests/SearchTests
(empty)
\`\`\`

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #400 progress

Search target deps now: \`SearchModels, SharedCore, SharedConstants, SharedModels, Logging, CoreProtocols, CorePackageIndexingModels, CoreSampleCode, ASTIndexer\`.

Only one behavioural cross-package import remains: \`CoreSampleCode\`, used by \`Search.Strategies.SampleCode\` for \`Sample.Core.Catalog\`. A parallel \`Sample.Core.CatalogReader\` protocol-seam would close that — but it's separate scope from this PR.