### PR TITLE
refactor(Indexer): #403 DocsService takes Search.DocsIndexingRun closure

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
@@ -39,11 +39,39 @@ extension CLI.Command.Save {
         let outcome = try await Indexer.DocsService.run(
             request,
             markdownToStructuredPage: Core.JSONParser.MarkdownToStructuredPage.convert,
-            sampleCatalogFetch: CLI.Command.Save.sampleCatalogFetch
+            sampleCatalogFetch: CLI.Command.Save.sampleCatalogFetch,
+            docsIndexingRun: CLI.Command.Save.docsIndexingRun
         ) { event in
             Self.handleDocsEvent(event, tracker: tracker)
         }
         Self.printDocsSummary(outcome: outcome)
+    }
+
+    /// Concrete implementation of `Search.DocsIndexingRun` used by
+    /// `Indexer.DocsService`. Wraps `Search.Index` + `Search.IndexBuilder`.
+    /// Lives at the CLI composition root so Indexer doesn't need
+    /// `import Search` for these actor types.
+    static let docsIndexingRun: Search.DocsIndexingRun = { input, onProgress in
+        let searchIndex = try await Search.Index(dbPath: input.searchDBPath)
+        let builder = Search.IndexBuilder(
+            searchIndex: searchIndex,
+            metadata: nil,
+            docsDirectory: input.docsDirectory,
+            evolutionDirectory: input.evolutionDirectory,
+            swiftOrgDirectory: input.swiftOrgDirectory,
+            archiveDirectory: input.archiveDirectory,
+            higDirectory: input.higDirectory,
+            markdownToStructuredPage: input.markdownToStructuredPage,
+            sampleCatalogFetch: input.sampleCatalogFetch
+        )
+        try await builder.buildIndex(clearExisting: input.clearExisting, onProgress: onProgress)
+        let docCount = try await searchIndex.documentCount()
+        let frameworks = try await searchIndex.listFrameworks()
+        await searchIndex.disconnect()
+        return Search.DocsIndexingOutcome(
+            documentCount: docCount,
+            frameworkCount: frameworks.count
+        )
     }
 
     // MARK: - Sample catalog adapter

--- a/Packages/Sources/Indexer/Indexer.DocsService.swift
+++ b/Packages/Sources/Indexer/Indexer.DocsService.swift
@@ -1,14 +1,16 @@
 import Foundation
 import Logging
-import Search
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 extension Indexer {
     /// Build `search.db` from on-disk corpus (apple-docs JSON, swift
-    /// evolution markdown, swift.org, archive, HIG). Wraps
-    /// `Search.IndexBuilder` and emits progress + completion events.
+    /// evolution markdown, swift.org, archive, HIG). Wraps an injected
+    /// `Search.DocsIndexingRun` closure with event-emission so this
+    /// target doesn't import `Search` directly — the CLI composition
+    /// root supplies a closure backed by `Search.Index` +
+    /// `Search.IndexBuilder`.
     public enum DocsService {
         public struct Request: Sendable {
             public let baseDir: URL
@@ -60,6 +62,7 @@ extension Indexer {
             _ request: Request,
             markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage,
             sampleCatalogFetch: @escaping Search.SampleCatalogFetch,
+            docsIndexingRun: Search.DocsIndexingRun,
             handler: @escaping @Sendable (Event) -> Void = { _ in }
         ) async throws -> Outcome {
             let docsURL = request.docsDir
@@ -83,7 +86,6 @@ extension Indexer {
             }
 
             handler(.initializingIndex)
-            let searchIndex = try await Search.Index(dbPath: searchDBURL)
 
             let evolutionDirToUse = optionalDir(evolutionURL, label: "Swift Evolution", handler: handler)
             let swiftOrgDirToUse = optionalDir(swiftOrgURL, label: "Swift.org", handler: handler)
@@ -94,31 +96,27 @@ extension Indexer {
                 handler(.availabilityMissing)
             }
 
-            let builder = Search.IndexBuilder(
-                searchIndex: searchIndex,
-                metadata: nil,
+            let input = Search.DocsIndexingInput(
+                searchDBPath: searchDBURL,
                 docsDirectory: docsURL,
                 evolutionDirectory: evolutionDirToUse,
                 swiftOrgDirectory: swiftOrgDirToUse,
                 archiveDirectory: archiveDirToUse,
                 higDirectory: higDirToUse,
+                clearExisting: request.clear,
                 markdownToStructuredPage: markdownToStructuredPage,
                 sampleCatalogFetch: sampleCatalogFetch
             )
 
-            try await builder.buildIndex(clearExisting: request.clear) { processed, total in
+            let result = try await docsIndexingRun(input) { processed, total in
                 let percent = Double(processed) / Double(total) * 100
                 handler(.progress(processed: processed, total: total, percent: percent))
             }
 
-            let docCount = try await searchIndex.documentCount()
-            let frameworks = try await searchIndex.listFrameworks()
-            await searchIndex.disconnect()
-
             let outcome = Outcome(
                 searchDBPath: searchDBURL,
-                documentCount: docCount,
-                frameworkCount: frameworks.count
+                documentCount: result.documentCount,
+                frameworkCount: result.frameworkCount
             )
             handler(.finished(outcome))
             return outcome

--- a/Packages/Sources/SearchModels/Search.DocsIndexingRun.swift
+++ b/Packages/Sources/SearchModels/Search.DocsIndexingRun.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+// MARK: - Search.DocsIndexingRun
+
+/// Closure shape for running a complete `search.db` documentation
+/// indexing pass: open the index, build the strategy array, walk every
+/// on-disk source directory (apple-docs JSON, Swift Evolution markdown,
+/// Swift.org, Apple Archive, HIG), write rows, and disconnect.
+///
+/// `Indexer.DocsService` accepts one of these instead of reaching
+/// directly into `Search.Index` + `Search.IndexBuilder`, so the
+/// Indexer SPM target keeps its dependency graph free of the
+/// concrete Search-target actors. The composition root (the CLI's
+/// `save` command) supplies the closure with the standard
+/// `Search.Index` + `Search.IndexBuilder` wiring.
+///
+/// Mirrors the `Search.PackageIndexingRun` /
+/// `Search.MarkdownToStructuredPage` / `Search.SampleCatalogFetch` /
+/// `MakeSearchDatabase` closure-typealias pattern already in
+/// SearchModels.
+public extension Search {
+    typealias DocsIndexingRun = @Sendable (
+        _ input: DocsIndexingInput,
+        _ onProgress: @escaping @Sendable (Int, Int) -> Void
+    ) async throws -> DocsIndexingOutcome
+}
+
+// MARK: - Search.DocsIndexingInput
+
+/// Parameter bundle for `Search.DocsIndexingRun`. Carries every URL
+/// the indexer needs to find the source corpus + the two markdown /
+/// sample-catalog closures the indexer threads down into its strategy
+/// implementations.
+public extension Search {
+    struct DocsIndexingInput: Sendable {
+        public let searchDBPath: URL
+        public let docsDirectory: URL
+        public let evolutionDirectory: URL?
+        public let swiftOrgDirectory: URL?
+        public let archiveDirectory: URL?
+        public let higDirectory: URL?
+        public let clearExisting: Bool
+        public let markdownToStructuredPage: Search.MarkdownToStructuredPage
+        public let sampleCatalogFetch: Search.SampleCatalogFetch
+
+        public init(
+            searchDBPath: URL,
+            docsDirectory: URL,
+            evolutionDirectory: URL?,
+            swiftOrgDirectory: URL?,
+            archiveDirectory: URL?,
+            higDirectory: URL?,
+            clearExisting: Bool,
+            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage,
+            sampleCatalogFetch: @escaping Search.SampleCatalogFetch
+        ) {
+            self.searchDBPath = searchDBPath
+            self.docsDirectory = docsDirectory
+            self.evolutionDirectory = evolutionDirectory
+            self.swiftOrgDirectory = swiftOrgDirectory
+            self.archiveDirectory = archiveDirectory
+            self.higDirectory = higDirectory
+            self.clearExisting = clearExisting
+            self.markdownToStructuredPage = markdownToStructuredPage
+            self.sampleCatalogFetch = sampleCatalogFetch
+        }
+    }
+}
+
+// MARK: - Search.DocsIndexingOutcome
+
+/// Statistics emitted by a completed `Search.DocsIndexingRun`. The
+/// Indexer translates this into its public `Indexer.DocsService.Outcome`
+/// event payload.
+public extension Search {
+    struct DocsIndexingOutcome: Sendable {
+        public let documentCount: Int
+        public let frameworkCount: Int
+
+        public init(documentCount: Int, frameworkCount: Int) {
+            self.documentCount = documentCount
+            self.frameworkCount = frameworkCount
+        }
+    }
+}


### PR DESCRIPTION
\`Indexer.DocsService.run\` no longer constructs \`Search.Index\` or \`Search.IndexBuilder\` directly. The whole indexing pass moves behind a \`Search.DocsIndexingRun\` closure typealias in SearchModels; the CLI composition root supplies the concrete implementation backed by the Search actors.

Same pattern as #491 (PackagesService).

## New types in SearchModels

- \`Search.DocsIndexingRun\` typealias: \`@Sendable (DocsIndexingInput, @escaping @Sendable (Int, Int) -> Void) async throws -> DocsIndexingOutcome\`
- \`Search.DocsIndexingInput\` (param bundle: 6 URLs + clearExisting + the markdownToStructuredPage + sampleCatalogFetch closures already threaded through)
- \`Search.DocsIndexingOutcome\` (documentCount + frameworkCount)

The two existing closure typealiases (\`markdownToStructuredPage\`, \`sampleCatalogFetch\`) become fields on \`DocsIndexingInput\` so the run closure carries them through to \`Search.IndexBuilder\` without Indexer having to construct the builder itself.

## Indexer.DocsService

The 40-line body that opened the index, built the strategies, called buildIndex, summarised, and disconnected collapses to:

\`\`\`swift
let input = Search.DocsIndexingInput(...)
let result = try await docsIndexingRun(input) { processed, total in
    handler(.progress(...))
}
\`\`\`

\`Indexer.DocsService\` still owns the \`Request\` / \`Outcome\` / \`Event\` types + the directory resolution + the preflight check. Only the Search-actor construction moved out.

## CLI composition root

\`CLI.Command.Save.Indexers.swift\` gains a static \`docsIndexingRun\` closure that wraps \`Search.Index\` + \`Search.IndexBuilder\`, and passes it to \`Indexer.DocsService.run\`.

## Indexer.DocsService.swift import set

**Dropped \`import Search\`** — DocsService operates through the closure + SearchModels typealias. Final imports: \`Foundation, Logging, SearchModels, SharedConstants, SharedCore\`.

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #403 progress

One service remains inside Indexer that still imports behavioural targets: \`Indexer.SamplesService\` imports \`SampleIndex\` + \`CoreSampleCode\` for \`Sample.Index.Database\` + \`Sample.Index.Builder\` + \`Sample.Core.Catalog\`. Same closure-injection treatment in the next slice closes #403.