### PR TITLE
refactor(di): #495 convert Services.ReadService.PackageFileLookup closure to protocol — closes #495 (8/8)

### DIFF
--- a/Packages/Sources/CLI/Commands/CLI.Command.Read.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Read.swift
@@ -88,15 +88,7 @@ extension CLI.Command {
                     samplesDB: sampleDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
                     packagesDB: packagesDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
                     searchDatabaseFactory: searchDatabaseFactory,
-                    packageFileLookup: { dbURL, owner, repo, relpath in
-                        // The Search.PackageQuery actor is the production
-                        // packages.db reader. CLI wires it in here so
-                        // Services.ReadService doesn't need to import the
-                        // Search target.
-                        let query = try await SearchModule.PackageQuery(dbPath: dbURL)
-                        defer { Task { await query.disconnect() } }
-                        return try await query.fileContent(owner: owner, repo: repo, relpath: relpath)
-                    }
+                    packageFileLookup: LivePackageFileLookupStrategy()
                 )
             } catch Services.ReadService.ReadError.docsNotFound(let id) {
                 Logging.Log.error("Document not found in search.db: \(id)")

--- a/Packages/Sources/CLI/SearchModuleAlias.swift
+++ b/Packages/Sources/CLI/SearchModuleAlias.swift
@@ -55,3 +55,24 @@ struct LiveMarkdownLookupStrategy: MCP.Support.MarkdownLookupStrategy {
         try await searchIndex.getDocumentContent(uri: uri, format: .markdown)
     }
 }
+
+// MARK: - Production PackageFileLookupStrategy
+
+// Concrete `Services.ReadService.PackageFileLookupStrategy` (GoF Strategy)
+// wrapping the `SearchModule.PackageQuery` actor. Lives at the CLI
+// composition root so `Services` doesn't need `import Search`.
+// `cupertino read` wires one of these into every `Services.ReadService.read`
+// call.
+
+struct LivePackageFileLookupStrategy: Services.ReadService.PackageFileLookupStrategy {
+    func fileContent(
+        dbURL: URL,
+        owner: String,
+        repo: String,
+        relpath: String
+    ) async throws -> String? {
+        let query = try await SearchModule.PackageQuery(dbPath: dbURL)
+        defer { Task { await query.disconnect() } }
+        return try await query.fileContent(owner: owner, repo: repo, relpath: relpath)
+    }
+}

--- a/Packages/Sources/Services/README.md
+++ b/Packages/Sources/Services/README.md
@@ -7,27 +7,27 @@ All public types now live under the `Services` namespace (per the namespacing sw
 ## Architecture
 
 ```
-                       ┌──────────────────────────────┐
-                       │  Services.ServiceContainer   │
-                       │      (Lifecycle Mgmt)        │
-                       └──────────────┬───────────────┘
-                                      │
-        ┌─────────────────────────────┼─────────────────────────────┐
-        │                             │                             │
-        ▼                             ▼                             ▼
-┌──────────────────┐         ┌──────────────────┐         ┌──────────────────────┐
-│ DocsSearchService│         │  HIGSearchService│         │ Sample.Search.Service│
-│   (Search.Index) │         │    (delegates)   │         │     (Sample.Index)   │
-└──────────────────┘         └──────────────────┘         └──────────────────────┘
-        │                             │                             │
-        └─────────────────────────────┼─────────────────────────────┘
-                                      │
-                                      ▼
-                       ┌──────────────────────────────┐
-                       │     Services.Formatters      │
-                       │ + Sample.Format.{Md,JSON,Txt}│
-                       │      (Text/JSON/Markdown)    │
-                       └──────────────────────────────┘
+                        ┌──────────────────────────────┐
+                        │  Services.ServiceContainer   │
+                        │      (Lifecycle Mgmt)        │
+                        └──────────────┬───────────────┘
+                                       │
+           ┌───────────────────────────┼───────────────────────────┐
+           │                           │                           │
+           ▼                           ▼                           ▼
+┌──────────────────────┐    ┌──────────────────────┐    ┌──────────────────────┐
+│   DocsSearchService  │    │   HIGSearchService   │    │ Sample.Search.Service│
+│    (Search.Index)    │    │     (delegates)      │    │    (Sample.Index)    │
+└──────────────────────┘    └──────────────────────┘    └──────────────────────┘
+           │                           │                           │
+           └───────────────────────────┼───────────────────────────┘
+                                       │
+                                       ▼
+                        ┌──────────────────────────────┐
+                        │     Services.Formatters      │
+                        │ + Sample.Format.{Md,JSON,Txt}│
+                        │     (Text/JSON/Markdown)     │
+                        └──────────────────────────────┘
 ```
 
 ## Services

--- a/Packages/Sources/Services/ReadCommands/Services.ReadService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.ReadService.swift
@@ -71,12 +71,31 @@ extension Services {
             }
         }
 
-        /// Closure that resolves a file inside `packages.db` to its raw
-        /// content. Production composition root (CLI) wires this as a
-        /// thin wrapper around `Search.PackageQuery(dbPath:).fileContent(...)`,
-        /// then `disconnect()`. ReadService doesn't import the Search
-        /// target, so the actor stays opaque behind this seam.
-        public typealias PackageFileLookup = @Sendable (_ dbURL: URL, _ owner: String, _ repo: String, _ relpath: String) async throws -> String?
+        /// Strategy for resolving a file inside `packages.db` to its
+        /// raw content. GoF Strategy pattern (Gamma et al, 1994):
+        /// production composition root (CLI) wires a
+        /// `LivePackageFileLookupStrategy` that wraps
+        /// `Search.PackageQuery(dbPath:).fileContent(...)` + a
+        /// matching `disconnect()`. ReadService doesn't import the
+        /// Search target, so the actor stays opaque behind this seam.
+        ///
+        /// Replaces the previous
+        /// `PackageFileLookup = @Sendable (URL, String, String, String) async throws -> String?`
+        /// closure typealias. The protocol form names the contract at
+        /// the constructor site, makes captured-state explicit, and
+        /// produces one-line test mocks.
+        public protocol PackageFileLookupStrategy: Sendable {
+            /// Look up the raw content of a file inside `packages.db`.
+            /// Returns `nil` when the identifier doesn't resolve;
+            /// throws if the lookup itself fails (DB open error,
+            /// SQL error, etc.).
+            func fileContent(
+                dbURL: URL,
+                owner: String,
+                repo: String,
+                relpath: String
+            ) async throws -> String?
+        }
 
         /// Read a document by identifier. When `explicit` is provided the
         /// matching backend is used; otherwise we infer:
@@ -90,7 +109,7 @@ extension Services {
             samplesDB: URL?,
             packagesDB: URL?,
             searchDatabaseFactory: any Search.DatabaseFactory,
-            packageFileLookup: PackageFileLookup
+            packageFileLookup: any PackageFileLookupStrategy
         ) async throws -> Result {
             if let explicit {
                 return try await readFrom(
@@ -160,7 +179,7 @@ extension Services {
             packagesDB: URL?,
             allowFallback: Bool,
             searchDatabaseFactory: any Search.DatabaseFactory,
-            packageFileLookup: PackageFileLookup
+            packageFileLookup: any PackageFileLookupStrategy
         ) async throws -> Result {
             switch source {
             case .docs:
@@ -210,7 +229,7 @@ extension Services {
             samplesDB: URL?,
             allowFallback: Bool,
             packagesDB: URL?,
-            packageFileLookup: PackageFileLookup
+            packageFileLookup: any PackageFileLookupStrategy
         ) async throws -> Result {
             let dbURL = samplesDB ?? Sample.Index.defaultDatabasePath
             guard FileManager.default.fileExists(atPath: dbURL.path) else {
@@ -258,7 +277,7 @@ extension Services {
         private static func readFromPackages(
             identifier: String,
             packagesDB: URL?,
-            packageFileLookup: PackageFileLookup
+            packageFileLookup: any PackageFileLookupStrategy
         ) async throws -> Result {
             // Identifier shape: `<owner>/<repo>/<relpath>`. Anything else is
             // not a valid package identifier — auto-source mode bails here.
@@ -277,7 +296,7 @@ extension Services {
 
             let content: String?
             do {
-                content = try await packageFileLookup(dbURL, owner, repo, relpath)
+                content = try await packageFileLookup.fileContent(dbURL: dbURL, owner: owner, repo: repo, relpath: relpath)
             } catch {
                 throw ReadError.backendFailed("packages.db query failed: \(error.localizedDescription)")
             }


### PR DESCRIPTION
## What

Last of 8 closure→protocol conversions in epic #495.

Replace
`Services.ReadService.PackageFileLookup = @Sendable (URL, String, String, String) async throws -> String?`
typealias with `Services.ReadService.PackageFileLookupStrategy`
protocol (GoF Strategy), with method
`fileContent(dbURL:owner:repo:relpath:)`.

## Composition root wiring

CLI's old inline closure inside `CLI.Command.Read.run` (which built
a `SearchModule.PackageQuery` actor on the fly) becomes
`LivePackageFileLookupStrategy: Services.ReadService.PackageFileLookupStrategy`
struct in `CLI/SearchModuleAlias.swift`, alongside the rest of the
GoF DI epic's `Live*` concretes. Services keeps zero
`import Search`; only the CLI composition root reaches the actor.

## Invocation sites

Callsite goes from positional
`packageFileLookup(dbURL, owner, repo, relpath)`
to named-parameter
`packageFileLookup.fileContent(dbURL:owner:repo:relpath:)`.

## Also in this commit

Fix the architecture ASCII diagram in `Sources/Services/README.md`:
the three middle boxes (`DocsSearchService` /
`HIGSearchService` / `Sample.Search.Service`) now have equal
width (24 cols each, 4-col gaps), arrows align with box centers,
top and bottom boxes centered above box 2.

## Tests

Zero changes required.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test`: **1441 tests in 161 suites passed**.
- `swiftformat .`: no changes.
- `swiftlint`: only pre-existing warnings.

## Epic #495 status

With this PR all 8 closure typealiases in the GoF Phase A roll are
done:

1. ✅ #494 `MakeSearchDatabase` → `Search.DatabaseFactory`
2. ✅ #496 `MarkdownToStructuredPage` → `MarkdownToStructuredPageStrategy`
3. ✅ #497 `SampleCatalogFetch` → `SampleCatalogProvider`
4. ✅ #498 `PackageIndexingRun` → `PackageIndexingRunner`
5. ✅ #499 `DocsIndexingRun` → `DocsIndexingRunner`
6. ✅ #500 `SamplesIndexingRun` → `SamplesIndexingRunner`
7. ✅ #501 `MarkdownLookup` → `MCP.Support.MarkdownLookupStrategy`
8. ✅ this PR `PackageFileLookup` → `PackageFileLookupStrategy`

Phase B (import-purification sweep) opens after this merges. Closes
#495.