### PR TITLE
refactor(di): #495 convert Sample.Index.SamplesIndexingRun closure to protocol (6/8)

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Save.Indexers.swift
@@ -283,84 +283,89 @@ extension CLI.Command.Save {
         let tracker = ProgressTracker()
         _ = try await Indexer.SamplesService.run(
             request,
-            samplesIndexingRun: CLI.Command.Save.samplesIndexingRun
+            samplesIndexingRunner: LiveSamplesIndexingRunner()
         ) { event in
             Self.handleSamplesEvent(event, tracker: tracker)
         }
     }
 
-    /// Concrete implementation of `Sample.Index.SamplesIndexingRun` used
-    /// by `Indexer.SamplesService`. Wraps `Sample.Index.Database` +
-    /// `Sample.Index.Builder` + `Sample.Core.Catalog`. Lives at the CLI
-    /// composition root so the Indexer SPM target doesn't import
+    /// Concrete `Sample.Index.SamplesIndexingRunner` (GoF Strategy)
+    /// used by `Indexer.SamplesService`. Wraps `Sample.Index.Database` +
+    /// `Sample.Index.Builder` + `Sample.Core.Catalog`. Lives at the
+    /// CLI composition root so the Indexer SPM target doesn't import
     /// SampleIndex or CoreSampleCode for these types.
-    static let samplesIndexingRun: Sample.Index.SamplesIndexingRun = { input, onPhase in
-        let database = try await Sample.Index.Database(dbPath: input.samplesDB)
-        if input.clear {
-            onPhase(.clearingExistingIndex)
-            try await database.clearAll()
-        }
+    struct LiveSamplesIndexingRunner: Sample.Index.SamplesIndexingRunner {
+        func run(
+            input: Sample.Index.SamplesIndexingInput,
+            onPhase: @escaping @Sendable (Sample.Index.SamplesIndexingPhase) -> Void
+        ) async throws -> Sample.Index.SamplesIndexingOutcome {
+            let database = try await Sample.Index.Database(dbPath: input.samplesDB)
+            if input.clear {
+                onPhase(.clearingExistingIndex)
+                try await database.clearAll()
+            }
 
-        let existingProjects = try await database.projectCount()
-        let existingFiles = try await database.fileCount()
-        if existingProjects > 0, !input.force, !input.clear {
-            onPhase(.existingIndexNotice(projects: existingProjects, files: existingFiles))
-        }
+            let existingProjects = try await database.projectCount()
+            let existingFiles = try await database.fileCount()
+            if existingProjects > 0, !input.force, !input.clear {
+                onPhase(.existingIndexNotice(projects: existingProjects, files: existingFiles))
+            }
 
-        onPhase(.loadingCatalog)
-        let catalogEntries = await Sample.Core.Catalog.allEntries
-        onPhase(.catalogLoaded(entryCount: catalogEntries.count))
+            onPhase(.loadingCatalog)
+            let catalogEntries = await Sample.Core.Catalog.allEntries
+            onPhase(.catalogLoaded(entryCount: catalogEntries.count))
 
-        let entries = catalogEntries.map { entry in
-            Sample.Index.SampleCodeEntryInfo(
-                title: entry.title,
-                description: entry.description,
-                frameworks: [entry.framework],
-                webURL: entry.webURL,
-                zipFilename: entry.zipFilename
+            let entries = catalogEntries.map { entry in
+                Sample.Index.SampleCodeEntryInfo(
+                    title: entry.title,
+                    description: entry.description,
+                    frameworks: [entry.framework],
+                    webURL: entry.webURL,
+                    zipFilename: entry.zipFilename
+                )
+            }
+
+            onPhase(.indexingStart)
+            let builder = Sample.Index.Builder(
+                database: database,
+                sampleCodeDirectory: input.sampleCodeDir
+            )
+
+            let startTime = Date()
+            let indexed = try await builder.indexAll(
+                entries: entries,
+                forceReindex: input.force
+            ) { progress in
+                let phase: Sample.Index.SamplesIndexingPhase.ProgressPhase
+                switch progress.status {
+                case .extracting: phase = .extracting
+                case .indexingFiles: phase = .indexingFiles
+                case .completed: phase = .completed
+                case .failed: phase = .failed
+                }
+                onPhase(.projectProgress(
+                    name: progress.currentProject,
+                    percent: progress.percentComplete,
+                    phase: phase
+                ))
+            }
+
+            let duration = Date().timeIntervalSince(startTime)
+
+            let finalProjects = try await database.projectCount()
+            let finalFiles = try await database.fileCount()
+            let finalSymbols = try await database.symbolCount()
+            let finalImports = try await database.importCount()
+
+            return Sample.Index.SamplesIndexingOutcome(
+                projectsIndexedThisRun: indexed,
+                projectsTotal: finalProjects,
+                filesTotal: finalFiles,
+                symbolsTotal: finalSymbols,
+                importsTotal: finalImports,
+                durationSeconds: duration
             )
         }
-
-        onPhase(.indexingStart)
-        let builder = Sample.Index.Builder(
-            database: database,
-            sampleCodeDirectory: input.sampleCodeDir
-        )
-
-        let startTime = Date()
-        let indexed = try await builder.indexAll(
-            entries: entries,
-            forceReindex: input.force
-        ) { progress in
-            let phase: Sample.Index.SamplesIndexingPhase.ProgressPhase
-            switch progress.status {
-            case .extracting: phase = .extracting
-            case .indexingFiles: phase = .indexingFiles
-            case .completed: phase = .completed
-            case .failed: phase = .failed
-            }
-            onPhase(.projectProgress(
-                name: progress.currentProject,
-                percent: progress.percentComplete,
-                phase: phase
-            ))
-        }
-
-        let duration = Date().timeIntervalSince(startTime)
-
-        let finalProjects = try await database.projectCount()
-        let finalFiles = try await database.fileCount()
-        let finalSymbols = try await database.symbolCount()
-        let finalImports = try await database.importCount()
-
-        return Sample.Index.SamplesIndexingOutcome(
-            projectsIndexedThisRun: indexed,
-            projectsTotal: finalProjects,
-            filesTotal: finalFiles,
-            symbolsTotal: finalSymbols,
-            importsTotal: finalImports,
-            durationSeconds: duration
-        )
     }
 
     static func handleSamplesEvent(

--- a/Packages/Sources/Indexer/Indexer.SamplesService.swift
+++ b/Packages/Sources/Indexer/Indexer.SamplesService.swift
@@ -6,10 +6,11 @@ import SharedCore
 extension Indexer {
     /// Build `samples.db` from extracted sample-code zips at
     /// `~/.cupertino/sample-code/`. Wraps an injected
-    /// `Sample.Index.SamplesIndexingRun` closure with event-emission
-    /// so this target doesn't import `SampleIndex` or `CoreSampleCode`
-    /// directly — the CLI composition root supplies a closure backed
-    /// by `Sample.Index.Database` + `Sample.Index.Builder` +
+    /// `Sample.Index.SamplesIndexingRunner` conformer with
+    /// event-emission so this target doesn't import `SampleIndex`
+    /// or `CoreSampleCode` directly — the CLI composition root
+    /// supplies a `LiveSamplesIndexingRunner` backed by
+    /// `Sample.Index.Database` + `Sample.Index.Builder` +
     /// `Sample.Core.Catalog`.
     public enum SamplesService {
         public struct Request: Sendable {
@@ -73,7 +74,7 @@ extension Indexer {
 
         public static func run(
             _ request: Request,
-            samplesIndexingRun: Sample.Index.SamplesIndexingRun,
+            samplesIndexingRunner: any Sample.Index.SamplesIndexingRunner,
             handler: @escaping @Sendable (Event) -> Void = { _ in }
         ) async throws -> Outcome {
             handler(.starting(
@@ -99,7 +100,7 @@ extension Indexer {
                 force: request.force
             )
 
-            let result = try await samplesIndexingRun(input) { phase in
+            let result = try await samplesIndexingRunner.run(input: input) { phase in
                 switch phase {
                 case .clearingExistingIndex:
                     handler(.clearingExistingIndex)

--- a/Packages/Sources/SampleIndexModels/Sample.Index.SamplesIndexingRun.swift
+++ b/Packages/Sources/SampleIndexModels/Sample.Index.SamplesIndexingRun.swift
@@ -1,33 +1,55 @@
 import Foundation
 import SharedConstants
 
-// MARK: - Sample.Index.SamplesIndexingRun
+// MARK: - Sample.Index.SamplesIndexingRunner
 
-/// Closure shape for running a complete `samples.db` indexing pass:
-/// open the database, optionally clear it, load the sample-code
-/// catalog, walk the on-disk sample ZIPs, write project + file +
-/// symbol rows, and close. The closure also emits lifecycle events
-/// through the supplied `onPhase` callback so `Indexer.SamplesService`
-/// can forward them to its `Event` API without inspecting the
-/// indexer's internals.
+/// Runner for a complete `samples.db` indexing pass: open the
+/// database, optionally clear it, load the sample-code catalog,
+/// walk the on-disk sample ZIPs, write project + file + symbol
+/// rows, and close. GoF Strategy pattern (Gamma et al, 1994): a
+/// family of algorithms (production `Sample.Index.Database` +
+/// `Sample.Index.Builder` + `Sample.Core.Catalog` pipeline, test
+/// fixture stubs) interchangeable behind a named protocol.
 ///
-/// `Indexer.SamplesService` accepts one of these instead of reaching
-/// directly into `Sample.Index.Database` / `Sample.Index.Builder` /
-/// `Sample.Core.Catalog`. The composition root (the CLI's `save`
-/// command) supplies the closure with the standard concrete wiring.
+/// The runner emits lifecycle events through the supplied `onPhase`
+/// callback so `Indexer.SamplesService` can forward them to its
+/// `Event` API without inspecting the indexer's internals.
 ///
-/// Mirrors the `Search.DocsIndexingRun` / `Search.PackageIndexingRun`
-/// pattern.
+/// `Indexer.SamplesService` accepts a conformer at run-time so the
+/// Indexer SPM target keeps its dependency graph free of the
+/// concrete sample-indexing actors. The composition root (the CLI's
+/// `save` command) supplies a `LiveSamplesIndexingRunner` backed by
+/// the standard concrete wiring.
+///
+/// This replaces the previous
+/// `Sample.Index.SamplesIndexingRun = @Sendable (Input, phaseCallback) async throws -> Outcome`
+/// closure typealias. The protocol form names the contract at the
+/// constructor site (`samplesIndexingRunner:`), makes captured-state
+/// surface explicit on the conforming type's stored properties, and
+/// produces one-line test mocks instead of multi-arg async closures.
+///
+/// The phase callback stays a closure — it's a genuine lifecycle
+/// event stream, not a strategy seam.
 public extension Sample.Index {
-    typealias SamplesIndexingRun = @Sendable (
-        _ input: SamplesIndexingInput,
-        _ onPhase: @escaping @Sendable (SamplesIndexingPhase) -> Void
-    ) async throws -> SamplesIndexingOutcome
+    protocol SamplesIndexingRunner: Sendable {
+        /// Run one full indexing pass and return its outcome.
+        ///
+        /// - Parameters:
+        ///   - input: Paths + clear / force flags.
+        ///   - onPhase: Callback that receives each lifecycle event
+        ///     (`.loadingCatalog`, `.projectProgress(...)`, …) so the
+        ///     caller can forward them to its event API.
+        /// - Returns: The aggregated `SamplesIndexingOutcome`.
+        func run(
+            input: SamplesIndexingInput,
+            onPhase: @escaping @Sendable (SamplesIndexingPhase) -> Void
+        ) async throws -> SamplesIndexingOutcome
+    }
 }
 
 // MARK: - Sample.Index.SamplesIndexingInput
 
-/// Parameter bundle for `Sample.Index.SamplesIndexingRun`. Mirrors
+/// Parameter bundle for `Sample.Index.SamplesIndexingRunner.run`. Mirrors
 /// `Indexer.SamplesService.Request` field-for-field; the Indexer
 /// service translates one to the other.
 public extension Sample.Index {
@@ -53,7 +75,7 @@ public extension Sample.Index {
 
 // MARK: - Sample.Index.SamplesIndexingPhase
 
-/// Lifecycle events emitted by a `Sample.Index.SamplesIndexingRun`
+/// Lifecycle events emitted by a `Sample.Index.SamplesIndexingRunner`
 /// closure. Indexer.SamplesService translates each phase into its
 /// matching public `Event` case (`.clearingExistingIndex`,
 /// `.existingIndexNotice(...)`, `.loadingCatalog`,
@@ -79,7 +101,7 @@ public extension Sample.Index {
 
 // MARK: - Sample.Index.SamplesIndexingOutcome
 
-/// Statistics emitted by a completed `Sample.Index.SamplesIndexingRun`.
+/// Statistics emitted by a completed `Sample.Index.SamplesIndexingRunner` run.
 public extension Sample.Index {
     struct SamplesIndexingOutcome: Sendable {
         public let projectsIndexedThisRun: Int


### PR DESCRIPTION
## What

6/8 of epic #495. Replace the
`Sample.Index.SamplesIndexingRun = @Sendable (Input, phaseCallback) async throws -> Outcome`
closure typealias with `Sample.Index.SamplesIndexingRunner` protocol
(GoF Strategy).

The phase callback stays a closure — it's a genuine lifecycle event
stream, not a strategy seam.

## Composition root wiring

CLI's old `CLI.Command.Save.samplesIndexingRun` static closure
becomes `LiveSamplesIndexingRunner: Sample.Index.SamplesIndexingRunner`
nested struct. Body unchanged. Indexer keeps zero
`import SampleIndex` / `import CoreSampleCode`; only the CLI
composition root reaches `Sample.Index.Database` /
`Sample.Index.Builder` / `Sample.Core.Catalog`.

## Tests

No test changes required — the samples-indexing service is tested via
the CLI command integration paths.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test`: **1441 tests in 161 suites passed**.
- `swiftformat .`: no changes.
- `swiftlint`: only pre-existing warnings.

## Follow-up

2 closure typealiases remain in epic #495:
- 7/8 `MarkdownLookup`
- 8/8 `Services.ReadService.PackageFileLookup`