### PR TITLE
refactor(di): #495 convert Search.PackageIndexingRun closure to protocol (4/8)

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
@@ -183,35 +183,41 @@ extension CLI.Command.Save {
 
         _ = try await Indexer.PackagesService.run(
             request,
-            packageIndexingRun: Self.packageIndexingRun
+            packageIndexingRunner: LivePackageIndexingRunner()
         ) { event in
             Self.handlePackagesEvent(event)
         }
     }
 
-    /// Concrete implementation of `Search.PackageIndexingRun` used by
+    /// Concrete `Search.PackageIndexingRunner` (GoF Strategy) used by
     /// `Indexer.PackagesService`. Wraps `Search.PackageIndex` +
     /// `Search.PackageIndexer`. Lives at the CLI composition root so
     /// the Indexer SPM target doesn't import `Search` for these types.
-    static let packageIndexingRun: Search.PackageIndexingRun = { packagesRoot, packagesDB, onProgress in
-        let startedAt = Date()
-        let index = try await Search.PackageIndex(dbPath: packagesDB)
-        let indexer = Search.PackageIndexer(rootDirectory: packagesRoot, index: index)
-        let stats = try await indexer.indexAll { name, done, total in
-            onProgress(name, done, total)
+    struct LivePackageIndexingRunner: Search.PackageIndexingRunner {
+        func run(
+            packagesRoot: URL,
+            packagesDB: URL,
+            onProgress: @escaping @Sendable (String, Int, Int) -> Void
+        ) async throws -> Search.PackageIndexingOutcome {
+            let startedAt = Date()
+            let index = try await Search.PackageIndex(dbPath: packagesDB)
+            let indexer = Search.PackageIndexer(rootDirectory: packagesRoot, index: index)
+            let stats = try await indexer.indexAll { name, done, total in
+                onProgress(name, done, total)
+            }
+            let summary = try await index.summary()
+            await index.disconnect()
+            return Search.PackageIndexingOutcome(
+                packagesIndexed: stats.packagesIndexed,
+                packagesFailed: stats.packagesFailed,
+                totalFiles: stats.totalFiles,
+                totalBytes: stats.totalBytes,
+                durationSeconds: Date().timeIntervalSince(startedAt),
+                totalPackagesInDB: summary.packageCount,
+                totalFilesInDB: summary.fileCount,
+                totalBytesInDB: summary.bytesIndexed
+            )
         }
-        let summary = try await index.summary()
-        await index.disconnect()
-        return Search.PackageIndexingOutcome(
-            packagesIndexed: stats.packagesIndexed,
-            packagesFailed: stats.packagesFailed,
-            totalFiles: stats.totalFiles,
-            totalBytes: stats.totalBytes,
-            durationSeconds: Date().timeIntervalSince(startedAt),
-            totalPackagesInDB: summary.packageCount,
-            totalFilesInDB: summary.fileCount,
-            totalBytesInDB: summary.bytesIndexed
-        )
     }
 
     static func handlePackagesEvent(_ event: Indexer.PackagesService.Event) {

--- a/Packages/Sources/Indexer/Indexer.PackagesService.swift
+++ b/Packages/Sources/Indexer/Indexer.PackagesService.swift
@@ -6,10 +6,10 @@ import SharedCore
 extension Indexer {
     /// Build `packages.db` from extracted package archives at
     /// `~/.cupertino/packages/<owner>/<repo>/`. Wraps an injected
-    /// `Search.PackageIndexingRun` closure with event-emission so this
-    /// target doesn't import `Search` directly — the CLI composition
-    /// root supplies a closure backed by `Search.PackageIndex` +
-    /// `Search.PackageIndexer`.
+    /// `Search.PackageIndexingRunner` conformer with event-emission
+    /// so this target doesn't import `Search` directly — the CLI
+    /// composition root supplies a `LivePackageIndexingRunner` backed
+    /// by `Search.PackageIndex` + `Search.PackageIndexer`.
     public enum PackagesService {
         public struct Request: Sendable {
             public let packagesRoot: URL
@@ -47,7 +47,7 @@ extension Indexer {
 
         public static func run(
             _ request: Request,
-            packageIndexingRun: Search.PackageIndexingRun,
+            packageIndexingRunner: any Search.PackageIndexingRunner,
             handler: @escaping @Sendable (Event) -> Void = { _ in }
         ) async throws -> Outcome {
             handler(.starting(
@@ -60,9 +60,9 @@ extension Indexer {
                 try FileManager.default.removeItem(at: request.packagesDB)
             }
 
-            let result = try await packageIndexingRun(
-                request.packagesRoot,
-                request.packagesDB
+            let result = try await packageIndexingRunner.run(
+                packagesRoot: request.packagesRoot,
+                packagesDB: request.packagesDB
             ) { name, done, total in
                 handler(.progress(name: name, done: done, total: total))
             }

--- a/Packages/Sources/SearchModels/Search.PackageIndexingRun.swift
+++ b/Packages/Sources/SearchModels/Search.PackageIndexingRun.swift
@@ -1,34 +1,52 @@
 import Foundation
 
-// MARK: - Search.PackageIndexingRun
+// MARK: - Search.PackageIndexingRunner
 
-/// Closure shape for running a complete `packages.db` indexing pass:
-/// open the index, walk the on-disk package tree, write every package
-/// row, summarise the resulting database, and disconnect.
+/// Runner for a complete `packages.db` indexing pass: open the index,
+/// walk the on-disk package tree, write every package row, summarise
+/// the resulting database, and disconnect. GoF Strategy pattern
+/// (Gamma et al, 1994): a family of algorithms (production
+/// `Search.PackageIndex` + `Search.PackageIndexer` pipeline, test
+/// fixture stubs) interchangeable behind a named protocol.
 ///
-/// `Indexer.PackagesService` accepts one of these instead of reaching
-/// directly into `Search.PackageIndex` + `Search.PackageIndexer`, so
-/// the Indexer SPM target keeps its dependency graph free of the
-/// concrete Search-target actors. The composition root (the CLI's
-/// `save` command) supplies the closure with the standard
-/// `Search.PackageIndex` + `Search.PackageIndexer` wiring.
+/// `Indexer.PackagesService` accepts a conformer at run-time so the
+/// Indexer SPM target keeps its dependency graph free of the concrete
+/// Search-target actors. The composition root (the CLI's `save`
+/// command) supplies a `LivePackageIndexingRunner` that wraps the
+/// standard `Search.PackageIndex` + `Search.PackageIndexer` wiring.
 ///
-/// Mirrors the `MakeSearchDatabase` / `MarkdownToStructuredPage` /
-/// `SampleCatalogFetch` closure-typealias pattern already in
-/// SearchModels: the abstraction lives in this value-types target,
-/// the implementation lives in the producer target, the wiring lives
-/// at the composition root.
+/// This replaces the previous
+/// `Search.PackageIndexingRun = @Sendable (URL, URL, callback) async throws -> Outcome`
+/// closure typealias. The protocol form names the contract at the
+/// constructor site (`packageIndexingRunner:`), makes captured-state
+/// surface explicit on the conforming type's stored properties, and
+/// produces one-line test mocks instead of multi-arg async closures.
+///
+/// The progress callback stays a closure — it's a genuine
+/// (name, done, total) callback, not a strategy seam.
 public extension Search {
-    typealias PackageIndexingRun = @Sendable (
-        _ packagesRoot: URL,
-        _ packagesDBPath: URL,
-        _ onProgress: @escaping @Sendable (String, Int, Int) -> Void
-    ) async throws -> PackageIndexingOutcome
+    protocol PackageIndexingRunner: Sendable {
+        /// Run one full indexing pass and return its outcome.
+        ///
+        /// - Parameters:
+        ///   - packagesRoot: On-disk root of extracted package archives
+        ///     (typically `~/.cupertino/packages/`).
+        ///   - packagesDB: Destination database file URL.
+        ///   - onProgress: Optional per-package progress callback,
+        ///     receiving the package name and the (done, total)
+        ///     counts.
+        /// - Returns: The aggregated `PackageIndexingOutcome`.
+        func run(
+            packagesRoot: URL,
+            packagesDB: URL,
+            onProgress: @escaping @Sendable (String, Int, Int) -> Void
+        ) async throws -> PackageIndexingOutcome
+    }
 }
 
 // MARK: - Search.PackageIndexingOutcome
 
-/// Statistics emitted by a `Search.PackageIndexingRun` closure.
+/// Statistics emitted by a `Search.PackageIndexingRunner` run.
 ///
 /// The Indexer translates this into its public
 /// `Indexer.PackagesService.Outcome` event payload (which keeps the


### PR DESCRIPTION
## What

4/8 of epic #495. Replace the
`Search.PackageIndexingRun = @Sendable (URL, URL, callback) async throws -> Outcome`
closure typealias with `Search.PackageIndexingRunner` protocol
(GoF Strategy).

The progress callback stays a closure — it's a genuine
(name, done, total) callback, not a strategy seam.

## Composition root wiring

CLI's old `CLI.Command.Save.packageIndexingRun` static closure
becomes `LivePackageIndexingRunner: Search.PackageIndexingRunner`
nested struct. Body unchanged. Indexer keeps zero `import Search`;
only the CLI composition root reaches `Search.PackageIndex` /
`Search.PackageIndexer`.

## Tests

No test changes required — the closure had no direct test callsites;
the indexer service was tested via integration paths that go through
the CLI command.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test`: **1441 tests in 161 suites passed**.
- `swiftformat .`: no changes.
- `swiftlint`: only pre-existing warnings.

## Follow-up

4 closure typealiases remain in epic #495:
- 5/8 `Search.DocsIndexingRun`
- 6/8 `Sample.Index.SamplesIndexingRun`
- 7/8 `MarkdownLookup`
- 8/8 `Services.ReadService.PackageFileLookup`