### PR TITLE
test(sqlite): #236 cover synchronous + journal_size_limit on all three DB actors

### DIFF
--- a/Packages/Sources/SampleIndex/Sample.Index.Database.swift
+++ b/Packages/Sources/SampleIndex/Sample.Index.Database.swift
@@ -80,6 +80,35 @@ extension Sample.Index {
             }
         }
 
+        /// Inspect `PRAGMA synchronous` on the actor's own connection
+        /// (0..3, matching SQLite's enum: 0=OFF, 1=NORMAL, 2=FULL,
+        /// 3=EXTRA). Per-connection; not header-persistent. Test-facing.
+        public func currentSynchronousMode() -> Int32? {
+            guard let database else { return nil }
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_prepare_v2(database, "PRAGMA synchronous;", -1, &stmt, nil) == SQLITE_OK,
+                  sqlite3_step(stmt) == SQLITE_ROW
+            else {
+                return nil
+            }
+            return sqlite3_column_int(stmt, 0)
+        }
+
+        /// Inspect `PRAGMA journal_size_limit` on the actor's own
+        /// connection (bytes, -1 = unlimited). Per-connection.
+        public func currentJournalSizeLimit() -> Int64? {
+            guard let database else { return nil }
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_prepare_v2(database, "PRAGMA journal_size_limit;", -1, &stmt, nil) == SQLITE_OK,
+                  sqlite3_step(stmt) == SQLITE_ROW
+            else {
+                return nil
+            }
+            return sqlite3_column_int64(stmt, 0)
+        }
+
         // MARK: - Database Setup
 
         private func openDatabase() async throws {

--- a/Packages/Sources/Search/PackageIndex.swift
+++ b/Packages/Sources/Search/PackageIndex.swift
@@ -63,6 +63,38 @@ extension Search {
             }
         }
 
+        /// Inspect `PRAGMA synchronous` on the actor's own connection
+        /// (returns 0..3, matching SQLite's enum: 0=OFF, 1=NORMAL,
+        /// 2=FULL, 3=EXTRA). Per-connection setting; not persistent
+        /// in the file header, so `Diagnostics.Probes` opening its
+        /// own connection would see SQLite's defaults. Test-facing.
+        public func currentSynchronousMode() -> Int32? {
+            guard let database else { return nil }
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_prepare_v2(database, "PRAGMA synchronous;", -1, &stmt, nil) == SQLITE_OK,
+                  sqlite3_step(stmt) == SQLITE_ROW
+            else {
+                return nil
+            }
+            return sqlite3_column_int(stmt, 0)
+        }
+
+        /// Inspect `PRAGMA journal_size_limit` on the actor's own
+        /// connection (bytes, -1 = unlimited). Same per-connection
+        /// caveat as `currentSynchronousMode`.
+        public func currentJournalSizeLimit() -> Int64? {
+            guard let database else { return nil }
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_prepare_v2(database, "PRAGMA journal_size_limit;", -1, &stmt, nil) == SQLITE_OK,
+                  sqlite3_step(stmt) == SQLITE_ROW
+            else {
+                return nil
+            }
+            return sqlite3_column_int64(stmt, 0)
+        }
+
         // MARK: - Public API
 
         public struct IndexResult: Sendable {

--- a/Packages/Tests/SearchTests/WALJournalModeTests.swift
+++ b/Packages/Tests/SearchTests/WALJournalModeTests.swift
@@ -114,4 +114,90 @@ struct WALJournalModeTests {
         // is -1 = unlimited).
         #expect(limit == 67108864, "Search.Index should set journal_size_limit=64 MiB (got \(limit ?? -1))")
     }
+
+    // MARK: - Search.PackageIndex per-connection PRAGMAs
+
+    @Test("Search.PackageIndex sets synchronous=NORMAL on its own connection")
+    func packageIndexSetsSynchronousNormal() async throws {
+        let tempDB = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wal-pkg-sync-\(UUID().uuidString).db")
+        defer { try? FileManager.default.removeItem(at: tempDB) }
+
+        let index = try await Search.PackageIndex(dbPath: tempDB)
+        let mode = await index.currentSynchronousMode()
+        await index.disconnect()
+
+        #expect(mode == 1, "Search.PackageIndex should set synchronous=NORMAL (got \(mode ?? -1))")
+    }
+
+    @Test("Search.PackageIndex sets journal_size_limit=64MB on its own connection")
+    func packageIndexSetsJournalSizeLimit() async throws {
+        let tempDB = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wal-pkg-jsl-\(UUID().uuidString).db")
+        defer { try? FileManager.default.removeItem(at: tempDB) }
+
+        let index = try await Search.PackageIndex(dbPath: tempDB)
+        let limit = await index.currentJournalSizeLimit()
+        await index.disconnect()
+
+        #expect(limit == 67108864, "Search.PackageIndex should set journal_size_limit=64 MiB (got \(limit ?? -1))")
+    }
+
+    @Test("Re-opening an already-WAL packages.db stays in WAL (idempotent PRAGMA)")
+    func packageIndexReopenIsIdempotent() async throws {
+        let tempDB = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wal-pkg-reopen-\(UUID().uuidString).db")
+        defer { try? FileManager.default.removeItem(at: tempDB) }
+
+        let first = try await Search.PackageIndex(dbPath: tempDB)
+        await first.disconnect()
+        #expect(Diagnostics.Probes.journalMode(at: tempDB) == "wal")
+
+        let second = try await Search.PackageIndex(dbPath: tempDB)
+        await second.disconnect()
+        #expect(Diagnostics.Probes.journalMode(at: tempDB) == "wal")
+    }
+
+    // MARK: - Sample.Index.Database per-connection PRAGMAs
+
+    @Test("Sample.Index.Database sets synchronous=NORMAL on its own connection")
+    func sampleIndexSetsSynchronousNormal() async throws {
+        let tempDB = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wal-sample-sync-\(UUID().uuidString).db")
+        defer { try? FileManager.default.removeItem(at: tempDB) }
+
+        let database = try await Sample.Index.Database(dbPath: tempDB)
+        let mode = await database.currentSynchronousMode()
+        await database.disconnect()
+
+        #expect(mode == 1, "Sample.Index.Database should set synchronous=NORMAL (got \(mode ?? -1))")
+    }
+
+    @Test("Sample.Index.Database sets journal_size_limit=64MB on its own connection")
+    func sampleIndexSetsJournalSizeLimit() async throws {
+        let tempDB = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wal-sample-jsl-\(UUID().uuidString).db")
+        defer { try? FileManager.default.removeItem(at: tempDB) }
+
+        let database = try await Sample.Index.Database(dbPath: tempDB)
+        let limit = await database.currentJournalSizeLimit()
+        await database.disconnect()
+
+        #expect(limit == 67108864, "Sample.Index.Database should set journal_size_limit=64 MiB (got \(limit ?? -1))")
+    }
+
+    @Test("Re-opening an already-WAL samples.db stays in WAL (idempotent PRAGMA)")
+    func sampleIndexReopenIsIdempotent() async throws {
+        let tempDB = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wal-sample-reopen-\(UUID().uuidString).db")
+        defer { try? FileManager.default.removeItem(at: tempDB) }
+
+        let first = try await Sample.Index.Database(dbPath: tempDB)
+        await first.disconnect()
+        #expect(Diagnostics.Probes.journalMode(at: tempDB) == "wal")
+
+        let second = try await Sample.Index.Database(dbPath: tempDB)
+        await second.disconnect()
+        #expect(Diagnostics.Probes.journalMode(at: tempDB) == "wal")
+    }
 }


### PR DESCRIPTION
## What

Backfills the per-connection PRAGMA coverage gap from #511.

#511 verified the new `synchronous = NORMAL` and
`journal_size_limit = 64 MiB` PRAGMAs on **only** `Search.Index`'s
own connection. `Search.PackageIndex` and `Sample.Index.Database`
have the same code (set in their respective `openDatabase()`) but
were only inferred-correct via the file-header
`journal_mode == "wal"` check — the per-connection PRAGMAs were
untested for those two actors.

## Changes

**Two new read-only inspection methods on each of the remaining
two actors** (same shape as the existing `Search.Index` ones):

- `Search.PackageIndex.currentSynchronousMode() -> Int32?`
- `Search.PackageIndex.currentJournalSizeLimit() -> Int64?`
- `Sample.Index.Database.currentSynchronousMode() -> Int32?`
- `Sample.Index.Database.currentJournalSizeLimit() -> Int64?`

Production code paths (constructors, `disconnect`, writer paths)
are unchanged.

## Tests

Six new tests in `WALJournalModeTests`:

- `Search.PackageIndex sets synchronous=NORMAL`
- `Search.PackageIndex sets journal_size_limit=64MB`
- `Search.PackageIndex re-open idempotency (journal_mode stays wal)`
- `Sample.Index.Database sets synchronous=NORMAL`
- `Sample.Index.Database sets journal_size_limit=64MB`
- `Sample.Index.Database re-open idempotency (journal_mode stays wal)`

`WALJournalModeTests` is now 12 tests (was 6); full package suite
is **1453 in 162** (was 1447/162), all green.

## Safety

Pure additive change. New methods are read-only PRAGMA inspectors;
no state mutation. Tests use UUID-tagged temp DBs under
`FileManager.temporaryDirectory` and `defer`-clean themselves up.
Zero touch of user data in `~/.cupertino/`.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test`: **1453 tests in 162 suites passed**.
- `swiftformat .`: no changes.
- `scripts/check-package-purity.sh`: clean ✅.