### PR TITLE
refactor(SearchToolProvider): #408 add Services.Teaser + Services.UnifiedSearcher protocol seams

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Serve.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Serve.swift
@@ -156,11 +156,21 @@ extension CLI.Command {
             // SearchToolProvider doesn't have to construct them itself.
             let docsService: (any Services.DocsSearcher)? = searchIndex.map(Services.DocsSearchService.init(database:))
             let sampleService: (any Sample.Search.Searcher)? = sampleIndex.map(Sample.Search.Service.init(database:))
+            let teaserService: (any Services.Teaser)? =
+                (searchIndex == nil && sampleIndex == nil)
+                    ? nil
+                    : Services.TeaserService(searchIndex: searchIndex, sampleDatabase: sampleIndex)
+            let unifiedService: (any Services.UnifiedSearcher)? =
+                (searchIndex == nil && sampleIndex == nil)
+                    ? nil
+                    : Services.UnifiedSearchService(searchIndex: searchIndex, sampleDatabase: sampleIndex)
             let toolProvider = CompositeToolProvider(
                 searchIndex: searchIndex,
                 sampleDatabase: sampleIndex,
                 docsService: docsService,
-                sampleService: sampleService
+                sampleService: sampleService,
+                teaserService: teaserService,
+                unifiedService: unifiedService
             )
             await server.registerToolProvider(toolProvider)
 

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -21,6 +21,8 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
 
     private let docsService: (any Services.DocsSearcher)?
     private let sampleService: (any Sample.Search.Searcher)?
+    private let teaserService: (any Services.Teaser)?
+    private let unifiedService: (any Services.UnifiedSearcher)?
 
     // Kept for low-level operations (list frameworks, read document,
     // semantic-symbol searches) that don't have a service-layer wrapper.
@@ -35,12 +37,16 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         searchIndex: (any Search.Database)?,
         sampleDatabase: (any Sample.Index.Reader)?,
         docsService: (any Services.DocsSearcher)?,
-        sampleService: (any Sample.Search.Searcher)?
+        sampleService: (any Sample.Search.Searcher)?,
+        teaserService: (any Services.Teaser)?,
+        unifiedService: (any Services.UnifiedSearcher)?
     ) {
         self.searchIndex = searchIndex
         self.sampleDatabase = sampleDatabase
         self.docsService = docsService
         self.sampleService = sampleService
+        self.teaserService = teaserService
+        self.unifiedService = unifiedService
     }
 
     /// Convenience init that wraps both indexes with the default service
@@ -49,11 +55,26 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
     /// database references. Composition-root code (the CLI's
     /// `serve` command) should prefer the explicit init above.
     public init(searchIndex: (any Search.Database)?, sampleDatabase: (any Sample.Index.Reader)?) {
+        let docs = searchIndex.map(Services.DocsSearchService.init(database:))
+        let sample = sampleDatabase.map(Sample.Search.Service.init(database:))
+        // TeaserService + UnifiedSearchService take both seams (some
+        // sources are docs-side, others sample-side). Always constructible
+        // — they internally short-circuit when both inputs are nil.
+        let teaser = Services.TeaserService(
+            searchIndex: searchIndex,
+            sampleDatabase: sampleDatabase
+        )
+        let unified = Services.UnifiedSearchService(
+            searchIndex: searchIndex,
+            sampleDatabase: sampleDatabase
+        )
         self.init(
             searchIndex: searchIndex,
             sampleDatabase: sampleDatabase,
-            docsService: searchIndex.map(Services.DocsSearchService.init(database:)),
-            sampleService: sampleDatabase.map(Sample.Search.Service.init(database:))
+            docsService: docs,
+            sampleService: sample,
+            teaserService: teaser,
+            unifiedService: unified
         )
     }
 
@@ -508,7 +529,7 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         currentSource: String?,
         includeArchive: Bool
     ) async -> Services.Formatter.TeaserResults {
-        let teaserService = Services.TeaserService(searchIndex: searchIndex, sampleDatabase: sampleDatabase)
+        guard let teaserService else { return Services.Formatter.TeaserResults() }
         return await teaserService.fetchAllTeasers(
             query: query,
             framework: framework,
@@ -595,8 +616,9 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         framework: String?,
         limit: Int
     ) async throws -> MCP.Core.Protocols.CallToolResult {
-        // Use Services.UnifiedSearchService to search all 8 sources
-        let unifiedService = Services.UnifiedSearchService(searchIndex: searchIndex, sampleDatabase: sampleDatabase)
+        guard let unifiedService else {
+            throw Shared.Core.ToolError.invalidArgument("source", "No indexes available for unified search")
+        }
         let input = await unifiedService.searchAll(
             query: query,
             framework: framework,

--- a/Packages/Sources/Services/ReadCommands/Services.TeaserService.Teaser.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.TeaserService.Teaser.swift
@@ -1,0 +1,11 @@
+import Foundation
+import ServicesModels
+
+// MARK: - Services.TeaserService conformance witness
+
+/// `Services.TeaserService` (concrete actor) satisfies the
+/// `Services.Teaser` protocol declared in `ServicesModels`. The
+/// actor's existing `fetchAllTeasers(query:framework:currentSource:includeArchive:)`
+/// method matches the protocol signature, so this is a one-line
+/// conformance witness.
+extension Services.TeaserService: Services.Teaser {}

--- a/Packages/Sources/Services/ReadCommands/Services.UnifiedSearchService.UnifiedSearcher.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.UnifiedSearchService.UnifiedSearcher.swift
@@ -1,0 +1,11 @@
+import Foundation
+import ServicesModels
+
+// MARK: - Services.UnifiedSearchService conformance witness
+
+/// `Services.UnifiedSearchService` (concrete actor) satisfies the
+/// `Services.UnifiedSearcher` protocol declared in `ServicesModels`.
+/// The actor's existing `searchAll(query:framework:limit:)` method
+/// matches the protocol signature, so this is a one-line conformance
+/// witness.
+extension Services.UnifiedSearchService: Services.UnifiedSearcher {}

--- a/Packages/Sources/ServicesModels/Services.Teaser.swift
+++ b/Packages/Sources/ServicesModels/Services.Teaser.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// MARK: - Services.Teaser
+
+/// Minimal read-only seam for the teaser-fetching service.
+///
+/// Captures the surface that `SearchToolProvider` actually calls on
+/// `Services.TeaserService` — a single
+/// `fetchAllTeasers(query:framework:currentSource:includeArchive:)`
+/// method that returns a `Services.Formatter.TeaserResults` snapshot.
+/// The concrete actor in the `Services` target conforms via a one-line
+/// witness extension; consumers hold `any Services.Teaser` and can drop
+/// their `import Services` for this call.
+///
+/// Mirrors the `Services.DocsSearcher` / `Sample.Search.Searcher`
+/// pattern from #487: protocol in a foundation-only Models target,
+/// conformance witness in the producer target, wiring at the
+/// composition root.
+extension Services {
+    public protocol Teaser: Sendable {
+        /// Fetch teaser results from every source except the one being
+        /// searched (driven by `currentSource`). Returns a populated
+        /// `Services.Formatter.TeaserResults` snapshot — empty
+        /// per-source arrays for sources that don't apply.
+        func fetchAllTeasers(
+            query: String,
+            framework: String?,
+            currentSource: String?,
+            includeArchive: Bool
+        ) async -> Services.Formatter.TeaserResults
+    }
+}

--- a/Packages/Sources/ServicesModels/Services.UnifiedSearcher.swift
+++ b/Packages/Sources/ServicesModels/Services.UnifiedSearcher.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// MARK: - Services.UnifiedSearcher
+
+/// Minimal read-only seam for the unified-search service.
+///
+/// Captures the surface that `SearchToolProvider` actually calls on
+/// `Services.UnifiedSearchService` — a single `searchAll(...)` method
+/// that returns a `Services.Formatter.Unified.Input` snapshot ready to
+/// be rendered by the unified-search formatter family.
+///
+/// Mirrors the `Services.DocsSearcher` / `Services.Teaser` /
+/// `Sample.Search.Searcher` pattern: protocol in a foundation-only
+/// Models target, conformance witness in the producer target, wiring
+/// at the composition root.
+extension Services {
+    public protocol UnifiedSearcher: Sendable {
+        /// Search every configured source (apple-docs, apple-archive,
+        /// samples, hig, swift-evolution, swift-org, swift-book,
+        /// packages) and return a `Services.Formatter.Unified.Input`
+        /// snapshot holding the per-source result arrays + the
+        /// per-source limit.
+        func searchAll(
+            query: String,
+            framework: String?,
+            limit: Int
+        ) async -> Services.Formatter.Unified.Input
+    }
+}


### PR DESCRIPTION
Follow-up to #487 (DocsSearcher / Sample.Search.Searcher). Two more service-side protocols capture the surface SearchToolProvider calls on \`Services.TeaserService\` and \`Services.UnifiedSearchService\`, so the inline per-call construction those two had can move to protocol-typed fields populated at the composition root.

## New protocols

- \`Services.Teaser\` in ServicesModels: \`fetchAllTeasers(query:framework:currentSource:includeArchive:) async -> Services.Formatter.TeaserResults\`
- \`Services.UnifiedSearcher\` in ServicesModels: \`searchAll(query:framework:limit:) async -> Services.Formatter.Unified.Input\`

Both return types live in ServicesModels (lifted in #488), so the protocols compile in the foundation-layer target without dragging in Services-target behaviour.

## Conformance witnesses

One-line extensions in the Services target:

\`\`\`swift
extension Services.TeaserService: Services.Teaser {}
extension Services.UnifiedSearchService: Services.UnifiedSearcher {}
\`\`\`

Existing actor method shapes already match the protocols, so no body / no signature changes are needed.

## SearchToolProvider

Two new fields on \`CompositeToolProvider\`:
- \`teaserService: (any Services.Teaser)?\`
- \`unifiedService: (any Services.UnifiedSearcher)?\`

The primary init grows from 4 to 6 params (the two new services on top of the existing 4). The convenience 2-param init constructs all 4 services internally (still used by tests + back-compat).

Two inline per-call constructions move to use the field:
- \`handleSearchAll\`: was \`let unifiedService = Services.UnifiedSearchService(...)\`, now \`guard let unifiedService else { throw ToolError... }\`.
- \`fetchAllTeasers\`: was \`let teaserService = Services.TeaserService(...)\`, now reads the field; returns an empty \`TeaserResults\` snapshot when nil. Behaviour-equivalent: an empty input would have been the result of the inline construction anyway when both seams are nil.

## CLI composition root

\`CLI.Command.Serve.swift\` constructs all 4 service actors from the loaded indexes (when at least one is present) and passes them across the protocol seam. The two convenience-init constructions stay nil when neither searchIndex nor sampleIndex is loaded.

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #408 progress

All 4 services SearchToolProvider needs are now protocol-typed. Inline per-call construction is gone — every service surface is either a field populated at init time or injected through one of the seams.

SearchToolProvider still imports Services for the convenience init that constructs concrete actors from indexes. Removing that convenience init (and the inline construction in it) means moving those 4 lines of construction to a CLI-side helper. Separate slice.