### PR TITLE
refactor(SearchToolProvider): #408 lift 24 formatter files to ServicesModels — closes #408

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -424,11 +424,11 @@ let targets: [Target] = {
 
     let searchToolProviderTarget = Target.target(
         name: "SearchToolProvider",
-        dependencies: ["MCPCore", "MCPSharedTools", "SearchModels", "SampleIndexModels", "ServicesModels", "SharedCore", "SharedConstants", "SharedUtils", "Services"]
+        dependencies: ["MCPCore", "MCPSharedTools", "SearchModels", "SampleIndexModels", "ServicesModels", "SharedCore", "SharedConstants", "SharedUtils"]
     )
     let searchToolProviderTestsTarget = Target.testTarget(
         name: "SearchToolProviderTests",
-        dependencies: ["SearchToolProvider", "SearchModels", "SampleIndexModels", "ServicesModels", "MCPSharedTools", "TestSupport"]
+        dependencies: ["SearchToolProvider", "SearchModels", "SampleIndex", "SampleIndexModels", "Services", "ServicesModels", "MCPSharedTools", "TestSupport"]
     )
 
     let mcpClientTarget = Target.target(
@@ -591,7 +591,7 @@ let targets: [Target] = {
     // CLI Command Test Targets
     let serveTestsTarget = Target.testTarget(
         name: "ServeTests",
-        dependencies: ["CLI", "Crawler", "MCPCore", "MCPSupport", "Search", "SearchModels", "SearchToolProvider", "SharedCore", "TestSupport"],
+        dependencies: ["CLI", "Crawler", "MCPCore", "MCPSupport", "Search", "SearchModels", "SearchToolProvider", "SampleIndex", "SampleIndexModels", "Services", "ServicesModels", "SharedCore", "SharedConstants", "TestSupport"],
         path: "Tests/CLICommandTests/ServeTests"
     )
 

--- a/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
+++ b/Packages/Sources/SearchToolProvider/CompositeToolProvider.swift
@@ -3,7 +3,6 @@ import MCPCore
 import MCPSharedTools
 import SampleIndexModels
 import SearchModels
-import Services
 import ServicesModels
 import SharedConstants
 import SharedCore
@@ -49,34 +48,11 @@ public actor CompositeToolProvider: MCP.Core.ToolProvider {
         self.unifiedService = unifiedService
     }
 
-    /// Convenience init that wraps both indexes with the default service
-    /// implementations. Kept for test harnesses + back-compat with code
-    /// that constructed `CompositeToolProvider` with just the two
-    /// database references. Composition-root code (the CLI's
-    /// `serve` command) should prefer the explicit init above.
-    public init(searchIndex: (any Search.Database)?, sampleDatabase: (any Sample.Index.Reader)?) {
-        let docs = searchIndex.map(Services.DocsSearchService.init(database:))
-        let sample = sampleDatabase.map(Sample.Search.Service.init(database:))
-        // TeaserService + UnifiedSearchService take both seams (some
-        // sources are docs-side, others sample-side). Always constructible
-        // — they internally short-circuit when both inputs are nil.
-        let teaser = Services.TeaserService(
-            searchIndex: searchIndex,
-            sampleDatabase: sampleDatabase
-        )
-        let unified = Services.UnifiedSearchService(
-            searchIndex: searchIndex,
-            sampleDatabase: sampleDatabase
-        )
-        self.init(
-            searchIndex: searchIndex,
-            sampleDatabase: sampleDatabase,
-            docsService: docs,
-            sampleService: sample,
-            teaserService: teaser,
-            unifiedService: unified
-        )
-    }
+    // The two-argument convenience init that constructed concrete
+    // service actors from the index seams moved to the
+    // SearchToolProviderTests target (`CompositeToolProvider+ServicesWiring.swift`).
+    // Production code calls the explicit six-argument init above; that
+    // shape keeps `import Services` out of this file.
 
     // MARK: - ToolProvider
 

--- a/Packages/Sources/ServicesModels/Formatters/Sample.Format.JSON.Search.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Sample.Format.JSON.Search.swift
@@ -1,6 +1,4 @@
-import ServicesModels
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SharedConstants
 import SharedCore

--- a/Packages/Sources/ServicesModels/Formatters/Sample.Format.Markdown.Search.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Sample.Format.Markdown.Search.swift
@@ -1,6 +1,4 @@
-import ServicesModels
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SharedConstants
 import SharedCore

--- a/Packages/Sources/ServicesModels/Formatters/Sample.Format.Text.Search.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Sample.Format.Text.Search.swift
@@ -1,6 +1,4 @@
-import ServicesModels
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SharedConstants
 import SharedCore

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Formattable.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Formattable.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 
 // MARK: - Footer Formattable Protocol

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Item.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Item.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 
 // MARK: - Footer Item

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Kind.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Kind.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 
 // MARK: - Footer Kind

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Markdown.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Markdown.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 
 // MARK: - Footer Markdown Formatter

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Provider.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Provider.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 
 // MARK: - Footer Provider Protocol

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Search.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Search.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SharedConstants
 

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Text.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Footer.Text.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 
 // MARK: - Footer Text Formatter

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Frameworks.JSON.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Frameworks.JSON.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SharedCore
 

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Frameworks.Markdown.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Frameworks.Markdown.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SharedConstants
 import SharedCore

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Frameworks.Text.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Frameworks.Text.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SharedConstants
 import SharedCore

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.HIG.JSON.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.HIG.JSON.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SearchModels
 import SharedCore

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.HIG.Markdown.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.HIG.Markdown.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SearchModels
 import SharedConstants

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.HIG.Text.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.HIG.Text.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SearchModels
 import SharedConstants

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.JSON.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.JSON.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SearchModels
 import SharedCore

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Markdown.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Markdown.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SearchModels
 import SharedConstants

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Result.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Result.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SearchModels
 import SharedCore

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.StringExtensions.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.StringExtensions.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 
 // MARK: - Formatter String Utilities

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Text.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Text.swift
@@ -1,4 +1,3 @@
-import ServicesModels
 import Foundation
 import SearchModels
 import SharedConstants

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Unified.JSON.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Unified.JSON.swift
@@ -1,6 +1,4 @@
-import ServicesModels
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SearchModels
 import SharedConstants

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Unified.Markdown.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Unified.Markdown.swift
@@ -1,6 +1,4 @@
-import ServicesModels
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SearchModels
 import SharedConstants

--- a/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Unified.Text.swift
+++ b/Packages/Sources/ServicesModels/Formatters/Services.Formatter.Unified.Text.swift
@@ -1,6 +1,4 @@
-import ServicesModels
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SearchModels
 import SharedConstants

--- a/Packages/Tests/CLICommandTests/ServeTests/CompositeToolProvider+ServicesWiring.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/CompositeToolProvider+ServicesWiring.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SampleIndex
+import SampleIndexModels
+import SearchModels
+import SearchToolProvider
+import Services
+import ServicesModels
+import SharedConstants
+
+// MARK: - CompositeToolProvider convenience init for ServeTests
+
+/// Mirrors the same-named helper in SearchToolProviderTests. Lives here
+/// because Swift test targets can't share extension files across
+/// directories without playing path tricks. Kept identical to the
+/// SearchToolProviderTests copy so the two test targets share the
+/// same two-arg ergonomics while the production
+/// `CompositeToolProvider` target stays free of `import Services`.
+public extension CompositeToolProvider {
+    init(
+        searchIndex: (any Search.Database)?,
+        sampleDatabase: (any Sample.Index.Reader)?
+    ) {
+        let docs = searchIndex.map(Services.DocsSearchService.init(database:))
+        let sample = sampleDatabase.map(Sample.Search.Service.init(database:))
+        let teaser: (any Services.Teaser)? =
+            (searchIndex == nil && sampleDatabase == nil)
+                ? nil
+                : Services.TeaserService(
+                    searchIndex: searchIndex,
+                    sampleDatabase: sampleDatabase
+                )
+        let unified: (any Services.UnifiedSearcher)? =
+            (searchIndex == nil && sampleDatabase == nil)
+                ? nil
+                : Services.UnifiedSearchService(
+                    searchIndex: searchIndex,
+                    sampleDatabase: sampleDatabase
+                )
+        self.init(
+            searchIndex: searchIndex,
+            sampleDatabase: sampleDatabase,
+            docsService: docs,
+            sampleService: sample,
+            teaserService: teaser,
+            unifiedService: unified
+        )
+    }
+}

--- a/Packages/Tests/SearchToolProviderTests/CompositeToolProvider+ServicesWiring.swift
+++ b/Packages/Tests/SearchToolProviderTests/CompositeToolProvider+ServicesWiring.swift
@@ -1,0 +1,52 @@
+import Foundation
+import SampleIndex
+import SampleIndexModels
+import SearchModels
+import SearchToolProvider
+import Services
+import ServicesModels
+import SharedConstants
+
+// MARK: - CompositeToolProvider convenience init for tests
+
+/// Test-side convenience initializer that wraps a pair of indexes with
+/// the default concrete service implementations and forwards to the
+/// primary protocol-typed init. Lives in the test target so the
+/// production `SearchToolProvider` target doesn't need `import Services`.
+///
+/// 27 existing test callsites (`CupertinoSearchToolProviderTests.swift`)
+/// construct the provider with just `searchIndex:` + `sampleDatabase:`;
+/// this helper preserves that two-argument shape while keeping the
+/// architectural seam clean — production code (the CLI's `serve`
+/// command) uses the 6-argument primary init.
+public extension CompositeToolProvider {
+    init(
+        searchIndex: (any Search.Database)?,
+        sampleDatabase: (any Sample.Index.Reader)?
+    ) {
+        let docs = searchIndex.map(Services.DocsSearchService.init(database:))
+        let sample = sampleDatabase.map(Sample.Search.Service.init(database:))
+        let teaser: (any Services.Teaser)? =
+            (searchIndex == nil && sampleDatabase == nil)
+                ? nil
+                : Services.TeaserService(
+                    searchIndex: searchIndex,
+                    sampleDatabase: sampleDatabase
+                )
+        let unified: (any Services.UnifiedSearcher)? =
+            (searchIndex == nil && sampleDatabase == nil)
+                ? nil
+                : Services.UnifiedSearchService(
+                    searchIndex: searchIndex,
+                    sampleDatabase: sampleDatabase
+                )
+        self.init(
+            searchIndex: searchIndex,
+            sampleDatabase: sampleDatabase,
+            docsService: docs,
+            sampleService: sample,
+            teaserService: teaser,
+            unifiedService: unified
+        )
+    }
+}


### PR DESCRIPTION
The last remaining behavioural import in SearchToolProvider was \`Services\` for the formatter family (Markdown, Text, JSON, HIG.*, Frameworks.*, Unified.*, Footer.*, Sample.Format.*). All 24 formatter files lift to ServicesModels in one mechanical move; they're pure value types (structs conforming to \`Services.Formatter.Result\`) with foundation-only deps.

**After this PR, SearchToolProvider has zero behavioural cross-package imports. #408 closes.**

## File moves

24 files from \`Sources/Services/Formatters/\` → \`Sources/ServicesModels/Formatters/\`:

- \`Services.Formatter.Result.swift\` (the protocol)
- \`Services.Formatter.StringExtensions.swift\` (helpers)
- \`Services.Formatter.{JSON, Markdown, Text}.swift\` (main search renderers)
- \`Services.Formatter.HIG.{JSON, Markdown, Text}.swift\`
- \`Services.Formatter.Frameworks.{JSON, Markdown, Text}.swift\`
- \`Services.Formatter.Unified.{JSON, Markdown, Text}.swift\`
- \`Services.Formatter.Footer.{Formattable, Item, Kind, Markdown, Provider, Search, Text}.swift\`
- \`Sample.Format.{JSON, Markdown, Text}.Search.swift\`

Stale \`import ServicesModels\` (self-import) and \`import SampleIndex\` (replaced by SampleIndexModels) trimmed from each file. Final shared import set: \`Foundation, SampleIndexModels, SearchModels, SharedConstants, SharedCore\`.

## SearchToolProvider

- **Drops \`import Services\`** from \`Sources/SearchToolProvider/CompositeToolProvider.swift\`
- Drops the 2-argument convenience init (which constructed concrete service actors). It moves to the test side as \`CompositeToolProvider+ServicesWiring.swift\` in two copies — one in SearchToolProviderTests, one in ServeTests — so the 30 existing test callsites keep their two-argument shape. The two test-target copies are identical; Swift test targets can't share extension files across directories without path tricks.
- Final production import set (foundation-only): \`Foundation, MCPCore, MCPSharedTools, SampleIndexModels, SearchModels, ServicesModels, SharedConstants, SharedCore, SharedUtils\`

## Package.swift

- SearchToolProvider target drops \`Services\` dep
- SearchToolProviderTests gains \`SampleIndex\` + \`Services\` deps for the test-side wiring helper
- ServeTests gains \`SampleIndex\` + \`SampleIndexModels\` + \`Services\` + \`ServicesModels\` + \`SharedConstants\` deps for the parallel wiring helper
- ServeTests's 3 callsites with the now-removed 2-arg init keep working via the local helper file

## Acceptance grep

\`\`\`
\$ grep -rln '^import Services\$\\|^import SampleIndex\$\\|^import Search\$' Packages/Sources/SearchToolProvider/
(empty)
\`\`\`

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #408 closes

SearchToolProvider's final import set is foundation-layer + Models targets only. The target compiles and tests in isolation; the CLI composition root constructs concrete service actors and passes them across protocol seams (\`DocsSearcher\`, \`Sample.Search.Searcher\`, \`Teaser\`, \`UnifiedSearcher\`).

DI epic #381: **2 of the 3 heavy-tier children now closed** (#400 Search, #408 SearchToolProvider). #403 Indexer remains as the final architectural slice.

Closes #408.