### PR TITLE
refactor(Indexer): #403 PackagesService takes Search.PackageIndexingRun closure

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
@@ -5,6 +5,7 @@ import Foundation
 import Indexer
 import Logging
 import SampleIndex
+import Search
 import SearchModels
 import SharedConstants
 import SharedCore
@@ -136,9 +137,37 @@ extension CLI.Command.Save {
             clear: clear
         )
 
-        _ = try await Indexer.PackagesService.run(request) { event in
+        _ = try await Indexer.PackagesService.run(
+            request,
+            packageIndexingRun: Self.packageIndexingRun
+        ) { event in
             Self.handlePackagesEvent(event)
         }
+    }
+
+    /// Concrete implementation of `Search.PackageIndexingRun` used by
+    /// `Indexer.PackagesService`. Wraps `Search.PackageIndex` +
+    /// `Search.PackageIndexer`. Lives at the CLI composition root so
+    /// the Indexer SPM target doesn't import `Search` for these types.
+    static let packageIndexingRun: Search.PackageIndexingRun = { packagesRoot, packagesDB, onProgress in
+        let startedAt = Date()
+        let index = try await Search.PackageIndex(dbPath: packagesDB)
+        let indexer = Search.PackageIndexer(rootDirectory: packagesRoot, index: index)
+        let stats = try await indexer.indexAll { name, done, total in
+            onProgress(name, done, total)
+        }
+        let summary = try await index.summary()
+        await index.disconnect()
+        return Search.PackageIndexingOutcome(
+            packagesIndexed: stats.packagesIndexed,
+            packagesFailed: stats.packagesFailed,
+            totalFiles: stats.totalFiles,
+            totalBytes: stats.totalBytes,
+            durationSeconds: Date().timeIntervalSince(startedAt),
+            totalPackagesInDB: summary.packageCount,
+            totalFilesInDB: summary.fileCount,
+            totalBytesInDB: summary.bytesIndexed
+        )
     }
 
     static func handlePackagesEvent(_ event: Indexer.PackagesService.Event) {

--- a/Packages/Sources/Indexer/Indexer.PackagesService.swift
+++ b/Packages/Sources/Indexer/Indexer.PackagesService.swift
@@ -1,13 +1,15 @@
 import Foundation
-import Search
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 extension Indexer {
     /// Build `packages.db` from extracted package archives at
-    /// `~/.cupertino/packages/<owner>/<repo>/`. Wraps
-    /// `Search.PackageIndexer` and emits progress events.
+    /// `~/.cupertino/packages/<owner>/<repo>/`. Wraps an injected
+    /// `Search.PackageIndexingRun` closure with event-emission so this
+    /// target doesn't import `Search` directly — the CLI composition
+    /// root supplies a closure backed by `Search.PackageIndex` +
+    /// `Search.PackageIndexer`.
     public enum PackagesService {
         public struct Request: Sendable {
             public let packagesRoot: URL
@@ -45,6 +47,7 @@ extension Indexer {
 
         public static func run(
             _ request: Request,
+            packageIndexingRun: Search.PackageIndexingRun,
             handler: @escaping @Sendable (Event) -> Void = { _ in }
         ) async throws -> Outcome {
             handler(.starting(
@@ -57,25 +60,22 @@ extension Indexer {
                 try FileManager.default.removeItem(at: request.packagesDB)
             }
 
-            let index = try await Search.PackageIndex()
-            let indexer = Search.PackageIndexer(rootDirectory: request.packagesRoot, index: index)
-
-            let stats = try await indexer.indexAll { name, done, total in
+            let result = try await packageIndexingRun(
+                request.packagesRoot,
+                request.packagesDB
+            ) { name, done, total in
                 handler(.progress(name: name, done: done, total: total))
             }
 
-            let summary = try await index.summary()
-            await index.disconnect()
-
             let outcome = Outcome(
-                packagesIndexed: stats.packagesIndexed,
-                packagesFailed: stats.packagesFailed,
-                totalFiles: stats.totalFiles,
-                totalBytes: stats.totalBytes,
-                durationSeconds: stats.durationSeconds,
-                totalPackagesInDB: summary.packageCount,
-                totalFilesInDB: summary.fileCount,
-                totalBytesInDB: summary.bytesIndexed
+                packagesIndexed: result.packagesIndexed,
+                packagesFailed: result.packagesFailed,
+                totalFiles: result.totalFiles,
+                totalBytes: result.totalBytes,
+                durationSeconds: result.durationSeconds,
+                totalPackagesInDB: result.totalPackagesInDB,
+                totalFilesInDB: result.totalFilesInDB,
+                totalBytesInDB: result.totalBytesInDB
             )
             handler(.finished(outcome))
             return outcome

--- a/Packages/Sources/SearchModels/Search.PackageIndexingRun.swift
+++ b/Packages/Sources/SearchModels/Search.PackageIndexingRun.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+// MARK: - Search.PackageIndexingRun
+
+/// Closure shape for running a complete `packages.db` indexing pass:
+/// open the index, walk the on-disk package tree, write every package
+/// row, summarise the resulting database, and disconnect.
+///
+/// `Indexer.PackagesService` accepts one of these instead of reaching
+/// directly into `Search.PackageIndex` + `Search.PackageIndexer`, so
+/// the Indexer SPM target keeps its dependency graph free of the
+/// concrete Search-target actors. The composition root (the CLI's
+/// `save` command) supplies the closure with the standard
+/// `Search.PackageIndex` + `Search.PackageIndexer` wiring.
+///
+/// Mirrors the `MakeSearchDatabase` / `MarkdownToStructuredPage` /
+/// `SampleCatalogFetch` closure-typealias pattern already in
+/// SearchModels: the abstraction lives in this value-types target,
+/// the implementation lives in the producer target, the wiring lives
+/// at the composition root.
+public extension Search {
+    typealias PackageIndexingRun = @Sendable (
+        _ packagesRoot: URL,
+        _ packagesDBPath: URL,
+        _ onProgress: @escaping @Sendable (String, Int, Int) -> Void
+    ) async throws -> PackageIndexingOutcome
+}
+
+// MARK: - Search.PackageIndexingOutcome
+
+/// Statistics emitted by a `Search.PackageIndexingRun` closure.
+///
+/// The Indexer translates this into its public
+/// `Indexer.PackagesService.Outcome` event payload (which keeps the
+/// same eight numeric fields).
+public extension Search {
+    struct PackageIndexingOutcome: Sendable {
+        public let packagesIndexed: Int
+        public let packagesFailed: Int
+        public let totalFiles: Int
+        public let totalBytes: Int64
+        public let durationSeconds: Double
+        public let totalPackagesInDB: Int
+        public let totalFilesInDB: Int
+        public let totalBytesInDB: Int64
+
+        public init(
+            packagesIndexed: Int,
+            packagesFailed: Int,
+            totalFiles: Int,
+            totalBytes: Int64,
+            durationSeconds: Double,
+            totalPackagesInDB: Int,
+            totalFilesInDB: Int,
+            totalBytesInDB: Int64
+        ) {
+            self.packagesIndexed = packagesIndexed
+            self.packagesFailed = packagesFailed
+            self.totalFiles = totalFiles
+            self.totalBytes = totalBytes
+            self.durationSeconds = durationSeconds
+            self.totalPackagesInDB = totalPackagesInDB
+            self.totalFilesInDB = totalFilesInDB
+            self.totalBytesInDB = totalBytesInDB
+        }
+    }
+}


### PR DESCRIPTION
\`Indexer.PackagesService.run\` no longer reaches into \`Search.PackageIndex\` / \`Search.PackageIndexer\` directly. The indexing pass (open index, walk packages, write rows, summarise, disconnect) moves behind a closure typealias defined in SearchModels. The CLI composition root supplies the concrete implementation backed by the Search actors.

Mirrors the \`MakeSearchDatabase\` / \`MarkdownToStructuredPage\` / \`SampleCatalogFetch\` closure-typealias pattern.

## New types in SearchModels

- \`Search.PackageIndexingRun\` typealias: \`@Sendable (URL, URL, @escaping @Sendable (String, Int, Int) -> Void) async throws -> Search.PackageIndexingOutcome\`
- \`Search.PackageIndexingOutcome\` struct (8 numeric stats fields)

Both foundation-layer-only deps (Foundation, no behavioural surface).

## Indexer.PackagesService

The 25-line body that constructed and ran the indexer collapses to a single closure call:

\`\`\`swift
let result = try await packageIndexingRun(
    request.packagesRoot,
    request.packagesDB
) { name, done, total in
    handler(.progress(name: name, done: done, total: total))
}
\`\`\`

\`Indexer.PackagesService\` still owns the \`Request\` / \`Outcome\` / \`Event\` types and the event-emission shape. Only the indexing implementation moved out.

## CLI composition root

\`CLI.Command.Save.Indexers.swift\` gains \`import Search\` and a static \`packageIndexingRun\` closure that wraps \`Search.PackageIndex\` + \`Search.PackageIndexer\`.

## Indexer.PackagesService.swift import set

**Dropped \`import Search\`** — operates entirely through the closure + SearchModels typealias. Final imports: \`Foundation, SearchModels, SharedConstants, SharedCore\`.

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #403 progress

Two services remain inside Indexer that still import behavioural targets:
- \`Indexer.DocsService\` — still imports \`Search\` for \`Search.Index\` + \`Search.IndexBuilder\`
- \`Indexer.SamplesService\` — still imports \`SampleIndex\` + \`CoreSampleCode\` for \`Sample.Index.Database\` + \`Sample.Index.Builder\` + \`Sample.Core.Catalog\`

Each gets the same closure-injection treatment in follow-up slices.