### PR TITLE
fix(release): #236 checkpoint-truncate each DB before bundling for release

### DIFF
--- a/Packages/Sources/ReleaseTool/Release.Command.Database.swift
+++ b/Packages/Sources/ReleaseTool/Release.Command.Database.swift
@@ -89,6 +89,25 @@ extension Release.Command {
                 Release.Console.warning("packages.db: missing (continuing because --allow-missing-packages was passed)")
             }
 
+            // #236: checkpoint-truncate each DB before bundling so
+            // any pages still in a `.db-wal` sidecar are folded into
+            // the main file. Without this step a release zip would
+            // ship a `.db` that's missing the most recent index
+            // pages, and `cupertino setup` users would silently
+            // search a stale corpus.
+            Release.Console.info("\n💾 Checkpoint-truncating WAL sidecars before bundle...")
+            for (label, url) in [
+                ("search.db", searchDBURL),
+                ("samples.db", samplesDBURL),
+            ] + (packagesDBPresent ? [("packages.db", packagesDBURL)] : []) {
+                let outcome = try Release.Publishing.checkpointTruncate(at: url)
+                let detail = outcome.walFileExisted
+                    ? "folded \(outcome.framesWritten)/\(outcome.framesTotal) frames"
+                    : "no WAL sidecar"
+                let busyNote = outcome.busy ? " ⚠ SQLITE_BUSY (was another process touching the DB?)" : ""
+                Release.Console.substep("✓ \(label): \(detail)\(busyNote)")
+            }
+
             // Bundle. The zip name still uses the historical "cupertino-databases-"
             // prefix so existing `cupertino setup` clients keep working.
             var bundled: [URL] = [searchDBURL, samplesDBURL]

--- a/Packages/Sources/ReleaseTool/Release.Publishing.swift
+++ b/Packages/Sources/ReleaseTool/Release.Publishing.swift
@@ -2,6 +2,7 @@ import Foundation
 import SharedConstants
 import SharedCore
 import SharedUtils
+import SQLite3
 
 // MARK: - Shared publishing helpers
 
@@ -46,6 +47,103 @@ extension Release.Publishing {
     static func fileSize(at url: URL) throws -> Int64 {
         let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
         return attrs[.size] as? Int64 ?? 0
+    }
+
+    // MARK: - WAL checkpoint (#236)
+
+    /// Outcome of a `wal_checkpoint(TRUNCATE)` on a SQLite file.
+    /// `framesWritten` is the number of WAL frames moved into the
+    /// main DB; `framesTotal` is the total WAL frame count before
+    /// the checkpoint started. A `busy` return means at least one
+    /// reader or writer was still using the WAL when the checkpoint
+    /// ran — TRUNCATE blocks on readers, so for a release flow where
+    /// nothing else should be touching the DB this would be a sign
+    /// the host machine has a stray cupertino process.
+    struct CheckpointOutcome {
+        let busy: Bool
+        let framesWritten: Int32
+        let framesTotal: Int32
+        let walFileExisted: Bool
+        let walSizeAfter: Int64
+    }
+
+    enum CheckpointError: Swift.Error, CustomStringConvertible {
+        case openFailed(path: String, message: String)
+        case checkpointFailed(path: String, message: String)
+        case walNotTruncated(path: String, sizeBytes: Int64)
+
+        var description: String {
+            switch self {
+            case .openFailed(let path, let message):
+                "Could not open \(path) for checkpoint: \(message)"
+            case .checkpointFailed(let path, let message):
+                "PRAGMA wal_checkpoint(TRUNCATE) failed on \(path): \(message)"
+            case .walNotTruncated(let path, let size):
+                "WAL sidecar at \(path) remained \(size) bytes after checkpoint — refusing to zip a partial bundle."
+            }
+        }
+    }
+
+    /// Run `PRAGMA wal_checkpoint(TRUNCATE)` on the SQLite file at
+    /// `dbURL`, fold any WAL pages into the main file, and confirm
+    /// the `.db-wal` sidecar is gone (or shrunk to zero bytes).
+    ///
+    /// Used by `Release.Command.Database` before zipping each
+    /// cupertino DB for the GitHub Release. The bundled `.db` files
+    /// users download via `cupertino setup` MUST contain all data —
+    /// any pages still in a `.db-wal` sidecar at zip time would
+    /// silently be missing from the user's installed corpus.
+    /// See #236 and `docs/artifacts/folders/*.db.md`.
+    @discardableResult
+    static func checkpointTruncate(at dbURL: URL) throws -> CheckpointOutcome {
+        var db: OpaquePointer?
+        guard sqlite3_open(dbURL.path, &db) == SQLITE_OK else {
+            let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown sqlite3 error"
+            sqlite3_close(db)
+            throw CheckpointError.openFailed(path: dbURL.path, message: message)
+        }
+        defer { sqlite3_close(db) }
+
+        // sqlite3_wal_checkpoint_v2 returns the busy / frame counts
+        // we need; the PRAGMA-string form swallows them. Per the
+        // SQLite docs:
+        //   pnLog out: Size of WAL log in frames
+        //   pnCkpt out: Total number of frames checkpointed
+        // Both are -1 if not in WAL mode.
+        var framesLog: Int32 = 0
+        var framesCheckpointed: Int32 = 0
+        let rc = sqlite3_wal_checkpoint_v2(db, nil, SQLITE_CHECKPOINT_TRUNCATE, &framesLog, &framesCheckpointed)
+        // SQLITE_OK (0) or SQLITE_BUSY (5). Both are non-fatal in
+        // theory; SQLITE_BUSY here would be very surprising in a
+        // release flow.
+        guard rc == SQLITE_OK || rc == SQLITE_BUSY else {
+            let message = String(cString: sqlite3_errmsg(db))
+            throw CheckpointError.checkpointFailed(path: dbURL.path, message: "rc=\(rc) \(message)")
+        }
+
+        let walURL = URL(fileURLWithPath: dbURL.path + "-wal")
+        let walExists = FileManager.default.fileExists(atPath: walURL.path)
+        let walSize: Int64
+        if walExists {
+            walSize = (try? fileSize(at: walURL)) ?? 0
+        } else {
+            walSize = 0
+        }
+
+        // TRUNCATE either deletes the sidecar or shrinks it to 0.
+        // Anything else means data is still trapped in the WAL —
+        // refuse to ship a partial bundle.
+        if walSize > 0 {
+            throw CheckpointError.walNotTruncated(path: walURL.path, sizeBytes: walSize)
+        }
+
+        return CheckpointOutcome(
+            busy: rc == SQLITE_BUSY,
+            framesWritten: framesCheckpointed,
+            framesTotal: framesLog,
+            walFileExisted: walExists,
+            walSizeAfter: walSize
+        )
     }
 
     static func createZip(containing files: [URL], at destination: URL) throws {

--- a/Packages/Tests/ReleaseToolTests/CheckpointTruncateTests.swift
+++ b/Packages/Tests/ReleaseToolTests/CheckpointTruncateTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+@testable import ReleaseTool
+import SQLite3
+import Testing
+
+// MARK: - Release.Publishing.checkpointTruncate (#236)
+
+// Verifies the release-time WAL checkpoint helper that runs before
+// `Release.Command.Database` zips the three cupertino DBs for the
+// GitHub Release artifact. Without it, a `.db` file in the zip
+// could be missing pages that are still trapped in a `.db-wal`
+// sidecar at zip time — `cupertino setup` users would silently
+// search a stale corpus.
+
+@Suite("Release.Publishing.checkpointTruncate (#236)")
+struct CheckpointTruncateTests {
+    @Test("Runs cleanly against a WAL-mode DB and leaves no WAL sidecar")
+    func checkpointTruncateLeavesNoSidecar() throws {
+        let tempDB = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rel-checkpoint-\(UUID().uuidString).db")
+        let walURL = URL(fileURLWithPath: tempDB.path + "-wal")
+        let shmURL = URL(fileURLWithPath: tempDB.path + "-shm")
+        defer {
+            try? FileManager.default.removeItem(at: tempDB)
+            try? FileManager.default.removeItem(at: walURL)
+            try? FileManager.default.removeItem(at: shmURL)
+        }
+
+        // Build a real WAL DB with data and let SQLite close it
+        // normally. SQLite's close-time checkpoint already folds
+        // everything in the WAL back into the main file in a
+        // single-process test scenario — there's no easy way to
+        // simulate a "dirty WAL at close" without process isolation
+        // (because the last connection's `sqlite3_close` always
+        // runs a final checkpoint). So this test verifies the
+        // post-condition: the helper runs cleanly, returns a sane
+        // outcome, and the `.db-wal` sidecar is gone afterward.
+        // The fold-frames behavior is exercised in real-world
+        // release-tool runs against a freshly-built bundle DB.
+        try buildWALDatabase(at: tempDB)
+
+        let outcome = try Release.Publishing.checkpointTruncate(at: tempDB)
+        #expect(!outcome.busy, "No concurrent connections — TRUNCATE should not return SQLITE_BUSY")
+
+        // Post-condition: WAL sidecar gone (or zero bytes).
+        let postExists = FileManager.default.fileExists(atPath: walURL.path)
+        if postExists {
+            let postSize = (try? FileManager.default.attributesOfItem(atPath: walURL.path)[.size] as? Int64) ?? -1
+            #expect(postSize == 0, "WAL sidecar should be truncated to 0 bytes (got \(postSize))")
+        }
+    }
+
+    @Test("Idempotent on an already-clean WAL DB (second call still ok)")
+    func checkpointTruncateIsIdempotent() throws {
+        let tempDB = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rel-checkpoint-idem-\(UUID().uuidString).db")
+        defer {
+            try? FileManager.default.removeItem(at: tempDB)
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: tempDB.path + "-wal"))
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: tempDB.path + "-shm"))
+        }
+
+        try buildWALDatabase(at: tempDB)
+        _ = try Release.Publishing.checkpointTruncate(at: tempDB)
+        let outcome = try Release.Publishing.checkpointTruncate(at: tempDB)
+        #expect(outcome.walSizeAfter == 0)
+        #expect(!outcome.busy)
+    }
+
+    @Test("Surfaces openFailed for a path under a missing directory")
+    func checkpointTruncateMissingFileFails() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rel-checkpoint-missing-\(UUID().uuidString)")
+            .appendingPathComponent("nope.db")
+        // Parent directory doesn't exist, so sqlite3_open's
+        // create-on-open fails.
+        #expect(throws: Release.Publishing.CheckpointError.self) {
+            _ = try Release.Publishing.checkpointTruncate(at: missing)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Build a fresh SQLite database in WAL mode with a bit of data
+    /// and close cleanly. Used by tests above to verify the helper
+    /// runs without error on real WAL files. Single-process Swift
+    /// tests can't easily leave a "dirty" WAL because SQLite's
+    /// close-time checkpoint always drains the sidecar; the helper's
+    /// behavior on dirty WALs is covered by real release-tool runs.
+    private func buildWALDatabase(at path: URL) throws {
+        var db: OpaquePointer?
+        guard sqlite3_open(path.path, &db) == SQLITE_OK else {
+            throw CheckpointTestError.openFailed
+        }
+        _ = sqlite3_exec(db, "PRAGMA journal_mode = WAL;", nil, nil, nil)
+        _ = sqlite3_exec(db, "CREATE TABLE t (id INTEGER PRIMARY KEY, payload BLOB);", nil, nil, nil)
+        _ = sqlite3_exec(db, "BEGIN;", nil, nil, nil)
+        let blob = String(repeating: "x", count: 4096)
+        for i in 0..<32 {
+            _ = sqlite3_exec(db, "INSERT INTO t VALUES (\(i), '\(blob)');", nil, nil, nil)
+        }
+        _ = sqlite3_exec(db, "COMMIT;", nil, nil, nil)
+        sqlite3_close(db)
+    }
+
+    private enum CheckpointTestError: Error {
+        case openFailed
+    }
+}


### PR DESCRIPTION
## What

Plugs a real footgun in the WAL-enablement work (#510): the
release-tool zipped each cupertino DB into the GitHub Release
bundle **without** running `PRAGMA wal_checkpoint(TRUNCATE)` on
it first. Any pages still sitting in a `.db-wal` sidecar at zip
time would be silently missing from the `.db` that ships, and
every `cupertino setup` user would search a stale corpus with
no error signal.

This PR adds the checkpoint step the audit conversation flagged.

## New helper

`Release.Publishing.checkpointTruncate(at: URL) throws -> CheckpointOutcome`:

- Opens the DB via sqlite3.
- Runs `sqlite3_wal_checkpoint_v2` with `SQLITE_CHECKPOINT_TRUNCATE`.
- Returns `framesWritten` / `framesTotal` / `walSizeAfter` / `busy`
  so the caller can log the fold counts and notice SQLITE_BUSY (a
  stray cupertino process touching the DB during the release flow).
- Verifies the `.db-wal` sidecar is gone or zero bytes; throws
  `CheckpointError.walNotTruncated` if not — release refuses to
  zip a partial bundle.

## Wired in

`Release.Command.Database` runs the helper for each of the three
DBs (search.db, samples.db, packages.db) right before the
`createZip(containing:)` call, with per-DB console output.

```
💾 Checkpoint-truncating WAL sidecars before bundle...
   ✓ search.db: folded 1234/1234 frames
   ✓ samples.db: folded 56/56 frames
   ✓ packages.db: no WAL sidecar
```

## Tests

3 new tests in `CheckpointTruncateTests`:

1. Runs cleanly against a real WAL-mode DB and leaves no sidecar.
2. Idempotent — second call against an already-clean DB succeeds.
3. Surfaces `CheckpointError.openFailed` for a path under a
   missing directory.

The "folds N frames" assertion was attempted but produced false
negatives in single-process tests: SQLite's close-time checkpoint
always drains the WAL before the test can inspect it. The
fold-frames path is exercised by real release-tool runs against
freshly-built bundle DBs — documented in the test header.

## Why this matters

Without this fix, the v1.0.3 release flow (or any future bundle
release where `cupertino save` finishes shortly before
`cupertino-rel database` runs) could silently produce a partial
DB. Caught by the user's "is this safe?" audit before tag.

## Verified

- `xcrun swift build`: complete.
- `xcrun swift test --filter CheckpointTruncateTests`: 3/3 pass.
- `xcrun swift test`: 1456 tests in 163 suites passed.
- `swiftformat .`: applied (one file).
- `scripts/check-package-purity.sh`: clean ✅.