### PR TITLE
refactor(Indexer): #403 drop stale Core + CoreProtocols deps

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -484,7 +484,7 @@ let targets: [Target] = {
     // ---------- Indexer (#244: SaveCommand indexer + preflight lift) ----------
     let indexerTarget = Target.target(
         name: "Indexer",
-        dependencies: ["SharedCore", "SharedConstants", "SharedUtils", "Search", "SampleIndex", "CoreProtocols", "Core", "CoreSampleCode", "Logging"]
+        dependencies: ["SharedCore", "SharedConstants", "SharedUtils", "Search", "SampleIndex", "CoreSampleCode", "Logging"]
     )
     let indexerTestsTarget = Target.testTarget(
         name: "IndexerTests",

--- a/Packages/Sources/Indexer/Indexer.SamplesService.swift
+++ b/Packages/Sources/Indexer/Indexer.SamplesService.swift
@@ -1,5 +1,3 @@
-import Core
-import CoreProtocols
 import CoreSampleCode
 import Foundation
 import SampleIndex


### PR DESCRIPTION
\`Indexer.SamplesService.swift\` imported \`Core\` + \`CoreProtocols\` but referenced neither — its only cross-package symbol is \`Sample.Core.Catalog\` which comes from \`CoreSampleCode\` (lifted in #476). Drops both imports and removes the corresponding deps from the Indexer target in Package.swift.

Tiny PR, #403 prep.

## Source

\`Sources/Indexer/Indexer.SamplesService.swift\`: drop \`import Core\` + \`import CoreProtocols\`.

## Package.swift

**Indexer target deps drop \`Core\`, \`CoreProtocols\`.** New deps list: \`SharedCore, SharedConstants, SharedUtils, Search, SampleIndex, CoreSampleCode, Logging\`.

## Acceptance grep

\`\`\`
\$ grep -rln '^import Core\$\\|^import CoreProtocols\$' Packages/Sources/Indexer
(empty)
\`\`\`

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #403 progress

**Before:** \`SharedCore, SharedConstants, SharedUtils, Search, SampleIndex, CoreProtocols, Core, CoreSampleCode, Logging\`

**After:** \`SharedCore, SharedConstants, SharedUtils, Search, SampleIndex, CoreSampleCode, Logging\`

Heavy-tier remaining for #403:
- \`Search\` — uses \`Search.Index\` + \`Search.IndexBuilder\` + \`Search.PackageIndex\` + \`Search.PackageIndexer\` actors
- \`SampleIndex\` — uses \`Sample.Index.Database\` + \`Sample.Index.Builder\` actors
- \`CoreSampleCode\` — uses \`Sample.Core.Catalog\` static surface

Each requires factory / protocol injection — multi-PR architectural slice for full #403 closure.