### PR TITLE
refactor(di): #503 Services drops import SampleIndex — closes #503 (Phase B)

### DIFF
--- a/Packages/Package.swift
+++ b/Packages/Package.swift
@@ -419,7 +419,7 @@ let targets: [Target] = {
     )
     let servicesTestsTarget = Target.testTarget(
         name: "ServicesTests",
-        dependencies: ["Services", "ServicesModels", "SearchModels", "TestSupport"]
+        dependencies: ["Services", "ServicesModels", "SearchModels", "SampleIndex", "SampleIndexModels", "TestSupport"]
     )
 
     let mcpSupportTarget = Target.target(

--- a/Packages/Sources/CLI/Commands/CLI.Command.ListSamples.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.ListSamples.swift
@@ -48,12 +48,13 @@ extension CLI.Command {
             let dbPath = resolveSampleDbPath()
 
             // Use Services.ServiceContainer for managed lifecycle
-            let (projects, totalProjects, totalFiles) = try await Services.ServiceContainer.withSampleService(dbPath: dbPath) { service in
-                let projects = try await service.listProjects(framework: framework, limit: limit)
-                let totalProjects = try await service.projectCount()
-                let totalFiles = try await service.fileCount()
-                return (projects, totalProjects, totalFiles)
-            }
+            let (projects, totalProjects, totalFiles) = try await Services.ServiceContainer
+                .withSampleService(dbPath: dbPath, sampleDatabaseFactory: sampleDatabaseFactory) { service in
+                    let projects = try await service.listProjects(framework: framework, limit: limit)
+                    let totalProjects = try await service.projectCount()
+                    let totalFiles = try await service.fileCount()
+                    return (projects, totalProjects, totalFiles)
+                }
 
             // Output results
             switch format {

--- a/Packages/Sources/CLI/Commands/CLI.Command.Read.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Read.swift
@@ -88,6 +88,7 @@ extension CLI.Command {
                     samplesDB: sampleDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
                     packagesDB: packagesDb.map { URL(fileURLWithPath: $0).expandingTildeInPath },
                     searchDatabaseFactory: searchDatabaseFactory,
+                    sampleDatabaseFactory: sampleDatabaseFactory,
                     packageFileLookup: LivePackageFileLookupStrategy()
                 )
             } catch Services.ReadService.ReadError.docsNotFound(let id) {

--- a/Packages/Sources/CLI/Commands/CLI.Command.ReadSample.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.ReadSample.swift
@@ -39,14 +39,14 @@ extension CLI.Command {
             let dbPath = resolveSampleDbPath()
 
             // Use Services.ServiceContainer for managed lifecycle
-            let (project, files) = try await Services.ServiceContainer.withSampleService(dbPath: dbPath) { service in
+            let (project, files) = try await Services.ServiceContainer.withSampleService(dbPath: dbPath, sampleDatabaseFactory: sampleDatabaseFactory) { service in
                 guard let project = try await service.getProject(id: projectId) else {
                     Logging.Log.error("Project not found: \(projectId)")
                     Logging.Log.output("Use 'cupertino list-samples' or 'cupertino search --source samples' to find valid project IDs.")
                     throw ExitCode.failure
                 }
 
-                let files = try await service.listFiles(projectId: projectId)
+                let files = try await service.listFiles(projectId: projectId, folder: nil)
                 return (project, files)
             }
 

--- a/Packages/Sources/CLI/Commands/CLI.Command.ReadSampleFile.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.ReadSampleFile.swift
@@ -42,7 +42,7 @@ extension CLI.Command {
             let dbPath = resolveSampleDbPath()
 
             // Use Services.ServiceContainer for managed lifecycle
-            let file = try await Services.ServiceContainer.withSampleService(dbPath: dbPath) { service in
+            let file = try await Services.ServiceContainer.withSampleService(dbPath: dbPath, sampleDatabaseFactory: sampleDatabaseFactory) { service in
                 guard let file = try await service.getFile(projectId: projectId, path: filePath) else {
                     Logging.Log.error("File not found: \(filePath) in project \(projectId)")
                     Logging.Log.output("Use 'cupertino read-sample \(projectId)' to list available files.")

--- a/Packages/Sources/CLI/Commands/CLI.Command.Search.SmartReport.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Search.SmartReport.swift
@@ -176,7 +176,8 @@ extension CLI.Command.Search {
             return nil
         }
         do {
-            let service = try await Sample.Search.Service(dbPath: url)
+            let database = try await Sample.Index.Database(dbPath: url)
+            let service = Sample.Search.Service(database: database)
             fetchers.append(Sample.Services.CandidateFetcher(
                 service: service,
                 availability: availability

--- a/Packages/Sources/CLI/Commands/CLI.Command.Search.SourceRunners.swift
+++ b/Packages/Sources/CLI/Commands/CLI.Command.Search.SourceRunners.swift
@@ -36,7 +36,8 @@ extension CLI.Command.Search {
         let teasers = try await Services.ServiceContainer.withTeaserService(
             searchDbPath: searchDb,
             sampleDbPath: resolveSampleDbPath(),
-            searchDatabaseFactory: searchDatabaseFactory
+            searchDatabaseFactory: searchDatabaseFactory,
+            sampleDatabaseFactory: sampleDatabaseFactory
         ) { service in
             await service.fetchAllTeasers(
                 query: query,
@@ -80,7 +81,7 @@ extension CLI.Command.Search {
     func runSampleSearch() async throws {
         let dbPath = resolveSampleDbPath()
 
-        let result = try await Services.ServiceContainer.withSampleService(dbPath: dbPath) { service in
+        let result = try await Services.ServiceContainer.withSampleService(dbPath: dbPath, sampleDatabaseFactory: sampleDatabaseFactory) { service in
             try await service.search(Sample.Search.Query(
                 text: query,
                 framework: framework,
@@ -98,7 +99,8 @@ extension CLI.Command.Search {
             teasers = try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: searchDb,
                 sampleDbPath: resolveSampleDbPath(),
-                searchDatabaseFactory: searchDatabaseFactory
+                searchDatabaseFactory: searchDatabaseFactory,
+                sampleDatabaseFactory: sampleDatabaseFactory
             ) { service in
                 await service.fetchAllTeasers(
                     query: query,
@@ -191,7 +193,8 @@ extension CLI.Command.Search {
         let teasers = try await Services.ServiceContainer.withTeaserService(
             searchDbPath: searchDb,
             sampleDbPath: resolveSampleDbPath(),
-            searchDatabaseFactory: searchDatabaseFactory
+            searchDatabaseFactory: searchDatabaseFactory,
+            sampleDatabaseFactory: sampleDatabaseFactory
         ) { service in
             await service.fetchAllTeasers(
                 query: query,

--- a/Packages/Sources/CLI/SearchModuleAlias.swift
+++ b/Packages/Sources/CLI/SearchModuleAlias.swift
@@ -1,10 +1,13 @@
 import Foundation
 import MCPCore
 import MCPSupport
+import SampleIndex
+import SampleIndexModels
 import Search
 import SearchModels
 import Services
 import ServicesModels
+import SharedConstants
 
 // MARK: - Search Module Disambiguator
 
@@ -76,3 +79,22 @@ struct LivePackageFileLookupStrategy: Services.ReadService.PackageFileLookupStra
         return try await query.fileContent(owner: owner, repo: repo, relpath: relpath)
     }
 }
+
+// MARK: - Production Sample.Index.DatabaseFactory
+
+// Concrete `Sample.Index.DatabaseFactory` (GoF Factory Method) wired
+// into every `Services.ServiceContainer.with*SampleService` /
+// `withTeaserService` / `withUnifiedSearchService` call. Parallel to
+// `LiveSearchDatabaseFactory` on the docs side: opens a real
+// `Sample.Index.Database` at the resolved path. `Services` builds the
+// `Sample.Search.Service` wrapper internally — the composition root
+// only knows about the low-level DB factory. `Services` no longer
+// imports `SampleIndex`; the concrete actor is reached only here.
+
+struct LiveSampleIndexDatabaseFactory: Sample.Index.DatabaseFactory {
+    func openDatabase(at url: URL) async throws -> any Sample.Index.Reader {
+        try await Sample.Index.Database(dbPath: url)
+    }
+}
+
+let sampleDatabaseFactory: any Sample.Index.DatabaseFactory = LiveSampleIndexDatabaseFactory()

--- a/Packages/Sources/SampleIndexModels/Sample.Index.DatabaseFactory.swift
+++ b/Packages/Sources/SampleIndexModels/Sample.Index.DatabaseFactory.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SharedConstants
+
+// MARK: - Sample.Index.DatabaseFactory
+
+/// Factory abstraction for opening a `Sample.Index.Reader`-conforming
+/// database actor from a file URL. GoF Factory Method, Swift-idiomatic
+/// expression — parallel to `Search.DatabaseFactory` on the docs side
+/// (#494).
+///
+/// The composition root (the CLI / TUI binary) supplies a concrete
+/// factory that opens the production `Sample.Index.Database` actor;
+/// tests supply a mock that returns a stub or throws on demand.
+/// Consumers (`Services.ServiceContainer.withSampleService`,
+/// `withTeaserService`, `withUnifiedSearchService`) depend on this
+/// protocol rather than on `import SampleIndex`, so the Services
+/// target stays free of any concrete-producer dependency.
+///
+/// "Product" = `any Sample.Index.Reader`
+/// "Creator" = `Sample.Index.DatabaseFactory` (this protocol)
+/// "ConcreteCreator" = `LiveSampleIndexDatabaseFactory` in the CLI
+/// (or a mock conforming type in tests).
+extension Sample.Index {
+    public protocol DatabaseFactory: Sendable {
+        /// Open (or create) a `Sample.Index.Reader`-conforming database
+        /// at `url`. The concrete factory decides which actor to
+        /// instantiate.
+        func openDatabase(at url: URL) async throws -> any Sample.Index.Reader
+    }
+}

--- a/Packages/Sources/SampleIndexModels/Sample.Index.Defaults.swift
+++ b/Packages/Sources/SampleIndexModels/Sample.Index.Defaults.swift
@@ -1,34 +1,35 @@
 import Foundation
 import SharedConstants
-import SharedCore
 
-// MARK: - Sample.Index Module Anchor
+// MARK: - Sample.Index static helpers
 
-/// `Sample.Index` provides indexing and search for Apple sample code projects.
-/// Unlike the main Search database, Sample.Index uses a separate database
-/// (`~/.cupertino/samples.db`) optimised for code-level search.
+/// Default paths + small lookup helpers for the sample-code index.
 ///
-/// The namespace enum itself is declared in `SharedConstants/Sample.swift`
-/// alongside the other `Sample.*` sub-namespaces. This file contributes the
-/// module-scope static helpers (`defaultDatabasePath`,
-/// `defaultSampleCodeDirectory`, `minColumn(for:)`) and acts as the
-/// SampleIndex SPM target's anchor.
+/// Lives in `SampleIndexModels` (foundation-only) so consumers can
+/// resolve the canonical on-disk locations of `samples.db` and the
+/// sample-code download root without importing the concrete
+/// `SampleIndex` target. The same pattern applies as the
+/// `Search.Database` / `Sample.Index.Reader` protocol seams: shared
+/// abstractions and constants live in the Models target; concrete
+/// actors live in the producer target.
 extension Sample.Index {
-    /// Default database path for source code search index
+    /// Default database path for the sample-code search index
+    /// (`~/.cupertino/samples.db` by default).
     public static var defaultDatabasePath: URL {
         Shared.Constants.defaultBaseDirectory
             .appendingPathComponent(Shared.Constants.FileName.samplesDatabase)
     }
 
-    /// Default sample code directory
+    /// Default sample-code download directory
+    /// (`~/.cupertino/sample-code/` by default).
     public static var defaultSampleCodeDirectory: URL {
         Shared.Constants.defaultBaseDirectory
             .appendingPathComponent(Shared.Constants.Directory.sampleCode)
     }
 
     /// Map a user-facing platform name (case-insensitive) to the
-    /// `projects.min_<x>` column on samples.db. Returns nil for unknown
-    /// platforms — caller treats that as "no filter". Mirrors
+    /// `projects.min_<x>` column on `samples.db`. Returns nil for
+    /// unknown platforms — caller treats that as "no filter". Mirrors
     /// `Search.PackageQuery.minColumn` for cross-DB consistency.
     public static func minColumn(for platform: String) -> String? {
         switch platform.lowercased() {

--- a/Packages/Sources/SampleIndexModels/Sample.Search.Searcher.swift
+++ b/Packages/Sources/SampleIndexModels/Sample.Search.Searcher.swift
@@ -21,5 +21,32 @@ extension Sample.Search {
         /// Search Apple sample-code projects and files for the given
         /// query parameters.
         func search(_ query: Sample.Search.Query) async throws -> Sample.Search.Result
+
+        /// Resolve a project by its catalog identifier. Returns nil
+        /// when the project isn't in this index.
+        func getProject(id: String) async throws -> Sample.Index.Project?
+
+        /// List projects in the index, optionally filtered by
+        /// framework. `limit` caps the returned count.
+        func listProjects(framework: String?, limit: Int) async throws -> [Sample.Index.Project]
+
+        /// Total project count in the index.
+        func projectCount() async throws -> Int
+
+        /// Resolve a single file inside a project. Returns nil when
+        /// the file doesn't exist or its project isn't indexed.
+        func getFile(projectId: String, path: String) async throws -> Sample.Index.File?
+
+        /// List files inside a project, optionally narrowed to a
+        /// folder path prefix.
+        func listFiles(projectId: String, folder: String?) async throws -> [Sample.Index.File]
+
+        /// Total file count in the index.
+        func fileCount() async throws -> Int
+
+        /// Release any resources held by the search service (DB
+        /// connections, in-memory caches). Mirrors
+        /// `Search.Database.disconnect()`.
+        func disconnect() async
     }
 }

--- a/Packages/Sources/Services/ReadCommands/Sample.Search.Service.swift
+++ b/Packages/Sources/Services/ReadCommands/Sample.Search.Service.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SharedConstants
 import SharedCore
@@ -26,14 +25,6 @@ extension Sample.Search {
         /// root supplies it.
         public init(database: any Sample.Index.Reader) {
             self.database = database
-        }
-
-        /// Initialize with a database path. Keeps the convenience init
-        /// that wraps `Sample.Index.Database` in callers that want a
-        /// one-line construct-and-use; the typed-against-protocol field
-        /// above means upper layers don't see this concrete dep.
-        public init(dbPath: URL) async throws {
-            database = try await Sample.Index.Database(dbPath: dbPath)
         }
 
         // MARK: - Search Methods

--- a/Packages/Sources/Services/ReadCommands/Services.ReadService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.ReadService.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SampleIndex
+import SampleIndexModels
 import SearchModels
 import ServicesModels
 import SharedConstants
@@ -109,6 +109,7 @@ extension Services {
             samplesDB: URL?,
             packagesDB: URL?,
             searchDatabaseFactory: any Search.DatabaseFactory,
+            sampleDatabaseFactory: any Sample.Index.DatabaseFactory,
             packageFileLookup: any PackageFileLookupStrategy
         ) async throws -> Result {
             if let explicit {
@@ -121,6 +122,7 @@ extension Services {
                     packagesDB: packagesDB,
                     allowFallback: false,
                     searchDatabaseFactory: searchDatabaseFactory,
+                    sampleDatabaseFactory: sampleDatabaseFactory,
                     packageFileLookup: packageFileLookup
                 )
             }
@@ -135,6 +137,7 @@ extension Services {
                     packagesDB: packagesDB,
                     allowFallback: false,
                     searchDatabaseFactory: searchDatabaseFactory,
+                    sampleDatabaseFactory: sampleDatabaseFactory,
                     packageFileLookup: packageFileLookup
                 )
             }
@@ -149,6 +152,7 @@ extension Services {
                     packagesDB: packagesDB,
                     allowFallback: true,
                     searchDatabaseFactory: searchDatabaseFactory,
+                    sampleDatabaseFactory: sampleDatabaseFactory,
                     packageFileLookup: packageFileLookup
                 )
             } catch ReadError.samplesNotFound, ReadError.packagesNotFound,
@@ -164,6 +168,7 @@ extension Services {
                 packagesDB: packagesDB,
                 allowFallback: false,
                 searchDatabaseFactory: searchDatabaseFactory,
+                sampleDatabaseFactory: sampleDatabaseFactory,
                 packageFileLookup: packageFileLookup
             )
         }
@@ -179,6 +184,7 @@ extension Services {
             packagesDB: URL?,
             allowFallback: Bool,
             searchDatabaseFactory: any Search.DatabaseFactory,
+            sampleDatabaseFactory: any Sample.Index.DatabaseFactory,
             packageFileLookup: any PackageFileLookupStrategy
         ) async throws -> Result {
             switch source {
@@ -195,6 +201,7 @@ extension Services {
                     samplesDB: samplesDB,
                     allowFallback: allowFallback,
                     packagesDB: packagesDB,
+                    sampleDatabaseFactory: sampleDatabaseFactory,
                     packageFileLookup: packageFileLookup
                 )
             case .packages:
@@ -229,6 +236,7 @@ extension Services {
             samplesDB: URL?,
             allowFallback: Bool,
             packagesDB: URL?,
+            sampleDatabaseFactory: any Sample.Index.DatabaseFactory,
             packageFileLookup: any PackageFileLookupStrategy
         ) async throws -> Result {
             let dbURL = samplesDB ?? Sample.Index.defaultDatabasePath
@@ -246,14 +254,20 @@ extension Services {
             if let slashIdx = identifier.firstIndex(of: "/") {
                 let projectId = String(identifier[..<slashIdx])
                 let path = String(identifier[identifier.index(after: slashIdx)...])
-                let file = try await Services.ServiceContainer.withSampleService(dbPath: dbURL) { service in
+                let file = try await Services.ServiceContainer.withSampleService(
+                    dbPath: dbURL,
+                    sampleDatabaseFactory: sampleDatabaseFactory
+                ) { service in
                     try await service.getFile(projectId: projectId, path: path)
                 }
                 if let file {
                     return Result(content: file.content, resolvedSource: .samples)
                 }
             } else {
-                let project = try await Services.ServiceContainer.withSampleService(dbPath: dbURL) { service in
+                let project = try await Services.ServiceContainer.withSampleService(
+                    dbPath: dbURL,
+                    sampleDatabaseFactory: sampleDatabaseFactory
+                ) { service in
                     try await service.getProject(id: identifier)
                 }
                 if let project {

--- a/Packages/Sources/Services/ReadCommands/Services.TeaserService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.TeaserService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SearchModels
 import ServicesModels
@@ -23,21 +22,6 @@ extension Services {
         public init(searchIndex: (any Search.Database)?, sampleDatabase: (any Sample.Index.Reader)?) {
             self.searchIndex = searchIndex
             self.sampleDatabase = sampleDatabase
-        }
-
-        /// Initialize with a sample-database path. The search-side database
-        /// is injected via `searchIndex:` because constructing a
-        /// `Search.Index` requires the Search target — which Services no
-        /// longer imports. The composition root (`withTeaserService` in
-        /// `Services.ServiceContainer`) wires both sides.
-        public init(searchIndex: (any Search.Database)?, sampleDbPath: URL?) async throws {
-            self.searchIndex = searchIndex
-
-            if let sampleDbPath, Shared.Utils.PathResolver.exists(sampleDbPath) {
-                sampleDatabase = try await Sample.Index.Database(dbPath: sampleDbPath)
-            } else {
-                sampleDatabase = nil
-            }
         }
 
         // MARK: - Fetch All Teasers

--- a/Packages/Sources/Services/ReadCommands/Services.UnifiedSearchService.swift
+++ b/Packages/Sources/Services/ReadCommands/Services.UnifiedSearchService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SampleIndex
 import SampleIndexModels
 import SearchModels
 import ServicesModels
@@ -23,22 +22,6 @@ extension Services {
         public init(searchIndex: (any Search.Database)?, sampleDatabase: (any Sample.Index.Reader)?) {
             self.searchIndex = searchIndex
             self.sampleDatabase = sampleDatabase
-        }
-
-        /// Initialize with a sample-database path. The search-side
-        /// database is injected via `searchIndex:` because constructing
-        /// a `Search.Index` requires the Search target — which Services
-        /// no longer imports. The composition root
-        /// (`withUnifiedSearchService` in `Services.ServiceContainer`)
-        /// wires both sides.
-        public init(searchIndex: (any Search.Database)?, sampleDbPath: URL?) async throws {
-            self.searchIndex = searchIndex
-
-            if let sampleDbPath, Shared.Utils.PathResolver.exists(sampleDbPath) {
-                sampleDatabase = try await Sample.Index.Database(dbPath: sampleDbPath)
-            } else {
-                sampleDatabase = nil
-            }
         }
 
         // MARK: - Unified Search

--- a/Packages/Sources/Services/Sample.Services.CandidateFetcher.swift
+++ b/Packages/Sources/Services/Sample.Services.CandidateFetcher.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SampleIndex
+import SampleIndexModels
 import SearchModels
 import SharedConstants
 import SharedCore

--- a/Packages/Sources/Services/Services.ServiceContainer.swift
+++ b/Packages/Sources/Services/Services.ServiceContainer.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SampleIndex
+import SampleIndexModels
 import SearchModels
 import ServicesModels
 import SharedConstants
@@ -49,19 +49,23 @@ extension Services {
         }
 
         /// Execute an operation with a sample service, handling lifecycle.
-        /// No `makeSearchDatabase` here: the sample service is backed by
-        /// `Sample.Search.Service`, which constructs its own
-        /// `Sample.Index.Database` — that's a SampleIndex-target concern,
-        /// not Search.
+        /// The sample database is opened through an injected
+        /// `Sample.Index.DatabaseFactory` (GoF Factory Method) —
+        /// symmetric with `Search.DatabaseFactory` on the docs side
+        /// (#494). This target builds the `Sample.Search.Service`
+        /// wrapper internally; the composition root never has to know
+        /// about it.
         public static func withSampleService<T: Sendable>(
             dbPath: URL,
-            operation: (Sample.Search.Service) async throws -> T
+            sampleDatabaseFactory: any Sample.Index.DatabaseFactory,
+            operation: (any Sample.Search.Searcher) async throws -> T
         ) async throws -> T {
             guard Shared.Utils.PathResolver.exists(dbPath) else {
                 throw Shared.Core.ToolError.noData("Sample database not found at \(dbPath.path). Run 'cupertino save --samples' to build the index.")
             }
 
-            let service = try await Sample.Search.Service(dbPath: dbPath)
+            let database = try await sampleDatabaseFactory.openDatabase(at: dbPath)
+            let service = Sample.Search.Service(database: database)
             let result = try await operation(service)
             await service.disconnect()
             return result
@@ -76,6 +80,7 @@ extension Services {
             searchDbPath: String? = nil,
             sampleDbPath: URL? = nil,
             searchDatabaseFactory: any Search.DatabaseFactory,
+            sampleDatabaseFactory: any Sample.Index.DatabaseFactory,
             operation: (Services.TeaserService) async throws -> T
         ) async throws -> T {
             let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
@@ -88,9 +93,16 @@ extension Services {
                 searchIndex = nil
             }
 
-            let service = try await Services.TeaserService(
+            let sampleDatabase: (any Sample.Index.Reader)?
+            if Shared.Utils.PathResolver.exists(resolvedSamplePath) {
+                sampleDatabase = try await sampleDatabaseFactory.openDatabase(at: resolvedSamplePath)
+            } else {
+                sampleDatabase = nil
+            }
+
+            let service = Services.TeaserService(
                 searchIndex: searchIndex,
-                sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil
+                sampleDatabase: sampleDatabase
             )
 
             return try await operation(service)
@@ -102,6 +114,7 @@ extension Services {
             searchDbPath: String? = nil,
             sampleDbPath: URL? = nil,
             searchDatabaseFactory: any Search.DatabaseFactory,
+            sampleDatabaseFactory: any Sample.Index.DatabaseFactory,
             operation: (Services.UnifiedSearchService) async throws -> T
         ) async throws -> T {
             let resolvedSearchPath = Shared.Utils.PathResolver.searchDatabase(searchDbPath)
@@ -114,9 +127,16 @@ extension Services {
                 searchIndex = nil
             }
 
-            let service = try await Services.UnifiedSearchService(
+            let sampleDatabase: (any Sample.Index.Reader)?
+            if Shared.Utils.PathResolver.exists(resolvedSamplePath) {
+                sampleDatabase = try await sampleDatabaseFactory.openDatabase(at: resolvedSamplePath)
+            } else {
+                sampleDatabase = nil
+            }
+
+            let service = Services.UnifiedSearchService(
                 searchIndex: searchIndex,
-                sampleDbPath: Shared.Utils.PathResolver.exists(resolvedSamplePath) ? resolvedSamplePath : nil
+                sampleDatabase: sampleDatabase
             )
 
             return try await operation(service)

--- a/Packages/Tests/ServicesTests/ServicesTests.swift
+++ b/Packages/Tests/ServicesTests/ServicesTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import SampleIndex
+import SampleIndexModels
 import SearchModels
 @testable import Services
 import ServicesModels
@@ -15,6 +17,15 @@ import Testing
 private struct ThrowingSearchDatabaseFactory: Search.DatabaseFactory {
     func openDatabase(at url: URL) async throws -> any Search.Database {
         throw NSError(domain: "ServicesTests.stub", code: 1)
+    }
+}
+
+/// `Sample.Index.DatabaseFactory` test double that always throws.
+/// Used to satisfy `withTeaserService` / `withUnifiedSearchService`
+/// signatures in tests that only exercise the search side.
+private struct ThrowingSampleDatabaseFactory: Sample.Index.DatabaseFactory {
+    func openDatabase(at url: URL) async throws -> any Sample.Index.Reader {
+        throw NSError(domain: "ServicesTests.stub", code: 2)
     }
 }
 
@@ -170,7 +181,8 @@ struct SampleCandidateFetcherTests {
             .appendingPathComponent("samples-fetcher-test-\(UUID().uuidString).db")
         defer { try? FileManager.default.removeItem(at: tempDB) }
 
-        let service = try await Sample.Search.Service(dbPath: tempDB)
+        let database = try await Sample.Index.Database(dbPath: tempDB)
+        let service = Sample.Search.Service(database: database)
         defer { Task { await service.disconnect() } }
 
         let fetcher = Sample.Services.CandidateFetcher(service: service)
@@ -183,7 +195,8 @@ struct SampleCandidateFetcherTests {
             .appendingPathComponent("samples-fetcher-test-\(UUID().uuidString).db")
         defer { try? FileManager.default.removeItem(at: tempDB) }
 
-        let service = try await Sample.Search.Service(dbPath: tempDB)
+        let database = try await Sample.Index.Database(dbPath: tempDB)
+        let service = Sample.Search.Service(database: database)
         defer { Task { await service.disconnect() } }
 
         let fetcher = Sample.Services.CandidateFetcher(service: service)
@@ -231,7 +244,8 @@ struct TeaserResultsResilienceTests {
             try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: tempDir.path,
                 sampleDbPath: nil,
-                searchDatabaseFactory: throwingFactory
+                searchDatabaseFactory: throwingFactory,
+                sampleDatabaseFactory: ThrowingSampleDatabaseFactory()
             ) { service in
                 _ = await service.fetchAllTeasers(
                     query: "swiftui",
@@ -255,7 +269,8 @@ struct TeaserResultsResilienceTests {
             teasers = try await Services.ServiceContainer.withTeaserService(
                 searchDbPath: "/var/empty/intentionally-broken-search.db.\(UUID().uuidString)",
                 sampleDbPath: nil,
-                searchDatabaseFactory: throwingFactory
+                searchDatabaseFactory: throwingFactory,
+                sampleDatabaseFactory: ThrowingSampleDatabaseFactory()
             ) { service in
                 await service.fetchAllTeasers(
                     query: "swiftui",


### PR DESCRIPTION
## What

Closes #503. `Services` was the last consumer target that imported
a concrete producer module (`SampleIndex`). After this PR, every
consumer SPM target imports only:

- `Foundation`
- its own `*Models` companion
- the Shared kernel (`SharedConstants` / `SharedCore` /
  `SharedUtils` / `SharedModels`)
- cross-cutting infra (`Logging`, `MCPCore` for MCP wire format)

The two binaries (`CLI`, `TUI`) remain the only places that touch
concrete producer modules — that's the **composition root pattern**
(Mark Seemann, building on GoF Factory Method).

## GoF reference

Factory Method (Gamma et al, 1994, p. 107):
> Define an interface for creating an object, but let subclasses
> decide which class to instantiate.

This PR adds `Sample.Index.DatabaseFactory`, symmetric with
`Search.DatabaseFactory` on the docs side (#494).

## Audit after this PR

| Target | Imports own `*Models` only? |
|---|---|
| Services | ✅ (no more SampleIndex) |
| Indexer | ✅ |
| SearchToolProvider | ✅ |
| MCPSupport | ✅ |
| MCPSharedTools | ✅ |
| MCPClient | ✅ |
| MCPCore | ✅ |

## Surface changes

- `SampleIndexModels`: new `Sample.Index.DatabaseFactory` protocol;
  static helpers `Sample.Index.defaultDatabasePath` /
  `defaultSampleCodeDirectory` / `minColumn(for:)` moved here.
  `Sample.Search.Searcher` widened to the full read-only surface.
- `Services.ServiceContainer`: `withSampleService`,
  `withTeaserService`, `withUnifiedSearchService` take
  `sampleDatabaseFactory:`. Container opens the DB via factory,
  wraps in `Sample.Search.Service` internally.
- `Services.TeaserService` + `Services.UnifiedSearchService`:
  the leaky `sampleDbPath:` inits removed. Composition is now in
  the container at the call site.
- `Services.ReadService.read` takes the factory end-to-end.
- `Sample.Services.CandidateFetcher` swaps stale
  `import SampleIndex` for `import SampleIndexModels`.
- `Sample.Search.Service.init(dbPath:)` removed (only
  `init(database:)` remains).
- CLI: `LiveSampleIndexDatabaseFactory` struct + module-scope
  `sampleDatabaseFactory` constant. Threaded through every CLI
  command callsite.

## Tests

- `ServicesTests` gains `import SampleIndex` /
  `import SampleIndexModels` (test targets *are* composition roots)
  + `ThrowingSampleDatabaseFactory` mock for failure-propagation
  tests. CandidateFetcher integration tests construct a
  `Sample.Index.Database` directly and wrap it.
- `Package.swift`: ServicesTests deps grow `SampleIndex` /
  `SampleIndexModels`.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test`: **1441 tests in 161 suites passed**.
- `swiftformat .`: 4 files.
- `swiftlint`: only pre-existing warnings.