### PR TITLE
refactor(di): #495 convert MCP.Support.MarkdownLookup closure to protocol (7/8)

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Serve.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Serve.swift
@@ -129,14 +129,12 @@ extension CLI.Command {
 
             // Register resource provider with optional search-index markdown
             // lookup. The provider doesn't see the Search target — it just
-            // gets a closure that returns markdown for a URI, or nil if the
+            // gets a strategy that returns markdown for a URI, or nil if the
             // URI isn't indexed. This keeps MCPSupport free of the Search
             // import per the DI epic (#406).
-            let markdownLookup: MCP.Support.DocsResourceProvider.MarkdownLookup?
+            let markdownLookup: (any MCP.Support.MarkdownLookupStrategy)?
             if let searchIndex {
-                markdownLookup = { uri in
-                    try await searchIndex.getDocumentContent(uri: uri, format: .markdown)
-                }
+                markdownLookup = LiveMarkdownLookupStrategy(searchIndex: searchIndex)
             } else {
                 markdownLookup = nil
             }

--- a/Packages/Sources/CLI/SearchModuleAlias.swift
+++ b/Packages/Sources/CLI/SearchModuleAlias.swift
@@ -1,4 +1,6 @@
 import Foundation
+import MCPCore
+import MCPSupport
 import Search
 import SearchModels
 import Services
@@ -36,3 +38,20 @@ struct LiveSearchDatabaseFactory: Search.DatabaseFactory {
 }
 
 let searchDatabaseFactory: any Search.DatabaseFactory = LiveSearchDatabaseFactory()
+
+// MARK: - Production MarkdownLookupStrategy
+
+// Concrete `MCP.Support.DocsResourceProvider.MarkdownLookupStrategy`
+// wrapping a `SearchModule.Index` actor's `getDocumentContent(uri:format:)`.
+// Wired by `cupertino serve` when a search.db is available so the MCP
+// resource provider can fall back to indexed markdown before going to
+// the filesystem. MCPSupport stays free of `import Search`; only the
+// CLI composition root reaches the actor.
+
+struct LiveMarkdownLookupStrategy: MCP.Support.MarkdownLookupStrategy {
+    let searchIndex: SearchModule.Index
+
+    func lookup(uri: String) async throws -> String? {
+        try await searchIndex.getDocumentContent(uri: uri, format: .markdown)
+    }
+}

--- a/Packages/Sources/MCP/Support/MCP.Support.DocsResourceProvider.swift
+++ b/Packages/Sources/MCP/Support/MCP.Support.DocsResourceProvider.swift
@@ -11,32 +11,42 @@ import SharedUtils
 // MARK: - Documentation Resource Provider
 
 extension MCP.Support {
+    /// Strategy for resolving a resource URI to pre-rendered markdown
+    /// out of a search-index database (or any other source). GoF
+    /// Strategy pattern: returns `nil` if the URI is not present;
+    /// throws if the lookup itself fails. `DocsResourceProvider`
+    /// treats either as a fall-back trigger to read from the
+    /// filesystem.
+    ///
+    /// Replaces the previous
+    /// `MarkdownLookup = @Sendable (String) async throws -> String?`
+    /// closure typealias. Conforming types name the contract, make
+    /// captured state explicit, and produce one-line test mocks
+    /// instead of inline closures.
+    public protocol MarkdownLookupStrategy: Sendable {
+        func lookup(uri: String) async throws -> String?
+    }
+
     /// Provides crawled documentation as MCP resources.
     ///
-    /// The provider's database lookup is injected as a closure rather than a
-    /// concrete `Search.Index` value, so this target stays free of any
-    /// behavioural dependency on Search. Consumers wire the closure at the
-    /// call site (CLI/MCP entrypoint) — typically a small adapter around
-    /// `Search.Index.getDocumentContent(uri:format:)`.
+    /// The provider's database lookup is injected as a
+    /// `MarkdownLookupStrategy` conformer rather than a concrete
+    /// `Search.Index` value, so this target stays free of any
+    /// behavioural dependency on Search. Consumers wire the strategy
+    /// at the call site (CLI/MCP entrypoint) — typically a small
+    /// adapter around `Search.Index.getDocumentContent(uri:format:)`.
     public actor DocsResourceProvider: MCP.Core.ResourceProvider {
-        /// Closure signature for resolving a resource URI to pre-rendered
-        /// markdown out of a search-index database (or any other source).
-        /// Returns `nil` if the URI is not present; throws if the lookup
-        /// itself fails. The provider treats either as a fall-back trigger
-        /// to read from the filesystem.
-        public typealias MarkdownLookup = @Sendable (String) async throws -> String?
-
         private let configuration: Shared.Configuration
         private var metadata: Shared.Models.CrawlMetadata?
         private let evolutionDirectory: URL
         private let archiveDirectory: URL
-        private let markdownLookup: MarkdownLookup?
+        private let markdownLookup: (any MCP.Support.MarkdownLookupStrategy)?
 
         public init(
             configuration: Shared.Configuration,
             evolutionDirectory: URL? = nil,
             archiveDirectory: URL? = nil,
-            markdownLookup: MarkdownLookup? = nil
+            markdownLookup: (any MCP.Support.MarkdownLookupStrategy)? = nil
         ) {
             self.configuration = configuration
             self.evolutionDirectory = evolutionDirectory ?? Shared.Constants.defaultSwiftEvolutionDirectory
@@ -128,7 +138,7 @@ extension MCP.Support {
 
             // Try database first if a markdown lookup was injected
             if let markdownLookup {
-                if let dbContent = try await markdownLookup(uri) {
+                if let dbContent = try await markdownLookup.lookup(uri: uri) {
                     // Found in database - return markdown
                     let contents = MCP.Core.Protocols.ResourceContents.text(
                         MCP.Core.Protocols.TextResourceContents(


### PR DESCRIPTION
## What

7/8 of epic #495. Replace the nested
`MCP.Support.DocsResourceProvider.MarkdownLookup = @Sendable (String) async throws -> String?`
closure typealias with `MCP.Support.MarkdownLookupStrategy`
protocol at the MCP.Support namespace level (GoF Strategy).

Hosting at namespace level (not nested inside the actor) because
Swift 6 protocols nested inside actor types end up actor-isolated,
which blocks external conformance from a plain Sendable struct in
the CLI composition root.

Optional injection preserved.

## Composition root wiring

CLI's old inline closure
`{ uri in try await searchIndex.getDocumentContent(uri: uri, format: .markdown) }`
becomes `LiveMarkdownLookupStrategy: MCP.Support.MarkdownLookupStrategy`
struct in `CLI/SearchModuleAlias.swift`. The struct holds the
`SearchModule.Index` actor as an explicit stored property —
captured-state surface is reviewable instead of hidden in a closure
capture list.

## Tests

Zero changes — existing markdownLookup test passes `nil`, which the
optional protocol-typed param accepts unchanged.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test`: **1441 tests in 161 suites passed** (one
  rerun: an unrelated network-dependent Apple-docs resolver test
  hung on first run, passed on second).
- `swiftformat .`: no changes.
- `swiftlint`: only pre-existing warnings.

## Follow-up

1 closure typealias remains in epic #495:
- 8/8 `Services.ReadService.PackageFileLookup`