### PR TITLE
refactor(di): #495 convert Search.DocsIndexingRun closure to protocol (5/8)

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
@@ -40,38 +40,43 @@ extension CLI.Command.Save {
             request,
             markdownStrategy: LiveMarkdownToStructuredPageStrategy(),
             sampleCatalogProvider: LiveSampleCatalogProvider(),
-            docsIndexingRun: CLI.Command.Save.docsIndexingRun
+            docsIndexingRunner: LiveDocsIndexingRunner()
         ) { event in
             Self.handleDocsEvent(event, tracker: tracker)
         }
         Self.printDocsSummary(outcome: outcome)
     }
 
-    /// Concrete implementation of `Search.DocsIndexingRun` used by
+    /// Concrete `Search.DocsIndexingRunner` (GoF Strategy) used by
     /// `Indexer.DocsService`. Wraps `Search.Index` + `Search.IndexBuilder`.
     /// Lives at the CLI composition root so Indexer doesn't need
     /// `import Search` for these actor types.
-    static let docsIndexingRun: Search.DocsIndexingRun = { input, onProgress in
-        let searchIndex = try await Search.Index(dbPath: input.searchDBPath)
-        let builder = Search.IndexBuilder(
-            searchIndex: searchIndex,
-            metadata: nil,
-            docsDirectory: input.docsDirectory,
-            evolutionDirectory: input.evolutionDirectory,
-            swiftOrgDirectory: input.swiftOrgDirectory,
-            archiveDirectory: input.archiveDirectory,
-            higDirectory: input.higDirectory,
-            markdownStrategy: input.markdownStrategy,
-            sampleCatalogProvider: input.sampleCatalogProvider
-        )
-        try await builder.buildIndex(clearExisting: input.clearExisting, onProgress: onProgress)
-        let docCount = try await searchIndex.documentCount()
-        let frameworks = try await searchIndex.listFrameworks()
-        await searchIndex.disconnect()
-        return Search.DocsIndexingOutcome(
-            documentCount: docCount,
-            frameworkCount: frameworks.count
-        )
+    struct LiveDocsIndexingRunner: Search.DocsIndexingRunner {
+        func run(
+            input: Search.DocsIndexingInput,
+            onProgress: @escaping @Sendable (Int, Int) -> Void
+        ) async throws -> Search.DocsIndexingOutcome {
+            let searchIndex = try await Search.Index(dbPath: input.searchDBPath)
+            let builder = Search.IndexBuilder(
+                searchIndex: searchIndex,
+                metadata: nil,
+                docsDirectory: input.docsDirectory,
+                evolutionDirectory: input.evolutionDirectory,
+                swiftOrgDirectory: input.swiftOrgDirectory,
+                archiveDirectory: input.archiveDirectory,
+                higDirectory: input.higDirectory,
+                markdownStrategy: input.markdownStrategy,
+                sampleCatalogProvider: input.sampleCatalogProvider
+            )
+            try await builder.buildIndex(clearExisting: input.clearExisting, onProgress: onProgress)
+            let docCount = try await searchIndex.documentCount()
+            let frameworks = try await searchIndex.listFrameworks()
+            await searchIndex.disconnect()
+            return Search.DocsIndexingOutcome(
+                documentCount: docCount,
+                frameworkCount: frameworks.count
+            )
+        }
     }
 
     // MARK: - Markdown strategy adapter

--- a/Packages/Sources/Indexer/Indexer.DocsService.swift
+++ b/Packages/Sources/Indexer/Indexer.DocsService.swift
@@ -7,7 +7,7 @@ import SharedCore
 extension Indexer {
     /// Build `search.db` from on-disk corpus (apple-docs JSON, swift
     /// evolution markdown, swift.org, archive, HIG). Wraps an injected
-    /// `Search.DocsIndexingRun` closure with event-emission so this
+    /// `Search.DocsIndexingRunner` conformer with event-emission so this
     /// target doesn't import `Search` directly — the CLI composition
     /// root supplies a closure backed by `Search.Index` +
     /// `Search.IndexBuilder`.
@@ -62,7 +62,7 @@ extension Indexer {
             _ request: Request,
             markdownStrategy: any Search.MarkdownToStructuredPageStrategy,
             sampleCatalogProvider: any Search.SampleCatalogProvider,
-            docsIndexingRun: Search.DocsIndexingRun,
+            docsIndexingRunner: any Search.DocsIndexingRunner,
             handler: @escaping @Sendable (Event) -> Void = { _ in }
         ) async throws -> Outcome {
             let docsURL = request.docsDir
@@ -108,7 +108,7 @@ extension Indexer {
                 sampleCatalogProvider: sampleCatalogProvider
             )
 
-            let result = try await docsIndexingRun(input) { processed, total in
+            let result = try await docsIndexingRunner.run(input: input) { processed, total in
                 let percent = Double(processed) / Double(total) * 100
                 handler(.progress(processed: processed, total: total, percent: percent))
             }

--- a/Packages/Sources/SearchModels/Search.DocsIndexingRun.swift
+++ b/Packages/Sources/SearchModels/Search.DocsIndexingRun.swift
@@ -1,36 +1,53 @@
 import Foundation
 
-// MARK: - Search.DocsIndexingRun
+// MARK: - Search.DocsIndexingRunner
 
-/// Closure shape for running a complete `search.db` documentation
-/// indexing pass: open the index, build the strategy array, walk every
-/// on-disk source directory (apple-docs JSON, Swift Evolution markdown,
+/// Runner for a complete `search.db` documentation indexing pass:
+/// open the index, build the strategy array, walk every on-disk
+/// source directory (apple-docs JSON, Swift Evolution markdown,
 /// Swift.org, Apple Archive, HIG), write rows, and disconnect.
+/// GoF Strategy pattern (Gamma et al, 1994): a family of algorithms
+/// (production `Search.Index` + `Search.IndexBuilder` pipeline,
+/// test fixture stubs) interchangeable behind a named protocol.
 ///
-/// `Indexer.DocsService` accepts one of these instead of reaching
-/// directly into `Search.Index` + `Search.IndexBuilder`, so the
+/// `Indexer.DocsService` accepts a conformer at run-time so the
 /// Indexer SPM target keeps its dependency graph free of the
 /// concrete Search-target actors. The composition root (the CLI's
-/// `save` command) supplies the closure with the standard
-/// `Search.Index` + `Search.IndexBuilder` wiring.
+/// `save` command) supplies a `LiveDocsIndexingRunner` backed by the
+/// standard `Search.Index` + `Search.IndexBuilder` wiring.
 ///
-/// Mirrors the `Search.PackageIndexingRun` /
-/// `Search.MarkdownToStructuredPage` / `Search.SampleCatalogFetch` /
-/// `MakeSearchDatabase` closure-typealias pattern already in
-/// SearchModels.
+/// This replaces the previous
+/// `Search.DocsIndexingRun = @Sendable (DocsIndexingInput, callback) async throws -> Outcome`
+/// closure typealias. The protocol form names the contract at the
+/// constructor site (`docsIndexingRunner:`), makes captured-state
+/// surface explicit on the conforming type's stored properties, and
+/// produces one-line test mocks instead of multi-arg async closures.
+///
+/// The progress callback stays a closure — it's a genuine
+/// (processed, total) callback, not a strategy seam.
 public extension Search {
-    typealias DocsIndexingRun = @Sendable (
-        _ input: DocsIndexingInput,
-        _ onProgress: @escaping @Sendable (Int, Int) -> Void
-    ) async throws -> DocsIndexingOutcome
+    protocol DocsIndexingRunner: Sendable {
+        /// Run one full indexing pass and return its outcome.
+        ///
+        /// - Parameters:
+        ///   - input: The full parameter bundle (paths + injected
+        ///     markdown strategy + injected sample-catalog provider).
+        ///   - onProgress: Optional `(processed, total)` callback,
+        ///     called periodically as the indexer makes progress.
+        /// - Returns: The aggregated `DocsIndexingOutcome`.
+        func run(
+            input: DocsIndexingInput,
+            onProgress: @escaping @Sendable (Int, Int) -> Void
+        ) async throws -> DocsIndexingOutcome
+    }
 }
 
 // MARK: - Search.DocsIndexingInput
 
-/// Parameter bundle for `Search.DocsIndexingRun`. Carries every URL
-/// the indexer needs to find the source corpus + the two markdown /
-/// sample-catalog closures the indexer threads down into its strategy
-/// implementations.
+/// Parameter bundle for `Search.DocsIndexingRunner.run`. Carries
+/// every URL the indexer needs to find the source corpus + the two
+/// strategy / provider conformers the indexer threads down into its
+/// strategy implementations.
 public extension Search {
     struct DocsIndexingInput: Sendable {
         public let searchDBPath: URL
@@ -69,9 +86,9 @@ public extension Search {
 
 // MARK: - Search.DocsIndexingOutcome
 
-/// Statistics emitted by a completed `Search.DocsIndexingRun`. The
-/// Indexer translates this into its public `Indexer.DocsService.Outcome`
-/// event payload.
+/// Statistics emitted by a completed `Search.DocsIndexingRunner` run.
+/// The Indexer translates this into its public
+/// `Indexer.DocsService.Outcome` event payload.
 public extension Search {
     struct DocsIndexingOutcome: Sendable {
         public let documentCount: Int


### PR DESCRIPTION
## What

5/8 of epic #495. Replace the
`Search.DocsIndexingRun = @Sendable (DocsIndexingInput, callback) async throws -> Outcome`
closure typealias with `Search.DocsIndexingRunner` protocol
(GoF Strategy).

The progress callback stays a closure — it's a genuine
(processed, total) callback, not a strategy seam.

## Composition root wiring

CLI's old `CLI.Command.Save.docsIndexingRun` static closure
becomes `LiveDocsIndexingRunner: Search.DocsIndexingRunner`
nested struct. Body unchanged. Indexer keeps zero `import Search`;
only the CLI composition root reaches `Search.Index` /
`Search.IndexBuilder`.

## Tests

No test changes required — the closure had no direct test callsites;
the docs-indexing service was tested via integration paths that go
through the CLI command.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test`: **1441 tests in 161 suites passed**.
- `swiftformat .`: no changes.
- `swiftlint`: only pre-existing warnings.

## Follow-up

3 closure typealiases remain in epic #495:
- 6/8 `Sample.Index.SamplesIndexingRun`
- 7/8 `MarkdownLookup`
- 8/8 `Services.ReadService.PackageFileLookup`