### PR TITLE
refactor(Search): #400 drop import CoreSampleCode via SampleCatalogFetch closure seam — closes #400

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -372,7 +372,7 @@ let targets: [Target] = {
         // the Strategies/ folder moves to Sources/SearchStrategies/ and gets its own
         // SPM target with deps: [SearchIndexCore, CoreJSONParser, CorePackageIndexing,
         // Core, SharedModels, SharedConstants, Resources, Logging].
-        dependencies: ["SearchModels", "SharedCore", "SharedConstants", "SharedModels", "Logging", "CoreProtocols", "CorePackageIndexingModels", "CoreSampleCode", "ASTIndexer"]
+        dependencies: ["SearchModels", "SharedCore", "SharedConstants", "SharedModels", "Logging", "CoreProtocols", "CorePackageIndexingModels", "ASTIndexer"]
     )
     let searchTestsTarget = Target.testTarget(
         name: "SearchTests",

--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
@@ -1,9 +1,11 @@
 import CoreJSONParser
 import CoreProtocols
+import CoreSampleCode
 import Foundation
 import Indexer
 import Logging
 import SampleIndex
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedUtils
@@ -35,11 +37,42 @@ extension CLI.Command.Save {
         let tracker = ProgressTracker()
         let outcome = try await Indexer.DocsService.run(
             request,
-            markdownToStructuredPage: Core.JSONParser.MarkdownToStructuredPage.convert
+            markdownToStructuredPage: Core.JSONParser.MarkdownToStructuredPage.convert,
+            sampleCatalogFetch: CLI.Command.Save.sampleCatalogFetch
         ) { event in
             Self.handleDocsEvent(event, tracker: tracker)
         }
         Self.printDocsSummary(outcome: outcome)
+    }
+
+    // MARK: - Sample catalog adapter
+
+    /// Bridges `Sample.Core.Catalog` (the CoreSampleCode singleton) over
+    /// to the `Search.SampleCatalogFetch` closure shape the Search
+    /// SampleCodeStrategy reads. Lives at the CLI composition root so
+    /// neither Search nor Indexer needs to import `CoreSampleCode`.
+    static let sampleCatalogFetch: @Sendable () async -> Search.SampleCatalogState = {
+        let entries = await Sample.Core.Catalog.allEntries
+        let loaded = await Sample.Core.Catalog.loadedSource ?? .missing
+        switch loaded {
+        case .onDisk:
+            let mapped = entries.map { entry in
+                Search.SampleCatalogEntry(
+                    title: entry.title,
+                    url: entry.url,
+                    framework: entry.framework,
+                    description: entry.description,
+                    zipFilename: entry.zipFilename,
+                    webURL: entry.webURL
+                )
+            }
+            return .loaded(entries: mapped)
+        case .missing:
+            let path = Shared.Constants.defaultSampleCodeDirectory
+                .appendingPathComponent(Sample.Core.Catalog.onDiskCatalogFilename)
+                .path
+            return .missing(onDiskPath: path)
+        }
     }
 
     static func handleDocsEvent(

--- a/Packages/Sources/Indexer/Indexer.DocsService.swift
+++ b/Packages/Sources/Indexer/Indexer.DocsService.swift
@@ -59,6 +59,7 @@ extension Indexer {
         public static func run(
             _ request: Request,
             markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage,
+            sampleCatalogFetch: @escaping Search.SampleCatalogFetch,
             handler: @escaping @Sendable (Event) -> Void = { _ in }
         ) async throws -> Outcome {
             let docsURL = request.docsDir
@@ -101,7 +102,8 @@ extension Indexer {
                 swiftOrgDirectory: swiftOrgDirToUse,
                 archiveDirectory: archiveDirToUse,
                 higDirectory: higDirToUse,
-                markdownToStructuredPage: markdownToStructuredPage
+                markdownToStructuredPage: markdownToStructuredPage,
+                sampleCatalogFetch: sampleCatalogFetch
             )
 
             try await builder.buildIndex(clearExisting: request.clear) { processed, total in

--- a/Packages/Sources/Search/Search.IndexBuilder.swift
+++ b/Packages/Sources/Search/Search.IndexBuilder.swift
@@ -95,7 +95,8 @@ extension Search {
             archiveDirectory: URL? = nil,
             higDirectory: URL? = nil,
             indexSampleCode: Bool = true,
-            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage
+            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage,
+            sampleCatalogFetch: @escaping Search.SampleCatalogFetch
         ) {
             self.init(
                 searchIndex: searchIndex,
@@ -107,7 +108,8 @@ extension Search {
                     archiveDirectory: archiveDirectory,
                     higDirectory: higDirectory,
                     indexSampleCode: indexSampleCode,
-                    markdownToStructuredPage: markdownToStructuredPage
+                    markdownToStructuredPage: markdownToStructuredPage,
+                    sampleCatalogFetch: sampleCatalogFetch
                 )
             )
         }
@@ -180,7 +182,8 @@ extension Search {
             archiveDirectory: URL? = nil,
             higDirectory: URL? = nil,
             indexSampleCode: Bool = true,
-            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage
+            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage,
+            sampleCatalogFetch: @escaping Search.SampleCatalogFetch
         ) -> [any Search.SourceIndexingStrategy] {
             var strategies: [any Search.SourceIndexingStrategy] = [
                 Search.AppleDocsStrategy(
@@ -204,7 +207,7 @@ extension Search {
                 strategies.append(Search.HIGStrategy(higDirectory: dir))
             }
             if indexSampleCode {
-                strategies.append(Search.SampleCodeStrategy())
+                strategies.append(Search.SampleCodeStrategy(sampleCatalogFetch: sampleCatalogFetch))
             }
             strategies.append(Search.SwiftPackagesStrategy())
             return strategies

--- a/Packages/Sources/Search/Strategies/Search.Strategies.SampleCode.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.SampleCode.swift
@@ -1,4 +1,3 @@
-import CoreSampleCode
 import Foundation
 import Logging
 import SearchModels
@@ -10,29 +9,46 @@ import SharedModels
 extension Search {
     /// Indexes the Apple sample code catalog into the search index.
     ///
-    /// The sample code catalog is loaded from the on-disk `catalog.json` file written by
-    /// `cupertino fetch --type code`.  Each entry's framework availability is looked up
-    /// from the search index and cached to avoid redundant database round-trips.
+    /// The catalog is provided via the injected `sampleCatalogFetch` closure,
+    /// which the composition root (the CLI binary) backs with
+    /// `Sample.Core.Catalog`. Test harnesses pass a closure that returns a
+    /// `Search.SampleCatalogState` fixture directly.
     ///
-    /// If the catalog is missing this strategy logs a helpful message and returns cleanly
-    /// rather than raising an error.
+    /// Each entry's framework availability is looked up from the search
+    /// index and cached to avoid redundant database round-trips.
+    ///
+    /// If the catalog is missing this strategy logs a helpful message and
+    /// returns cleanly rather than raising an error.
     ///
     /// ## Example
     /// ```swift
-    /// let strategy = Search.SampleCodeStrategy()
+    /// let strategy = Search.SampleCodeStrategy(sampleCatalogFetch: { /* … */ })
     /// let stats = try await strategy.indexItems(into: index, progress: nil)
     /// ```
     public struct SampleCodeStrategy: SourceIndexingStrategy {
         /// The source identifier written into the FTS index.
         public let source = "sample-code"
 
-        /// Create a strategy for indexing the sample code catalog.
-        public init() {}
+        /// Closure that returns the current state of the Apple sample-code
+        /// catalog. Injected so this target doesn't depend on
+        /// `CoreSampleCode`; the composition root supplies the adapter
+        /// over `Sample.Core.Catalog`.
+        private let sampleCatalogFetch: Search.SampleCatalogFetch
 
-        /// Index all sample code entries from the on-disk catalog.
+        /// Create a strategy for indexing the sample code catalog.
         ///
-        /// Reads entries via ``Sample/Core/Catalog/allEntries``.  When the catalog
-        /// is absent, logs a user-friendly message and returns with zero counts.
+        /// - Parameter sampleCatalogFetch: Closure that returns the
+        ///   `Search.SampleCatalogState` to index. Injected at the
+        ///   composition root so the strategy can read the catalog
+        ///   without depending on the `CoreSampleCode` target directly.
+        public init(sampleCatalogFetch: @escaping Search.SampleCatalogFetch) {
+            self.sampleCatalogFetch = sampleCatalogFetch
+        }
+
+        /// Index all sample code entries from the catalog fetch closure.
+        ///
+        /// When the catalog is absent, logs a user-friendly message and
+        /// returns with zero counts.
         ///
         /// - Parameters:
         ///   - index: The ``Search/Index`` to write into.
@@ -42,21 +58,19 @@ extension Search {
             into index: Search.Index,
             progress: Search.IndexingProgressCallback?
         ) async throws -> Search.IndexStats {
-            let entries = await Sample.Core.Catalog.allEntries
-            let catalogSource = await Sample.Core.Catalog.loadedSource ?? .missing
+            let state = await sampleCatalogFetch()
 
-            switch catalogSource {
-            case .onDisk:
+            let entries: [Search.SampleCatalogEntry]
+            switch state {
+            case .loaded(let loadedEntries):
                 Logging.Log.info(
                     "📦 Indexing sample code catalog from on-disk catalog.json (#214)...",
                     category: .search
                 )
-            case .missing:
-                let path = Shared.Constants.defaultSampleCodeDirectory
-                    .appendingPathComponent(Sample.Core.Catalog.onDiskCatalogFilename)
-                    .path
+                entries = loadedEntries
+            case .missing(let onDiskPath):
                 Logging.Log.info(
-                    "⚠️  No sample-code catalog at \(path) — skipping sample-code indexing.",
+                    "⚠️  No sample-code catalog at \(onDiskPath) — skipping sample-code indexing.",
                     category: .search
                 )
                 Logging.Log.info(

--- a/Packages/Sources/SearchModels/Search.SampleCatalogFetch.swift
+++ b/Packages/Sources/SearchModels/Search.SampleCatalogFetch.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SharedConstants
+
+// MARK: - Search.SampleCatalogFetch
+
+/// Closure shape that returns the current state of the Apple sample-code
+/// catalog. The Search target's `SampleCodeStrategy` uses one of these
+/// instead of reaching into `CoreSampleCode` directly — that's how the
+/// strategy can index the sample catalog while the Search SPM target
+/// keeps a foundation-only dependency graph.
+///
+/// The composition root (the CLI binary) supplies the concrete closure
+/// which adapts from `Sample.Core.Catalog`'s static API into the
+/// `SampleCatalogState` shape declared below. Test harnesses pass a
+/// closure that returns a fixture state directly.
+///
+/// Mirrors the `Search.Database` / `Search.MarkdownToStructuredPage` /
+/// `MakeSearchDatabase` / `PackageFileLookup` / `MarkdownLookup`
+/// closure-typealias pattern already in SearchModels: the abstraction
+/// lives in this value-types target, the implementation lives in the
+/// producer target, the wiring lives at the composition root.
+public extension Search {
+    typealias SampleCatalogFetch = @Sendable () async -> SampleCatalogState
+}
+
+// MARK: - Search.SampleCatalogState
+
+/// Snapshot of what's available in the sample-code catalog at the
+/// moment the indexer runs.
+public extension Search {
+    enum SampleCatalogState: Sendable {
+        /// The catalog was loaded successfully (either from the on-disk
+        /// JSON or from an embedded fallback). Entries may still be
+        /// empty if the catalog file existed but parsed to zero rows.
+        case loaded(entries: [SampleCatalogEntry])
+
+        /// The catalog file was not found. The associated path is the
+        /// fully-resolved on-disk location the indexer is reporting in
+        /// the "run `cupertino fetch --type code` to populate" message.
+        case missing(onDiskPath: String)
+    }
+}
+
+// MARK: - Search.SampleCatalogEntry
+
+/// One row from the sample-code catalog, mirroring `Sample.Core.Entry`'s
+/// shape. Lives in SearchModels (a foundation-only target) so the
+/// strategy that consumes the catalog can be typed against the snapshot
+/// without importing the CoreSampleCode target where the concrete
+/// `Sample.Core.Entry` lives.
+///
+/// The composition root maps `Sample.Core.Entry` → this struct
+/// field-for-field when building the `SampleCatalogFetch` closure;
+/// the round-trip is lossless because both types carry the same six
+/// fields.
+public extension Search {
+    struct SampleCatalogEntry: Sendable {
+        public let title: String
+        public let url: String
+        public let framework: String
+        public let description: String
+        public let zipFilename: String
+        public let webURL: String
+
+        public init(
+            title: String,
+            url: String,
+            framework: String,
+            description: String,
+            zipFilename: String,
+            webURL: String
+        ) {
+            self.title = title
+            self.url = url
+            self.framework = framework
+            self.description = description
+            self.zipFilename = zipFilename
+            self.webURL = webURL
+        }
+    }
+}

--- a/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
+++ b/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
@@ -57,7 +57,8 @@ struct SaveCommandTests {
             metadata: metadata,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownToStructuredPage: { _, _ in nil },
+            sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
         try await builder.buildIndex()
@@ -112,7 +113,8 @@ struct SaveCommandTests {
             metadata: metadata,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownToStructuredPage: { _, _ in nil },
+            sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
         try await builder.buildIndex()
 
@@ -155,7 +157,8 @@ struct SaveCommandTests {
             metadata: emptyMetadata,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownToStructuredPage: { _, _ in nil },
+            sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
         // Should not throw, just save 0 documents
@@ -215,7 +218,8 @@ struct SaveCommandTests {
             metadata: metadata,
             docsDirectory: docsDir,
             evolutionDirectory: evolutionDir,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownToStructuredPage: { _, _ in nil },
+            sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
         try await builder.buildIndex()
@@ -286,7 +290,8 @@ struct SaveCommandTests {
             metadata: nil, // No metadata!
             docsDirectory: tempDir.appendingPathComponent("docs"),
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownToStructuredPage: { _, _ in nil },
+            sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
         try await builder.buildIndex()
@@ -341,7 +346,8 @@ struct SaveCommandTests {
             metadata: nil,
             docsDirectory: tempDir.appendingPathComponent("docs"),
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownToStructuredPage: { _, _ in nil },
+            sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
         try await builder.buildIndex()
@@ -391,7 +397,8 @@ struct SaveCommandTests {
             metadata: nil,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownToStructuredPage: { _, _ in nil },
+            sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
         try await builder.buildIndex()
@@ -424,7 +431,8 @@ struct SaveCommandTests {
             metadata: nil,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownToStructuredPage: { _, _ in nil },
+            sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
         try await builder.buildIndex()

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -393,7 +393,8 @@ struct MCPServerIntegrationTests {
             metadata: metadata,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownToStructuredPage: { _, _ in nil },
+            sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
         try await builder.buildIndex()
         print("   ✅ Index built")

--- a/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
@@ -135,7 +135,8 @@ struct IndexBuilderSymbolsIntegrationTests {
             metadata: nil,
             docsDirectory: docsDir,
             indexSampleCode: false,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownToStructuredPage: { _, _ in nil },
+            sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
         try await builder.buildIndex(clearExisting: true)


### PR DESCRIPTION
The last behavioural cross-package import in Search was \`CoreSampleCode\`, used by \`Search.Strategies.SampleCode\` to read \`Sample.Core.Catalog\`. This PR introduces the \`SampleCatalogFetch\` closure seam — same shape as the \`MarkdownToStructuredPage\` / \`PackageFileLookup\` / \`MarkdownLookup\` / \`MakeSearchDatabase\` typealiases already in SearchModels.

**After this PR, Search target's dependency graph contains only foundation-layer + Models targets. #400 closes.**

## New types in SearchModels

\`\`\`swift
public extension Search {
    typealias SampleCatalogFetch = @Sendable () async -> SampleCatalogState
}
public extension Search {
    enum SampleCatalogState: Sendable {
        case loaded(entries: [SampleCatalogEntry])
        case missing(onDiskPath: String)
    }
}
public extension Search {
    struct SampleCatalogEntry: Sendable { /* 6 fields mirroring Sample.Core.Entry */ }
}
\`\`\`

The composition root (CLI) adapts \`Sample.Core.Catalog.allEntries\` + \`loadedSource\` into this snapshot shape, mapping each \`Sample.Core.Entry\` to \`Search.SampleCatalogEntry\` field-for-field.

## Strategy update

\`Search.Strategies.SampleCode\` drops \`import CoreSampleCode\`. Its init now takes \`sampleCatalogFetch: @escaping Search.SampleCatalogFetch\` instead of reaching directly into \`Sample.Core.Catalog\`. The body switches on \`Search.SampleCatalogState\` (\`loaded\` / \`missing\`) and reads the lifted \`Search.SampleCatalogEntry\` fields.

## IndexBuilder threads the closure

\`Search.IndexBuilder.makeDefaultStrategies\` + the convenience init both take \`sampleCatalogFetch:\` alongside the existing \`markdownToStructuredPage:\`. The SampleCode strategy receives it when \`indexSampleCode: true\` (the default).

## Indexer.DocsService

Adds \`sampleCatalogFetch:\` parameter to \`run(_:markdownToStructuredPage:handler:)\`. Indexer doesn't import CoreSampleCode either — it just forwards the closure into \`Search.IndexBuilder\`.

## CLI composition root

\`CLI.Command.Save.Indexers.swift\` adds \`import CoreSampleCode\` and defines a \`sampleCatalogFetch\` static closure that adapts:
- \`Sample.Core.Catalog.allEntries\` → \`[Search.SampleCatalogEntry]\` (mapping each \`Sample.Core.Entry\`)
- \`Sample.Core.Catalog.loadedSource\` → \`.loaded\` or \`.missing\`
- \`Sample.Core.Catalog.onDiskCatalogFilename\` → resolved on-disk path string

The CLI passes this closure into \`Indexer.DocsService.run\`.

## Package.swift

**Search target deps drop \`CoreSampleCode\`.** Final deps:

\`SearchModels, SharedCore, SharedConstants, SharedModels, Logging, CoreProtocols, CorePackageIndexingModels, ASTIndexer\`

Foundation layer + Models targets only. No behavioural cross-package imports remain.

## Test updates

Tests that constructed \`Search.IndexBuilder\` directly gain \`sampleCatalogFetch: { .missing(onDiskPath: \"\") }\` alongside their existing \`markdownToStructuredPage:\` closure. The \"missing\" state is appropriate because none of these tests exercise sample-code indexing end-to-end. Strategy-level direct tests (\`AppleDocsStrategy\` / \`SwiftOrgStrategy\` callsites) don't construct SampleCodeStrategy so they don't take the closure.

## Acceptance grep

\`\`\`
\$ grep -rln '^import CoreSampleCode\$' Packages/Sources/Search Packages/Tests/SearchTests
(empty)
\`\`\`

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #400 closes

Search target's final import set (production sources):

\`ASTIndexer, CorePackageIndexingModels, CoreProtocols, Foundation, Logging, SQLite3, SearchModels, SharedConstants, SharedCore, SharedModels, SharedUtils\`

That's the acceptance criterion for #400 met: every non-Apple-system import is either a foundation-tier package or a foundation-layer Models target. No behavioural cross-package imports. **The Search SPM target now compiles, tests, and reasons about itself without depending on any other internal package for behavior.**

Closes #400.