### PR TITLE
refactor(Indexer): #403 SamplesService takes Sample.Index.SamplesIndexingRun closure — closes #403, closes #381

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -497,7 +497,7 @@ let targets: [Target] = {
     // ---------- Indexer (#244: SaveCommand indexer + preflight lift) ----------
     let indexerTarget = Target.target(
         name: "Indexer",
-        dependencies: ["SharedCore", "SharedConstants", "SharedUtils", "Search", "SampleIndex", "CoreSampleCode", "Logging"]
+        dependencies: ["SearchModels", "SampleIndexModels", "SharedCore", "SharedConstants", "SharedUtils", "Logging"]
     )
     let indexerTestsTarget = Target.testTarget(
         name: "IndexerTests",

--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
@@ -254,9 +254,86 @@ extension CLI.Command.Save {
         )
 
         let tracker = ProgressTracker()
-        _ = try await Indexer.SamplesService.run(request) { event in
+        _ = try await Indexer.SamplesService.run(
+            request,
+            samplesIndexingRun: CLI.Command.Save.samplesIndexingRun
+        ) { event in
             Self.handleSamplesEvent(event, tracker: tracker)
         }
+    }
+
+    /// Concrete implementation of `Sample.Index.SamplesIndexingRun` used
+    /// by `Indexer.SamplesService`. Wraps `Sample.Index.Database` +
+    /// `Sample.Index.Builder` + `Sample.Core.Catalog`. Lives at the CLI
+    /// composition root so the Indexer SPM target doesn't import
+    /// SampleIndex or CoreSampleCode for these types.
+    static let samplesIndexingRun: Sample.Index.SamplesIndexingRun = { input, onPhase in
+        let database = try await Sample.Index.Database(dbPath: input.samplesDB)
+        if input.clear {
+            onPhase(.clearingExistingIndex)
+            try await database.clearAll()
+        }
+
+        let existingProjects = try await database.projectCount()
+        let existingFiles = try await database.fileCount()
+        if existingProjects > 0, !input.force, !input.clear {
+            onPhase(.existingIndexNotice(projects: existingProjects, files: existingFiles))
+        }
+
+        onPhase(.loadingCatalog)
+        let catalogEntries = await Sample.Core.Catalog.allEntries
+        onPhase(.catalogLoaded(entryCount: catalogEntries.count))
+
+        let entries = catalogEntries.map { entry in
+            Sample.Index.SampleCodeEntryInfo(
+                title: entry.title,
+                description: entry.description,
+                frameworks: [entry.framework],
+                webURL: entry.webURL,
+                zipFilename: entry.zipFilename
+            )
+        }
+
+        onPhase(.indexingStart)
+        let builder = Sample.Index.Builder(
+            database: database,
+            sampleCodeDirectory: input.sampleCodeDir
+        )
+
+        let startTime = Date()
+        let indexed = try await builder.indexAll(
+            entries: entries,
+            forceReindex: input.force
+        ) { progress in
+            let phase: Sample.Index.SamplesIndexingPhase.ProgressPhase
+            switch progress.status {
+            case .extracting: phase = .extracting
+            case .indexingFiles: phase = .indexingFiles
+            case .completed: phase = .completed
+            case .failed: phase = .failed
+            }
+            onPhase(.projectProgress(
+                name: progress.currentProject,
+                percent: progress.percentComplete,
+                phase: phase
+            ))
+        }
+
+        let duration = Date().timeIntervalSince(startTime)
+
+        let finalProjects = try await database.projectCount()
+        let finalFiles = try await database.fileCount()
+        let finalSymbols = try await database.symbolCount()
+        let finalImports = try await database.importCount()
+
+        return Sample.Index.SamplesIndexingOutcome(
+            projectsIndexedThisRun: indexed,
+            projectsTotal: finalProjects,
+            filesTotal: finalFiles,
+            symbolsTotal: finalSymbols,
+            importsTotal: finalImports,
+            durationSeconds: duration
+        )
     }
 
     static func handleSamplesEvent(

--- a/Packages/Sources/Indexer/Indexer.SamplesService.swift
+++ b/Packages/Sources/Indexer/Indexer.SamplesService.swift
@@ -1,13 +1,16 @@
-import CoreSampleCode
 import Foundation
-import SampleIndex
+import SampleIndexModels
 import SharedConstants
 import SharedCore
 
 extension Indexer {
     /// Build `samples.db` from extracted sample-code zips at
-    /// `~/.cupertino/sample-code/`. Wraps `Sample.Index.Builder` and emits
-    /// progress events.
+    /// `~/.cupertino/sample-code/`. Wraps an injected
+    /// `Sample.Index.SamplesIndexingRun` closure with event-emission
+    /// so this target doesn't import `SampleIndex` or `CoreSampleCode`
+    /// directly — the CLI composition root supplies a closure backed
+    /// by `Sample.Index.Database` + `Sample.Index.Builder` +
+    /// `Sample.Core.Catalog`.
     public enum SamplesService {
         public struct Request: Sendable {
             public let sampleCodeDir: URL
@@ -16,8 +19,8 @@ extension Indexer {
             public let force: Bool
 
             public init(
-                sampleCodeDir: URL = Sample.Index.defaultSampleCodeDirectory,
-                samplesDB: URL = Sample.Index.defaultDatabasePath,
+                sampleCodeDir: URL,
+                samplesDB: URL,
                 clear: Bool = false,
                 force: Bool = false
             ) {
@@ -70,6 +73,7 @@ extension Indexer {
 
         public static func run(
             _ request: Request,
+            samplesIndexingRun: Sample.Index.SamplesIndexingRun,
             handler: @escaping @Sendable (Event) -> Void = { _ in }
         ) async throws -> Outcome {
             handler(.starting(
@@ -88,72 +92,45 @@ extension Indexer {
                 try FileManager.default.removeItem(at: request.samplesDB)
             }
 
-            let database = try await Sample.Index.Database(dbPath: request.samplesDB)
-            if request.clear {
-                handler(.clearingExistingIndex)
-                try await database.clearAll()
-            }
-
-            let existingProjects = try await database.projectCount()
-            let existingFiles = try await database.fileCount()
-            if existingProjects > 0, !request.force, !request.clear {
-                handler(.existingIndexNotice(projects: existingProjects, files: existingFiles))
-            }
-
-            handler(.loadingCatalog)
-            let catalogEntries = await Sample.Core.Catalog.allEntries
-            handler(.catalogLoaded(entryCount: catalogEntries.count))
-
-            let entries = catalogEntries.map { entry in
-                Sample.Index.SampleCodeEntryInfo(
-                    title: entry.title,
-                    description: entry.description,
-                    frameworks: [entry.framework],
-                    webURL: entry.webURL,
-                    zipFilename: entry.zipFilename
-                )
-            }
-
-            handler(.indexingStart)
-            let builder = Sample.Index.Builder(
-                database: database,
-                sampleCodeDirectory: request.sampleCodeDir
+            let input = Sample.Index.SamplesIndexingInput(
+                sampleCodeDir: request.sampleCodeDir,
+                samplesDB: request.samplesDB,
+                clear: request.clear,
+                force: request.force
             )
 
-            let startTime = Date()
-            let indexed = try await builder.indexAll(
-                entries: entries,
-                forceReindex: request.force
-            ) { progress in
-                let phase: Event.Phase
-                switch progress.status {
-                case .extracting: phase = .extracting
-                case .indexingFiles: phase = .indexingFiles
-                case .completed: phase = .completed
-                case .failed: phase = .failed
+            let result = try await samplesIndexingRun(input) { phase in
+                switch phase {
+                case .clearingExistingIndex:
+                    handler(.clearingExistingIndex)
+                case .existingIndexNotice(let projects, let files):
+                    handler(.existingIndexNotice(projects: projects, files: files))
+                case .loadingCatalog:
+                    handler(.loadingCatalog)
+                case .catalogLoaded(let entryCount):
+                    handler(.catalogLoaded(entryCount: entryCount))
+                case .indexingStart:
+                    handler(.indexingStart)
+                case .projectProgress(let name, let percent, let p):
+                    let mapped: Event.Phase
+                    switch p {
+                    case .extracting: mapped = .extracting
+                    case .indexingFiles: mapped = .indexingFiles
+                    case .completed: mapped = .completed
+                    case .failed: mapped = .failed
+                    }
+                    handler(.projectProgress(name: name, percent: percent, phase: mapped))
                 }
-                handler(.projectProgress(
-                    name: progress.currentProject,
-                    percent: progress.percentComplete,
-                    phase: phase
-                ))
             }
-
-            let duration = Date().timeIntervalSince(startTime)
-
-            let finalProjects = try await database.projectCount()
-            let finalFiles = try await database.fileCount()
-            let finalSymbols = try await database.symbolCount()
-            let finalImports = try await database.importCount()
 
             let outcome = Outcome(
                 samplesDBPath: request.samplesDB,
-                projectsIndexedThisRun: indexed,
-                projectsTotal: finalProjects,
-                filesTotal: finalFiles,
-                symbolsTotal: finalSymbols,
-                importsTotal: finalImports,
-                durationSeconds: duration
+                projectsIndexedThisRun: result.projectsIndexedThisRun,
+                projectsTotal: result.projectsTotal,
+                filesTotal: result.filesTotal,
+                symbolsTotal: result.symbolsTotal,
+                importsTotal: result.importsTotal,
+                durationSeconds: result.durationSeconds
             )
             handler(.finished(outcome))
             return outcome

--- a/Packages/Sources/SampleIndexModels/Sample.Index.SamplesIndexingRun.swift
+++ b/Packages/Sources/SampleIndexModels/Sample.Index.SamplesIndexingRun.swift
@@ -1,0 +1,108 @@
+import Foundation
+import SharedConstants
+
+// MARK: - Sample.Index.SamplesIndexingRun
+
+/// Closure shape for running a complete `samples.db` indexing pass:
+/// open the database, optionally clear it, load the sample-code
+/// catalog, walk the on-disk sample ZIPs, write project + file +
+/// symbol rows, and close. The closure also emits lifecycle events
+/// through the supplied `onPhase` callback so `Indexer.SamplesService`
+/// can forward them to its `Event` API without inspecting the
+/// indexer's internals.
+///
+/// `Indexer.SamplesService` accepts one of these instead of reaching
+/// directly into `Sample.Index.Database` / `Sample.Index.Builder` /
+/// `Sample.Core.Catalog`. The composition root (the CLI's `save`
+/// command) supplies the closure with the standard concrete wiring.
+///
+/// Mirrors the `Search.DocsIndexingRun` / `Search.PackageIndexingRun`
+/// pattern.
+public extension Sample.Index {
+    typealias SamplesIndexingRun = @Sendable (
+        _ input: SamplesIndexingInput,
+        _ onPhase: @escaping @Sendable (SamplesIndexingPhase) -> Void
+    ) async throws -> SamplesIndexingOutcome
+}
+
+// MARK: - Sample.Index.SamplesIndexingInput
+
+/// Parameter bundle for `Sample.Index.SamplesIndexingRun`. Mirrors
+/// `Indexer.SamplesService.Request` field-for-field; the Indexer
+/// service translates one to the other.
+public extension Sample.Index {
+    struct SamplesIndexingInput: Sendable {
+        public let sampleCodeDir: URL
+        public let samplesDB: URL
+        public let clear: Bool
+        public let force: Bool
+
+        public init(
+            sampleCodeDir: URL,
+            samplesDB: URL,
+            clear: Bool,
+            force: Bool
+        ) {
+            self.sampleCodeDir = sampleCodeDir
+            self.samplesDB = samplesDB
+            self.clear = clear
+            self.force = force
+        }
+    }
+}
+
+// MARK: - Sample.Index.SamplesIndexingPhase
+
+/// Lifecycle events emitted by a `Sample.Index.SamplesIndexingRun`
+/// closure. Indexer.SamplesService translates each phase into its
+/// matching public `Event` case (`.clearingExistingIndex`,
+/// `.existingIndexNotice(...)`, `.loadingCatalog`,
+/// `.catalogLoaded(entryCount:)`, `.indexingStart`,
+/// `.projectProgress(name:percent:phase:)`).
+public extension Sample.Index {
+    enum SamplesIndexingPhase: Sendable {
+        case clearingExistingIndex
+        case existingIndexNotice(projects: Int, files: Int)
+        case loadingCatalog
+        case catalogLoaded(entryCount: Int)
+        case indexingStart
+        case projectProgress(name: String, percent: Double, phase: ProgressPhase)
+
+        public enum ProgressPhase: String, Sendable {
+            case extracting
+            case indexingFiles
+            case completed
+            case failed
+        }
+    }
+}
+
+// MARK: - Sample.Index.SamplesIndexingOutcome
+
+/// Statistics emitted by a completed `Sample.Index.SamplesIndexingRun`.
+public extension Sample.Index {
+    struct SamplesIndexingOutcome: Sendable {
+        public let projectsIndexedThisRun: Int
+        public let projectsTotal: Int
+        public let filesTotal: Int
+        public let symbolsTotal: Int
+        public let importsTotal: Int
+        public let durationSeconds: Double
+
+        public init(
+            projectsIndexedThisRun: Int,
+            projectsTotal: Int,
+            filesTotal: Int,
+            symbolsTotal: Int,
+            importsTotal: Int,
+            durationSeconds: Double
+        ) {
+            self.projectsIndexedThisRun = projectsIndexedThisRun
+            self.projectsTotal = projectsTotal
+            self.filesTotal = filesTotal
+            self.symbolsTotal = symbolsTotal
+            self.importsTotal = importsTotal
+            self.durationSeconds = durationSeconds
+        }
+    }
+}


### PR DESCRIPTION
Final slice of the Indexer DI work. \`Indexer.SamplesService\` no longer constructs \`Sample.Index.Database\` / \`Sample.Index.Builder\` / \`Sample.Core.Catalog\` directly. The indexing pass moves behind a \`Sample.Index.SamplesIndexingRun\` closure typealias in SampleIndexModels; the CLI composition root supplies the concrete implementation backed by the SampleIndex + CoreSampleCode actors.

**After this PR, Indexer target imports only foundation-layer + Models targets. #403 closes. The DI epic ring (#381) is fully closed: all 27 children done.**

## New types in SampleIndexModels

- \`Sample.Index.SamplesIndexingRun\` typealias: \`@Sendable (SamplesIndexingInput, @escaping @Sendable (SamplesIndexingPhase) -> Void) async throws -> SamplesIndexingOutcome\`
- \`Sample.Index.SamplesIndexingInput\` (param bundle: sampleCodeDir, samplesDB, clear, force)
- \`Sample.Index.SamplesIndexingPhase\` enum (6 phase cases the closure emits)
- \`Sample.Index.SamplesIndexingOutcome\` (6 stat fields the closure returns)

## Indexer.SamplesService

The 60-line body that opened the database, loaded the catalog, mapped entries, built the indexer, ran indexAll, and queried final counts collapses to a closure call. \`Indexer.SamplesService\` still owns the Request / Outcome / Event types + the \`.starting\` / \`.removingExistingDB\` / \`.finished\` orchestration. The closure handles all Sample.* interactions and emits per-phase events that Indexer maps to its own Event surface.

## Request init breaking change

The default-arg URLs (\`Sample.Index.defaultSampleCodeDirectory\` + \`Sample.Index.defaultDatabasePath\`) dropped from \`Indexer.SamplesService.Request\` init — callers must supply paths explicitly. CLI is the only caller and it already constructs both URLs from Shared.Constants paths before the request.

## CLI composition root

\`CLI.Command.Save.Indexers.swift\` gains a static \`samplesIndexingRun\` closure that wraps \`Sample.Index.Database\` + \`Sample.Index.Builder\` + \`Sample.Core.Catalog\`.

## Indexer target deps + imports

\`Indexer.SamplesService.swift\`: drops \`import SampleIndex\` + \`import CoreSampleCode\`. Final imports: \`Foundation, SampleIndexModels, SharedConstants, SharedCore\`.

Package.swift Indexer target deps: **dropped \`Search\`, \`SampleIndex\`, \`CoreSampleCode\`.** Final deps: \`SearchModels, SampleIndexModels, SharedCore, SharedConstants, SharedUtils, Logging\`.

## Acceptance

\`\`\`
\$ grep -rln '^import Search\$\\|^import SampleIndex\$\\|^import CoreSampleCode\$\\|^import Core\$' Packages/Sources/Indexer/
(empty)
\`\`\`

## Verification

\`\`\`
xcrun swift build  # clean
xcrun swift test   # 1441 tests in 161 suites pass
\`\`\`

## #403 + #381 close

Indexer's final import set: \`Foundation, Logging, SampleIndexModels, SearchModels, SharedConstants, SharedCore, SharedUtils\`.

Foundation + Logging + 4 Models targets. The Indexer SPM target compiles, tests, and reasons about itself without depending on any internal cupertino package for behaviour — composition lives at the CLI, every cross-package surface flows through a closure typealias in a Models target.

**DI epic #381: all 27 children closed.**

Closes #403.
Closes #381.