### PR TITLE
refactor(di): #495 convert Search.MarkdownToStructuredPage closure to protocol (2/8)

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
@@ -38,7 +38,7 @@ extension CLI.Command.Save {
         let tracker = ProgressTracker()
         let outcome = try await Indexer.DocsService.run(
             request,
-            markdownToStructuredPage: Core.JSONParser.MarkdownToStructuredPage.convert,
+            markdownStrategy: LiveMarkdownToStructuredPageStrategy(),
             sampleCatalogFetch: CLI.Command.Save.sampleCatalogFetch,
             docsIndexingRun: CLI.Command.Save.docsIndexingRun
         ) { event in
@@ -61,7 +61,7 @@ extension CLI.Command.Save {
             swiftOrgDirectory: input.swiftOrgDirectory,
             archiveDirectory: input.archiveDirectory,
             higDirectory: input.higDirectory,
-            markdownToStructuredPage: input.markdownToStructuredPage,
+            markdownStrategy: input.markdownStrategy,
             sampleCatalogFetch: input.sampleCatalogFetch
         )
         try await builder.buildIndex(clearExisting: input.clearExisting, onProgress: onProgress)
@@ -72,6 +72,19 @@ extension CLI.Command.Save {
             documentCount: docCount,
             frameworkCount: frameworks.count
         )
+    }
+
+    // MARK: - Markdown strategy adapter
+
+    /// Concrete `Search.MarkdownToStructuredPageStrategy` (GoF Strategy)
+    /// wrapping the `Core.JSONParser.MarkdownToStructuredPage.convert`
+    /// static method. Lives at the CLI composition root so neither
+    /// Search nor Indexer needs to import `CoreJSONParser` —
+    /// the Search target sees only the protocol from SearchModels.
+    struct LiveMarkdownToStructuredPageStrategy: Search.MarkdownToStructuredPageStrategy {
+        func convert(markdown: String, url: URL?) -> Shared.Models.StructuredDocumentationPage? {
+            Core.JSONParser.MarkdownToStructuredPage.convert(markdown, url: url)
+        }
     }
 
     // MARK: - Sample catalog adapter

--- a/Packages/Sources/Indexer/Indexer.DocsService.swift
+++ b/Packages/Sources/Indexer/Indexer.DocsService.swift
@@ -60,7 +60,7 @@ extension Indexer {
 
         public static func run(
             _ request: Request,
-            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage,
+            markdownStrategy: any Search.MarkdownToStructuredPageStrategy,
             sampleCatalogFetch: @escaping Search.SampleCatalogFetch,
             docsIndexingRun: Search.DocsIndexingRun,
             handler: @escaping @Sendable (Event) -> Void = { _ in }
@@ -104,7 +104,7 @@ extension Indexer {
                 archiveDirectory: archiveDirToUse,
                 higDirectory: higDirToUse,
                 clearExisting: request.clear,
-                markdownToStructuredPage: markdownToStructuredPage,
+                markdownStrategy: markdownStrategy,
                 sampleCatalogFetch: sampleCatalogFetch
             )
 

--- a/Packages/Sources/Search/Search.IndexBuilder.swift
+++ b/Packages/Sources/Search/Search.IndexBuilder.swift
@@ -95,7 +95,7 @@ extension Search {
             archiveDirectory: URL? = nil,
             higDirectory: URL? = nil,
             indexSampleCode: Bool = true,
-            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage,
+            markdownStrategy: any Search.MarkdownToStructuredPageStrategy,
             sampleCatalogFetch: @escaping Search.SampleCatalogFetch
         ) {
             self.init(
@@ -108,7 +108,7 @@ extension Search {
                     archiveDirectory: archiveDirectory,
                     higDirectory: higDirectory,
                     indexSampleCode: indexSampleCode,
-                    markdownToStructuredPage: markdownToStructuredPage,
+                    markdownStrategy: markdownStrategy,
                     sampleCatalogFetch: sampleCatalogFetch
                 )
             )
@@ -182,13 +182,13 @@ extension Search {
             archiveDirectory: URL? = nil,
             higDirectory: URL? = nil,
             indexSampleCode: Bool = true,
-            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage,
+            markdownStrategy: any Search.MarkdownToStructuredPageStrategy,
             sampleCatalogFetch: @escaping Search.SampleCatalogFetch
         ) -> [any Search.SourceIndexingStrategy] {
             var strategies: [any Search.SourceIndexingStrategy] = [
                 Search.AppleDocsStrategy(
                     docsDirectory: docsDirectory,
-                    markdownToStructuredPage: markdownToStructuredPage
+                    markdownStrategy: markdownStrategy
                 ),
             ]
             if let dir = evolutionDirectory {
@@ -197,7 +197,7 @@ extension Search {
             if let dir = swiftOrgDirectory {
                 strategies.append(Search.SwiftOrgStrategy(
                     swiftOrgDirectory: dir,
-                    markdownToStructuredPage: markdownToStructuredPage
+                    markdownStrategy: markdownStrategy
                 ))
             }
             if let dir = archiveDirectory {

--- a/Packages/Sources/Search/Strategies/Search.Strategies.AppleDocs.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.AppleDocs.swift
@@ -42,26 +42,26 @@ extension Search {
         /// Root directory containing the crawled Apple documentation files.
         public let docsDirectory: URL
 
-        /// Closure that converts raw markdown to a structured page.
+        /// Strategy for converting raw markdown to a structured page.
         /// Injected so this target doesn't depend on `CoreJSONParser`;
-        /// the composition root supplies
+        /// the composition root supplies a concrete conformer wrapping
         /// `Core.JSONParser.MarkdownToStructuredPage.convert`.
-        private let markdownToStructuredPage: Search.MarkdownToStructuredPage
+        private let markdownStrategy: any Search.MarkdownToStructuredPageStrategy
 
         /// Create a strategy for indexing Apple Developer Documentation.
         ///
         /// - Parameters:
         ///   - docsDirectory: Root directory of the crawled documentation.
-        ///   - markdownToStructuredPage: Closure that converts raw markdown into a
+        ///   - markdownStrategy: Conformer that converts raw markdown into a
         ///     `Shared.Models.StructuredDocumentationPage`. Injected at the
         ///     composition root so the strategy can parse `.md` pages without
         ///     depending on the `CoreJSONParser` target directly.
         public init(
             docsDirectory: URL,
-            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage
+            markdownStrategy: any Search.MarkdownToStructuredPageStrategy
         ) {
             self.docsDirectory = docsDirectory
-            self.markdownToStructuredPage = markdownToStructuredPage
+            self.markdownStrategy = markdownStrategy
         }
 
         /// Index all Apple documentation pages by scanning ``docsDirectory``.
@@ -174,7 +174,7 @@ extension Search {
                         string: "\(Shared.Constants.BaseURL.appleDeveloperDocs)\(framework)/" +
                             "\(file.deletingPathExtension().lastPathComponent)"
                     )
-                    guard let converted = markdownToStructuredPage(mdContent, pageURL) else {
+                    guard let converted = markdownStrategy.convert(markdown: mdContent, url: pageURL) else {
                         Logging.Log.error(
                             "❌ Failed to convert \(file.lastPathComponent) to structured page",
                             category: .search

--- a/Packages/Sources/Search/Strategies/Search.Strategies.SwiftOrg.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.SwiftOrg.swift
@@ -37,26 +37,26 @@ extension Search {
         /// Root directory containing the Swift.org documentation files.
         public let swiftOrgDirectory: URL
 
-        /// Closure that converts raw markdown to a structured page.
+        /// Strategy for converting raw markdown to a structured page.
         /// Injected so this target doesn't depend on `CoreJSONParser`;
-        /// the composition root supplies
+        /// the composition root supplies a concrete conformer wrapping
         /// `Core.JSONParser.MarkdownToStructuredPage.convert`.
-        private let markdownToStructuredPage: Search.MarkdownToStructuredPage
+        private let markdownStrategy: any Search.MarkdownToStructuredPageStrategy
 
         /// Create a strategy for indexing Swift.org documentation.
         ///
         /// - Parameters:
         ///   - swiftOrgDirectory: Root directory of the Swift.org corpus.
-        ///   - markdownToStructuredPage: Closure that converts raw markdown into a
+        ///   - markdownStrategy: Conformer that converts raw markdown into a
         ///     `Shared.Models.StructuredDocumentationPage`. Injected at the
         ///     composition root so the strategy can parse `.md` pages without
         ///     depending on the `CoreJSONParser` target directly.
         public init(
             swiftOrgDirectory: URL,
-            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage
+            markdownStrategy: any Search.MarkdownToStructuredPageStrategy
         ) {
             self.swiftOrgDirectory = swiftOrgDirectory
-            self.markdownToStructuredPage = markdownToStructuredPage
+            self.markdownStrategy = markdownStrategy
         }
 
         /// Index all Swift.org documentation pages found under ``swiftOrgDirectory``.
@@ -129,7 +129,7 @@ extension Search {
                         string: "https://www.swift.org/documentation/" +
                             "\(file.deletingPathExtension().lastPathComponent)"
                     )
-                    guard let converted = markdownToStructuredPage(mdContent, pageURL) else {
+                    guard let converted = markdownStrategy.convert(markdown: mdContent, url: pageURL) else {
                         Logging.Log.error(
                             "❌ Failed to convert \(file.lastPathComponent) to structured page",
                             category: .search

--- a/Packages/Sources/SearchModels/Search.DocsIndexingRun.swift
+++ b/Packages/Sources/SearchModels/Search.DocsIndexingRun.swift
@@ -40,7 +40,7 @@ public extension Search {
         public let archiveDirectory: URL?
         public let higDirectory: URL?
         public let clearExisting: Bool
-        public let markdownToStructuredPage: Search.MarkdownToStructuredPage
+        public let markdownStrategy: any Search.MarkdownToStructuredPageStrategy
         public let sampleCatalogFetch: Search.SampleCatalogFetch
 
         public init(
@@ -51,7 +51,7 @@ public extension Search {
             archiveDirectory: URL?,
             higDirectory: URL?,
             clearExisting: Bool,
-            markdownToStructuredPage: @escaping Search.MarkdownToStructuredPage,
+            markdownStrategy: any Search.MarkdownToStructuredPageStrategy,
             sampleCatalogFetch: @escaping Search.SampleCatalogFetch
         ) {
             self.searchDBPath = searchDBPath
@@ -61,7 +61,7 @@ public extension Search {
             self.archiveDirectory = archiveDirectory
             self.higDirectory = higDirectory
             self.clearExisting = clearExisting
-            self.markdownToStructuredPage = markdownToStructuredPage
+            self.markdownStrategy = markdownStrategy
             self.sampleCatalogFetch = sampleCatalogFetch
         }
     }

--- a/Packages/Sources/SearchModels/Search.MarkdownToStructuredPage.swift
+++ b/Packages/Sources/SearchModels/Search.MarkdownToStructuredPage.swift
@@ -2,29 +2,40 @@ import Foundation
 import SharedConstants
 import SharedModels
 
-// MARK: - Search.MarkdownToStructuredPage
+// MARK: - Search.MarkdownToStructuredPageStrategy
 
-/// Closure shape for converting raw markdown (with optional YAML / TOML
+/// Strategy for converting raw markdown (with optional YAML / TOML
 /// front-matter) into a `Shared.Models.StructuredDocumentationPage`.
+/// GoF Strategy pattern (Gamma et al, 1994): a family of algorithms
+/// (one production parser, many test stubs) interchangeable behind a
+/// named protocol.
 ///
-/// The Search target's strategies (`AppleDocsStrategy`, `SwiftOrgStrategy`)
-/// take one of these at init so they can parse markdown pages without
-/// directly depending on the `CoreJSONParser` target where the concrete
+/// The Search target's strategies (`AppleDocsStrategy`,
+/// `SwiftOrgStrategy`) accept a conformer at init so they can parse
+/// markdown pages without directly depending on the `CoreJSONParser`
+/// target where the concrete
 /// `Core.JSONParser.MarkdownToStructuredPage.convert(_:url:)` lives.
 ///
 /// The composition root (the CLI binary, the Indexer service entry
-/// point, or a test harness) supplies the concrete function. Indexing
+/// point, or a test harness) supplies the concrete conformer. Indexing
 /// callers that don't need markdown→structured conversion can pass a
 /// stub that always returns `nil`; the strategies that don't call the
-/// closure (HIG, Archive, SampleCode, SwiftPackages) won't invoke it.
+/// converter (HIG, Archive, SampleCode, SwiftPackages) won't invoke
+/// it.
 ///
-/// Mirrors the `Search.Database` / `Sample.Index.Reader` / `MakeSearchDatabase`
-/// pattern: the abstraction lives in a value-types target, the
-/// implementation lives in the producer target, the wiring lives at the
-/// composition root.
+/// This replaces the previous
+/// `Search.MarkdownToStructuredPage = @Sendable (String, URL?) -> Page?`
+/// closure typealias. The protocol form names the contract at the
+/// constructor site (`markdownStrategy: any Search.MarkdownToStructuredPageStrategy`),
+/// makes captured-state surface explicit on the conforming type's
+/// stored properties, and produces one-line test mocks instead of
+/// captured-throw closures.
 public extension Search {
-    typealias MarkdownToStructuredPage = @Sendable (
-        _ markdown: String,
-        _ url: URL?
-    ) -> Shared.Models.StructuredDocumentationPage?
+    protocol MarkdownToStructuredPageStrategy: Sendable {
+        /// Convert raw markdown + an optional originating URL into a
+        /// structured documentation page. Returns `nil` when the
+        /// markdown can't be parsed (malformed front-matter, empty
+        /// body, etc.) — the caller decides whether that's fatal.
+        func convert(markdown: String, url: URL?) -> Shared.Models.StructuredDocumentationPage?
+    }
 }

--- a/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
+++ b/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
@@ -14,6 +14,14 @@ import SharedUtils
 import Testing
 import TestSupport
 
+// MARK: - Test Doubles
+
+private struct NoopMarkdownStrategy: Search.MarkdownToStructuredPageStrategy {
+    func convert(markdown: String, url: URL?) -> Shared.Models.StructuredDocumentationPage? {
+        nil
+    }
+}
+
 // MARK: - Save Command Tests
 
 // Tests for the `cupertino save` command
@@ -57,7 +65,7 @@ struct SaveCommandTests {
             metadata: metadata,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil },
+            markdownStrategy: NoopMarkdownStrategy(),
             sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
@@ -113,7 +121,7 @@ struct SaveCommandTests {
             metadata: metadata,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil },
+            markdownStrategy: NoopMarkdownStrategy(),
             sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
         try await builder.buildIndex()
@@ -157,7 +165,7 @@ struct SaveCommandTests {
             metadata: emptyMetadata,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil },
+            markdownStrategy: NoopMarkdownStrategy(),
             sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
@@ -218,7 +226,7 @@ struct SaveCommandTests {
             metadata: metadata,
             docsDirectory: docsDir,
             evolutionDirectory: evolutionDir,
-            markdownToStructuredPage: { _, _ in nil },
+            markdownStrategy: NoopMarkdownStrategy(),
             sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
@@ -290,7 +298,7 @@ struct SaveCommandTests {
             metadata: nil, // No metadata!
             docsDirectory: tempDir.appendingPathComponent("docs"),
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil },
+            markdownStrategy: NoopMarkdownStrategy(),
             sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
@@ -346,7 +354,7 @@ struct SaveCommandTests {
             metadata: nil,
             docsDirectory: tempDir.appendingPathComponent("docs"),
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil },
+            markdownStrategy: NoopMarkdownStrategy(),
             sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
@@ -397,7 +405,7 @@ struct SaveCommandTests {
             metadata: nil,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil },
+            markdownStrategy: NoopMarkdownStrategy(),
             sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 
@@ -431,7 +439,7 @@ struct SaveCommandTests {
             metadata: nil,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil },
+            markdownStrategy: NoopMarkdownStrategy(),
             sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -15,6 +15,14 @@ import SharedModels
 import Testing
 import TestSupport
 
+// MARK: - Test Doubles
+
+private struct NoopMarkdownStrategy: Search.MarkdownToStructuredPageStrategy {
+    func convert(markdown: String, url: URL?) -> Shared.Models.StructuredDocumentationPage? {
+        nil
+    }
+}
+
 // MARK: - MCP Command Tests
 
 // Tests for the `cupertino serve` command
@@ -393,7 +401,7 @@ struct MCPServerIntegrationTests {
             metadata: metadata,
             docsDirectory: tempDir,
             evolutionDirectory: nil,
-            markdownToStructuredPage: { _, _ in nil },
+            markdownStrategy: NoopMarkdownStrategy(),
             sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
         try await builder.buildIndex()

--- a/Packages/Tests/SearchTests/IndexBuilderMalformedURLSkipTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderMalformedURLSkipTests.swift
@@ -6,6 +6,17 @@ import SharedCore
 import SharedModels
 import Testing
 
+// MARK: - Test Doubles
+
+/// `Search.MarkdownToStructuredPageStrategy` test double that returns
+/// `nil` for every input. Used by indexer tests that never exercise the
+/// markdown→page conversion path.
+private struct NoopMarkdownStrategy: Search.MarkdownToStructuredPageStrategy {
+    func convert(markdown: String, url: URL?) -> Shared.Models.StructuredDocumentationPage? {
+        nil
+    }
+}
+
 // Covers the malformed-URL skip path in
 // `Search.AppleDocsStrategy.indexFromMetadata(into:metadata:progress:)`.
 //
@@ -68,7 +79,7 @@ struct IndexBuilderMalformedURLSkipTests {
         let index = try await Search.Index(dbPath: dbPath)
         let strategy = Search.AppleDocsStrategy(
             docsDirectory: docsDir,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownStrategy: NoopMarkdownStrategy()
         )
 
         let stats = try await strategy.indexFromMetadata(
@@ -109,7 +120,7 @@ struct IndexBuilderMalformedURLSkipTests {
         let index = try await Search.Index(dbPath: dbPath)
         let strategy = Search.AppleDocsStrategy(
             docsDirectory: docsDir,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownStrategy: NoopMarkdownStrategy()
         )
 
         let stats = try await strategy.indexFromMetadata(

--- a/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
@@ -9,6 +9,14 @@ import SharedModels
 import SQLite3
 import Testing
 
+// MARK: - Test Doubles
+
+private struct NoopMarkdownStrategy: Search.MarkdownToStructuredPageStrategy {
+    func convert(markdown: String, url: URL?) -> Shared.Models.StructuredDocumentationPage? {
+        nil
+    }
+}
+
 // End-to-end test that a real `Search.IndexBuilder` run on a fixture
 // directory of structured JSON docs produces populated `doc_symbols` rows,
 // a `docs_metadata.symbols` blob, AND a searchable `docs_fts.symbols`
@@ -135,7 +143,7 @@ struct IndexBuilderSymbolsIntegrationTests {
             metadata: nil,
             docsDirectory: docsDir,
             indexSampleCode: false,
-            markdownToStructuredPage: { _, _ in nil },
+            markdownStrategy: NoopMarkdownStrategy(),
             sampleCatalogFetch: { .missing(onDiskPath: "") }
         )
 

--- a/Packages/Tests/SearchTests/StrategyMissingDirectoryTests.swift
+++ b/Packages/Tests/SearchTests/StrategyMissingDirectoryTests.swift
@@ -2,7 +2,16 @@ import Foundation
 @testable import Search
 import SearchModels
 import SharedConstants
+import SharedModels
 import Testing
+
+// MARK: - Test Doubles
+
+private struct NoopMarkdownStrategy: Search.MarkdownToStructuredPageStrategy {
+    func convert(markdown: String, url: URL?) -> Shared.Models.StructuredDocumentationPage? {
+        nil
+    }
+}
 
 // Unit tests for the "directory not found" fast path of each concrete
 // SourceIndexingStrategy type.  These tests exercise the guard at the top of
@@ -41,7 +50,7 @@ struct StrategyMissingDirectoryTests {
         let index = try await makeIndex(in: tempRoot)
         let strategy = Search.AppleDocsStrategy(
             docsDirectory: missingDir,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownStrategy: NoopMarkdownStrategy()
         )
 
         let stats = try await strategy.indexItems(into: index, progress: nil)
@@ -61,7 +70,7 @@ struct StrategyMissingDirectoryTests {
         let index = try await makeIndex(in: tempRoot)
         let strategy = Search.AppleDocsStrategy(
             docsDirectory: emptyDir,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownStrategy: NoopMarkdownStrategy()
         )
 
         let stats = try await strategy.indexItems(into: index, progress: nil)
@@ -159,7 +168,7 @@ struct StrategyMissingDirectoryTests {
         let index = try await makeIndex(in: tempRoot)
         let strategy = Search.SwiftOrgStrategy(
             swiftOrgDirectory: missingDir,
-            markdownToStructuredPage: { _, _ in nil }
+            markdownStrategy: NoopMarkdownStrategy()
         )
 
         let stats = try await strategy.indexItems(into: index, progress: nil)


### PR DESCRIPTION
## What

2/8 of epic #495. Replace the
`Search.MarkdownToStructuredPage = @Sendable (String, URL?) -> Page?`
closure typealias with a named
`Search.MarkdownToStructuredPageStrategy` protocol.

## Why

GoF Strategy (Gamma et al, 1994): the family of algorithms here is
"things that turn markdown into a `Shared.Models.StructuredDocumentationPage`".
Production has one (`Core.JSONParser.MarkdownToStructuredPage.convert`)
and tests have a noop, but the contract is the same. Protocols make
that contract named at the constructor site:

```swift
init(docsDirectory: URL, markdownStrategy: any Search.MarkdownToStructuredPageStrategy)
```

vs the closure form which hid the contract behind `@escaping`.

## Composition root wiring

CLI grows a `LiveMarkdownToStructuredPageStrategy` struct in
`CLI.Command.Save.Indexers.swift` that wraps
`Core.JSONParser.MarkdownToStructuredPage.convert`. The Search and
Indexer targets stay free of `import CoreJSONParser`; only the CLI
composition root reaches the concrete parser.

## Tests

5 test files (`SearchTests` × 3, `SaveTests`, `ServeTests`) each
grow a one-line `NoopMarkdownStrategy: Search.MarkdownToStructuredPageStrategy`
struct that returns `nil` for every input, replacing the inline
`{ _, _ in nil }` closure. The seam reads as a named contract
conformance.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test`: **1441 tests in 161 suites passed**.
- `swiftformat .`: applied (only the 5 touched test files).
- `swiftlint`: only pre-existing warnings.

## Follow-up

6 closure typealiases remain in epic #495:

- 3/8 `Search.SampleCatalogFetch`
- 4/8 `Search.PackageIndexingRun`
- 5/8 `Search.DocsIndexingRun`
- 6/8 `Sample.Index.SamplesIndexingRun`
- 7/8 `MarkdownLookup`
- 8/8 `Services.ReadService.PackageFileLookup`