### PR TITLE
refactor(di): #495 convert Search.SampleCatalogFetch closure to protocol (3/8)

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
@@ -39,7 +39,7 @@ extension CLI.Command.Save {
         let outcome = try await Indexer.DocsService.run(
             request,
             markdownStrategy: LiveMarkdownToStructuredPageStrategy(),
-            sampleCatalogFetch: CLI.Command.Save.sampleCatalogFetch,
+            sampleCatalogProvider: LiveSampleCatalogProvider(),
             docsIndexingRun: CLI.Command.Save.docsIndexingRun
         ) { event in
             Self.handleDocsEvent(event, tracker: tracker)
@@ -62,7 +62,7 @@ extension CLI.Command.Save {
             archiveDirectory: input.archiveDirectory,
             higDirectory: input.higDirectory,
             markdownStrategy: input.markdownStrategy,
-            sampleCatalogFetch: input.sampleCatalogFetch
+            sampleCatalogProvider: input.sampleCatalogProvider
         )
         try await builder.buildIndex(clearExisting: input.clearExisting, onProgress: onProgress)
         let docCount = try await searchIndex.documentCount()
@@ -89,31 +89,34 @@ extension CLI.Command.Save {
 
     // MARK: - Sample catalog adapter
 
-    /// Bridges `Sample.Core.Catalog` (the CoreSampleCode singleton) over
-    /// to the `Search.SampleCatalogFetch` closure shape the Search
-    /// SampleCodeStrategy reads. Lives at the CLI composition root so
-    /// neither Search nor Indexer needs to import `CoreSampleCode`.
-    static let sampleCatalogFetch: @Sendable () async -> Search.SampleCatalogState = {
-        let entries = await Sample.Core.Catalog.allEntries
-        let loaded = await Sample.Core.Catalog.loadedSource ?? .missing
-        switch loaded {
-        case .onDisk:
-            let mapped = entries.map { entry in
-                Search.SampleCatalogEntry(
-                    title: entry.title,
-                    url: entry.url,
-                    framework: entry.framework,
-                    description: entry.description,
-                    zipFilename: entry.zipFilename,
-                    webURL: entry.webURL
-                )
+    /// Concrete `Search.SampleCatalogProvider` (GoF Strategy) that
+    /// bridges `Sample.Core.Catalog` (the CoreSampleCode singleton)
+    /// to the catalog-state shape the Search `SampleCodeStrategy`
+    /// reads. Lives at the CLI composition root so neither Search nor
+    /// Indexer needs to import `CoreSampleCode`.
+    struct LiveSampleCatalogProvider: Search.SampleCatalogProvider {
+        func fetch() async -> Search.SampleCatalogState {
+            let entries = await Sample.Core.Catalog.allEntries
+            let loaded = await Sample.Core.Catalog.loadedSource ?? .missing
+            switch loaded {
+            case .onDisk:
+                let mapped = entries.map { entry in
+                    Search.SampleCatalogEntry(
+                        title: entry.title,
+                        url: entry.url,
+                        framework: entry.framework,
+                        description: entry.description,
+                        zipFilename: entry.zipFilename,
+                        webURL: entry.webURL
+                    )
+                }
+                return .loaded(entries: mapped)
+            case .missing:
+                let path = Shared.Constants.defaultSampleCodeDirectory
+                    .appendingPathComponent(Sample.Core.Catalog.onDiskCatalogFilename)
+                    .path
+                return .missing(onDiskPath: path)
             }
-            return .loaded(entries: mapped)
-        case .missing:
-            let path = Shared.Constants.defaultSampleCodeDirectory
-                .appendingPathComponent(Sample.Core.Catalog.onDiskCatalogFilename)
-                .path
-            return .missing(onDiskPath: path)
         }
     }
 

--- a/Packages/Sources/Indexer/Indexer.DocsService.swift
+++ b/Packages/Sources/Indexer/Indexer.DocsService.swift
@@ -61,7 +61,7 @@ extension Indexer {
         public static func run(
             _ request: Request,
             markdownStrategy: any Search.MarkdownToStructuredPageStrategy,
-            sampleCatalogFetch: @escaping Search.SampleCatalogFetch,
+            sampleCatalogProvider: any Search.SampleCatalogProvider,
             docsIndexingRun: Search.DocsIndexingRun,
             handler: @escaping @Sendable (Event) -> Void = { _ in }
         ) async throws -> Outcome {
@@ -105,7 +105,7 @@ extension Indexer {
                 higDirectory: higDirToUse,
                 clearExisting: request.clear,
                 markdownStrategy: markdownStrategy,
-                sampleCatalogFetch: sampleCatalogFetch
+                sampleCatalogProvider: sampleCatalogProvider
             )
 
             let result = try await docsIndexingRun(input) { processed, total in

--- a/Packages/Sources/Search/Search.IndexBuilder.swift
+++ b/Packages/Sources/Search/Search.IndexBuilder.swift
@@ -96,7 +96,7 @@ extension Search {
             higDirectory: URL? = nil,
             indexSampleCode: Bool = true,
             markdownStrategy: any Search.MarkdownToStructuredPageStrategy,
-            sampleCatalogFetch: @escaping Search.SampleCatalogFetch
+            sampleCatalogProvider: any Search.SampleCatalogProvider
         ) {
             self.init(
                 searchIndex: searchIndex,
@@ -109,7 +109,7 @@ extension Search {
                     higDirectory: higDirectory,
                     indexSampleCode: indexSampleCode,
                     markdownStrategy: markdownStrategy,
-                    sampleCatalogFetch: sampleCatalogFetch
+                    sampleCatalogProvider: sampleCatalogProvider
                 )
             )
         }
@@ -183,7 +183,7 @@ extension Search {
             higDirectory: URL? = nil,
             indexSampleCode: Bool = true,
             markdownStrategy: any Search.MarkdownToStructuredPageStrategy,
-            sampleCatalogFetch: @escaping Search.SampleCatalogFetch
+            sampleCatalogProvider: any Search.SampleCatalogProvider
         ) -> [any Search.SourceIndexingStrategy] {
             var strategies: [any Search.SourceIndexingStrategy] = [
                 Search.AppleDocsStrategy(
@@ -207,7 +207,7 @@ extension Search {
                 strategies.append(Search.HIGStrategy(higDirectory: dir))
             }
             if indexSampleCode {
-                strategies.append(Search.SampleCodeStrategy(sampleCatalogFetch: sampleCatalogFetch))
+                strategies.append(Search.SampleCodeStrategy(sampleCatalogProvider: sampleCatalogProvider))
             }
             strategies.append(Search.SwiftPackagesStrategy())
             return strategies

--- a/Packages/Sources/Search/Strategies/Search.Strategies.SampleCode.swift
+++ b/Packages/Sources/Search/Strategies/Search.Strategies.SampleCode.swift
@@ -9,10 +9,10 @@ import SharedModels
 extension Search {
     /// Indexes the Apple sample code catalog into the search index.
     ///
-    /// The catalog is provided via the injected `sampleCatalogFetch` closure,
-    /// which the composition root (the CLI binary) backs with
-    /// `Sample.Core.Catalog`. Test harnesses pass a closure that returns a
-    /// `Search.SampleCatalogState` fixture directly.
+    /// The catalog is provided via the injected `sampleCatalogProvider`
+    /// conformer, which the composition root (the CLI binary) backs with
+    /// `Sample.Core.Catalog`. Test harnesses pass a struct that returns
+    /// a `Search.SampleCatalogState` fixture directly.
     ///
     /// Each entry's framework availability is looked up from the search
     /// index and cached to avoid redundant database round-trips.
@@ -22,27 +22,27 @@ extension Search {
     ///
     /// ## Example
     /// ```swift
-    /// let strategy = Search.SampleCodeStrategy(sampleCatalogFetch: { /* … */ })
+    /// let strategy = Search.SampleCodeStrategy(sampleCatalogProvider: MyProvider())
     /// let stats = try await strategy.indexItems(into: index, progress: nil)
     /// ```
     public struct SampleCodeStrategy: SourceIndexingStrategy {
         /// The source identifier written into the FTS index.
         public let source = "sample-code"
 
-        /// Closure that returns the current state of the Apple sample-code
-        /// catalog. Injected so this target doesn't depend on
-        /// `CoreSampleCode`; the composition root supplies the adapter
-        /// over `Sample.Core.Catalog`.
-        private let sampleCatalogFetch: Search.SampleCatalogFetch
+        /// Conformer that returns the current state of the Apple
+        /// sample-code catalog. Injected so this target doesn't depend
+        /// on `CoreSampleCode`; the composition root supplies the
+        /// adapter over `Sample.Core.Catalog`.
+        private let sampleCatalogProvider: any Search.SampleCatalogProvider
 
         /// Create a strategy for indexing the sample code catalog.
         ///
-        /// - Parameter sampleCatalogFetch: Closure that returns the
-        ///   `Search.SampleCatalogState` to index. Injected at the
+        /// - Parameter sampleCatalogProvider: Conformer that returns
+        ///   the `Search.SampleCatalogState` to index. Injected at the
         ///   composition root so the strategy can read the catalog
         ///   without depending on the `CoreSampleCode` target directly.
-        public init(sampleCatalogFetch: @escaping Search.SampleCatalogFetch) {
-            self.sampleCatalogFetch = sampleCatalogFetch
+        public init(sampleCatalogProvider: any Search.SampleCatalogProvider) {
+            self.sampleCatalogProvider = sampleCatalogProvider
         }
 
         /// Index all sample code entries from the catalog fetch closure.
@@ -58,7 +58,7 @@ extension Search {
             into index: Search.Index,
             progress: Search.IndexingProgressCallback?
         ) async throws -> Search.IndexStats {
-            let state = await sampleCatalogFetch()
+            let state = await sampleCatalogProvider.fetch()
 
             let entries: [Search.SampleCatalogEntry]
             switch state {

--- a/Packages/Sources/SearchModels/Search.DocsIndexingRun.swift
+++ b/Packages/Sources/SearchModels/Search.DocsIndexingRun.swift
@@ -41,7 +41,7 @@ public extension Search {
         public let higDirectory: URL?
         public let clearExisting: Bool
         public let markdownStrategy: any Search.MarkdownToStructuredPageStrategy
-        public let sampleCatalogFetch: Search.SampleCatalogFetch
+        public let sampleCatalogProvider: any Search.SampleCatalogProvider
 
         public init(
             searchDBPath: URL,
@@ -52,7 +52,7 @@ public extension Search {
             higDirectory: URL?,
             clearExisting: Bool,
             markdownStrategy: any Search.MarkdownToStructuredPageStrategy,
-            sampleCatalogFetch: @escaping Search.SampleCatalogFetch
+            sampleCatalogProvider: any Search.SampleCatalogProvider
         ) {
             self.searchDBPath = searchDBPath
             self.docsDirectory = docsDirectory
@@ -62,7 +62,7 @@ public extension Search {
             self.higDirectory = higDirectory
             self.clearExisting = clearExisting
             self.markdownStrategy = markdownStrategy
-            self.sampleCatalogFetch = sampleCatalogFetch
+            self.sampleCatalogProvider = sampleCatalogProvider
         }
     }
 }

--- a/Packages/Sources/SearchModels/Search.SampleCatalogFetch.swift
+++ b/Packages/Sources/SearchModels/Search.SampleCatalogFetch.swift
@@ -1,26 +1,34 @@
 import Foundation
 import SharedConstants
 
-// MARK: - Search.SampleCatalogFetch
+// MARK: - Search.SampleCatalogProvider
 
-/// Closure shape that returns the current state of the Apple sample-code
-/// catalog. The Search target's `SampleCodeStrategy` uses one of these
-/// instead of reaching into `CoreSampleCode` directly — that's how the
-/// strategy can index the sample catalog while the Search SPM target
-/// keeps a foundation-only dependency graph.
+/// Provider of the current sample-code catalog state for the Search
+/// indexer. GoF Strategy pattern (Gamma et al, 1994): a family of
+/// algorithms (load from on-disk JSON, embedded fallback, test
+/// fixture) interchangeable behind a named protocol.
 ///
-/// The composition root (the CLI binary) supplies the concrete closure
-/// which adapts from `Sample.Core.Catalog`'s static API into the
-/// `SampleCatalogState` shape declared below. Test harnesses pass a
-/// closure that returns a fixture state directly.
+/// The Search target's `SampleCodeStrategy` accepts a conformer at
+/// init so it can index the catalog without reaching into
+/// `CoreSampleCode` directly. The composition root (the CLI binary)
+/// supplies a concrete conformer that adapts from `Sample.Core.Catalog`'s
+/// static API into the `SampleCatalogState` shape declared below.
+/// Test harnesses pass a struct that returns a fixture state directly.
 ///
-/// Mirrors the `Search.Database` / `Search.MarkdownToStructuredPage` /
-/// `MakeSearchDatabase` / `PackageFileLookup` / `MarkdownLookup`
-/// closure-typealias pattern already in SearchModels: the abstraction
-/// lives in this value-types target, the implementation lives in the
-/// producer target, the wiring lives at the composition root.
+/// This replaces the previous
+/// `Search.SampleCatalogFetch = @Sendable () async -> SampleCatalogState`
+/// closure typealias. The protocol form names the contract at the
+/// constructor site (`sampleCatalogProvider:`), makes captured-state
+/// surface explicit on the conforming type's stored properties, and
+/// produces one-line test mocks instead of inline async closures.
 public extension Search {
-    typealias SampleCatalogFetch = @Sendable () async -> SampleCatalogState
+    protocol SampleCatalogProvider: Sendable {
+        /// Return the catalog state at the moment of call. The
+        /// concrete provider decides whether to read on-disk JSON,
+        /// hit an embedded fallback, or return a fixture; the Search
+        /// strategy doesn't care.
+        func fetch() async -> SampleCatalogState
+    }
 }
 
 // MARK: - Search.SampleCatalogState
@@ -50,9 +58,8 @@ public extension Search {
 /// `Sample.Core.Entry` lives.
 ///
 /// The composition root maps `Sample.Core.Entry` → this struct
-/// field-for-field when building the `SampleCatalogFetch` closure;
-/// the round-trip is lossless because both types carry the same six
-/// fields.
+/// field-for-field when building the catalog provider; the round-trip
+/// is lossless because both types carry the same six fields.
 public extension Search {
     struct SampleCatalogEntry: Sendable {
         public let title: String

--- a/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
+++ b/Packages/Tests/CLICommandTests/SaveTests/SaveTests.swift
@@ -22,6 +22,12 @@ private struct NoopMarkdownStrategy: Search.MarkdownToStructuredPageStrategy {
     }
 }
 
+private struct MissingSampleCatalogProvider: Search.SampleCatalogProvider {
+    func fetch() async -> Search.SampleCatalogState {
+        .missing(onDiskPath: "")
+    }
+}
+
 // MARK: - Save Command Tests
 
 // Tests for the `cupertino save` command
@@ -66,7 +72,7 @@ struct SaveCommandTests {
             docsDirectory: tempDir,
             evolutionDirectory: nil,
             markdownStrategy: NoopMarkdownStrategy(),
-            sampleCatalogFetch: { .missing(onDiskPath: "") }
+            sampleCatalogProvider: MissingSampleCatalogProvider()
         )
 
         try await builder.buildIndex()
@@ -122,7 +128,7 @@ struct SaveCommandTests {
             docsDirectory: tempDir,
             evolutionDirectory: nil,
             markdownStrategy: NoopMarkdownStrategy(),
-            sampleCatalogFetch: { .missing(onDiskPath: "") }
+            sampleCatalogProvider: MissingSampleCatalogProvider()
         )
         try await builder.buildIndex()
 
@@ -166,7 +172,7 @@ struct SaveCommandTests {
             docsDirectory: tempDir,
             evolutionDirectory: nil,
             markdownStrategy: NoopMarkdownStrategy(),
-            sampleCatalogFetch: { .missing(onDiskPath: "") }
+            sampleCatalogProvider: MissingSampleCatalogProvider()
         )
 
         // Should not throw, just save 0 documents
@@ -227,7 +233,7 @@ struct SaveCommandTests {
             docsDirectory: docsDir,
             evolutionDirectory: evolutionDir,
             markdownStrategy: NoopMarkdownStrategy(),
-            sampleCatalogFetch: { .missing(onDiskPath: "") }
+            sampleCatalogProvider: MissingSampleCatalogProvider()
         )
 
         try await builder.buildIndex()
@@ -299,7 +305,7 @@ struct SaveCommandTests {
             docsDirectory: tempDir.appendingPathComponent("docs"),
             evolutionDirectory: nil,
             markdownStrategy: NoopMarkdownStrategy(),
-            sampleCatalogFetch: { .missing(onDiskPath: "") }
+            sampleCatalogProvider: MissingSampleCatalogProvider()
         )
 
         try await builder.buildIndex()
@@ -355,7 +361,7 @@ struct SaveCommandTests {
             docsDirectory: tempDir.appendingPathComponent("docs"),
             evolutionDirectory: nil,
             markdownStrategy: NoopMarkdownStrategy(),
-            sampleCatalogFetch: { .missing(onDiskPath: "") }
+            sampleCatalogProvider: MissingSampleCatalogProvider()
         )
 
         try await builder.buildIndex()
@@ -406,7 +412,7 @@ struct SaveCommandTests {
             docsDirectory: tempDir,
             evolutionDirectory: nil,
             markdownStrategy: NoopMarkdownStrategy(),
-            sampleCatalogFetch: { .missing(onDiskPath: "") }
+            sampleCatalogProvider: MissingSampleCatalogProvider()
         )
 
         try await builder.buildIndex()
@@ -440,7 +446,7 @@ struct SaveCommandTests {
             docsDirectory: tempDir,
             evolutionDirectory: nil,
             markdownStrategy: NoopMarkdownStrategy(),
-            sampleCatalogFetch: { .missing(onDiskPath: "") }
+            sampleCatalogProvider: MissingSampleCatalogProvider()
         )
 
         try await builder.buildIndex()

--- a/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
+++ b/Packages/Tests/CLICommandTests/ServeTests/ServeTests.swift
@@ -23,6 +23,12 @@ private struct NoopMarkdownStrategy: Search.MarkdownToStructuredPageStrategy {
     }
 }
 
+private struct MissingSampleCatalogProvider: Search.SampleCatalogProvider {
+    func fetch() async -> Search.SampleCatalogState {
+        .missing(onDiskPath: "")
+    }
+}
+
 // MARK: - MCP Command Tests
 
 // Tests for the `cupertino serve` command
@@ -402,7 +408,7 @@ struct MCPServerIntegrationTests {
             docsDirectory: tempDir,
             evolutionDirectory: nil,
             markdownStrategy: NoopMarkdownStrategy(),
-            sampleCatalogFetch: { .missing(onDiskPath: "") }
+            sampleCatalogProvider: MissingSampleCatalogProvider()
         )
         try await builder.buildIndex()
         print("   ✅ Index built")

--- a/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderSymbolsIntegrationTests.swift
@@ -17,6 +17,15 @@ private struct NoopMarkdownStrategy: Search.MarkdownToStructuredPageStrategy {
     }
 }
 
+/// `Search.SampleCatalogProvider` test double that reports the catalog
+/// as missing. Used by indexer tests that don't need to exercise the
+/// sample-code indexing path.
+private struct MissingSampleCatalogProvider: Search.SampleCatalogProvider {
+    func fetch() async -> Search.SampleCatalogState {
+        .missing(onDiskPath: "")
+    }
+}
+
 // End-to-end test that a real `Search.IndexBuilder` run on a fixture
 // directory of structured JSON docs produces populated `doc_symbols` rows,
 // a `docs_metadata.symbols` blob, AND a searchable `docs_fts.symbols`
@@ -144,7 +153,7 @@ struct IndexBuilderSymbolsIntegrationTests {
             docsDirectory: docsDir,
             indexSampleCode: false,
             markdownStrategy: NoopMarkdownStrategy(),
-            sampleCatalogFetch: { .missing(onDiskPath: "") }
+            sampleCatalogProvider: MissingSampleCatalogProvider()
         )
 
         try await builder.buildIndex(clearExisting: true)


### PR DESCRIPTION
## What

3/8 of epic #495. Replace the
`Search.SampleCatalogFetch = @Sendable () async -> SampleCatalogState`
closure typealias with `Search.SampleCatalogProvider` protocol
(GoF Strategy).

## Composition root wiring

CLI's old `CLI.Command.Save.sampleCatalogFetch` static closure
graduates to `LiveSampleCatalogProvider: Search.SampleCatalogProvider`
struct (same body — Sample.Core.Catalog adapter — wrapped in a named
contract conformance). The Search and Indexer targets stay free of
`import CoreSampleCode`; only the CLI reaches the concrete catalog.

## Tests

3 test files (`IndexBuilderSymbolsIntegrationTests`, `SaveTests`,
`ServeTests`) gain a `MissingSampleCatalogProvider` struct that
returns `.missing(onDiskPath: "")`, replacing inline
`{ .missing(onDiskPath: "") }` closures.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test`: **1441 tests in 161 suites passed**.
- `swiftformat .`: applied (only the 3 touched test files).
- `swiftlint`: only pre-existing warnings.

## Follow-up

5 closure typealiases remain in epic #495:
- 4/8 `Search.PackageIndexingRun`
- 5/8 `Search.DocsIndexingRun`
- 6/8 `Sample.Index.SamplesIndexingRun`
- 7/8 `MarkdownLookup`
- 8/8 `Services.ReadService.PackageFileLookup`