### PR TITLE
refactor(ServicesModels): #408 lift TeaserResults + Unified.Input value types out of Services

### DIFF
--- a/Packages/Sources/ServicesModels/Services.Formatter.TeaserResults.swift
+++ b/Packages/Sources/ServicesModels/Services.Formatter.TeaserResults.swift
@@ -1,10 +1,7 @@
-import ServicesModels
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SearchModels
 import SharedConstants
-import SharedCore
 
 // MARK: - Teaser Results
 

--- a/Packages/Sources/ServicesModels/Services.Formatter.Unified.Input.swift
+++ b/Packages/Sources/ServicesModels/Services.Formatter.Unified.Input.swift
@@ -1,10 +1,7 @@
-import ServicesModels
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SearchModels
 import SharedConstants
-import SharedCore
 
 // MARK: - Unified Search Input
 


### PR DESCRIPTION
Two more pure value types move from Services to ServicesModels:

- \`Services.Formatter.TeaserResults\` (struct, 8 \`[Search.Result]\` / \`[Sample.Index.Project]\` fields holding per-source teaser hits)
- \`Services.Formatter.Unified.Input\` (struct, 8 result-array fields + limit, the data shape unified-search formatters render from)

Both are pure value types — no actor behaviour, no Services-internal dependencies. They only reference \`Search.Result\` (from SearchModels) and \`Sample.Index.Project\` (from SampleIndexModels), both already foundation-layer.

## Why

These are the return types of \`Services.TeaserService.fetchAllTeasers\` and \`Services.UnifiedSearchService.searchAll\`. The follow-up slice that lifts those services as protocols (parallel to DocsSearcher / Sample.Search.Searcher in #487) requires the return types to be declarable in ServicesModels first. This PR is that prerequisite.

## File moves

\`\`\`
Sources/Services/Formatters/Services.Formatter.TeaserResults.swift
  -> Sources/ServicesModels/Services.Formatter.TeaserResults.swift
Sources/Services/Formatters/Services.Formatter.Unified.Input.swift
  -> Sources/ServicesModels/Services.Formatter.Unified.Input.swift
\`\`\`

Both files' import lists trimmed to what they actually use (\`SampleIndexModels\` + \`SearchModels\` + \`SharedConstants\` — dropped the \`SampleIndex\` / \`SharedCore\` / \`ServicesModels\` self-import noise).

## Consumer updates

None. Consumers already import ServicesModels (PR #486 added it across the board); the types now resolve through that target instead of through Services. The fully-qualified names are unchanged (\`Services.Formatter.TeaserResults\`, \`Services.Formatter.Unified.Input\`).

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`