### PR TITLE
refactor(SearchToolProvider): #408 add DocsSearcher + Sample.Search.Searcher protocol seams

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Serve.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Serve.swift
@@ -7,12 +7,15 @@ import Logging
 import MCPCore
 import MCPSupport
 import SampleIndex
+import SampleIndexModels
 import Search
+import SearchModels
 import SearchToolProvider
+import Services
+import ServicesModels
 import SharedConfiguration
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - Serve Command
 
@@ -147,8 +150,18 @@ extension CLI.Command {
             // Initialize sample code index if available
             let sampleIndex = await loadSampleIndex()
 
-            // Register composite tool provider with both indexes
-            let toolProvider = CompositeToolProvider(searchIndex: searchIndex, sampleDatabase: sampleIndex)
+            // Register composite tool provider with both indexes. The
+            // service-layer wrappers are constructed here at the
+            // composition root and passed across the protocol seam so
+            // SearchToolProvider doesn't have to construct them itself.
+            let docsService: (any Services.DocsSearcher)? = searchIndex.map(Services.DocsSearchService.init(database:))
+            let sampleService: (any Sample.Search.Searcher)? = sampleIndex.map(Sample.Search.Service.init(database:))
+            let toolProvider = CompositeToolProvider(
+                searchIndex: searchIndex,
+                sampleDatabase: sampleIndex,
+                docsService: docsService,
+                sampleService: sampleService
+            )
             await server.registerToolProvider(toolProvider)
 
             // Log availability of each index

--- a/Packages/Sources/SampleIndexModels/Sample.Search.Searcher.swift
+++ b/Packages/Sources/SampleIndexModels/Sample.Search.Searcher.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SharedConstants
+
+// MARK: - Sample.Search.Searcher
+
+/// Minimal read-only seam for a sample-code-search service.
+///
+/// Captures the surface that `SearchToolProvider` (and any future MCP /
+/// CLI consumer) actually calls on `Sample.Search.Service` — a single
+/// `search(_:) async throws -> Sample.Search.Result` method. The
+/// concrete actor in the `Services` target conforms via a one-line
+/// witness extension; consumers hold `any Sample.Search.Searcher`
+/// instead of the actor.
+///
+/// Mirrors the `Search.Database` / `Sample.Index.Reader` /
+/// `Services.DocsSearcher` pattern: protocol in a foundation-only
+/// Models target, conformance witness in the producer target, wiring
+/// at the composition root.
+extension Sample.Search {
+    public protocol Searcher: Sendable {
+        /// Search Apple sample-code projects and files for the given
+        /// query parameters.
+        func search(_ query: Sample.Search.Query) async throws -> Sample.Search.Result
+    }
+}

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -14,33 +14,47 @@ import SharedUtils
 /// Composite tool provider that provides unified search across all documentation sources.
 /// Handles `search_docs` with `source` parameter to search docs, samples, HIG, archive, etc.
 public actor CompositeToolProvider: MCP.Core.ToolProvider {
-    // Use service layer for consistency with CLI
-    private let docsService: Services.DocsSearchService?
-    private let sampleService: Sample.Search.Service?
+    // Protocol-typed so this file doesn't import the Search, SampleIndex,
+    // or Services behavioural targets — every cross-package surface is
+    // an abstraction from a Models target. The CLI composition root
+    // constructs the concrete actors and passes them across the seam.
 
-    // Keep direct access for low-level operations (list frameworks, read
-    // document, semantic-symbol searches). Protocol-typed so this file
-    // doesn't import the Search or SampleIndex targets — it pulls only
-    // the abstractions from SearchModels + SampleIndexModels.
+    private let docsService: (any Services.DocsSearcher)?
+    private let sampleService: (any Sample.Search.Searcher)?
+
+    // Kept for low-level operations (list frameworks, read document,
+    // semantic-symbol searches) that don't have a service-layer wrapper.
     private let searchIndex: (any Search.Database)?
     private let sampleDatabase: (any Sample.Index.Reader)?
 
-    public init(searchIndex: (any Search.Database)?, sampleDatabase: (any Sample.Index.Reader)?) {
+    /// Primary init used by the CLI composition root. Each cross-package
+    /// surface arrives pre-wired as a protocol-typed value so this file
+    /// doesn't have to import the Search / SampleIndex / Services
+    /// behavioural targets to do any wiring of its own.
+    public init(
+        searchIndex: (any Search.Database)?,
+        sampleDatabase: (any Sample.Index.Reader)?,
+        docsService: (any Services.DocsSearcher)?,
+        sampleService: (any Sample.Search.Searcher)?
+    ) {
         self.searchIndex = searchIndex
         self.sampleDatabase = sampleDatabase
+        self.docsService = docsService
+        self.sampleService = sampleService
+    }
 
-        // Wrap databases with services for search operations
-        if let searchIndex {
-            docsService = Services.DocsSearchService(database: searchIndex)
-        } else {
-            docsService = nil
-        }
-
-        if let sampleDatabase {
-            sampleService = Sample.Search.Service(database: sampleDatabase)
-        } else {
-            sampleService = nil
-        }
+    /// Convenience init that wraps both indexes with the default service
+    /// implementations. Kept for test harnesses + back-compat with code
+    /// that constructed `CompositeToolProvider` with just the two
+    /// database references. Composition-root code (the CLI's
+    /// `serve` command) should prefer the explicit init above.
+    public init(searchIndex: (any Search.Database)?, sampleDatabase: (any Sample.Index.Reader)?) {
+        self.init(
+            searchIndex: searchIndex,
+            sampleDatabase: sampleDatabase,
+            docsService: searchIndex.map(Services.DocsSearchService.init(database:)),
+            sampleService: sampleDatabase.map(Sample.Search.Service.init(database:))
+        )
     }
 
     // MARK: - ToolProvider

--- a/Packages/Sources/Services/ReadCommands/Sample.Search.Service.Searcher.swift
+++ b/Packages/Sources/Services/ReadCommands/Sample.Search.Service.Searcher.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SampleIndexModels
+import SharedConstants
+
+// MARK: - Sample.Search.Service conformance witness
+
+/// `Sample.Search.Service` (concrete actor in this target) satisfies
+/// the `Sample.Search.Searcher` protocol declared in `SampleIndexModels`.
+/// The actor's existing `search(_:) async throws -> Sample.Search.Result`
+/// already matches the protocol method-for-method, so this is a
+/// one-line conformance with no body.
+///
+/// Mirrors the `Sample.Index.Database: Sample.Index.Reader` witness
+/// pattern in #475 and the `Services.DocsSearchService: Services.DocsSearcher`
+/// witness alongside it.
+extension Sample.Search.Service: Sample.Search.Searcher {}

--- a/Packages/Sources/Services/ReadCommands/Services.DocsSearchService.DocsSearcher.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.DocsSearchService.DocsSearcher.swift
@@ -1,0 +1,16 @@
+import Foundation
+import ServicesModels
+
+// MARK: - Services.DocsSearchService conformance witness
+
+/// `Services.DocsSearchService` (concrete actor) satisfies the
+/// `Services.DocsSearcher` protocol declared in `ServicesModels`. The
+/// method signature already matches — `search(_ query:)
+/// async throws -> [Search.Result]` is the actor's existing public
+/// method — so this is a one-line conformance with no body.
+///
+/// Lives in the `Services` target so consumers (`SearchToolProvider`)
+/// can hold `any Services.DocsSearcher` after importing only
+/// `ServicesModels`. The CLI composition root constructs the actor and
+/// passes it across the seam as a `Services.DocsSearcher` existential.
+extension Services.DocsSearchService: Services.DocsSearcher {}

--- a/Packages/Sources/ServicesModels/Services.DocsSearcher.swift
+++ b/Packages/Sources/ServicesModels/Services.DocsSearcher.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SearchModels
+
+// MARK: - Services.DocsSearcher
+
+/// Minimal read-only seam for a docs-search service.
+///
+/// Captures the surface that `SearchToolProvider` (and any future MCP /
+/// CLI consumer) actually calls on `Services.DocsSearchService` — a
+/// single `search(_:) async throws -> [Search.Result]` method. The
+/// concrete actor in the `Services` target conforms via a one-line
+/// witness extension; consumers hold `any Services.DocsSearcher`
+/// instead of the actor, so they can drop their `import Services`
+/// once their other Services uses are also seamed.
+///
+/// Mirrors the `Search.Database` / `Sample.Index.Reader` /
+/// `Sample.Search.Searcher` pattern: protocol in a foundation-only
+/// Models target, conformance witness in the producer target, wiring
+/// at the composition root.
+extension Services {
+    public protocol DocsSearcher: Sendable {
+        /// Search for documents matching the query across the configured
+        /// sources (apple-docs, swift-evolution, swift-org, swift-book,
+        /// apple-archive, hig).
+        func search(_ query: Services.SearchQuery) async throws -> [Search.Result]
+    }
+}


### PR DESCRIPTION
Two new minimal protocols capture the single-method surface SearchToolProvider actually calls on the docs + sample service actors. Sets up the architectural primitives for SearchToolProvider to eventually drop \`import Services\` and \`import Sample.Search\`-shaped behaviour entirely; this PR is the protocol-seam foundation, future PRs will move the construction out of the convenience init.

## New protocols

- \`Services.DocsSearcher\` in ServicesModels: \`func search(_ query: Services.SearchQuery) async throws -> [Search.Result]\`
- \`Sample.Search.Searcher\` in SampleIndexModels: \`func search(_ query: Sample.Search.Query) async throws -> Sample.Search.Result\`

Both protocols are foundation-layer-only (deps on SearchModels + SharedConstants + SampleIndexModels which already lives in foundation).

## Conformance witnesses

One-line extensions in Services target:

\`\`\`swift
extension Services.DocsSearchService: Services.DocsSearcher {}
extension Sample.Search.Service: Sample.Search.Searcher {}
\`\`\`

Both actors already have the matching method shape — no body needed.

## SearchToolProvider

\`CompositeToolProvider.docsService\` and \`sampleService\` fields change from concrete actor types to \`(any Services.DocsSearcher)?\` / \`(any Sample.Search.Searcher)?\`. The init grows from 2 params to 4: the two database seams + two service seams. Production callsite (CLI's \`serve\` command) now passes pre-constructed actors across the seam.

A convenience init preserving the old 2-param shape stays for the 27 test callsites + back-compat — it still constructs the concrete service actors inline (so the file still imports Services). Removing that convenience init + moving construction fully to the composition root is the follow-up slice.

## CLI composition root

\`CLI.Command.Serve.swift\` constructs \`Services.DocsSearchService\` + \`Sample.Search.Service\` from the loaded indexes and passes them across the protocol seam to \`CompositeToolProvider\`. Gains imports for \`SampleIndexModels\`, \`Services\`, \`ServicesModels\`.

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #408 progress

SearchToolProvider's behavioural surface for docs + sample searches is now protocol-typed. Still imports Services for the convenience init and for \`Services.TeaserService\` + \`Services.UnifiedSearchService\` which are constructed inline per call (next slices). The protocol foundation is laid; further work decommissions the inline constructions.