### PR TITLE
refactor(SampleIndexModels): #408 lift Sample.Search.Query + Sample.Search.Result value types out of Services

### DIFF
--- a/Packages/Sources/SampleIndexModels/Sample.Search.Query.swift
+++ b/Packages/Sources/SampleIndexModels/Sample.Search.Query.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SharedConstants
+
+// MARK: - Sample.Search.Query
+
+/// Query parameters for sample-code searches against the SampleIndex database.
+///
+/// Previously declared inside `Sources/Services/ReadCommands/Sample.Search.Service.swift`.
+/// Lifted to a foundation-layer value type so consumers (`SearchToolProvider`,
+/// CLI commands, MCP tool surfaces) can hold a `Sample.Search.Query` value
+/// without importing the full `Services` target.
+///
+/// `Sample.Search.Service` (the actor in Services that consumes this query
+/// and runs it against a `Sample.Index.Reader`) keeps its existing
+/// signature — only the type definition moved.
+extension Sample.Search {
+    public struct Query: Sendable {
+        public let text: String
+        public let framework: String?
+        public let searchFiles: Bool
+        public let limit: Int
+
+        /// Optional platform filter (#233). When set together with
+        /// `minVersion`, restricts results to projects whose
+        /// `min_<platform>` column is non-NULL and lex-≤ the requested
+        /// version. nil on either disables the filter.
+        public let platform: String?
+        public let minVersion: String?
+
+        public init(
+            text: String,
+            framework: String? = nil,
+            searchFiles: Bool = true,
+            limit: Int = Shared.Constants.Limit.defaultSearchLimit,
+            platform: String? = nil,
+            minVersion: String? = nil
+        ) {
+            self.text = text
+            self.framework = framework
+            self.searchFiles = searchFiles
+            self.limit = min(limit, Shared.Constants.Limit.maxSearchLimit)
+            self.platform = platform
+            self.minVersion = minVersion
+        }
+    }
+}

--- a/Packages/Sources/SampleIndexModels/Sample.Search.Result.swift
+++ b/Packages/Sources/SampleIndexModels/Sample.Search.Result.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SharedConstants
+
+// MARK: - Sample.Search.Result
+
+/// Combined result from a sample-code search: matched projects + matched
+/// file rows.
+///
+/// Previously declared inside
+/// `Sources/Services/ReadCommands/Sample.Search.Service.swift`. Lifted
+/// to a foundation-layer value type so consumers (`SearchToolProvider`,
+/// CLI commands, MCP tool surfaces) can hold one without importing the
+/// full `Services` target.
+///
+/// Carries `Sample.Index.Project` and `Sample.Index.FileSearchResult`
+/// which already live in this same `SampleIndexModels` target, so the
+/// lift introduces no new transitive dependencies.
+extension Sample.Search {
+    public struct Result: Sendable {
+        public let projects: [Sample.Index.Project]
+        public let files: [Sample.Index.FileSearchResult]
+
+        public init(
+            projects: [Sample.Index.Project],
+            files: [Sample.Index.FileSearchResult]
+        ) {
+            self.projects = projects
+            self.files = files
+        }
+
+        /// Check if the result is empty.
+        public var isEmpty: Bool {
+            projects.isEmpty && files.isEmpty
+        }
+
+        /// Total count of results across both projects and files.
+        public var totalCount: Int {
+            projects.count + files.count
+        }
+    }
+}

--- a/Packages/Sources/Services/ReadCommands/Sample.Search.Service.swift
+++ b/Packages/Sources/Services/ReadCommands/Sample.Search.Service.swift
@@ -4,64 +4,13 @@ import SampleIndexModels
 import SharedConstants
 import SharedCore
 
-// MARK: - Sample Search Query
+// MARK: - Sample Search
 
-/// Query parameters for sample code searches
-extension Sample.Search {
-    public struct Query: Sendable {
-        public let text: String
-        public let framework: String?
-        public let searchFiles: Bool
-        public let limit: Int
-        /// Optional platform filter (#233). When set together with
-        /// `minVersion`, restricts results to projects whose
-        /// `min_<platform>` column is non-NULL and lex-≤ the requested
-        /// version. nil on either disables the filter.
-        public let platform: String?
-        public let minVersion: String?
-
-        public init(
-            text: String,
-            framework: String? = nil,
-            searchFiles: Bool = true,
-            limit: Int = Shared.Constants.Limit.defaultSearchLimit,
-            platform: String? = nil,
-            minVersion: String? = nil
-        ) {
-            self.text = text
-            self.framework = framework
-            self.searchFiles = searchFiles
-            self.limit = min(limit, Shared.Constants.Limit.maxSearchLimit)
-            self.platform = platform
-            self.minVersion = minVersion
-        }
-    }
-}
-
-// MARK: - Sample Search Result
-
-/// Combined result from project and file searches
-extension Sample.Search {
-    public struct Result: Sendable {
-        public let projects: [Sample.Index.Project]
-        public let files: [Sample.Index.FileSearchResult]
-
-        public init(projects: [Sample.Index.Project], files: [Sample.Index.FileSearchResult]) {
-            self.projects = projects
-            self.files = files
-        }
-
-        /// Check if the result is empty
-        public var isEmpty: Bool {
-            projects.isEmpty && files.isEmpty
-        }
-
-        /// Total count of results
-        public var totalCount: Int {
-            projects.count + files.count
-        }
-    }
-}
+// `Sample.Search.Query` and `Sample.Search.Result` lifted to the
+// `SampleIndexModels` target so callers (`SearchToolProvider` and
+// future MCP / CLI surfaces) can construct queries without importing
+// the full `Services` target. The actor below stays here because it
+// holds behaviour over `any Sample.Index.Reader`.
 
 // MARK: - Sample Search Service
 


### PR DESCRIPTION
Two pure value types previously declared inside \`Sources/Services/ReadCommands/Sample.Search.Service.swift\` move to the foundation-layer \`SampleIndexModels\` target. The \`Sample.Search.Service\` actor (the behavioural surface) stays in Services because it holds an \`any Sample.Index.Reader\`.

Same lift pattern established in #475 (\`Sample.Index.Reader\`), #465 (\`Search.Database\`), #479-#483 (CorePackageIndexingModels family), and the SearchModels closure-typealias family.

Step toward closing #408.

## What moved

- \`Sample.Search.Query\` (struct, 6 fields) → \`SampleIndexModels\`
- \`Sample.Search.Result\` (struct, 2 fields + 2 computed) → \`SampleIndexModels\`

\`Sample.Search.Result\` references \`Sample.Index.Project\` and \`Sample.Index.FileSearchResult\` which already live in \`SampleIndexModels\` — zero new transitive dependencies.

## Why

Callers that need to construct a \`Sample.Search.Query\` (the MCP \`SearchToolProvider\` is the main one) or hold a \`Sample.Search.Result\` (future CLI / MCP read-paths) can now do so by importing \`SampleIndexModels\` instead of pulling in the full \`Services\` target.

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

No source-compatibility break: \`Sample.Search.Query\` and \`Sample.Search.Result\` are still reachable by the same fully-qualified name; only the target they live in changed. SearchToolProvider already imports \`SampleIndexModels\` (from #475), so no consumer-side updates are required for this PR.