### PR TITLE
refactor(SharedUtils): replace fatalError in URL.knownGood with throwing init

### DIFF
--- a/Packages/Sources/Availability/Availability.Fetcher.swift
+++ b/Packages/Sources/Availability/Availability.Fetcher.swift
@@ -566,7 +566,7 @@ extension Availability {
                 apiPath = path
             }
 
-            return URL.knownGood("\(configuration.apiBaseURL)/\(apiPath).json")
+            return try! URL(knownGood: "\(configuration.apiBaseURL)/\(apiPath).json")
         }
 
         private func fetchAvailability(from url: URL) async -> Availability.Info? {

--- a/Packages/Sources/Core/PackageIndexing/Core.PackageIndexing.PackageDependencyResolver.swift
+++ b/Packages/Sources/Core/PackageIndexing/Core.PackageIndexing.PackageDependencyResolver.swift
@@ -304,8 +304,8 @@ extension Core.PackageIndexing {
             if let cache, let cached = await cache.read(owner: owner, repo: repo, branch: branch, file: file) {
                 return .hit(cached)
             }
-            let url = URL.knownGood("https://raw.githubusercontent.com/\(owner)/\(repo)/\(branch)/\(file)")
             do {
+                let url = try URL(knownGood: "https://raw.githubusercontent.com/\(owner)/\(repo)/\(branch)/\(file)")
                 let (data, response) = try await session.data(from: url)
                 guard let http = response as? HTTPURLResponse else {
                     return .transientError

--- a/Packages/Sources/Core/PackageIndexing/Core.PackageIndexing.PackageFetcher.swift
+++ b/Packages/Sources/Core/PackageIndexing/Core.PackageIndexing.PackageFetcher.swift
@@ -17,7 +17,7 @@ import SharedUtils
 /// Fetches Swift packages from SwiftPackageIndex and enriches with GitHub metadata
 extension Core.PackageIndexing {
     public actor PackageFetcher {
-        private let packageListURL = URL.knownGood(Shared.Constants.BaseURL.swiftPackageList)
+        private let packageListURL = try! URL(knownGood: Shared.Constants.BaseURL.swiftPackageList)
         private let outputDirectory: URL
         private let limit: Int?
         private let resumeFromCheckpoint: Bool
@@ -308,7 +308,7 @@ extension Core.PackageIndexing {
         }
 
         private func fetchStarCount(owner: String, repo: String) async throws -> Int {
-            let url = URL.knownGood("\(Shared.Constants.BaseURL.githubAPIRepos)/\(owner)/\(repo)")
+            let url = try URL(knownGood: "\(Shared.Constants.BaseURL.githubAPIRepos)/\(owner)/\(repo)")
 
             var request = URLRequest(url: url)
             request.setValue(Shared.Constants.HTTPHeader.githubAccept, forHTTPHeaderField: "Accept")
@@ -354,7 +354,7 @@ extension Core.PackageIndexing {
 
         private func fetchGitHubMetadata(owner: String, repo: String) async throws -> PackageInfo {
             let cacheKey = "\(owner)/\(repo)"
-            let request = createGitHubRequest(owner: owner, repo: repo)
+            let request = try createGitHubRequest(owner: owner, repo: repo)
             let (data, response) = try await URLSession.shared.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
@@ -371,8 +371,8 @@ extension Core.PackageIndexing {
             return createPackageInfo(owner: owner, repo: repo, repoData: repoData, stars: stars)
         }
 
-        private func createGitHubRequest(owner: String, repo: String) -> URLRequest {
-            let url = URL.knownGood("\(Shared.Constants.BaseURL.githubAPIRepos)/\(owner)/\(repo)")
+        private func createGitHubRequest(owner: String, repo: String) throws -> URLRequest {
+            let url = try URL(knownGood: "\(Shared.Constants.BaseURL.githubAPIRepos)/\(owner)/\(repo)")
             var request = URLRequest(url: url)
             request.setValue(Shared.Constants.HTTPHeader.githubAccept, forHTTPHeaderField: "Accept")
             request.setValue(Shared.Constants.App.userAgent, forHTTPHeaderField: "User-Agent")

--- a/Packages/Sources/Core/Sample.Core.Downloader.swift
+++ b/Packages/Sources/Core/Sample.Core.Downloader.swift
@@ -242,7 +242,7 @@ extension Sample.Core {
         private func fetchSampleList() async throws -> [SampleMetadata] {
             // Load the sample code listing page
             let webView = await createWebView()
-            _ = try await loadPage(webView, url: URL.knownGood(sampleCodeListURL))
+            _ = try await loadPage(webView, url: try URL(knownGood: sampleCodeListURL))
 
             // Wait extra time for dynamic content to load
             try await Task.sleep(for: Shared.Constants.Delay.sampleCodePageLoad)
@@ -546,7 +546,7 @@ extension Sample.Core {
             window.center()
             window.isReleasedWhenClosed = false
 
-            let loginURL = URL.knownGood(Shared.Constants.BaseURL.appleDeveloperAccount)
+            let loginURL = try URL(knownGood: Shared.Constants.BaseURL.appleDeveloperAccount)
 
             // NOTE: show the window BEFORE load()+delegate wiring so the user
             // immediately sees something; but do NOT call webView.load() here —

--- a/Packages/Sources/Crawler/Crawler.ArchiveGuideCatalog.swift
+++ b/Packages/Sources/Crawler/Crawler.ArchiveGuideCatalog.swift
@@ -306,7 +306,7 @@ extension Crawler {
         public static var testGuides: [URL] {
             [
                 // Just the Objective-C Runtime Guide - well-structured, moderate size
-                URL.knownGood("\(baseURL)/Cocoa/Conceptual/ObjCRuntimeGuide"),
+                try! URL(knownGood: "\(baseURL)/Cocoa/Conceptual/ObjCRuntimeGuide"),
             ]
         }
 

--- a/Packages/Sources/Crawler/Crawler.Evolution.swift
+++ b/Packages/Sources/Crawler/Crawler.Evolution.swift
@@ -116,7 +116,7 @@ extension Crawler {
             path: String,
             prefix: String
         ) async throws -> [ProposalMetadata] {
-            let url = URL.knownGood("\(githubAPI)/repos/\(repo)/contents/\(path)?ref=\(branch)")
+            let url = try URL(knownGood: "\(githubAPI)/repos/\(repo)/contents/\(path)?ref=\(branch)")
 
             var request = URLRequest(url: url)
             request.setValue(

--- a/Packages/Sources/Crawler/Crawler.HIG.swift
+++ b/Packages/Sources/Crawler/Crawler.HIG.swift
@@ -66,7 +66,7 @@ extension Crawler {
             )
 
             // Start from HIG root
-            let rootURL = URL.knownGood(Shared.Constants.BaseURL.appleHIG)
+            let rootURL = try URL(knownGood: Shared.Constants.BaseURL.appleHIG)
 
             // Discover all HIG pages
             logInfo("Discovering HIG pages...")

--- a/Packages/Sources/Crawler/Crawler.TechnologiesIndex.swift
+++ b/Packages/Sources/Crawler/Crawler.TechnologiesIndex.swift
@@ -11,9 +11,7 @@ extension Crawler {
     /// Used to seed the crawler queue for complete framework coverage.
     /// See: https://github.com/mihaelamj/cupertino/issues/160
     public enum TechnologiesIndex {
-        private static let indexURL = URL.knownGood(
-            "\(Shared.Constants.BaseURL.appleTutorialsDocs)/technologies.json"
-        )
+        private static let indexURL = try! URL(knownGood: "\(Shared.Constants.BaseURL.appleTutorialsDocs)/technologies.json")
 
         /// Fetch all active framework root URLs from Apple's technology index
         public static func fetchFrameworkURLs() async throws -> [URL] {

--- a/Packages/Sources/ReleaseTool/Release.Command.Full.swift
+++ b/Packages/Sources/ReleaseTool/Release.Command.Full.swift
@@ -157,9 +157,7 @@ extension Release.Command {
 
             for attempt in 1...maxAttempts {
                 // Check if release asset exists
-                let assetURL = URL.knownGood(
-                    "https://github.com/mihaelamj/cupertino/releases/download/\(version.tag)/cupertino-\(version.tag)-macos-universal.tar.gz"
-                )
+                let assetURL = try URL(knownGood: "https://github.com/mihaelamj/cupertino/releases/download/\(version.tag)/cupertino-\(version.tag)-macos-universal.tar.gz")
 
                 var request = URLRequest(url: assetURL)
                 request.httpMethod = "HEAD"

--- a/Packages/Sources/ReleaseTool/Release.Command.Homebrew.swift
+++ b/Packages/Sources/ReleaseTool/Release.Command.Homebrew.swift
@@ -123,9 +123,7 @@ extension Release.Command {
         }
 
         private func fetchSHA256(version: Release.Version) async throws -> String {
-            let sha256URL = URL.knownGood(
-                "https://github.com/\(repo)/releases/download/\(version.tag)/cupertino-\(version.tag)-macos-universal.tar.gz.sha256"
-            )
+            let sha256URL = try URL(knownGood: "https://github.com/\(repo)/releases/download/\(version.tag)/cupertino-\(version.tag)-macos-universal.tar.gz.sha256")
 
             let (data, response) = try await URLSession.shared.data(from: sha256URL)
             guard let httpResponse = response as? HTTPURLResponse,

--- a/Packages/Sources/ReleaseTool/Release.Publishing.swift
+++ b/Packages/Sources/ReleaseTool/Release.Publishing.swift
@@ -140,7 +140,7 @@ extension Release.Publishing {
     }
 
     static func checkReleaseExists(repo: String, tag: String, token: String) async throws -> Bool {
-        let url = URL.knownGood("https://api.github.com/repos/\(repo)/releases/tags/\(tag)")
+        let url = try URL(knownGood: "https://api.github.com/repos/\(repo)/releases/tags/\(tag)")
         let request = githubRequest(url: url, token: token)
 
         let (_, response) = try await URLSession.shared.data(for: request)
@@ -151,7 +151,7 @@ extension Release.Publishing {
     }
 
     static func deleteRelease(repo: String, tag: String, token: String) async throws {
-        let getURL = URL.knownGood("https://api.github.com/repos/\(repo)/releases/tags/\(tag)")
+        let getURL = try URL(knownGood: "https://api.github.com/repos/\(repo)/releases/tags/\(tag)")
         let getRequest = githubRequest(url: getURL, token: token)
 
         let (data, _) = try await URLSession.shared.data(for: getRequest)
@@ -160,7 +160,7 @@ extension Release.Publishing {
             throw Release.Publishing.Error.apiError("Failed to get release ID")
         }
 
-        let deleteURL = URL.knownGood("https://api.github.com/repos/\(repo)/releases/\(releaseId)")
+        let deleteURL = try URL(knownGood: "https://api.github.com/repos/\(repo)/releases/\(releaseId)")
         let deleteRequest = githubRequest(url: deleteURL, token: token, method: "DELETE")
 
         let (_, response) = try await URLSession.shared.data(for: deleteRequest)
@@ -170,7 +170,7 @@ extension Release.Publishing {
         }
 
         // Best-effort tag cleanup; missing tag is fine.
-        let tagURL = URL.knownGood("https://api.github.com/repos/\(repo)/git/refs/tags/\(tag)")
+        let tagURL = try URL(knownGood: "https://api.github.com/repos/\(repo)/git/refs/tags/\(tag)")
         let tagRequest = githubRequest(url: tagURL, token: token, method: "DELETE")
         _ = try? await URLSession.shared.data(for: tagRequest)
     }
@@ -183,7 +183,7 @@ extension Release.Publishing {
         name: String,
         body: String
     ) async throws -> String {
-        let url = URL.knownGood("https://api.github.com/repos/\(repo)/releases")
+        let url = try URL(knownGood: "https://api.github.com/repos/\(repo)/releases")
         var request = githubRequest(url: url, token: token, method: "POST")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 

--- a/Packages/Sources/RemoteSync/RemoteSync.GitHubFetcher.swift
+++ b/Packages/Sources/RemoteSync/RemoteSync.GitHubFetcher.swift
@@ -44,7 +44,7 @@ extension RemoteSync {
         private func ensureTreeLoaded() async throws {
             if cachedTree != nil { return }
 
-            let url = URL.knownGood("\(RemoteSync.gitHubAPIBaseURL)/repos/\(repository)/git/trees/\(branch)?recursive=1")
+            let url = try URL(knownGood: "\(RemoteSync.gitHubAPIBaseURL)/repos/\(repository)/git/trees/\(branch)?recursive=1")
             var request = URLRequest(url: url)
 
             // Add auth header if token available
@@ -106,7 +106,7 @@ extension RemoteSync {
 
         /// Fetch raw file content
         public func fetchFileContent(path: String) async throws -> Data {
-            let url = buildRawURL(path: path)
+            let url = try buildRawURL(path: path)
             let (data, response) = try await session.data(from: url)
 
             try validateResponse(response, for: url)
@@ -133,10 +133,10 @@ extension RemoteSync {
 
         // MARK: - URL Building
 
-        private func buildRawURL(path: String) -> URL {
+        private func buildRawURL(path: String) throws -> URL {
             let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
             let urlString = "\(RemoteSync.rawGitHubBaseURL)/\(repository)/\(branch)/\(cleanPath)"
-            return URL.knownGood(urlString)
+            return try URL(knownGood: urlString)
         }
 
         // MARK: - Response Validation

--- a/Packages/Sources/Shared/Configuration/Shared.Configuration.Crawler.swift
+++ b/Packages/Sources/Shared/Configuration/Shared.Configuration.Crawler.swift
@@ -35,7 +35,7 @@ extension Shared.Configuration {
         public let htmlLinkAugmentationMaxRefs: Int
 
         public init(
-            startURL: URL = URL.knownGood(Shared.Constants.BaseURL.appleDeveloperDocs),
+            startURL: URL = try! URL(knownGood: Shared.Constants.BaseURL.appleDeveloperDocs),
             allowedPrefixes: [String]? = nil,
             maxPages: Int = Shared.Constants.Limit.defaultMaxPages,
             maxDepth: Int = 15,

--- a/Packages/Sources/Shared/Utils/URLExtensions.swift
+++ b/Packages/Sources/Shared/Utils/URLExtensions.swift
@@ -18,26 +18,18 @@ extension URL {
     ///
     /// Use for URLs constructed from compile-time literals or from internal
     /// constants (e.g. `Shared.Constants.BaseURL.*`) interpolated with
-    /// sanitized components. Equivalent to `URL(string: s)!`, but:
+    /// sanitized components.
     ///
-    /// - communicates the "known-good" contract at the call site,
-    /// - crashes with a message naming the offending string and the source
-    ///   location, instead of a bare "unexpectedly found nil while unwrapping
-    ///   an Optional value",
-    /// - localizes the force-unwrap to a single audited place.
+    /// - Throws: `URLError(.badURL)` if the string cannot be parsed.
     ///
-    /// **Do not use for URLs sourced from external/runtime data** (parsed
-    /// JSON, HTTP responses, indexed page metadata): a malformed string is
-    /// a recoverable condition there, not a programmer error. Use plain
-    /// `URL(string:)` + `guard let` in those cases.
-    public static func knownGood(
-        _ string: String,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) -> URL {
+    /// For truly known-good compile-time literals where `try` is unavailable
+    /// (stored properties, default parameters), `try! URL(knownGood:)` is
+    /// appropriate. For URLs sourced from external/runtime data, use plain
+    /// `URL(string:)` + `guard let` instead.
+    public init(knownGood string: String) throws {
         guard let url = URL(string: string) else {
-            fatalError("URL.knownGood: malformed URL string '\(string)'", file: file, line: line)
+            throw URLError(.badURL, userInfo: [NSURLErrorFailingURLStringErrorKey: string])
         }
-        return url
+        self = url
     }
 }

--- a/Packages/Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift
+++ b/Packages/Tests/SearchTests/IndexBuilderTitleErrorDefenseTests.swift
@@ -128,7 +128,7 @@ struct IndexBuilderJavaScriptFallbackDefenseTests {
         rawMarkdown: String? = nil
     ) -> Shared.Models.StructuredDocumentationPage {
         Shared.Models.StructuredDocumentationPage(
-            url: URL.knownGood("https://developer.apple.com/documentation/test"),
+            url: try! URL(knownGood: "https://developer.apple.com/documentation/test"),
             title: title,
             kind: kind,
             source: source,

--- a/Packages/Tests/Shared/CoreTests/URLKnownGoodTests.swift
+++ b/Packages/Tests/Shared/CoreTests/URLKnownGoodTests.swift
@@ -4,17 +4,15 @@ import SharedCore
 import SharedUtils
 import Testing
 
-// Direct coverage for the `URL.knownGood(_:file:line:)` helper introduced in
-// the v1.0.2-followup refactor (PR #288). The fatal-error branch on
-// malformed input cannot be exercised from a unit test without crashing
-// the host process; these tests cover the happy paths it's actually used
-// for in production.
+// Direct coverage for the `URL(knownGood:)` throwing initializer introduced in
+// the v1.0.2-followup refactor (PR #288), replacing the fatalError-based
+// `URL.knownGood(_:file:line:)` static method (issue #318).
 
-@Suite("URL.knownGood")
+@Suite("URL(knownGood:)")
 struct URLKnownGoodTests {
     @Test("returns the URL for a literal https string")
-    func returnsURLForLiteralString() {
-        let url = URL.knownGood("https://developer.apple.com/documentation/swiftui")
+    func returnsURLForLiteralString() throws {
+        let url = try URL(knownGood: "https://developer.apple.com/documentation/swiftui")
         #expect(url.absoluteString == "https://developer.apple.com/documentation/swiftui")
         #expect(url.scheme == "https")
         #expect(url.host == "developer.apple.com")
@@ -22,18 +20,26 @@ struct URLKnownGoodTests {
     }
 
     @Test("returns the URL for a string interpolated from internal constants")
-    func returnsURLForInterpolatedString() {
+    func returnsURLForInterpolatedString() throws {
         let owner = "apple"
         let repo = "swift-syntax"
-        let url = URL.knownGood("\(Shared.Constants.BaseURL.githubAPIRepos)/\(owner)/\(repo)")
+        let url = try URL(knownGood: "\(Shared.Constants.BaseURL.githubAPIRepos)/\(owner)/\(repo)")
         #expect(url.absoluteString == "https://api.github.com/repos/apple/swift-syntax")
     }
 
     @Test("preserves a query string component intact")
-    func preservesQueryString() {
-        let url = URL.knownGood("https://api.github.com/repos/x/y/contents/z?ref=main")
+    func preservesQueryString() throws {
+        let url = try URL(knownGood: "https://api.github.com/repos/x/y/contents/z?ref=main")
         #expect(url.query == "ref=main")
         #expect(url.path == "/repos/x/y/contents/z")
+    }
+
+    @Test("throws URLError(.badURL) for a malformed string")
+    func throwsForMalformedString() {
+        // Malformed IPv6 literal — Foundation's URL(string:) returns nil.
+        #expect(throws: URLError.self) {
+            try URL(knownGood: "http://[bad ipv6")
+        }
     }
 
     @Test("matches plain URL(string:) on every BaseURL constant we ship")
@@ -51,7 +57,7 @@ struct URLKnownGoodTests {
         ]
 
         for candidate in candidates {
-            let viaHelper = URL.knownGood(candidate)
+            let viaHelper = try URL(knownGood: candidate)
             let viaInit = try #require(URL(string: candidate))
             #expect(viaHelper == viaInit)
         }

--- a/Packages/Tests/SharedUtilsTests/SharedUtilsTests.swift
+++ b/Packages/Tests/SharedUtilsTests/SharedUtilsTests.swift
@@ -65,12 +65,11 @@ struct SharedUtilsPublicSurfaceTests {
         _ = Shared.Utils.SchemaVersion.self
     }
 
-    @Test("URL.knownGood produces a usable URL")
-    func urlKnownGoodExtension() {
-        // The URL.knownGood extension is the canonical Cupertino way to
-        // assert a literal URL is valid — used wherever a string literal
-        // is known to parse. Crash here would mean the extension is gone.
-        let url = URL.knownGood("https://developer.apple.com/documentation/")
+    @Test("URL(knownGood:) produces a usable URL")
+    func urlKnownGoodExtension() throws {
+        // URL(knownGood:) is the canonical Cupertino way to assert a literal
+        // URL is valid — used wherever a string literal is known to parse.
+        let url = try URL(knownGood: "https://developer.apple.com/documentation/")
         #expect(url.scheme == "https")
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `URL.knownGood(_:file:line:)` static method (which called `fatalError` on malformed input) with a throwing `URL.init(knownGood:)` initializer that throws `URLError(.badURL)` instead
- Callers in `async throws` contexts updated to `try URL(knownGood:)`; stored-property and default-parameter sites use `try!` (compile-time guaranteed constants)
- `buildRawURL` in `RemoteSync.GitHubFetcher` and `createGitHubRequest` in `PackageFetcher` made `throws` to properly propagate errors from dynamic string inputs
- Adds a new malformed-URL test case to `URLKnownGoodTests` (previously untestable because `fatalError` would crash the test process)

Closes #318

## Test plan

- [x] `swift build` — clean build, zero warnings from changed files
- [x] `swift test --filter URLKnownGood` — all 5 tests pass (including new error-path test)