### PR TITLE
refactor(di): convert MakeSearchDatabase closure to Search.DatabaseFactory protocol (1/8)

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -376,7 +376,18 @@ let targets: [Target] = {
     )
     let searchTestsTarget = Target.testTarget(
         name: "SearchTests",
-        dependencies: ["Search", "SearchModels", "SharedCore", "SharedConstants", "SharedModels", "SharedUtils", "TestSupport", "CorePackageIndexingModels", "ASTIndexer", "SampleIndex"]
+        dependencies: [
+            "Search",
+            "SearchModels",
+            "SharedCore",
+            "SharedConstants",
+            "SharedModels",
+            "SharedUtils",
+            "TestSupport",
+            "CorePackageIndexingModels",
+            "ASTIndexer",
+            "SampleIndex",
+        ]
     )
 
     let sampleIndexTarget = Target.target(
@@ -591,7 +602,22 @@ let targets: [Target] = {
     // CLI Command Test Targets
     let serveTestsTarget = Target.testTarget(
         name: "ServeTests",
-        dependencies: ["CLI", "Crawler", "MCPCore", "MCPSupport", "Search", "SearchModels", "SearchToolProvider", "SampleIndex", "SampleIndexModels", "Services", "ServicesModels", "SharedCore", "SharedConstants", "TestSupport"],
+        dependencies: [
+            "CLI",
+            "Crawler",
+            "MCPCore",
+            "MCPSupport",
+            "Search",
+            "SearchModels",
+            "SearchToolProvider",
+            "SampleIndex",
+            "SampleIndexModels",
+            "Services",
+            "ServicesModels",
+            "SharedCore",
+            "SharedConstants",
+            "TestSupport",
+        ],
         path: "Tests/CLICommandTests/ServeTests"
     )
 

--- a/Packages/Sources/CLI/Commands/CLI.Command.Doctor.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Doctor.swift
@@ -10,11 +10,11 @@ import MCPCore
 import MCPSupport
 import SampleIndex
 import Search
+import SearchModels
 import SearchToolProvider
 import SharedConstants
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - Doctor Command
 

--- a/Packages/Sources/CLI/Commands/CLI.Command.ListFrameworks.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.ListFrameworks.swift
@@ -1,8 +1,8 @@
-import ServicesModels
 import ArgumentParser
 import Foundation
 import Logging
 import Services
+import ServicesModels
 import SharedCore
 
 // MARK: - List Frameworks Command
@@ -30,7 +30,7 @@ extension CLI.Command {
 
         mutating func run() async throws {
             // Use Services.ServiceContainer for managed lifecycle
-            let (frameworks, totalDocs) = try await Services.ServiceContainer.withDocsService(dbPath: searchDb, makeSearchDatabase: makeSearchDatabase) { service in
+            let (frameworks, totalDocs) = try await Services.ServiceContainer.withDocsService(dbPath: searchDb, searchDatabaseFactory: searchDatabaseFactory) { service in
                 let frameworks = try await service.listFrameworks()
                 let totalDocs = try await service.documentCount()
                 return (frameworks, totalDocs)

--- a/Packages/Sources/CLI/Commands/CLI.Command.ListSamples.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.ListSamples.swift
@@ -1,9 +1,9 @@
-import ServicesModels
 import ArgumentParser
 import Foundation
 import Logging
 import SampleIndex
 import Services
+import ServicesModels
 import SharedConstants
 import SharedCore
 import SharedUtils

--- a/Packages/Sources/CLI/Commands/CLI.Command.PackageSearch.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.PackageSearch.swift
@@ -2,10 +2,10 @@ import ArgumentParser
 import Foundation
 import Logging
 import Search
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - Package Search Command (hidden)
 

--- a/Packages/Sources/CLI/Commands/CLI.Command.Read.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Read.swift
@@ -1,13 +1,13 @@
-import ServicesModels
 import ArgumentParser
 import Foundation
 import Logging
 import SampleIndex
 import Search
+import SearchModels
 import Services
+import ServicesModels
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - Read Command (unified, #239 follow-up)
 
@@ -87,7 +87,7 @@ extension CLI.Command {
                     searchDB: searchDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
                     samplesDB: sampleDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
                     packagesDB: packagesDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
-                    makeSearchDatabase: makeSearchDatabase,
+                    searchDatabaseFactory: searchDatabaseFactory,
                     packageFileLookup: { dbURL, owner, repo, relpath in
                         // The Search.PackageQuery actor is the production
                         // packages.db reader. CLI wires it in here so

--- a/Packages/Sources/CLI/Commands/CLI.Command.ReadSample.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.ReadSample.swift
@@ -1,9 +1,9 @@
-import ServicesModels
 import ArgumentParser
 import Foundation
 import Logging
 import SampleIndex
 import Services
+import ServicesModels
 import SharedConstants
 import SharedCore
 import SharedUtils

--- a/Packages/Sources/CLI/Commands/CLI.Command.ReadSampleFile.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.ReadSampleFile.swift
@@ -1,9 +1,9 @@
-import ServicesModels
 import ArgumentParser
 import Foundation
 import Logging
 import SampleIndex
 import Services
+import ServicesModels
 import SharedConstants
 import SharedCore
 import SharedUtils

--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.swift
@@ -5,10 +5,10 @@ import Logging
 import RemoteSync
 import SampleIndex
 import Search
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - Save Command
 
@@ -251,7 +251,7 @@ extension CLI.Command.Save {
                     lastCrawled: Date(),
                     sourceType: source,
                     packageId: nil,
-                    jsonData: jsonData,
+                    jsonData: jsonData
                 ))
             },
             onProgress: { progress in

--- a/Packages/Sources/CLI/Commands/CLI.Command.Search.SmartReport.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Search.SmartReport.swift
@@ -1,14 +1,14 @@
-import ServicesModels
 import ArgumentParser
 import Foundation
 import Logging
 import SampleIndex
 import Search
+import SearchModels
 import Services
+import ServicesModels
 import SharedConstants
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - SmartQuery fan-out helpers (#239)
 

--- a/Packages/Sources/CLI/Commands/CLI.Command.Search.SourceRunners.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Search.SourceRunners.swift
@@ -1,13 +1,13 @@
-import ServicesModels
 import ArgumentParser
 import Foundation
 import Logging
 import Search
+import SearchModels
 import Services
+import ServicesModels
 import SharedConstants
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - Per-source runners
 
@@ -17,7 +17,7 @@ import SearchModels
 /// `CLI.Command.Search+SmartReport.swift` (#239).
 extension CLI.Command.Search {
     func runDocsSearch() async throws {
-        let results = try await Services.ServiceContainer.withDocsService(dbPath: searchDb, makeSearchDatabase: makeSearchDatabase) { service in
+        let results = try await Services.ServiceContainer.withDocsService(dbPath: searchDb, searchDatabaseFactory: searchDatabaseFactory) { service in
             try await service.search(Services.SearchQuery(
                 text: query,
                 source: source,
@@ -36,7 +36,7 @@ extension CLI.Command.Search {
         let teasers = try await Services.ServiceContainer.withTeaserService(
             searchDbPath: searchDb,
             sampleDbPath: resolveSampleDbPath(),
-            makeSearchDatabase: makeSearchDatabase,
+            searchDatabaseFactory: searchDatabaseFactory
         ) { service in
             await service.fetchAllTeasers(
                 query: query,
@@ -98,7 +98,7 @@ extension CLI.Command.Search {
             teasers = try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: searchDb,
                 sampleDbPath: resolveSampleDbPath(),
-                makeSearchDatabase: makeSearchDatabase,
+                searchDatabaseFactory: searchDatabaseFactory
             ) { service in
                 await service.fetchAllTeasers(
                     query: query,
@@ -177,7 +177,7 @@ extension CLI.Command.Search {
     }
 
     func runHIGSearch() async throws {
-        let results = try await Services.ServiceContainer.withDocsService(dbPath: searchDb, makeSearchDatabase: makeSearchDatabase) { service in
+        let results = try await Services.ServiceContainer.withDocsService(dbPath: searchDb, searchDatabaseFactory: searchDatabaseFactory) { service in
             try await service.search(Services.SearchQuery(
                 text: query,
                 source: Shared.Constants.SourcePrefix.hig,
@@ -191,7 +191,7 @@ extension CLI.Command.Search {
         let teasers = try await Services.ServiceContainer.withTeaserService(
             searchDbPath: searchDb,
             sampleDbPath: resolveSampleDbPath(),
-            makeSearchDatabase: makeSearchDatabase,
+            searchDatabaseFactory: searchDatabaseFactory
         ) { service in
             await service.fetchAllTeasers(
                 query: query,

--- a/Packages/Sources/CLI/Commands/CLI.Command.Search.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Search.swift
@@ -1,14 +1,14 @@
-import ServicesModels
 import ArgumentParser
 import Foundation
 import Logging
 import SampleIndex
 import Search
+import SearchModels
 import Services
+import ServicesModels
 import SharedConstants
 import SharedCore
 import SharedUtils
-import SearchModels
 
 // MARK: - Search Command
 

--- a/Packages/Sources/CLI/SearchModuleAlias.swift
+++ b/Packages/Sources/CLI/SearchModuleAlias.swift
@@ -1,8 +1,8 @@
-import ServicesModels
 import Foundation
 import Search
 import SearchModels
 import Services
+import ServicesModels
 
 // MARK: - Search Module Disambiguator
 
@@ -19,13 +19,20 @@ import Services
 
 typealias SearchModule = Search
 
-// MARK: - Production Search.Database Factory
+// MARK: - Production Search.DatabaseFactory
 
-// The factory closure CLI threads into every `Services.ServiceContainer.with*Service`
-// call. Production wiring: open a `SearchModule.Index` at the resolved path —
-// `Search.Index` conforms to `Search.Database` (the protocol in SearchModels) so
-// the concrete actor flows through Services' protocol-typed inits unchanged.
-// One declaration covers every with*Service call site in CLI.
-let makeSearchDatabase: Services.ServiceContainer.MakeSearchDatabase = { dbURL in
-    try await SearchModule.Index(dbPath: dbURL)
+// Concrete `Search.DatabaseFactory` (GoF Factory Method) wired into every
+// `Services.ServiceContainer.with*Service` and `Services.ReadService` call.
+// Production wiring opens a `SearchModule.Index` at the resolved path —
+// `Search.Index` conforms to `Search.Database` (the protocol in SearchModels)
+// so the concrete actor flows through Services' protocol-typed inits
+// unchanged. One declaration covers every callsite in CLI; tests substitute a
+// mock conforming to `Search.DatabaseFactory`.
+
+struct LiveSearchDatabaseFactory: Search.DatabaseFactory {
+    func openDatabase(at url: URL) async throws -> any Search.Database {
+        try await SearchModule.Index(dbPath: url)
+    }
 }
+
+let searchDatabaseFactory: any Search.DatabaseFactory = LiveSearchDatabaseFactory()

--- a/Packages/Sources/Search/CandidateFetcher.swift
+++ b/Packages/Sources/Search/CandidateFetcher.swift
@@ -1,7 +1,7 @@
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - Smart-query abstraction (#192 section E)
 

--- a/Packages/Sources/Search/DocKind.swift
+++ b/Packages/Sources/Search/DocKind.swift
@@ -15,10 +15,10 @@
 // and a corresponding case to `DocKind`.
 
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedModels
-import SearchModels
 
 extension Search {
     /// High-level document-shape taxonomy stored per row in `docs_metadata`.

--- a/Packages/Sources/Search/Search.ComposableResult.swift
+++ b/Packages/Sources/Search/Search.ComposableResult.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable function_body_length
 import Foundation
-import SharedConstants
 import SearchModels
+import SharedConstants
 
 /// Sample.Search (in SharedConstants) shadows the Search SPM target inside any
 /// extension Sample {} scope. Pin the SPM target so Sample.Atom.source can still

--- a/Packages/Sources/Search/Search.Index.CodeExamples.swift
+++ b/Packages/Sources/Search/Search.Index.CodeExamples.swift
@@ -1,9 +1,9 @@
 import Foundation
-import SharedUtils
+import SearchModels
 import SharedConstants
 import SharedCore
+import SharedUtils
 import SQLite3
-import SearchModels
 
 // swiftlint:disable function_body_length
 // Justification: extracted from SearchIndex.swift; the original 4598-line

--- a/Packages/Sources/Search/Search.Index.ContentAndPackages.swift
+++ b/Packages/Sources/Search/Search.Index.ContentAndPackages.swift
@@ -1,9 +1,9 @@
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedModels
 import SQLite3
-import SearchModels
 
 // swiftlint:disable function_body_length
 // Justification: extracted from SearchIndex.swift; the original 4598-line

--- a/Packages/Sources/Search/Search.Index.CountsAndAliases.swift
+++ b/Packages/Sources/Search/Search.Index.CountsAndAliases.swift
@@ -1,9 +1,9 @@
 import Foundation
-import SharedConstants
-import SharedUtils
-import SharedCore
-import SQLite3
 import SearchModels
+import SharedConstants
+import SharedCore
+import SharedUtils
+import SQLite3
 
 extension Search.Index {
     public func symbolCount() async throws -> Int {

--- a/Packages/Sources/Search/Search.Index.Helpers.swift
+++ b/Packages/Sources/Search/Search.Index.Helpers.swift
@@ -1,8 +1,8 @@
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
 import SQLite3
-import SearchModels
 
 extension Search.Index {
     func detectLanguage(from content: String) -> String {

--- a/Packages/Sources/Search/Search.Index.IndexDocumentParams.swift
+++ b/Packages/Sources/Search/Search.Index.IndexDocumentParams.swift
@@ -53,7 +53,7 @@ extension Search.Index {
             minTvOS: String? = nil,
             minWatchOS: String? = nil,
             minVisionOS: String? = nil,
-            availabilitySource: String? = nil,
+            availabilitySource: String? = nil
         ) {
             self.uri = uri
             self.source = source

--- a/Packages/Sources/Search/Search.Index.Indexing.swift
+++ b/Packages/Sources/Search/Search.Index.Indexing.swift
@@ -1,8 +1,8 @@
 import ASTIndexer
 import Foundation
+import SearchModels
 import SharedCore
 import SQLite3
-import SearchModels
 
 // swiftlint:disable function_parameter_count
 // Justification: extracted from SearchIndex.swift; the original 4598-line

--- a/Packages/Sources/Search/Search.Index.IndexingDocs.swift
+++ b/Packages/Sources/Search/Search.Index.IndexingDocs.swift
@@ -1,10 +1,10 @@
 import ASTIndexer
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedModels
 import SQLite3
-import SearchModels
 
 // swiftlint:disable function_body_length function_parameter_count
 // Justification: extracted from SearchIndex.swift; the original 4598-line
@@ -182,7 +182,7 @@ extension Search.Index {
                 minTvOS: item.minTvOS,
                 minWatchOS: item.minWatchOS,
                 minVisionOS: item.minVisionOS,
-                availabilitySource: item.availabilitySource,
+                availabilitySource: item.availabilitySource
             ))
             return
         }
@@ -214,7 +214,7 @@ extension Search.Index {
             minTvOS: processedItem.minTvOS,
             minWatchOS: processedItem.minWatchOS,
             minVisionOS: processedItem.minVisionOS,
-            availabilitySource: processedItem.availabilitySource,
+            availabilitySource: processedItem.availabilitySource
         ))
 
         // Extract and index AST symbols if enabled

--- a/Packages/Sources/Search/Search.Index.Migrations.swift
+++ b/Packages/Sources/Search/Search.Index.Migrations.swift
@@ -1,8 +1,8 @@
 import Foundation
+import SearchModels
 import SharedCore
 import SharedModels
 import SQLite3
-import SearchModels
 
 extension Search.Index {
     func getSchemaVersion() -> Int32 {

--- a/Packages/Sources/Search/Search.Index.QueryParsing.swift
+++ b/Packages/Sources/Search/Search.Index.QueryParsing.swift
@@ -1,7 +1,7 @@
 import Foundation
+import SearchModels
 import SharedCore
 import SQLite3
-import SearchModels
 
 extension Search.Index {
     func extractSourcePrefix(_ query: String) -> (source: String?, remainingQuery: String) {

--- a/Packages/Sources/Search/Search.Index.Schema.swift
+++ b/Packages/Sources/Search/Search.Index.Schema.swift
@@ -1,7 +1,7 @@
 import Foundation
+import SearchModels
 import SharedCore
 import SQLite3
-import SearchModels
 
 // swiftlint:disable function_body_length
 // Justification: extracted from SearchIndex.swift; the original 4598-line

--- a/Packages/Sources/Search/Search.Index.Search.swift
+++ b/Packages/Sources/Search/Search.Index.Search.swift
@@ -1,8 +1,8 @@
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
 import SQLite3
-import SearchModels
 
 // swiftlint:disable function_body_length file_length
 // Justification: extracted from SearchIndex.swift; the original 4598-line

--- a/Packages/Sources/Search/Search.Index.SearchByAttribute.swift
+++ b/Packages/Sources/Search/Search.Index.SearchByAttribute.swift
@@ -1,8 +1,8 @@
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
 import SQLite3
-import SearchModels
 
 extension Search.Index {
     /// Get full JSON data for a document

--- a/Packages/Sources/Search/Search.Index.SemanticSearch.swift
+++ b/Packages/Sources/Search/Search.Index.SemanticSearch.swift
@@ -1,8 +1,8 @@
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
 import SQLite3
-import SearchModels
 
 // swiftlint:disable function_body_length
 // Justification: extracted from SearchIndex.swift; the original 4598-line

--- a/Packages/Sources/Search/Search.Index.swift
+++ b/Packages/Sources/Search/Search.Index.swift
@@ -1,10 +1,10 @@
 import ASTIndexer
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedModels
 import SQLite3
-import SearchModels
 
 // MARK: - Search Index
 

--- a/Packages/Sources/Search/Search.PackageQuery.swift
+++ b/Packages/Sources/Search/Search.PackageQuery.swift
@@ -1,8 +1,8 @@
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
 import SQLite3
-import SearchModels
 
 extension Search {
     // MARK: - Public API

--- a/Packages/Sources/Search/Search.SearchResult.swift
+++ b/Packages/Sources/Search/Search.SearchResult.swift
@@ -1,7 +1,7 @@
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - Framework Availability (Search Module)
 

--- a/Packages/Sources/Search/Search.SourceDefinition.swift
+++ b/Packages/Sources/Search/Search.SourceDefinition.swift
@@ -1,7 +1,7 @@
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - Source Definition
 

--- a/Packages/Sources/Search/Search.SourceIndexer.swift
+++ b/Packages/Sources/Search/Search.SourceIndexer.swift
@@ -1,8 +1,8 @@
 import ASTIndexer
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - Source Item
 

--- a/Packages/Sources/Search/SmartQuery.swift
+++ b/Packages/Sources/Search/SmartQuery.swift
@@ -1,7 +1,7 @@
 import Foundation
+import SearchModels
 import SharedConstants
 import SharedCore
-import SearchModels
 
 // MARK: - Smart cross-source query (#192 section E)
 

--- a/Packages/Sources/Search/Strategies/Search.Strategies.AppleArchive.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.AppleArchive.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Logging
+import SearchModels
 import SharedConstants
 import SharedModels
-import SearchModels
 
 // MARK: - AppleArchiveStrategy
 
@@ -118,7 +118,7 @@ extension Search {
                         minTvOS: availability.minTvOS,
                         minWatchOS: availability.minWatchOS,
                         minVisionOS: availability.minVisionOS,
-                        availabilitySource: availability.minIOS != nil ? "framework" : nil,
+                        availabilitySource: availability.minIOS != nil ? "framework" : nil
                     ))
                     indexed += 1
                 } catch {

--- a/Packages/Sources/Search/Strategies/Search.Strategies.AppleDocs.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.AppleDocs.swift
@@ -79,7 +79,7 @@ extension Search {
             progress: Search.IndexingProgressCallback?
         ) async throws -> Search.IndexStats {
             // Always use the directory-scan path; metadata is for crawling, not indexing.
-            return try await indexFromDirectory(into: index, progress: progress)
+            try await indexFromDirectory(into: index, progress: progress)
         }
 
         // MARK: - Directory-Scan Path
@@ -137,7 +137,7 @@ extension Search {
                 ) else {
                     Logging.Log.error(
                         "❌ Could not extract framework from path: \(file.path) " +
-                        "(relative to \(docsDirectory.path))",
+                            "(relative to \(docsDirectory.path))",
                         category: .search
                     )
                     skipped += 1
@@ -172,7 +172,7 @@ extension Search {
                     }
                     let pageURL = URL(
                         string: "\(Shared.Constants.BaseURL.appleDeveloperDocs)\(framework)/" +
-                                "\(file.deletingPathExtension().lastPathComponent)"
+                            "\(file.deletingPathExtension().lastPathComponent)"
                     )
                     guard let converted = markdownToStructuredPage(mdContent, pageURL) else {
                         Logging.Log.error(
@@ -201,8 +201,8 @@ extension Search {
                 if Search.StrategyHelpers.titleLooksLikeHTTPErrorTemplate(structuredPage.title) {
                     Logging.Log.error(
                         "⛔ Skipping HTTP-error-template page (#284 indexer defence): " +
-                        "title=\(structuredPage.title.prefix(60)) " +
-                        "file=\(file.lastPathComponent)",
+                            "title=\(structuredPage.title.prefix(60)) " +
+                            "file=\(file.lastPathComponent)",
                         category: .search
                     )
                     skipped += 1
@@ -211,8 +211,8 @@ extension Search {
                 if Search.StrategyHelpers.pageLooksLikeJavaScriptFallback(structuredPage) {
                     Logging.Log.error(
                         "⛔ Skipping JS-disabled-fallback page (#284 indexer defence): " +
-                        "title=\(structuredPage.title.prefix(60)) " +
-                        "file=\(file.lastPathComponent)",
+                            "title=\(structuredPage.title.prefix(60)) " +
+                            "file=\(file.lastPathComponent)",
                         category: .search
                     )
                     skipped += 1
@@ -257,7 +257,7 @@ extension Search {
                     progress?(idx + 1, docFiles.count)
                     Logging.Log.info(
                         "   Progress: \(idx + 1)/\(docFiles.count) " +
-                        "(\(indexed) indexed, \(skipped) skipped)",
+                            "(\(indexed) indexed, \(skipped) skipped)",
                         category: .search
                     )
                 }
@@ -325,7 +325,7 @@ extension Search {
                 let title = Search.StrategyHelpers.extractTitle(from: content)
                     ?? Shared.Models.URLUtilities.filename(from: parsedURL)
                 let uri = "apple-docs://\(pageMetadata.framework)/" +
-                          "\(Shared.Models.URLUtilities.filename(from: parsedURL))"
+                    "\(Shared.Models.URLUtilities.filename(from: parsedURL))"
 
                 do {
                     try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -336,7 +336,7 @@ extension Search {
                         content: content,
                         filePath: pageMetadata.filePath,
                         contentHash: pageMetadata.contentHash,
-                        lastCrawled: pageMetadata.lastCrawled,
+                        lastCrawled: pageMetadata.lastCrawled
                     ))
                     indexed += 1
                 } catch {
@@ -351,7 +351,7 @@ extension Search {
                     progress?(processed, total)
                     Logging.Log.info(
                         "   Progress: \(processed)/\(total) " +
-                        "(\(indexed) indexed, \(skipped) skipped)",
+                            "(\(indexed) indexed, \(skipped) skipped)",
                         category: .search
                     )
                 }

--- a/Packages/Sources/Search/Strategies/Search.Strategies.HIG.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.HIG.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Logging
+import SearchModels
 import SharedConstants
 import SharedModels
-import SearchModels
 
 // MARK: - HIGStrategy
 
@@ -107,7 +107,7 @@ extension Search {
                         minTvOS: "9.0",
                         minWatchOS: "2.0",
                         minVisionOS: "1.0",
-                        availabilitySource: "universal",
+                        availabilitySource: "universal"
                     ))
                     indexed += 1
                 } catch {

--- a/Packages/Sources/Search/Strategies/Search.Strategies.SwiftEvolution.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.SwiftEvolution.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Logging
+import SearchModels
 import SharedConstants
 import SharedModels
-import SearchModels
 
 // MARK: - SwiftEvolutionStrategy
 
@@ -123,15 +123,16 @@ extension Search {
             )
             return files.filter {
                 $0.pathExtension == "md" &&
-                ($0.lastPathComponent.hasPrefix(Shared.Constants.Search.sePrefix) ||
-                 $0.lastPathComponent.hasPrefix(Shared.Constants.Search.stPrefix))
+                    ($0.lastPathComponent.hasPrefix(Shared.Constants.Search.sePrefix) ||
+                        $0.lastPathComponent.hasPrefix(Shared.Constants.Search.stPrefix))
             }
         }
 
         /// Write a single proposal to the index.
         ///
         /// Extracts the proposal ID from the filename, derives a Swift-version-based
-        /// availability range, and calls ``Search/Index/indexDocument(uri:source:framework:title:content:filePath:contentHash:lastCrawled:minIOS:minMacOS:minTvOS:minWatchOS:minVisionOS:availabilitySource:)``.
+        /// availability range, and calls
+        /// ``Search/Index/indexDocument(uri:source:framework:title:content:filePath:contentHash:lastCrawled:minIOS:minMacOS:minTvOS:minWatchOS:minVisionOS:availabilitySource:)``.
         ///
         /// - Parameters:
         ///   - file: The proposal `.md` file URL.
@@ -165,7 +166,7 @@ extension Search {
                 lastCrawled: modDate,
                 minIOS: availability.iOS,
                 minMacOS: availability.macOS,
-                availabilitySource: availability.iOS != nil ? "swift-version" : nil,
+                availabilitySource: availability.iOS != nil ? "swift-version" : nil
             ))
         }
     }

--- a/Packages/Sources/Search/Strategies/Search.Strategies.SwiftOrg.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.SwiftOrg.swift
@@ -127,7 +127,7 @@ extension Search {
                     }
                     let pageURL = URL(
                         string: "https://www.swift.org/documentation/" +
-                                "\(file.deletingPathExtension().lastPathComponent)"
+                            "\(file.deletingPathExtension().lastPathComponent)"
                     )
                     guard let converted = markdownToStructuredPage(mdContent, pageURL) else {
                         Logging.Log.error(

--- a/Packages/Sources/SearchModels/Search.Database.swift
+++ b/Packages/Sources/SearchModels/Search.Database.swift
@@ -39,7 +39,7 @@ extension Search {
             minMacOS: String?,
             minTvOS: String?,
             minWatchOS: String?,
-            minVisionOS: String?,
+            minVisionOS: String?
         ) async throws -> [Search.Result]
 
         /// Fetch the pre-rendered document content for a URI.
@@ -66,7 +66,7 @@ extension Search {
             kind: String?,
             isAsync: Bool?,
             framework: String?,
-            limit: Int,
+            limit: Int
         ) async throws -> [Search.SymbolSearchResult]
 
         /// Semantic search for property-wrapper attributes (e.g. `@Observable`,
@@ -74,7 +74,7 @@ extension Search {
         func searchPropertyWrappers(
             wrapper: String,
             framework: String?,
-            limit: Int,
+            limit: Int
         ) async throws -> [Search.SymbolSearchResult]
 
         /// Semantic search for Swift concurrency patterns
@@ -82,14 +82,14 @@ extension Search {
         func searchConcurrencyPatterns(
             pattern: String,
             framework: String?,
-            limit: Int,
+            limit: Int
         ) async throws -> [Search.SymbolSearchResult]
 
         /// Semantic search for types by protocol conformance.
         func searchConformances(
             protocolName: String,
             framework: String?,
-            limit: Int,
+            limit: Int
         ) async throws -> [Search.SymbolSearchResult]
     }
 }
@@ -106,7 +106,7 @@ extension Search.Database {
         framework: String? = nil,
         language: String? = nil,
         limit: Int = Shared.Constants.Limit.defaultSearchLimit,
-        includeArchive: Bool = false,
+        includeArchive: Bool = false
     ) async throws -> [Search.Result] {
         try await search(
             query: query,
@@ -119,7 +119,7 @@ extension Search.Database {
             minMacOS: nil,
             minTvOS: nil,
             minWatchOS: nil,
-            minVisionOS: nil,
+            minVisionOS: nil
         )
     }
 }

--- a/Packages/Sources/SearchModels/Search.DatabaseFactory.swift
+++ b/Packages/Sources/SearchModels/Search.DatabaseFactory.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+// MARK: - Search.DatabaseFactory
+
+/// Factory abstraction for opening a `Search.Database`-conforming
+/// actor from a file URL. GoF Factory Method, Swift-idiomatic
+/// expression.
+///
+/// The composition root (the CLI binary) supplies a concrete factory
+/// that opens the production `Search.Index` actor; tests supply a
+/// mock that returns a stub or throws on demand. Consumers
+/// (`Services.ServiceContainer.with*Service` static methods,
+/// `Services.ReadService`) depend on this protocol rather than on a
+/// `@Sendable (URL) async throws -> any Search.Database` closure so
+/// the contract is named, the injection point is named, and the
+/// captured-state surface is explicit (it lives on the conforming
+/// type's stored properties, not in a closure's implicit capture
+/// list).
+///
+/// This is the GoF Factory Method pattern in Swift:
+/// - "Product" = `any Search.Database`
+/// - "Creator" = `Search.DatabaseFactory` protocol (this file)
+/// - "ConcreteCreator" = `LiveSearchDatabaseFactory` in the CLI (or a
+///   `MockSearchDatabaseFactory` in tests)
+extension Search {
+    public protocol DatabaseFactory: Sendable {
+        /// Open (or create) a `Search.Database` at `url`. The
+        /// concrete factory decides which actor to instantiate.
+        func openDatabase(at url: URL) async throws -> any Search.Database
+    }
+}

--- a/Packages/Sources/SearchModels/Search.PlatformAvailability.swift
+++ b/Packages/Sources/SearchModels/Search.PlatformAvailability.swift
@@ -18,7 +18,7 @@ extension Search {
             introducedAt: String? = nil,
             deprecated: Bool = false,
             unavailable: Bool = false,
-            beta: Bool = false,
+            beta: Bool = false
         ) {
             self.name = name
             self.introducedAt = introducedAt

--- a/Packages/Sources/SearchModels/Search.Result.swift
+++ b/Packages/Sources/SearchModels/Search.Result.swift
@@ -35,7 +35,7 @@ extension Search {
             wordCount: Int,
             rank: Double,
             availability: [Search.PlatformAvailability]? = nil,
-            matchedSymbols: [MatchedSymbol]? = nil,
+            matchedSymbols: [MatchedSymbol]? = nil
         ) {
             self.id = id
             self.uri = uri

--- a/Packages/Sources/SearchModels/Search.SmartCandidate.swift
+++ b/Packages/Sources/SearchModels/Search.SmartCandidate.swift
@@ -37,7 +37,7 @@ extension Search {
             chunk: String,
             rawScore: Double,
             kind: String? = nil,
-            metadata: [String: String] = [:],
+            metadata: [String: String] = [:]
         ) {
             self.source = source
             self.identifier = identifier

--- a/Packages/Sources/SearchModels/Search.SymbolSearchResult.swift
+++ b/Packages/Sources/SearchModels/Search.SymbolSearchResult.swift
@@ -31,7 +31,7 @@ extension Search {
             attributes: String?,
             conformances: String?,
             isAsync: Bool,
-            isPublic: Bool,
+            isPublic: Bool
         ) {
             self.docUri = docUri
             self.docTitle = docTitle

--- a/Packages/Sources/Services/ReadCommands/Services.DocsSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.DocsSearchService.swift
@@ -1,6 +1,6 @@
-import ServicesModels
 import Foundation
 import SearchModels
+import ServicesModels
 import SharedConstants
 import SharedCore
 

--- a/Packages/Sources/Services/ReadCommands/Services.ReadService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.ReadService.swift
@@ -1,7 +1,7 @@
-import ServicesModels
 import Foundation
 import SampleIndex
 import SearchModels
+import ServicesModels
 import SharedConstants
 import SharedCore
 
@@ -89,7 +89,7 @@ extension Services {
             searchDB: URL?,
             samplesDB: URL?,
             packagesDB: URL?,
-            makeSearchDatabase: Services.ServiceContainer.MakeSearchDatabase,
+            searchDatabaseFactory: any Search.DatabaseFactory,
             packageFileLookup: PackageFileLookup
         ) async throws -> Result {
             if let explicit {
@@ -101,7 +101,7 @@ extension Services {
                     samplesDB: samplesDB,
                     packagesDB: packagesDB,
                     allowFallback: false,
-                    makeSearchDatabase: makeSearchDatabase,
+                    searchDatabaseFactory: searchDatabaseFactory,
                     packageFileLookup: packageFileLookup
                 )
             }
@@ -115,7 +115,7 @@ extension Services {
                     samplesDB: samplesDB,
                     packagesDB: packagesDB,
                     allowFallback: false,
-                    makeSearchDatabase: makeSearchDatabase,
+                    searchDatabaseFactory: searchDatabaseFactory,
                     packageFileLookup: packageFileLookup
                 )
             }
@@ -129,7 +129,7 @@ extension Services {
                     samplesDB: samplesDB,
                     packagesDB: packagesDB,
                     allowFallback: true,
-                    makeSearchDatabase: makeSearchDatabase,
+                    searchDatabaseFactory: searchDatabaseFactory,
                     packageFileLookup: packageFileLookup
                 )
             } catch ReadError.samplesNotFound, ReadError.packagesNotFound,
@@ -144,7 +144,7 @@ extension Services {
                 samplesDB: samplesDB,
                 packagesDB: packagesDB,
                 allowFallback: false,
-                makeSearchDatabase: makeSearchDatabase,
+                searchDatabaseFactory: searchDatabaseFactory,
                 packageFileLookup: packageFileLookup
             )
         }
@@ -159,7 +159,7 @@ extension Services {
             samplesDB: URL?,
             packagesDB: URL?,
             allowFallback: Bool,
-            makeSearchDatabase: Services.ServiceContainer.MakeSearchDatabase,
+            searchDatabaseFactory: any Search.DatabaseFactory,
             packageFileLookup: PackageFileLookup
         ) async throws -> Result {
             switch source {
@@ -168,7 +168,7 @@ extension Services {
                     identifier: identifier,
                     format: format,
                     searchDB: searchDB,
-                    makeSearchDatabase: makeSearchDatabase
+                    searchDatabaseFactory: searchDatabaseFactory
                 )
             case .samples:
                 return try await readFromSamples(
@@ -191,11 +191,11 @@ extension Services {
             identifier: String,
             format: Search.DocumentFormat,
             searchDB: URL?,
-            makeSearchDatabase: Services.ServiceContainer.MakeSearchDatabase
+            searchDatabaseFactory: any Search.DatabaseFactory
         ) async throws -> Result {
             let content = try await Services.ServiceContainer.withDocsService(
                 dbPath: searchDB?.path,
-                makeSearchDatabase: makeSearchDatabase
+                searchDatabaseFactory: searchDatabaseFactory
             ) { service in
                 try await service.read(uri: identifier, format: format)
             }

--- a/Packages/Sources/Services/ReadCommands/Services.TeaserService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.TeaserService.swift
@@ -1,8 +1,8 @@
-import ServicesModels
 import Foundation
 import SampleIndex
 import SampleIndexModels
 import SearchModels
+import ServicesModels
 import SharedConstants
 import SharedCore
 import SharedUtils

--- a/Packages/Sources/Services/ReadCommands/Services.UnifiedSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.UnifiedSearchService.swift
@@ -1,8 +1,8 @@
-import ServicesModels
 import Foundation
 import SampleIndex
 import SampleIndexModels
 import SearchModels
+import ServicesModels
 import SharedConstants
 import SharedCore
 import SharedUtils

--- a/Packages/Sources/Services/Services.ServiceContainer.swift
+++ b/Packages/Sources/Services/Services.ServiceContainer.swift
@@ -1,7 +1,7 @@
-import ServicesModels
 import Foundation
 import SampleIndex
 import SearchModels
+import ServicesModels
 import SharedConstants
 import SharedCore
 import SharedUtils
@@ -16,24 +16,20 @@ import SharedUtils
 /// command.
 ///
 /// The container does not import the Search target. Every search-side
-/// database (`Search.Index`) is constructed by an injected factory
-/// closure (`makeSearchDatabase`) that callers wire from the
-/// composition root — CLI typically passes
-/// `{ try await Search.Index(dbPath: $0) }`.
+/// database (`Search.Index`) is constructed by an injected
+/// `Search.DatabaseFactory` (GoF Factory Method) that callers wire
+/// from the composition root: CLI supplies a concrete
+/// `LiveSearchDatabaseFactory` whose `openDatabase(at:)` opens a real
+/// `Search.Index` actor; tests supply a mock conforming type.
 extension Services {
     public enum ServiceContainer {
-        /// Closure signature for opening a `Search.Database` from a URL.
-        /// CLI passes `{ try await Search.Index(dbPath: $0) }`; tests
-        /// can pass a fake.
-        public typealias MakeSearchDatabase = @Sendable (URL) async throws -> any Search.Database
-
         // MARK: - Convenience Factory Methods
 
         /// Execute an operation with a docs service, handling lifecycle.
         public static func withDocsService<T>(
             dbPath: String? = nil,
-            makeSearchDatabase: MakeSearchDatabase,
-            operation: (Services.DocsSearchService) async throws -> T,
+            searchDatabaseFactory: any Search.DatabaseFactory,
+            operation: (Services.DocsSearchService) async throws -> T
         ) async throws -> T {
             let resolvedPath = Shared.Utils.PathResolver.searchDatabase(dbPath)
 
@@ -41,7 +37,7 @@ extension Services {
                 throw Shared.Core.ToolError.noData("Search database not found at \(resolvedPath.path). Run 'cupertino save' to build the index.")
             }
 
-            let database = try await makeSearchDatabase(resolvedPath)
+            let database = try await searchDatabaseFactory.openDatabase(at: resolvedPath)
             let service = Services.DocsSearchService(database: database)
             defer {
                 Task {
@@ -59,7 +55,7 @@ extension Services {
         /// not Search.
         public static func withSampleService<T: Sendable>(
             dbPath: URL,
-            operation: (Sample.Search.Service) async throws -> T,
+            operation: (Sample.Search.Service) async throws -> T
         ) async throws -> T {
             guard Shared.Utils.PathResolver.exists(dbPath) else {
                 throw Shared.Core.ToolError.noData("Sample database not found at \(dbPath.path). Run 'cupertino save --samples' to build the index.")
@@ -79,22 +75,22 @@ extension Services {
         public static func withTeaserService<T: Sendable>(
             searchDbPath: String? = nil,
             sampleDbPath: URL? = nil,
-            makeSearchDatabase: MakeSearchDatabase,
-            operation: (Services.TeaserService) async throws -> T,
+            searchDatabaseFactory: any Search.DatabaseFactory,
+            operation: (Services.TeaserService) async throws -> T
         ) async throws -> T {
             let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
             let resolvedSamplePath = sampleDbPath ?? Sample.Index.defaultDatabasePath
 
             let searchIndex: (any Search.Database)?
             if Shared.Utils.PathResolver.exists(resolvedSearchPath) {
-                searchIndex = try await makeSearchDatabase(resolvedSearchPath)
+                searchIndex = try await searchDatabaseFactory.openDatabase(at: resolvedSearchPath)
             } else {
                 searchIndex = nil
             }
 
             let service = try await Services.TeaserService(
                 searchIndex: searchIndex,
-                sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil,
+                sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil
             )
 
             return try await operation(service)
@@ -105,22 +101,22 @@ extension Services {
         public static func withUnifiedSearchService<T: Sendable>(
             searchDbPath: String? = nil,
             sampleDbPath: URL? = nil,
-            makeSearchDatabase: MakeSearchDatabase,
-            operation: (Services.UnifiedSearchService) async throws -> T,
+            searchDatabaseFactory: any Search.DatabaseFactory,
+            operation: (Services.UnifiedSearchService) async throws -> T
         ) async throws -> T {
             let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
             let resolvedSamplePath = sampleDbPath ?? Sample.Index.defaultDatabasePath
 
             let searchIndex: (any Search.Database)?
             if Shared.Utils.PathResolver.exists(resolvedSearchPath) {
-                searchIndex = try await makeSearchDatabase(resolvedSearchPath)
+                searchIndex = try await searchDatabaseFactory.openDatabase(at: resolvedSearchPath)
             } else {
                 searchIndex = nil
             }
 
             let service = try await Services.UnifiedSearchService(
                 searchIndex: searchIndex,
-                sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil,
+                sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil
             )
 
             return try await operation(service)

--- a/Packages/Tests/ASTIndexerTests/ASTIndexerPublicSurfaceTests.swift
+++ b/Packages/Tests/ASTIndexerTests/ASTIndexerPublicSurfaceTests.swift
@@ -90,7 +90,7 @@ struct ASTIndexerPublicSurfaceTests {
             isStatic: false,
             attributes: ["@MainActor"],
             conformances: [],
-            genericParameters: [],
+            genericParameters: []
         )
         #expect(symbol.name == "View")
         #expect(symbol.kind == .protocol)

--- a/Packages/Tests/AvailabilityTests/AvailabilityTests.swift
+++ b/Packages/Tests/AvailabilityTests/AvailabilityTests.swift
@@ -583,21 +583,21 @@ struct FetcherBuildAPIURLTests {
     )
 
     @Test("strips /documentation/ prefix, lowercases path, and appends .json")
-    func stripsDocumentationPrefix() async {
-        let docURL = URL(string: "https://developer.apple.com/documentation/SwiftUI/View")!
+    func stripsDocumentationPrefix() async throws {
+        let docURL = try #require(URL(string: "https://developer.apple.com/documentation/SwiftUI/View"))
         let result = await defaultFetcher.buildAPIURL(from: docURL)
         #expect(result.absoluteString == "https://developer.apple.com/tutorials/data/documentation/swiftui/view.json")
     }
 
     @Test("handles mixed-case framework and symbol names")
-    func mixedCasePath() async {
-        let docURL = URL(string: "https://developer.apple.com/documentation/Foundation/URL")!
+    func mixedCasePath() async throws {
+        let docURL = try #require(URL(string: "https://developer.apple.com/documentation/Foundation/URL"))
         let result = await defaultFetcher.buildAPIURL(from: docURL)
         #expect(result.absoluteString == "https://developer.apple.com/tutorials/data/documentation/foundation/url.json")
     }
 
     @Test("custom apiBaseURL is used in constructed URL")
-    func customBaseURL() async {
+    func customBaseURL() async throws {
         let config = Availability.Fetcher.Configuration(
             apiBaseURL: "https://custom.example.com/data/documentation"
         )
@@ -605,14 +605,14 @@ struct FetcherBuildAPIURLTests {
             docsDirectory: URL(fileURLWithPath: "/tmp"),
             configuration: config
         )
-        let docURL = URL(string: "https://developer.apple.com/documentation/Combine/Publisher")!
+        let docURL = try #require(URL(string: "https://developer.apple.com/documentation/Combine/Publisher"))
         let result = await fetcher.buildAPIURL(from: docURL)
         #expect(result.absoluteString == "https://custom.example.com/data/documentation/combine/publisher.json")
     }
 
     @Test("always produces a URL ending in .json")
-    func alwaysEndsInJSON() async {
-        let docURL = URL(string: "https://developer.apple.com/documentation/SwiftUI")!
+    func alwaysEndsInJSON() async throws {
+        let docURL = try #require(URL(string: "https://developer.apple.com/documentation/SwiftUI"))
         let result = await defaultFetcher.buildAPIURL(from: docURL)
         #expect(result.absoluteString.hasSuffix(".json"))
     }

--- a/Packages/Tests/CLICommandTests/DoctorTests/DoctorTests.swift
+++ b/Packages/Tests/CLICommandTests/DoctorTests/DoctorTests.swift
@@ -1,4 +1,3 @@
-import SearchModels
 @testable import CLI
 import Core
 import CoreProtocols
@@ -7,6 +6,7 @@ import Foundation
 import MCPCore
 import MCPSupport
 import Search
+import SearchModels
 import SharedCore
 import SQLite3
 import Testing

--- a/Packages/Tests/CLICommandTests/FetchTests/CrawlTests.swift
+++ b/Packages/Tests/CLICommandTests/FetchTests/CrawlTests.swift
@@ -1,4 +1,3 @@
-import SearchModels
 import AppKit
 @testable import CLI
 @testable import Core
@@ -6,6 +5,7 @@ import CoreProtocols
 import Crawler
 import Foundation
 @testable import Search
+import SearchModels
 import SharedConfiguration
 import SharedConstants
 @testable import SharedCore

--- a/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
+++ b/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
@@ -1,4 +1,3 @@
-import SearchModels
 import AppKit
 @testable import CLI
 @testable import Core
@@ -6,6 +5,7 @@ import CoreProtocols
 import Crawler
 import Foundation
 @testable import Search
+import SearchModels
 import SharedConfiguration
 import SharedConstants
 @testable import SharedCore

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -1,4 +1,3 @@
-import SearchModels
 import AppKit
 @testable import Core
 import CoreProtocols
@@ -7,6 +6,7 @@ import Foundation
 @testable import MCPCore
 @testable import MCPSupport
 @testable import Search
+import SearchModels
 @testable import SearchToolProvider
 import SharedConfiguration
 import SharedConstants
@@ -155,8 +155,8 @@ struct MCPCommandTests {
             content: "Swift is a powerful programming language for iOS, macOS, and more.",
             filePath: "/test/swift.md",
             contentHash: "test-hash",
-            lastCrawled: Date(),
-            ))
+            lastCrawled: Date()
+        ))
 
         let server = MCP.Core.Server(name: "test-server", version: "1.0.0")
         let provider = CompositeToolProvider(searchIndex: searchIndex, sampleDatabase: nil)
@@ -200,8 +200,8 @@ struct MCPCommandTests {
             content: "An ordered, random-access collection of elements.",
             filePath: "/test/array.md",
             contentHash: "test-hash-array",
-            lastCrawled: Date(),
-            ))
+            lastCrawled: Date()
+        ))
 
         let provider = CompositeToolProvider(searchIndex: searchIndex, sampleDatabase: nil)
 

--- a/Packages/Tests/CoreJSONParserTests/CoreJSONParserTests.swift
+++ b/Packages/Tests/CoreJSONParserTests/CoreJSONParserTests.swift
@@ -1,5 +1,5 @@
-import CoreProtocols
 @testable import CoreJSONParser
+import CoreProtocols
 import Foundation
 import Testing
 

--- a/Packages/Tests/CoreProtocolsTests/CoreProtocolsTests.swift
+++ b/Packages/Tests/CoreProtocolsTests/CoreProtocolsTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import CoreProtocols
+import Foundation
 import Resources
 import SharedConstants
 import SharedCore
@@ -47,7 +47,7 @@ struct CoreProtocolsPublicSurfaceTests {
         let result = Core.Protocols.FetchResult(
             content: "hello",
             url: url,
-            responseHeaders: ["Content-Type": "text/html"],
+            responseHeaders: ["Content-Type": "text/html"]
         )
         #expect(result.content == "hello")
         #expect(result.url == url)
@@ -71,14 +71,14 @@ struct CoreProtocolsPublicSurfaceTests {
             description: "Description",
             framework: "SwiftUI",
             platforms: ["iOS"],
-            isDeprecated: false,
+            isDeprecated: false
         )
         let url = try #require(URL(string: "https://developer.apple.com/documentation/swiftui/view"))
         let result = Core.Protocols.TransformResult(
             markdown: "# View",
             links: [url],
             metadata: metadata,
-            structuredPage: nil,
+            structuredPage: nil
         )
         #expect(result.markdown == "# View")
         #expect(result.links == [url])
@@ -115,7 +115,7 @@ struct CoreProtocolsPublicSurfaceTests {
     }
 
     @Test("Core.Protocols.GitHubCanonicalizer primes and snapshots its cache")
-    func gitHubCanonicalizerCachePrimeAndSnapshot() async throws {
+    func gitHubCanonicalizerCachePrimeAndSnapshot() async {
         // Don't write to disk for a smoke test; the actor accepts any
         // cache URL and only persists on demand.
         let cacheURL = FileManager.default.temporaryDirectory
@@ -125,7 +125,7 @@ struct CoreProtocolsPublicSurfaceTests {
             inputOwner: "Mihaela",
             inputRepo: "Cupertino",
             canonicalOwner: "mihaelamj",
-            canonicalRepo: "cupertino",
+            canonicalRepo: "cupertino"
         )
         let snapshot = await canonicalizer.cacheSnapshot()
         // The snapshot key shape (input owner+repo lowercased) is an

--- a/Packages/Tests/CrawlerTests/Crawler.AppleDocs.IntegrationTests.swift
+++ b/Packages/Tests/CrawlerTests/Crawler.AppleDocs.IntegrationTests.swift
@@ -26,7 +26,6 @@ import TestSupport
 // CupertinoCoreTests pre-extraction is preserved verbatim. No
 // behavioural change.
 
-
 // MARK: - Integration Tests
 
 /// Integration test: Downloads a real Apple documentation page
@@ -658,4 +657,3 @@ func crawlerStateAutoSaveInterval() async throws {
     #expect(modDate1 == modDate2)
     print("   ✅ Auto-save respects interval (file not modified)")
 }
-

--- a/Packages/Tests/LoggingTests/LoggingPublicSurfaceTests.swift
+++ b/Packages/Tests/LoggingTests/LoggingPublicSurfaceTests.swift
@@ -141,7 +141,7 @@ struct LoggingPublicSurfaceTests {
             fileURL: URL(fileURLWithPath: "/tmp/cupertino-test.log"),
             minLevel: .warning,
             showTimestamps: false,
-            showCategory: true,
+            showCategory: true
         )
         #expect(opts.consoleEnabled == false)
         #expect(opts.fileEnabled == true)
@@ -166,7 +166,7 @@ struct LoggingPublicSurfaceTests {
             fileURL: nil,
             minLevel: .error,
             showTimestamps: false,
-            showCategory: false,
+            showCategory: false
         )
         await Logging.Unified.shared.configure(opts)
         // Reset to default so we don't pollute follow-on tests.

--- a/Packages/Tests/SampleIndexModelsTests/SampleIndexModelsTests.swift
+++ b/Packages/Tests/SampleIndexModelsTests/SampleIndexModelsTests.swift
@@ -25,8 +25,8 @@ struct SampleIndexModelsTests {
             webURL: "https://developer.apple.com/sample/swiftui-essentials",
             zipFilename: "swiftui-essentials.zip",
             fileCount: 42,
-            totalSize: 1_234_567,
-            indexedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            totalSize: 1234567,
+            indexedAt: Date(timeIntervalSince1970: 1700000000),
             deploymentTargets: ["ios": "17.0", "macos": "14.0"],
             availabilitySource: "sample-swift"
         )

--- a/Packages/Tests/SearchModelsTests/SearchModelsTests.swift
+++ b/Packages/Tests/SearchModelsTests/SearchModelsTests.swift
@@ -33,7 +33,7 @@ struct SearchModelsPublicSurfaceTests {
             introducedAt: "15.0",
             deprecated: false,
             unavailable: false,
-            beta: false,
+            beta: false
         )
         #expect(availability.name == "iOS")
         #expect(availability.introducedAt == "15.0")
@@ -61,7 +61,7 @@ struct SearchModelsPublicSurfaceTests {
             kind: "func",
             name: "scaledFont",
             signature: "scaledFont(for:)",
-            isAsync: false,
+            isAsync: false
         )
         // The signature path is what fans out into search-result
         // rendering; pin the format so a refactor doesn't drop the
@@ -106,7 +106,7 @@ struct SearchModelsPublicSurfaceTests {
             wordCount: 100,
             rank: -1.5,
             availability: [availability],
-            matchedSymbols: [symbol],
+            matchedSymbols: [symbol]
         )
         #expect(result.uri == "apple-docs://swift/task")
         #expect(result.source == "apple-docs")
@@ -126,7 +126,7 @@ struct SearchModelsPublicSurfaceTests {
         // contract.
         let r = Search.Result(
             uri: "x", source: "y", framework: "z",
-            title: "t", summary: "s", filePath: "/", wordCount: 1, rank: -2.5,
+            title: "t", summary: "s", filePath: "/", wordCount: 1, rank: -2.5
         )
         #expect(r.score == 2.5)
     }
@@ -141,7 +141,7 @@ struct SearchModelsPublicSurfaceTests {
         let r = Search.Result(
             uri: "x", source: "y", framework: "z",
             title: "t", summary: "s", filePath: "/", wordCount: 1, rank: 0,
-            availability: platforms,
+            availability: platforms
         )
         let str = r.availabilityString ?? ""
         #expect(str.contains("iOS 15.0+"))
@@ -161,7 +161,7 @@ struct SearchModelsPublicSurfaceTests {
             filePath: "/tmp/task.json",
             wordCount: 100,
             rank: -1.5,
-            availability: [availability],
+            availability: [availability]
         )
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(Search.Result.self, from: data)

--- a/Packages/Tests/SearchTests/AppleDocsIndexerValidateTests.swift
+++ b/Packages/Tests/SearchTests/AppleDocsIndexerValidateTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import SharedCore
 import Testing
 

--- a/Packages/Tests/SearchTests/BM25TitleWeightingTests.swift
+++ b/Packages/Tests/SearchTests/BM25TitleWeightingTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import SQLite3
 import Testing
 
@@ -79,8 +79,8 @@ struct BM25TitleWeightingTests {
             content: "An asynchronous unit of work without the query term repeated.",
             filePath: "/tmp/a",
             contentHash: "a",
-            lastCrawled: Date(),
-            ))
+            lastCrawled: Date()
+        ))
 
         // B: query term appears only in the body, title is unrelated.
         try await idx.indexDocument(Search.Index.IndexDocumentParams(
@@ -91,8 +91,8 @@ struct BM25TitleWeightingTests {
             content: "A mach task contains threads and memory regions. Task accounting is reported here.",
             filePath: "/tmp/b",
             contentHash: "b",
-            lastCrawled: Date(),
-            ))
+            lastCrawled: Date()
+        ))
 
         await idx.disconnect()
 
@@ -123,8 +123,8 @@ struct BM25TitleWeightingTests {
             content: "Bundle is the entry point for resource lookup. " + String(repeating: "Filler sentence. ", count: 40),
             filePath: "/tmp/s1",
             contentHash: "s1",
-            lastCrawled: Date(),
-            ))
+            lastCrawled: Date()
+        ))
 
         // B: query term only appears deep in the body, past the summary cut.
         let bodyB = String(repeating: "Unrelated padding text. ", count: 60) + " Bundle is mentioned only here at the end."
@@ -136,8 +136,8 @@ struct BM25TitleWeightingTests {
             content: bodyB,
             filePath: "/tmp/s2",
             contentHash: "s2",
-            lastCrawled: Date(),
-            ))
+            lastCrawled: Date()
+        ))
 
         await idx.disconnect()
 

--- a/Packages/Tests/SearchTests/CanonicalTypeRankingTests.swift
+++ b/Packages/Tests/SearchTests/CanonicalTypeRankingTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import Testing
 
 // Wide canonical-type ranking battery covering #254 + #256 acceptance.
@@ -38,8 +38,8 @@ private func indexPage(
         content: content,
         filePath: "/tmp/\(framework)-\(UUID().uuidString)",
         contentHash: UUID().uuidString,
-        lastCrawled: Date(),
-        ))
+        lastCrawled: Date()
+    ))
 }
 
 @Suite("Canonical type ranking (#254 + #256)")

--- a/Packages/Tests/SearchTests/CodeExampleSymbolsTests.swift
+++ b/Packages/Tests/SearchTests/CodeExampleSymbolsTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedModels
@@ -84,7 +84,7 @@ private func seedDoc(index: Search.Index, uri: String) async throws {
         content: "placeholder body",
         filePath: "/tmp/x",
         contentHash: "h",
-        lastCrawled: Date(),
+        lastCrawled: Date()
     ))
 }
 

--- a/Packages/Tests/SearchTests/CupertinoSearchTests.swift
+++ b/Packages/Tests/SearchTests/CupertinoSearchTests.swift
@@ -1,9 +1,9 @@
-import SharedConstants
-import Testing
 import Foundation
-import SearchModels
 @testable import Search
+import SearchModels
+import SharedConstants
 @testable import SharedCore
+import Testing
 
 // MARK: - Test Helpers
 
@@ -47,8 +47,8 @@ func createTestSearchIndexWithDocument(
         filePath: "/test.md",
         contentHash: "test-hash",
         lastCrawled: Date(),
-        sourceType: "test",
-        ))
+        sourceType: "test"
+    ))
 
     return (index, cleanup)
 }
@@ -159,8 +159,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "uikit://array",
@@ -171,8 +171,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         // Search with framework filter
         let swiftResults = try await index.search(query: "array", framework: "swift", limit: 10)
@@ -207,8 +207,8 @@ struct CupertinoSearchTests {
                 filePath: "/test.md",
                 contentHash: "test-hash",
                 lastCrawled: Date(),
-                sourceType: "apple",
-                ))
+                sourceType: "apple"
+            ))
         }
 
         // Search with limit
@@ -251,8 +251,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "hash1",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         // Update document
         try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -264,8 +264,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "hash2",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         // Search for new content
         let results = try await index.search(query: "dictionaries", framework: nil, limit: 10)
@@ -323,8 +323,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         // Doc 2: Content match only (lower relevance)
         try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -336,8 +336,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         // Doc 3: Single content match (lowest relevance)
         try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -349,8 +349,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         let results = try await index.search(query: "SwiftUI", framework: nil, limit: 10)
 
@@ -391,8 +391,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "evolution://SE-0001",
@@ -403,8 +403,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "swift-evolution",
-            ))
+            sourceType: "swift-evolution"
+        ))
 
         let results = try await index.search(query: "documentation", framework: nil, limit: 10)
         #expect(results.count == 2)
@@ -429,8 +429,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "swift-evolution://SE-0302",
@@ -441,8 +441,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "swift-evolution",
-            ))
+            sourceType: "swift-evolution"
+        ))
 
         try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "swift-book://concurrency",
@@ -453,8 +453,8 @@ struct CupertinoSearchTests {
             filePath: "/test.md",
             contentHash: "test-hash",
             lastCrawled: Date(),
-            sourceType: "swift-book",
-            ))
+            sourceType: "swift-book"
+        ))
 
         // Search all sources with common keyword
         let allResults = try await index.search(query: "swift", source: nil, framework: nil, limit: 10)
@@ -501,8 +501,8 @@ struct CupertinoSearchTests {
             contentHash: "test-hash",
             lastCrawled: Date(),
             sourceType: "swift-book",
-            jsonData: "{\"title\":\"Concurrency\",\"rawMarkdown\":null,\"url\":\"\(uri)\"}",
-            ))
+            jsonData: "{\"title\":\"Concurrency\",\"rawMarkdown\":null,\"url\":\"\(uri)\"}"
+        ))
 
         // Get content as markdown - should fall back to FTS content
         let content = try await index.getDocumentContent(uri: uri, format: .markdown)
@@ -545,8 +545,8 @@ struct CupertinoSearchTests {
             contentHash: "test-hash",
             lastCrawled: Date(),
             sourceType: "apple",
-            jsonData: jsonData,
-            ))
+            jsonData: jsonData
+        ))
 
         // Get content as JSON
         let content = try await index.getDocumentContent(uri: uri, format: .json)
@@ -574,8 +574,8 @@ struct CupertinoSearchTests {
             filePath: "/test/ST-0001.md",
             contentHash: "st-hash",
             lastCrawled: Date(),
-            sourceType: "swift-evolution",
-            ))
+            sourceType: "swift-evolution"
+        ))
 
         // Search should find it
         let results = try await index.search(query: "refactor bug", source: "swift-evolution", framework: nil, limit: 10)
@@ -602,8 +602,8 @@ struct CupertinoSearchTests {
             filePath: "/test/SE-0302.md",
             contentHash: "se-hash",
             lastCrawled: Date(),
-            sourceType: "swift-evolution",
-            ))
+            sourceType: "swift-evolution"
+        ))
 
         // Index an ST proposal (accepted)
         try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -615,8 +615,8 @@ struct CupertinoSearchTests {
             filePath: "/test/ST-0001.md",
             contentHash: "st-hash",
             lastCrawled: Date(),
-            sourceType: "swift-evolution",
-            ))
+            sourceType: "swift-evolution"
+        ))
 
         // Both should be findable under swift-evolution source
         let allResults = try await index.search(query: "swift", source: "swift-evolution", framework: nil, limit: 10)
@@ -745,8 +745,8 @@ struct CupertinoSearchTests {
             contentHash: "test-hash",
             lastCrawled: Date(),
             sourceType: "swift-book",
-            jsonData: "{\"title\":\"The Basics\",\"rawMarkdown\":null}",
-            ))
+            jsonData: "{\"title\":\"The Basics\",\"rawMarkdown\":null}"
+        ))
 
         // Get content as JSON - should return the original JSON (since it exists in metadata)
         // Note: FTS fallback only happens when metadata doesn't exist or can't be decoded

--- a/Packages/Tests/SearchTests/DocKindIntegrationTests.swift
+++ b/Packages/Tests/SearchTests/DocKindIntegrationTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import SQLite3
 import Testing
 
@@ -148,8 +148,8 @@ struct IndexDocumentKindTests {
             content: "Some content for the test.",
             filePath: "/tmp/x",
             contentHash: "h",
-            lastCrawled: Date(),
-            ))
+            lastCrawled: Date()
+        ))
         await idx.disconnect()
 
         return try readColumn(at: dbPath, column: "kind", forURI: uri)
@@ -216,8 +216,8 @@ struct SymbolsColumnTests {
             content: "Body",
             filePath: "/tmp/x",
             contentHash: "h",
-            lastCrawled: Date(),
-            ))
+            lastCrawled: Date()
+        ))
         await idx.disconnect()
 
         // Column exists, value is NULL — readColumn returns nil for NULL.

--- a/Packages/Tests/SearchTests/DocKindTests.swift
+++ b/Packages/Tests/SearchTests/DocKindTests.swift
@@ -1,4 +1,5 @@
 import SearchModels
+
 // swiftlint:disable identifier_name
 import Foundation
 @testable import Search

--- a/Packages/Tests/SearchTests/DocsSourceCandidateFetcherTests.swift
+++ b/Packages/Tests/SearchTests/DocsSourceCandidateFetcherTests.swift
@@ -1,7 +1,7 @@
-import Testing
 import Foundation
-import SearchModels
 @testable import Search
+import SearchModels
+import Testing
 
 // Covers H5 from #192: `DocsSourceCandidateFetcher` against a fixture
 // search.db. Verifies that the fetcher scopes to its source, adapts
@@ -23,8 +23,8 @@ private func seedIndex() async throws -> (Search.Index, URL) {
         content: "A SwiftUI view protocol.",
         filePath: "/tmp/view.md",
         contentHash: "h1",
-        lastCrawled: Date(),
-        ))
+        lastCrawled: Date()
+    ))
     try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "apple-docs://swiftui/animation",
         source: "apple-docs",
@@ -33,8 +33,8 @@ private func seedIndex() async throws -> (Search.Index, URL) {
         content: "SwiftUI animation APIs.",
         filePath: "/tmp/anim.md",
         contentHash: "h2",
-        lastCrawled: Date(),
-        ))
+        lastCrawled: Date()
+    ))
     try await index.indexDocument(Search.Index.IndexDocumentParams(
         uri: "swift-evolution://SE-0306",
         source: "swift-evolution",
@@ -43,8 +43,8 @@ private func seedIndex() async throws -> (Search.Index, URL) {
         content: "Swift actors proposal.",
         filePath: "/tmp/se306.md",
         contentHash: "h3",
-        lastCrawled: Date(),
-        ))
+        lastCrawled: Date()
+    ))
     return (index, dbPath)
 }
 

--- a/Packages/Tests/SearchTests/ExactTitlePeerTiebreakTests.swift
+++ b/Packages/Tests/SearchTests/ExactTitlePeerTiebreakTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import Testing
 
 // Exact-title peer tiebreak inside HEURISTIC 1 (#256).
@@ -43,8 +43,8 @@ private func indexPage(
         content: content,
         filePath: "/tmp/\(framework)",
         contentHash: framework,
-        lastCrawled: Date(),
-        ))
+        lastCrawled: Date()
+    ))
 }
 
 @Suite("Exact title peer tiebreak (#256)")

--- a/Packages/Tests/SearchTests/IndexBuilderDeduplicationTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderDeduplicationTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedModels
@@ -17,7 +17,7 @@ import Testing
 @Suite("Search.StrategyHelpers.deduplicateDocFilesByCanonicalURL (#200)", .serialized)
 struct IndexBuilderDeduplicationTests {
     @Test("Two files with same canonical URL: keeps the one with newer crawledAt even when its mtime is older")
-    func keepsNewestByCrawledAtNotMtime() async throws {
+    func keepsNewestByCrawledAtNotMtime() throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("cupertino-dedup-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
@@ -66,7 +66,7 @@ struct IndexBuilderDeduplicationTests {
     }
 
     @Test("Single file with no duplicates passes through unchanged")
-    func singleFilePassesThrough() async throws {
+    func singleFilePassesThrough() throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("cupertino-dedup-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
@@ -90,7 +90,7 @@ struct IndexBuilderDeduplicationTests {
     }
 
     @Test("Distinct canonical URLs both survive (no false-positive dedup)")
-    func distinctURLsBothSurvive() async throws {
+    func distinctURLsBothSurvive() throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("cupertino-dedup-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
@@ -121,7 +121,7 @@ struct IndexBuilderDeduplicationTests {
     }
 
     @Test("loadStructuredPage: decoder is configured with .iso8601 (regression for codex review on #264)")
-    func loadStructuredPageDecodesIso8601() async throws {
+    func loadStructuredPageDecodesIso8601() throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("cupertino-dedup-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)

--- a/Packages/Tests/SearchTests/IndexBuilderMalformedURLSkipTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderMalformedURLSkipTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedModels

--- a/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
@@ -1,8 +1,8 @@
-import SearchModels
 import CoreProtocols
 import Foundation
 import Logging
 @testable import Search
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedModels

--- a/Packages/Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import SharedConstants
 import SharedCore
 import SharedModels

--- a/Packages/Tests/SearchTests/PackageQueryTests.swift
+++ b/Packages/Tests/SearchTests/PackageQueryTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import SharedCore
 import Testing
 

--- a/Packages/Tests/SearchTests/SmartQueryIntentRoutingTests.swift
+++ b/Packages/Tests/SearchTests/SmartQueryIntentRoutingTests.swift
@@ -1,8 +1,8 @@
+import Foundation
+@testable import Search
+import SearchModels
 import SharedConstants
 import Testing
-import Foundation
-import SearchModels
-@testable import Search
 
 // Intent routing for cross-source smart query (#254).
 //

--- a/Packages/Tests/SearchTests/SmartQueryTests.swift
+++ b/Packages/Tests/SearchTests/SmartQueryTests.swift
@@ -1,7 +1,7 @@
-import Testing
 import Foundation
-import SearchModels
 @testable import Search
+import SearchModels
+import Testing
 
 // Reciprocal rank fusion (#192 section E4). Covered with a deterministic
 // in-memory `MockFetcher` so the fusion math is guarded independently of

--- a/Packages/Tests/SearchTests/SwiftOrgIndexTests.swift
+++ b/Packages/Tests/SearchTests/SwiftOrgIndexTests.swift
@@ -1,6 +1,6 @@
-import SearchModels
 import Foundation
 @testable import Search
+import SearchModels
 import Testing
 
 // MARK: - is404Page heuristic (fix for #110)

--- a/Packages/Tests/SearchTests/SymbolDatabaseIntegrationTests.swift
+++ b/Packages/Tests/SearchTests/SymbolDatabaseIntegrationTests.swift
@@ -1,4 +1,5 @@
 import SearchModels
+
 // SymbolDatabaseIntegrationTests.swift
 // Integration tests for AST symbol storage and search (#81)
 

--- a/Packages/Tests/SearchTests/VersionFilterTests.swift
+++ b/Packages/Tests/SearchTests/VersionFilterTests.swift
@@ -1,7 +1,7 @@
-import Testing
 import Foundation
-import SearchModels
 @testable import Search
+import SearchModels
+import Testing
 
 // MARK: - Release.Version Filter Tests
 
@@ -247,8 +247,8 @@ struct VersionFilterTests {
             filePath: "/test.md",
             contentHash: "hash",
             lastCrawled: Date(),
-            sourceType: "test",
-            ))
+            sourceType: "test"
+        ))
 
         // Without availability, should not appear in filtered results
         let filtered = try await index.search(query: "Availability", minIOS: "15.0")
@@ -385,8 +385,8 @@ struct VersionFilterTests {
             minMacOS: minMacOS,
             minTvOS: minTvOS,
             minWatchOS: minWatchOS,
-            minVisionOS: minVisionOS,
-            ))
+            minVisionOS: minVisionOS
+        ))
 
         let cleanup: @Sendable () -> Void = {
             Task { await index.disconnect() }

--- a/Packages/Tests/SearchToolProviderTests/CupertinoSearchToolProviderTests.swift
+++ b/Packages/Tests/SearchToolProviderTests/CupertinoSearchToolProviderTests.swift
@@ -1,13 +1,14 @@
 import ServicesModels
-import TestSupport
 import SharedConstants
 import Testing
+import TestSupport
+
 // swiftlint:disable file_length
 import Foundation
 import MCPCore
-import SearchModels
 @testable import SampleIndex
 @testable import Search
+import SearchModels
 @testable import SearchToolProvider
 @testable import Services
 @testable import SharedCore
@@ -41,8 +42,8 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/animation.md",
         contentHash: "hash1",
         lastCrawled: Date(),
-        sourceType: "apple",
-        ))
+        sourceType: "apple"
+    ))
 
     // Apple archive
     try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -54,8 +55,8 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/coreanimation.md",
         contentHash: "hash2",
         lastCrawled: Date(),
-        sourceType: "archive",
-        ))
+        sourceType: "archive"
+    ))
 
     // HIG
     try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -67,8 +68,8 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/hig-motion.md",
         contentHash: "hash3",
         lastCrawled: Date(),
-        sourceType: "hig",
-        ))
+        sourceType: "hig"
+    ))
 
     // Swift Evolution
     try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -80,8 +81,8 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/se-0392.md",
         contentHash: "hash4",
         lastCrawled: Date(),
-        sourceType: "swift-evolution",
-        ))
+        sourceType: "swift-evolution"
+    ))
 
     // Swift.org
     try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -93,8 +94,8 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/swift-org-animation.md",
         contentHash: "hash5",
         lastCrawled: Date(),
-        sourceType: "swift-org",
-        ))
+        sourceType: "swift-org"
+    ))
 
     // Swift Book
     try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -106,8 +107,8 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/swift-book-animation.md",
         contentHash: "hash6",
         lastCrawled: Date(),
-        sourceType: "swift-book",
-        ))
+        sourceType: "swift-book"
+    ))
 
     // Packages
     try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -119,8 +120,8 @@ func createMultiSourceSearchIndex() async throws -> (index: Search.Index, cleanu
         filePath: "/test/packages-animation.md",
         contentHash: "hash7",
         lastCrawled: Date(),
-        sourceType: "packages",
-        ))
+        sourceType: "packages"
+    ))
 
     return (index, cleanup)
 }
@@ -487,8 +488,8 @@ struct UnifiedSearchTests {
             filePath: "/test/string.md",
             contentHash: "hash",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
@@ -555,8 +556,8 @@ struct TeaserResultsTests {
                 filePath: "/test/archive\(docNumber).md",
                 contentHash: "hash\(docNumber)",
                 lastCrawled: Date(),
-                sourceType: "archive",
-                ))
+                sourceType: "archive"
+            ))
         }
 
         // Add apple-docs to search
@@ -569,8 +570,8 @@ struct TeaserResultsTests {
             filePath: "/test/swiftui.md",
             contentHash: "hashMain",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
@@ -610,8 +611,8 @@ struct TeaserResultsTests {
             filePath: "/test/networking.md",
             contentHash: "hash1",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         // Add archive doc that matches "networking"
         try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -623,8 +624,8 @@ struct TeaserResultsTests {
             filePath: "/test/archive-network.md",
             contentHash: "hash2",
             lastCrawled: Date(),
-            sourceType: "archive",
-            ))
+            sourceType: "archive"
+        ))
 
         // Add archive doc about "graphics" - completely different topic
         try await index.indexDocument(Search.Index.IndexDocumentParams(
@@ -636,8 +637,8 @@ struct TeaserResultsTests {
             filePath: "/test/archive-graphics.md",
             contentHash: "hash3",
             lastCrawled: Date(),
-            sourceType: "archive",
-            ))
+            sourceType: "archive"
+        ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
 
@@ -698,8 +699,8 @@ struct TeaserResultsTests {
             filePath: "/test/unique.md",
             contentHash: "hash",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
@@ -735,8 +736,8 @@ struct SearchFilteringTests {
             filePath: "/test/view.md",
             contentHash: "hash1",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-docs://uikit/view",
@@ -747,8 +748,8 @@ struct SearchFilteringTests {
             filePath: "/test/uiview.md",
             contentHash: "hash2",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
         let args: [String: MCP.Core.Protocols.AnyCodable] = [
@@ -782,8 +783,8 @@ struct SearchFilteringTests {
                 filePath: "/test/swift\(docNumber).md",
                 contentHash: "hash\(docNumber)",
                 lastCrawled: Date(),
-                sourceType: "apple",
-                ))
+                sourceType: "apple"
+            ))
         }
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
@@ -820,8 +821,8 @@ struct SearchFilteringTests {
             filePath: "/test/string.md",
             contentHash: "hash1",
             lastCrawled: Date(),
-            sourceType: "apple",
-            ))
+            sourceType: "apple"
+        ))
 
         try await index.indexDocument(Search.Index.IndexDocumentParams(
             uri: "apple-archive://string-guide",
@@ -832,8 +833,8 @@ struct SearchFilteringTests {
             filePath: "/test/archive-string.md",
             contentHash: "hash2",
             lastCrawled: Date(),
-            sourceType: "archive",
-            ))
+            sourceType: "archive"
+        ))
 
         let provider = CompositeToolProvider(searchIndex: index, sampleDatabase: nil)
 

--- a/Packages/Tests/ServicesTests/ServicesTests.swift
+++ b/Packages/Tests/ServicesTests/ServicesTests.swift
@@ -1,10 +1,22 @@
-import ServicesModels
-import SharedConstants
-import Testing
 import Foundation
 import SearchModels
 @testable import Services
+import ServicesModels
+import SharedConstants
 @testable import SharedCore
+import Testing
+
+// MARK: - Test Doubles
+
+/// `Search.DatabaseFactory` test double whose `openDatabase` always throws.
+/// Used to verify `Services.ServiceContainer.withTeaserService` propagates
+/// factory failures (matches the resilience pattern in CLI search runners
+/// that catch and fall back to empty teasers).
+private struct ThrowingSearchDatabaseFactory: Search.DatabaseFactory {
+    func openDatabase(at url: URL) async throws -> any Search.Database {
+        throw NSError(domain: "ServicesTests.stub", code: 1)
+    }
+}
 
 // MARK: - Services Tests
 
@@ -214,14 +226,12 @@ struct TeaserResultsResilienceTests {
         // Stub factory: when withTeaserService finds a "path" that exists
         // (here a directory rather than a real .db), it calls the factory.
         // Our stub throws — the test verifies the outer call propagates it.
-        let throwingFactory: Services.ServiceContainer.MakeSearchDatabase = { _ in
-            throw NSError(domain: "ServicesTests.stub", code: 1)
-        }
+        let throwingFactory = ThrowingSearchDatabaseFactory()
         await #expect(throws: (any Error).self) {
             try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: tempDir.path,
                 sampleDbPath: nil,
-                makeSearchDatabase: throwingFactory,
+                searchDatabaseFactory: throwingFactory
             ) { service in
                 _ = await service.fetchAllTeasers(
                     query: "swiftui",
@@ -239,15 +249,13 @@ struct TeaserResultsResilienceTests {
         // catch the throw, fall back to TeaserResults(). Verifies the
         // fallback contract (empty + iterable) so future changes don't
         // accidentally make the empty struct require parameters.
-        let throwingFactory: Services.ServiceContainer.MakeSearchDatabase = { _ in
-            throw NSError(domain: "ServicesTests.stub", code: 1)
-        }
+        let throwingFactory = ThrowingSearchDatabaseFactory()
         let teasers: Services.Formatter.TeaserResults
         do {
             teasers = try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: "/var/empty/intentionally-broken-search.db.\(UUID().uuidString)",
                 sampleDbPath: nil,
-                makeSearchDatabase: throwingFactory,
+                searchDatabaseFactory: throwingFactory
             ) { service in
                 await service.fetchAllTeasers(
                     query: "swiftui",

--- a/Packages/Tests/SharedConfigurationTests/SharedConfigurationTests.swift
+++ b/Packages/Tests/SharedConfigurationTests/SharedConfigurationTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import SharedConstants
 @testable import SharedConfiguration
+import SharedConstants
 import SharedUtils
 import Testing
 
@@ -84,7 +84,7 @@ struct SharedConfigurationPublicSurfaceTests {
         let outDir = URL(fileURLWithPath: "/tmp/cupertino-out")
         let detection = Shared.Configuration.ChangeDetection(
             metadataFile: explicit,
-            outputDirectory: outDir,
+            outputDirectory: outDir
         )
         #expect(detection.metadataFile == explicit)
     }
@@ -119,7 +119,7 @@ struct SharedConfigurationPublicSurfaceTests {
         let original = Shared.Configuration(
             crawler: Shared.Configuration.Crawler(),
             changeDetection: Shared.Configuration.ChangeDetection(),
-            output: Shared.Configuration.Output(format: .markdown, includeMarkdown: true),
+            output: Shared.Configuration.Output(format: .markdown, includeMarkdown: true)
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -159,7 +159,7 @@ struct SharedConfigurationPublicSurfaceTests {
         let sentinel = Shared.Configuration(
             crawler: Shared.Configuration.Crawler(),
             changeDetection: Shared.Configuration.ChangeDetection(),
-            output: Shared.Configuration.Output(format: .html, includeMarkdown: true),
+            output: Shared.Configuration.Output(format: .html, includeMarkdown: true)
         )
         try sentinel.save(to: tmp)
 


### PR DESCRIPTION
## What

First of 8 GoF Factory Method conversions. Replaces the
`Services.ServiceContainer.MakeSearchDatabase` closure typealias
with a named `Search.DatabaseFactory` protocol (GoF Factory
Method).

## Why protocols over closures

Closures hide their captured state behind an implicit capture list:
the constructor that takes `@Sendable (URL) async throws -> X`
can't tell you what gets bound in. Protocols pin the contract by
name, make captured state explicit on the conforming type's stored
properties, and produce mockable, reviewable hooks.

`Design Patterns` (Gamma, Helm, Johnson, Vlissides, 1994), Factory
Method:
- **Product** = `any Search.Database`
- **Creator** = `Search.DatabaseFactory` (new protocol, SearchModels)
- **ConcreteCreator** = `LiveSearchDatabaseFactory` (CLI) and
  `ThrowingSearchDatabaseFactory` (ServicesTests)

Closures are reserved for genuinely callback-shaped operations only
(progress callbacks `(Int, Int) -> Void`).

## Changes

- `SearchModels`: add `Search.DatabaseFactory` protocol.
- `Services.ServiceContainer`: drop `MakeSearchDatabase`,
  `with*Service` static methods take `searchDatabaseFactory:`.
- `Services.ReadService`: end-to-end signature swap.
- `CLI/SearchModuleAlias.swift`: `LiveSearchDatabaseFactory`
  struct replaces the closure constant.
- `ServicesTests`: `ThrowingSearchDatabaseFactory` struct
  replaces inline throwing closures in the two failure-propagation
  tests.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test`: **1441 tests in 161 suites passed**.
- `swiftformat .`: applied (extra files in diff are pure
  import-order normalisation, no logic change).
- `swiftlint`: only pre-existing warnings.

## Follow-up

Remaining 7 closure typealiases convert in separate PRs (one each):
MarkdownToStructuredPage, SampleCatalogFetch, PackageIndexingRun,
DocsIndexingRun, SamplesIndexingRun, MarkdownLookup,
PackageFileLookup. After all 8 land, a sweep PR tightens every
consumer target's imports to drop concrete producer modules.